### PR TITLE
feat(specs): add extensions field to CreateSandboxRequest

### DIFF
--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -712,6 +712,19 @@ components:
           example:
             - "python"
             - "/app/main.py"
+
+        extensions:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Opaque container for provider-specific or transient parameters not supported by the core API.
+
+            **Note**: This field is reserved for internal features, experimental flags, or temporary behaviors. Standard parameters should be proposed as core API fields.
+
+            **Best Practices**:
+            - **Namespacing**: Use prefixed keys (e.g., `storage.id`) to prevent collisions.
+            - **Pass-through**: SDKs and middleware must treat this object as opaque and pass it through transparently.
     ResourceLimits:
       type: object
       description: |


### PR DESCRIPTION
# Summary
- Add extensions field to CreateSandboxRequest in sandbox-lifecycle specs.
- See #37 for context

# Testing
- [x] Not run (Not yet implemented)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
