### PR TITLE
fix(components/execd): fix the issue where command init message arrives before memory state, causing interrupt to throw a 404 error

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -37,7 +37,6 @@ import (
 // runCommand executes shell commands and streams their output.
 func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest) error {
 	session := c.newContextID()
-	request.Hooks.OnExecuteInit(session)
 
 	signals := make(chan os.Signal, 1)
 	defer close(signals)
@@ -71,6 +70,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	err = cmd.Start()
 	if err != nil {
+		request.Hooks.OnExecuteInit(session)
 		request.Hooks.OnExecuteError(&execute.ErrorOutput{EName: "CommandExecError", EValue: err.Error()})
 		logs.Error("CommandExecError: error starting commands: %v", err)
 		return nil
@@ -80,6 +80,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		pid: cmd.Process.Pid,
 	}
 	c.storeCommandKernel(session, kernel)
+	request.Hooks.OnExecuteInit(session)
 
 	go func() {
 		for {


### PR DESCRIPTION
# Summary
- Fix the issue where command init event arrives before memory state, causing interrupt to throw a 404 error
- Now we write memory state first, then send command initevent


# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
