### PR TITLE
refactor(label): standardize label keys

### DIFF
--- a/docs/single_host_network.md
+++ b/docs/single_host_network.md
@@ -6,7 +6,7 @@ Detailed routing for a single-host deployment: how execd’s proxy gives every s
 
 ## Single-host routing model
 - Every sandbox container starts `execd` listening on container port `44772`. `execd` bundles a lightweight reverse proxy that intercepts requests with the `/proxy/{port}` prefix and forwards them to `127.0.0.1:{port}` inside the same container.
-- The Docker runtime binds only the host side of the execd proxy port (labeled `sandbox.dev/embeddingProxyPort`). Callers use `get_endpoint(..., port=X)` to receive `{public_host}:{host_proxy_port}/proxy/{X}`, and execd transparently routes the request back to the sandbox service on port `X`.
+- The Docker runtime binds only the host side of the execd proxy port (labeled `opensandbox.io/embedding-proxy-port`). Callers use `get_endpoint(..., port=X)` to receive `{public_host}:{host_proxy_port}/proxy/{X}`, and execd transparently routes the request back to the sandbox service on port `X`.
 - Because the proxy preserves `Upgrade`, `Connection`, and other HTTP headers, HTTP, Server-Sent Events, and WebSocket traffic share the same mapped host port without additional configuration.
 - With this setup, a single host port per sandbox suffices to reach **all** container ports. You can safely run many sandboxes on one machine without worrying about overlapping host port allocations.
 - When the caller lives inside the same Docker network (e.g., another container or Kubernetes pod), use `get_endpoint(..., resolve_internal=True)` to bypass the host mapping and return the sandbox IP (e.g., `172.17.0.3:5900`) instead.
@@ -22,8 +22,8 @@ Detailed routing for a single-host deployment: how execd’s proxy gives every s
 ### Bridge network mode (default for single-host deployments)
 - Docker places sandboxes on an isolated bridge network, preventing container ports from being reachable without explicit mapping.
 - For single-host scaling, OpenSandbox maps only execd’s proxy port (`44772`) and, optionally, port `8080`. Any other container port stays private and is reached via the proxy.
-- The reverse proxy label (`sandbox.dev/embeddingProxyPort`) identifies a host port that fronts `execd`. `get_endpoint(..., port=X)` returns `{public_host}:{host_proxy_port}/proxy/{X}`, so all internal ports can share the same host binding.
-- Port `8080` may also receive a direct host binding (`sandbox.dev/httpPort`), providing a conventional HTTP endpoint without the proxy path when required.
+- The reverse proxy label (`opensandbox.io/embedding-proxy-port`) identifies a host port that fronts `execd`. `get_endpoint(..., port=X)` returns `{public_host}:{host_proxy_port}/proxy/{X}`, so all internal ports can share the same host binding.
+- Port `8080` may also receive a direct host binding (`opensandbox.io/http-port`), providing a conventional HTTP endpoint without the proxy path when required.
 - This bridge setup lets a single machine host many sandboxes without port conflicts, because the same host proxy port can multiplex requests for HTTP, SSE, WebSocket, VNC, etc.
 
 ## Operational notes

--- a/examples/chrome/main.py
+++ b/examples/chrome/main.py
@@ -25,7 +25,7 @@ async def main():
             image="opensandbox/chrome:latest",
             timeout=timedelta(minutes=5),
             entrypoint=["/entrypoint"],
-            metadata={"examples.opensandbox.dev": "chrome"},
+            metadata={"examples.opensandbox.io": "chrome"},
             connection_config=ConnectionConfig(
                 domain="localhost:8080"
             )

--- a/sdks/code-interpreter/kotlin/README.md
+++ b/sdks/code-interpreter/kotlin/README.md
@@ -46,7 +46,7 @@ public class QuickStart {
     public static void main(String[] args) {
         // 1. Configure connection
         ConnectionConfig config = ConnectionConfig.builder()
-            .domain("api.opensandbox.dev")
+            .domain("api.opensandbox.io")
             .apiKey("your-api-key")
             .build();
 

--- a/sdks/code-interpreter/kotlin/README_zh.md
+++ b/sdks/code-interpreter/kotlin/README_zh.md
@@ -46,7 +46,7 @@ public class QuickStart {
     public static void main(String[] args) {
         // 1. 配置连接信息
         ConnectionConfig config = ConnectionConfig.builder()
-            .domain("api.opensandbox.dev")
+            .domain("api.opensandbox.io")
             .apiKey("your-api-key")
             .build();
 

--- a/sdks/code-interpreter/python/README.md
+++ b/sdks/code-interpreter/python/README.md
@@ -45,7 +45,7 @@ from opensandbox.config import ConnectionConfig
 async def main() -> None:
     # 1. Configure connection
     config = ConnectionConfig(
-        domain="api.opensandbox.dev",
+        domain="api.opensandbox.io",
         api_key="your-api-key",
         request_timeout=timedelta(seconds=60),
     )
@@ -102,7 +102,7 @@ from opensandbox import SandboxSync
 from opensandbox.config import ConnectionConfigSync
 
 config = ConnectionConfigSync(
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     api_key="your-api-key",
     request_timeout=timedelta(seconds=60),
     transport=httpx.HTTPTransport(limits=httpx.Limits(max_connections=20)),

--- a/sdks/code-interpreter/python/README_zh.md
+++ b/sdks/code-interpreter/python/README_zh.md
@@ -41,7 +41,7 @@ from opensandbox.config import ConnectionConfig
 async def main() -> None:
     # 1. 配置连接信息
     config = ConnectionConfig(
-        domain="api.opensandbox.dev",
+        domain="api.opensandbox.io",
         api_key="your-api-key",
         request_timeout=timedelta(seconds=60),
     )
@@ -98,7 +98,7 @@ from opensandbox import SandboxSync
 from opensandbox.config import ConnectionConfigSync
 
 config = ConnectionConfigSync(
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     api_key="your-api-key",
     request_timeout=timedelta(seconds=60),
     transport=httpx.HTTPTransport(limits=httpx.Limits(max_connections=20)),

--- a/sdks/sandbox/kotlin/README.md
+++ b/sdks/sandbox/kotlin/README.md
@@ -40,7 +40,7 @@ public class QuickStart {
     public static void main(String[] args) {
         // 1. Configure connection
         ConnectionConfig config = ConnectionConfig.builder()
-            .domain("api.opensandbox.dev")
+            .domain("api.opensandbox.io")
             .apiKey("your-api-key")
             .build();
 
@@ -223,7 +223,7 @@ The `ConnectionConfig` class manages API server connection settings.
 // 1. Basic configuration
 ConnectionConfig config = ConnectionConfig.builder()
     .apiKey("your-key")
-    .domain("api.opensandbox.dev")
+    .domain("api.opensandbox.io")
     .requestTimeout(Duration.ofSeconds(60))
     .build();
 
@@ -233,7 +233,7 @@ ConnectionPool sharedPool = new ConnectionPool(50, 5, TimeUnit.MINUTES);
 
 ConnectionConfig sharedConfig = ConnectionConfig.builder()
     .apiKey("your-key")
-    .domain("api.opensandbox.dev")
+    .domain("api.opensandbox.io")
     .connectionPool(sharedPool) // Inject shared pool
     .build();
 ```

--- a/sdks/sandbox/kotlin/README_zh.md
+++ b/sdks/sandbox/kotlin/README_zh.md
@@ -41,7 +41,7 @@ public class QuickStart {
     public static void main(String[] args) {
         // 1. 配置连接信息
         ConnectionConfig config = ConnectionConfig.builder()
-            .domain("api.opensandbox.dev")
+            .domain("api.opensandbox.io")
             .apiKey("your-api-key")
             .build();
 
@@ -224,7 +224,7 @@ sandboxes.getSandboxInfos().forEach(info -> {
 // 1. 基础配置
 ConnectionConfig config = ConnectionConfig.builder()
     .apiKey("your-key")
-    .domain("api.opensandbox.dev")
+    .domain("api.opensandbox.io")
     .requestTimeout(Duration.ofSeconds(60))
     .build();
 
@@ -234,7 +234,7 @@ ConnectionPool sharedPool = new ConnectionPool(50, 5, TimeUnit.MINUTES);
 
 ConnectionConfig sharedConfig = ConnectionConfig.builder()
     .apiKey("your-key")
-    .domain("api.opensandbox.dev")
+    .domain("api.opensandbox.io")
     .connectionPool(sharedPool) // 注入共享连接池
     .build();
 ```

--- a/sdks/sandbox/python/README.md
+++ b/sdks/sandbox/python/README.md
@@ -33,7 +33,7 @@ from opensandbox.exceptions import SandboxException
 async def main():
     # 1. Configure connection
     config = ConnectionConfig(
-        domain="api.opensandbox.dev",
+        domain="api.opensandbox.io",
         api_key="your-api-key"
     )
 
@@ -77,7 +77,7 @@ from opensandbox import SandboxSync
 from opensandbox.config import ConnectionConfigSync
 
 config = ConnectionConfigSync(
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     api_key="your-api-key",
     request_timeout=timedelta(seconds=30),
     transport=httpx.HTTPTransport(limits=httpx.Limits(max_connections=20)),
@@ -249,7 +249,7 @@ from datetime import timedelta
 # 1. Basic configuration
 config = ConnectionConfig(
     api_key="your-key",
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     request_timeout=timedelta(seconds=60)
 )
 
@@ -259,7 +259,7 @@ import httpx
 
 config = ConnectionConfig(
     api_key="your-key",
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     headers={"X-Custom-Header": "value"},
     transport=httpx.AsyncHTTPTransport(
         limits=httpx.Limits(

--- a/sdks/sandbox/python/README_zh.md
+++ b/sdks/sandbox/python/README_zh.md
@@ -33,7 +33,7 @@ from opensandbox.exceptions import SandboxException
 async def main():
     # 1. 配置连接信息
     config = ConnectionConfig(
-        domain="api.opensandbox.dev",
+        domain="api.opensandbox.io",
         api_key="your-api-key"
     )
 
@@ -77,7 +77,7 @@ from opensandbox import SandboxSync
 from opensandbox.config import ConnectionConfigSync
 
 config = ConnectionConfigSync(
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     api_key="your-api-key",
     request_timeout=timedelta(seconds=30),
     transport=httpx.HTTPTransport(limits=httpx.Limits(max_connections=20)),
@@ -249,7 +249,7 @@ from datetime import timedelta
 # 1. 基础配置
 config = ConnectionConfig(
     api_key="your-key",
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     request_timeout=timedelta(seconds=60)
 )
 
@@ -259,7 +259,7 @@ import httpx
 
 config = ConnectionConfig(
     api_key="your-key",
-    domain="api.opensandbox.dev",
+    domain="api.opensandbox.io",
     headers={"X-Custom-Header": "value"},
     transport=httpx.AsyncHTTPTransport(
         limits=httpx.Limits(

--- a/sdks/sandbox/python/src/opensandbox/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/__init__.py
@@ -56,7 +56,7 @@ from opensandbox.models.sandboxes import SandboxImageSpec, SandboxImageAuth
 async def main():
     config = ConnectionConfig(
         api_key="your-api-key",
-        domain="api.opensandbox.dev"
+        domain="api.opensandbox.io"
     )
 
     # With private registry auth

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -44,13 +44,13 @@ class RouterConfig(BaseModel):
 
     domain: Optional[str] = Field(
         default=None,
-        description="Base domain used to expose sandbox endpoints (e.g., 'opensandbox.dev').",
+        description="Base domain used to expose sandbox endpoints (e.g., 'opensandbox.io').",
         min_length=1,
     )
     wildcard_domain: Optional[str] = Field(
         default=None,
         alias="wildcard-domain",
-        description="Wildcard domain pattern (e.g., '*.sandbox.dev') used for sandbox endpoints.",
+        description="Wildcard domain pattern (e.g., '*.opensandbox.io') used for sandbox endpoints.",
         min_length=1,
     )
 

--- a/server/src/services/constants.py
+++ b/server/src/services/constants.py
@@ -14,11 +14,11 @@
 
 """Shared constants for sandbox services."""
 
-SANDBOX_ID_LABEL = "sandbox.dev/id"
-SANDBOX_EXPIRES_AT_LABEL = "sandbox.dev/expiresAt"
+SANDBOX_ID_LABEL = "opensandbox.io/id"
+SANDBOX_EXPIRES_AT_LABEL = "opensandbox.io/expires-at"
 # Host-mapped ports recorded on containers (bridge mode).
-SANDBOX_EMBEDDING_PROXY_PORT_LABEL = "sandbox.dev/embeddingProxyPort"  # maps container 44772 -> host port
-SANDBOX_HTTP_PORT_LABEL = "sandbox.dev/httpPort"  # maps container 8080 -> host port
+SANDBOX_EMBEDDING_PROXY_PORT_LABEL = "opensandbox.io/embedding-proxy-port"  # maps container 44772 -> host port
+SANDBOX_HTTP_PORT_LABEL = "opensandbox.io/http-port"  # maps container 8080 -> host port
 
 
 class SandboxErrorCodes:

--- a/server/src/services/docker.py
+++ b/server/src/services/docker.py
@@ -317,7 +317,7 @@ class DockerSandboxService(SandboxService):
                 expires_at = parse_timestamp(expires_label)
             else:
                 logger.warning(
-                    "Sandbox %s missing expiresAt label; skipping expiration scheduling.",
+                    "Sandbox %s missing expires-at label; skipping expiration scheduling.",
                     sandbox_id,
                 )
                 continue

--- a/server/tests/test_auth_middleware.py
+++ b/server/tests/test_auth_middleware.py
@@ -23,7 +23,7 @@ def _app_config_with_api_key() -> AppConfig:
     return AppConfig(
         server=ServerConfig(api_key="secret-key"),
         runtime=RuntimeConfig(type="docker", execd_image="ghcr.io/opensandbox/platform:latest"),
-        router=RouterConfig(domain="opensandbox.dev"),
+        router=RouterConfig(domain="opensandbox.io"),
     )
 
 

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -40,7 +40,7 @@ def test_load_config_from_file(tmp_path, monkeypatch):
         execd_image = "ghcr.io/opensandbox/platform:test"
 
         [router]
-        domain = "opensandbox.dev"
+        domain = "opensandbox.io"
         """
     )
     config_path = tmp_path / "config.toml"
@@ -54,7 +54,7 @@ def test_load_config_from_file(tmp_path, monkeypatch):
     assert loaded.runtime.type == "docker"
     assert loaded.runtime.execd_image == "ghcr.io/opensandbox/platform:test"
     assert loaded.router is not None
-    assert loaded.router.domain == "opensandbox.dev"
+    assert loaded.router.domain == "opensandbox.io"
     assert loaded.docker.network_mode == "host"
 
 
@@ -77,6 +77,6 @@ def test_router_requires_exactly_one_domain():
     with pytest.raises(ValueError):
         RouterConfig(domain=None, wildcard_domain=None)
     with pytest.raises(ValueError):
-        RouterConfig(domain="opensandbox.dev", wildcard_domain="*.sandbox.dev")
-    cfg = RouterConfig(domain="opensandbox.dev")
-    assert cfg.domain == "opensandbox.dev"
+        RouterConfig(domain="opensandbox.io", wildcard_domain="*.opensandbox.io")
+    cfg = RouterConfig(domain="opensandbox.io")
+    assert cfg.domain == "opensandbox.io"

--- a/server/tests/test_docker_endpoint.py
+++ b/server/tests/test_docker_endpoint.py
@@ -63,8 +63,8 @@ def test_get_endpoint_bridge_http_port(mock_docker_service):
     service.network_mode = "bridge"
 
     labels = {
-        "sandbox.dev/embeddingProxyPort": "50002",
-        "sandbox.dev/httpPort": "50001",
+        "opensandbox.io/embedding-proxy-port": "50002",
+        "opensandbox.io/http-port": "50001",
     }
     mock_container = MagicMock()
     mock_container.attrs = {
@@ -86,8 +86,8 @@ def test_get_endpoint_bridge_other_port_via_execd(mock_docker_service):
     service.network_mode = "bridge"
 
     labels = {
-        "sandbox.dev/embeddingProxyPort": "50002",
-        "sandbox.dev/httpPort": "50001",
+        "opensandbox.io/embedding-proxy-port": "50002",
+        "opensandbox.io/http-port": "50001",
     }
     mock_container = MagicMock()
     mock_container.attrs = {

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -38,7 +38,7 @@ def _app_config() -> AppConfig:
     return AppConfig(
         server=ServerConfig(),
         runtime=RuntimeConfig(type="docker", execd_image="ghcr.io/opensandbox/platform:latest"),
-        router=RouterConfig(domain="opensandbox.dev"),
+        router=RouterConfig(domain="opensandbox.io"),
     )
 
 

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -19,7 +19,7 @@ def test_ensure_metadata_labels_accepts_common_k8s_forms():
     # Various valid label shapes: with/without prefix, mixed chars, empty value allowed.
     valid_metadata = {
         "app": "web",
-        "opensandbox.dev/hello": "world",
+        "opensandbox.io/hello": "world",
         "k8s.io/name": "app-1",
         "example.com/label": "a.b_c-1",
         "team": "A1_b-2.c",

--- a/server/tests/testdata/config.toml
+++ b/server/tests/testdata/config.toml
@@ -23,4 +23,4 @@ type = "docker"
 execd_image = "ghcr.io/opensandbox/platform:latest"
 
 [router]
-domain = "opensandbox.dev"
+domain = "opensandbox.io"

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -780,7 +780,7 @@ components:
           description: |
             Public URL to access the service from outside the sandbox.
             Format: {endpoint-host}/sandboxes/{sandboxId}/port/{port}
-            Example: endpoint.opensandbox.dev/sandboxes/abc123/port/8080
+            Example: endpoint.opensandbox.io/sandboxes/abc123/port/8080
       required:
         - endpoint
       additionalProperties: false


### PR DESCRIPTION
# Summary

  - Updated sandbox label namespaces from sandbox.dev to opensandbox.io and normalized label suffixes to kebab-case (expires-at, embedding-proxy-port, http-port, id) across services, tests, and docs to
    match the new domain/label conventions.
  - Swapped all remaining opensandbox.dev references (including wildcard domains) to opensandbox.io and updated SDK documentation domains from api.opensandbox.dev to api.opensandbox.io for consistency.

  # Testing

  - [ ] Not run (explain why)
  - [ ] Unit tests
  - [ ] Integration tests
  - [ ] e2e / manual verification

  # Breaking Changes

  - [ ] None
  - [x] Yes (describe impact and migration path)
      - Docker labels now use the opensandbox.io prefix and kebab-case keys; existing containers/scripts/tests expecting sandbox.dev/* or camelCase label names must update to the new keys.

  # Checklist

  - [x] Linked Issue or clearly described motivation
  - [x] Added/updated docs (if needed)
  - [ ] Added/updated tests (if needed)
  - [x] Security impact considered
  - [x] Backward compatibility considered