### PR TITLE
feat(components/execd): expose command status/output apis, track exit info, and document RFC3339 timestamps for command responses

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -48,6 +48,8 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	if err != nil {
 		return fmt.Errorf("failed to get stdlog descriptor: %w", err)
 	}
+	stdoutPath := c.stdoutFileName(session)
+	stderrPath := c.stderrFileName(session)
 
 	startAt := time.Now()
 	logs.Info("received command: %v", request.Code)
@@ -58,10 +60,10 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	done := make(chan struct{}, 1)
 	safego.Go(func() {
-		c.tailStdPipe(c.stdoutFileName(session), request.Hooks.OnExecuteStdout, done)
+		c.tailStdPipe(stdoutPath, request.Hooks.OnExecuteStdout, done)
 	})
 	safego.Go(func() {
-		c.tailStdPipe(c.stderrFileName(session), request.Hooks.OnExecuteStderr, done)
+		c.tailStdPipe(stderrPath, request.Hooks.OnExecuteStderr, done)
 	})
 
 	cmd.Dir = request.Cwd
@@ -77,7 +79,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	}
 
 	kernel := &commandKernel{
-		pid: cmd.Process.Pid,
+		pid:        cmd.Process.Pid,
+		stdoutPath: stdoutPath,
+		stderrPath: stderrPath,
+		startedAt:  startAt,
+		running:    true,
 	}
 	c.storeCommandKernel(session, kernel)
 
@@ -102,6 +108,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	close(done)
 	if err != nil {
 		var eName, eValue string
+		var eCode int
 		var traceback []string
 
 		var exitError *exec.ExitError
@@ -109,9 +116,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 			exitCode := exitError.ExitCode()
 			eName = "CommandExecError"
 			eValue = strconv.Itoa(exitCode)
+			eCode = exitCode
 		} else {
 			eName = "CommandExecError"
 			eValue = err.Error()
+			eCode = 1
 		}
 		traceback = []string{err.Error()}
 
@@ -122,8 +131,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		})
 
 		logs.Error("CommandExecError: error running commands: %v", err)
+		c.markCommandFinished(session, eCode, err.Error())
 		return nil
 	}
+
+	c.markCommandFinished(session, 0, "")
 	request.Hooks.OnExecuteComplete(time.Since(startAt))
 	return nil
 }
@@ -132,6 +144,13 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 func (c *Controller) runBackgroundCommand(_ context.Context, request *ExecuteCodeRequest) error {
 	session := c.newContextID()
 	request.Hooks.OnExecuteInit(session)
+
+	stdout, stderr, err := c.stdLogDescriptor(session)
+	if err != nil {
+		return fmt.Errorf("failed to get stdlog descriptor: %w", err)
+	}
+	stdoutPath := c.stdoutFileName(session)
+	stderrPath := c.stderrFileName(session)
 
 	signals := make(chan os.Signal, 1)
 	defer close(signals)
@@ -144,25 +163,46 @@ func (c *Controller) runBackgroundCommand(_ context.Context, request *ExecuteCod
 
 	cmd.Dir = request.Cwd
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	// use DevNull as stdin so interactive programs exit immediately.
 	cmd.Stdin = os.NewFile(uintptr(syscall.Stdin), os.DevNull)
 
 	safego.Go(func() {
 		err := cmd.Start()
-		if err != nil {
-			logs.Error("CommandExecError: error starting commands: %v", err)
+		kernel := &commandKernel{
+			pid:        -1,
+			stdoutPath: stdoutPath,
+			stderrPath: stderrPath,
+			startedAt:  startAt,
+			running:    true,
 		}
 
-		kernel := &commandKernel{
-			pid: cmd.Process.Pid,
+		if err != nil {
+			logs.Error("CommandExecError: error starting commands: %v", err)
+			kernel.running = false
+			c.storeCommandKernel(session, kernel)
+			c.markCommandFinished(session, 255, err.Error())
+			return
 		}
+
+		kernel.running = true
+		kernel.pid = cmd.Process.Pid
 		c.storeCommandKernel(session, kernel)
 
 		err = cmd.Wait()
 		if err != nil {
 			logs.Error("CommandExecError: error running commands: %v", err)
+			exitCode := 1
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				exitCode = exitError.ExitCode()
+			}
+			c.markCommandFinished(session, exitCode, err.Error())
+			return
 		}
+		c.markCommandFinished(session, 0, "")
 	})
 
 	request.Hooks.OnExecuteComplete(time.Since(startAt))

--- a/components/execd/pkg/runtime/command_status.go
+++ b/components/execd/pkg/runtime/command_status.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// CommandStatus describes the lifecycle state of a command.
+type CommandStatus struct {
+	Session    string     `json:"session"`
+	Running    bool       `json:"running"`
+	ExitCode   *int       `json:"exit_code,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	StartedAt  time.Time  `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+// CommandOutput contains non-streamed stdout/stderr plus status.
+type CommandOutput struct {
+	CommandStatus
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+}
+
+func (c *Controller) commandSnapshot(session string) *commandKernel {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	kernel, ok := c.commandClientMap[session]
+	if !ok || kernel == nil {
+		return nil
+	}
+
+	cp := *kernel
+	return &cp
+}
+
+// GetCommandStatus returns the execution status for a command session.
+func (c *Controller) GetCommandStatus(session string) (*CommandStatus, error) {
+	kernel := c.commandSnapshot(session)
+	if kernel == nil {
+		return nil, fmt.Errorf("command not found: %s", session)
+	}
+
+	status := &CommandStatus{
+		Session:    session,
+		Running:    kernel.running,
+		ExitCode:   kernel.exitCode,
+		Error:      kernel.errMsg,
+		StartedAt:  kernel.startedAt,
+		FinishedAt: kernel.finishedAt,
+	}
+	return status, nil
+}
+
+// GetCommandOutput returns accumulated stdout/stderr and status for a session.
+func (c *Controller) GetCommandOutput(session string) (*CommandOutput, error) {
+	kernel := c.commandSnapshot(session)
+	if kernel == nil {
+		return nil, fmt.Errorf("command not found: %s", session)
+	}
+
+	status, err := c.GetCommandStatus(session)
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, err := os.ReadFile(kernel.stdoutPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read stdout: %w", err)
+	}
+	stderr, err := os.ReadFile(kernel.stderrPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read stderr: %w", err)
+	}
+
+	return &CommandOutput{
+		CommandStatus: *status,
+		Stdout:        string(stdout),
+		Stderr:        string(stderr),
+	}, nil
+}
+
+// markCommandFinished updates bookkeeping when a command exits.
+func (c *Controller) markCommandFinished(session string, exitCode int, errMsg string) {
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	kernel, ok := c.commandClientMap[session]
+	if !ok || kernel == nil {
+		return
+	}
+
+	kernel.exitCode = &exitCode
+	kernel.errMsg = errMsg
+	kernel.running = false
+	kernel.finishedAt = &now
+}

--- a/components/execd/pkg/runtime/command_status_test.go
+++ b/components/execd/pkg/runtime/command_status_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetCommandStatus_NotFound(t *testing.T) {
+	c := NewController("", "")
+
+	if _, err := c.GetCommandStatus("missing"); err == nil {
+		t.Fatalf("expected error for missing session")
+	}
+}
+
+func TestGetCommandStatus_Running(t *testing.T) {
+	c := NewController("", "")
+
+	session := "sess-running"
+	started := time.Now().Add(-time.Second)
+	kernel := &commandKernel{
+		pid:        123,
+		stdoutPath: filepath.Join(os.TempDir(), session+".stdout"),
+		stderrPath: filepath.Join(os.TempDir(), session+".stderr"),
+		startedAt:  started,
+		running:    true,
+	}
+	c.storeCommandKernel(session, kernel)
+
+	status, err := c.GetCommandStatus(session)
+	if err != nil {
+		t.Fatalf("GetCommandStatus error: %v", err)
+	}
+	if !status.Running {
+		t.Fatalf("expected running=true")
+	}
+	if status.ExitCode != nil {
+		t.Fatalf("expected exitCode to be nil for running command")
+	}
+	if status.FinishedAt != nil {
+		t.Fatalf("expected finishedAt to be nil for running command")
+	}
+	if !status.StartedAt.Equal(started) {
+		t.Fatalf("startedAt mismatch")
+	}
+}
+
+func TestGetCommandOutput_Completed(t *testing.T) {
+	c := NewController("", "")
+
+	tmpDir := t.TempDir()
+	session := "sess-done"
+	stdoutPath := filepath.Join(tmpDir, session+".stdout")
+	stderrPath := filepath.Join(tmpDir, session+".stderr")
+
+	stdoutContent := "hello stdout"
+	stderrContent := "oops stderr"
+	if err := os.WriteFile(stdoutPath, []byte(stdoutContent), 0o644); err != nil {
+		t.Fatalf("write stdout: %v", err)
+	}
+	if err := os.WriteFile(stderrPath, []byte(stderrContent), 0o644); err != nil {
+		t.Fatalf("write stderr: %v", err)
+	}
+
+	started := time.Now().Add(-2 * time.Second)
+	finished := time.Now()
+	exitCode := 0
+	kernel := &commandKernel{
+		pid:        456,
+		stdoutPath: stdoutPath,
+		stderrPath: stderrPath,
+		startedAt:  started,
+		finishedAt: &finished,
+		exitCode:   &exitCode,
+		errMsg:     "",
+		running:    false,
+	}
+	c.storeCommandKernel(session, kernel)
+
+	output, err := c.GetCommandOutput(session)
+	if err != nil {
+		t.Fatalf("GetCommandOutput error: %v", err)
+	}
+	if output.Running {
+		t.Fatalf("expected running=false")
+	}
+	if output.ExitCode == nil || *output.ExitCode != 0 {
+		t.Fatalf("expected exitCode=0, got %v", output.ExitCode)
+	}
+	if output.Stdout != stdoutContent {
+		t.Fatalf("stdout mismatch: %q", output.Stdout)
+	}
+	if output.Stderr != stderrContent {
+		t.Fatalf("stderr mismatch: %q", output.Stderr)
+	}
+	if output.FinishedAt == nil || !output.FinishedAt.Equal(finished) {
+		t.Fatalf("finishedAt mismatch")
+	}
+	if !output.StartedAt.Equal(started) {
+		t.Fatalf("startedAt mismatch")
+	}
+}

--- a/components/execd/pkg/runtime/ctrl.go
+++ b/components/execd/pkg/runtime/ctrl.go
@@ -52,7 +52,14 @@ type jupyterKernel struct {
 }
 
 type commandKernel struct {
-	pid int
+	pid        int
+	stdoutPath string
+	stderrPath string
+	startedAt  time.Time
+	finishedAt *time.Time
+	exitCode   *int
+	errMsg     string
+	running    bool
 }
 
 // NewController creates a runtime controller.

--- a/components/execd/pkg/web/model/command.go
+++ b/components/execd/pkg/web/model/command.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "time"
+
+// CommandStatusResponse represents command status for REST APIs.
+type CommandStatusResponse struct {
+	Session    string     `json:"session"`
+	Running    bool       `json:"running"`
+	ExitCode   *int       `json:"exit_code,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	StartedAt  time.Time  `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+// CommandOutputResponse returns non-streamed stdout/stderr plus status.
+type CommandOutputResponse struct {
+	CommandStatusResponse
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+}

--- a/components/execd/pkg/web/router.go
+++ b/components/execd/pkg/web/router.go
@@ -77,6 +77,8 @@ func init() {
 
 	command := web.NewNamespace("/command",
 		web.NSRouter("", &controller.CodeInterpretingController{}, "post:RunCommand;delete:InterruptCommand"),
+		web.NSRouter("/status/:session", &controller.CodeInterpretingController{}, "get:GetCommandStatus"),
+		web.NSRouter("/output/:session", &controller.CodeInterpretingController{}, "get:GetCommandOutput"),
 	)
 
 	metric := web.NewNamespace("metrics",

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -230,6 +230,68 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /command/status/{session}:
+    get:
+      summary: Get command status
+      description: |
+        Returns the current status of a command (foreground or background) by session ID.
+        Includes running flag, exit code, error (if any), and start/finish timestamps.
+      operationId: getCommandStatus
+      tags:
+        - Command
+      parameters:
+        - name: session
+          in: path
+          required: true
+          description: Command session ID returned by RunCommand
+          schema:
+            type: string
+          example: cmd-abc123
+      responses:
+        "200":
+          description: Command status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommandStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /command/output/{session}:
+    get:
+      summary: Get command output (non-streamed)
+      description: |
+        Returns accumulated stdout and stderr for a command (foreground or background) by session ID,
+        along with its status. Useful for polling background tasks without SSE.
+      operationId: getCommandOutput
+      tags:
+        - Command
+      parameters:
+        - name: session
+          in: path
+          required: true
+          description: Command session ID returned by RunCommand
+          schema:
+            type: string
+          example: cmd-abc123
+      responses:
+        "200":
+          description: Command output and status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommandOutputResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /files/info:
     get:
       summary: Get file metadata
@@ -722,6 +784,82 @@ components:
           description: Whether to run command in detached mode
           default: false
           example: false
+
+    CommandStatusResponse:
+      type: object
+      description: Command execution status for a session (foreground or background)
+      properties:
+        session:
+          type: string
+          description: Command session ID
+          example: cmd-abc123
+        running:
+          type: boolean
+          description: Whether the command is still running
+          example: false
+        exit_code:
+          type: integer
+          format: int32
+          nullable: true
+          description: Exit code if the command has finished
+          example: 0
+        error:
+          type: string
+          description: Error message if the command failed
+          example: permission denied
+        started_at:
+          type: string
+          format: date-time
+          description: Start time in RFC3339 format
+          example: "2025-12-22T09:08:05Z"
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Finish time in RFC3339 format (null if still running)
+          example: "2025-12-22T09:08:09Z"
+
+    CommandOutputResponse:
+      type: object
+      description: Non-streamed stdout/stderr plus status for a command session
+      properties:
+        session:
+          type: string
+          description: Command session ID
+          example: cmd-abc123
+        running:
+          type: boolean
+          description: Whether the command is still running
+          example: false
+        exit_code:
+          type: integer
+          format: int32
+          nullable: true
+          description: Exit code if the command has finished
+          example: 0
+        error:
+          type: string
+          description: Error message if the command failed
+          example: permission denied
+        started_at:
+          type: string
+          format: date-time
+          description: Start time in RFC3339 format
+          example: "2025-12-22T09:08:05Z"
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Finish time in RFC3339 format (null if still running)
+          example: "2025-12-22T09:08:09Z"
+        stdout:
+          type: string
+          description: Accumulated standard output
+          example: "line1\nline2\n"
+        stderr:
+          type: string
+          description: Accumulated standard error output
+          example: "warn: something\n"
 
     ServerStreamEvent:
       type: object


### PR DESCRIPTION
# Summary
- Add status/output bookkeeping for command sessions (foreground & background), returning exit code, error, and start/finish times (RFC3339).
- Expose REST APIs GET /command/status/{session} and GET /command/output/{session}; specs updated with corresponding schemas.
- Return non-streamed stdout/stderr for commands; time fields now use time.Time in responses.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
