### PR TITLE
fix(workflow): fix code-interpreter image name

### DIFF
--- a/sandboxes/code-interpreter/build.sh
+++ b/sandboxes/code-interpreter/build.sh
@@ -32,7 +32,7 @@ docker buildx ls
 #  .
 
 docker buildx build \
-  -t opensandbox/code-interpreter-base:${TAG} \
+  -t opensandbox/code-interpreter:${TAG} \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:${TAG} \
   --platform linux/amd64,linux/arm64 \
   --push \


### PR DESCRIPTION
# Summary
- fix code-interpreter image name mismatch under sandboxes/code-interpreter/build.sh
