### PR TITLE
feat(sdks): support extensions in kotlin sdk when creating sandbox

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
@@ -36,8 +36,14 @@ interface Sandboxes {
     /**
      * Creates a new sandbox with the specified configuration.
      *
-     * @param spec Image specification for the sandbox
-     * @return Sandbox create response
+     * @param spec Container image specification for provisioning the sandbox
+     * @param entrypoint The command to run as the sandbox's main process (e.g. `["python", "/app/main.py"]`)
+     * @param env Environment variables injected into the sandbox runtime
+     * @param metadata User-defined metadata used for management and filtering
+     * @param timeout Sandbox lifetime. The server may terminate the sandbox when it expires
+     * @param resource Runtime resource limits (e.g. cpu/memory). Exact semantics are server-defined
+     * @param extensions Opaque extension parameters passed through to the server as-is. Prefer namespaced keys
+     * @return Sandbox creation response containing the sandbox id
      */
     fun createSandbox(
         spec: SandboxImageSpec,
@@ -46,6 +52,7 @@ interface Sandboxes {
         metadata: Map<String, String>,
         timeout: Duration,
         resource: Map<String, String>,
+        extensions: Map<String, String>,
     ): SandboxCreateResponse
 
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -73,6 +73,7 @@ internal object SandboxModelConverter {
         metadata: Map<String, String>,
         timeout: Duration,
         resource: Map<String, String>,
+        extensions: Map<String, String>,
     ): CreateSandboxRequest {
         return CreateSandboxRequest(
             image = spec.toApiImageSpec(),
@@ -81,6 +82,7 @@ internal object SandboxModelConverter {
             metadata = metadata,
             timeout = timeout.seconds.toInt(),
             resourceLimits = resource,
+            extensions = extensions,
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
@@ -57,11 +57,21 @@ internal class SandboxesAdapter(
         metadata: Map<String, String>,
         timeout: Duration,
         resource: Map<String, String>,
+        extensions: Map<String, String>,
     ): SandboxCreateResponse {
         logger.info("Creating sandbox with image: {}", spec.image)
 
         return try {
-            val createRequest = SandboxModelConverter.toApiCreateSandboxRequest(spec, entrypoint, env, metadata, timeout, resource)
+            val createRequest =
+                SandboxModelConverter.toApiCreateSandboxRequest(
+                    spec = spec,
+                    entrypoint = entrypoint,
+                    env = env,
+                    metadata = metadata,
+                    timeout = timeout,
+                    resource = resource,
+                    extensions = extensions,
+                )
             val apiResponse = api.sandboxesPost(createRequest)
             val response = apiResponse.toSandboxCreateResponse()
 


### PR DESCRIPTION
# Summary
- Support extensions in kotlin sdk when creating sandbox
- See #37 for context

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
