### PR TITLE
feat(sdks): support extensions in python sdk when creating sandbox

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -90,6 +90,7 @@ class SandboxModelConverter:
         metadata: dict[str, str],
         timeout: timedelta,
         resource: dict[str, str],
+        extensions: dict[str, str],
     ) -> CreateSandboxRequest:
         """Convert domain parameters to API CreateSandboxRequest."""
         from opensandbox.api.lifecycle.models.create_sandbox_request import (
@@ -97,6 +98,9 @@ class SandboxModelConverter:
         )
         from opensandbox.api.lifecycle.models.create_sandbox_request_env import (
             CreateSandboxRequestEnv,
+        )
+        from opensandbox.api.lifecycle.models.create_sandbox_request_extensions import (
+            CreateSandboxRequestExtensions,
         )
         from opensandbox.api.lifecycle.models.create_sandbox_request_metadata import (
             CreateSandboxRequestMetadata,
@@ -117,6 +121,10 @@ class SandboxModelConverter:
         # Convert resource limits dict to API model
         api_resource_limits = ResourceLimits.from_dict(resource)
 
+        api_extensions = (
+            CreateSandboxRequestExtensions.from_dict(extensions) if extensions else UNSET
+        )
+
         return CreateSandboxRequest(
             image=SandboxModelConverter.to_api_image_spec(spec),
             entrypoint=entrypoint,
@@ -124,6 +132,7 @@ class SandboxModelConverter:
             metadata=api_metadata,
             timeout=int(timeout.total_seconds()),
             resource_limits=api_resource_limits,
+            extensions=api_extensions,
         )
 
     @staticmethod

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -114,6 +114,7 @@ class SandboxesAdapter(Sandboxes):
         metadata: dict[str, str],
         timeout: timedelta,
         resource: dict[str, str],
+        extensions: dict[str, str],
     ) -> SandboxCreateResponse:
         """Create a new sandbox instance with the specified configuration."""
         logger.info(f"Creating sandbox with image: {spec.image}")
@@ -122,7 +123,13 @@ class SandboxesAdapter(Sandboxes):
             from opensandbox.api.lifecycle.api.sandboxes import post_sandboxes
 
             create_request = SandboxModelConverter.to_api_create_sandbox_request(
-                spec, entrypoint, env, metadata, timeout, resource
+                spec=spec,
+                entrypoint=entrypoint,
+                env=env,
+                metadata=metadata,
+                timeout=timeout,
+                resource=resource,
+                extensions=extensions,
             )
 
             client = await self._get_client()

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -366,6 +366,7 @@ class Sandbox:
         env: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
         resource: dict[str, str] | None = None,
+        extensions: dict[str, str] | None = None,
         entrypoint: list[str] | None = None,
         connection_config: ConnectionConfig | None = None,
         health_check: Callable[["Sandbox"], Awaitable[bool]] | None = None,
@@ -381,6 +382,8 @@ class Sandbox:
             env: Environment variables for the sandbox
             metadata: Custom metadata for the sandbox
             resource: Resource limits (CPU, memory, etc.)
+            extensions: Opaque extension parameters passed through to the server as-is.
+                Prefer namespaced keys (e.g. ``storage.id``).
             entrypoint: Command to run as entrypoint
             connection_config: Connection configuration
             health_check: Custom async health check function
@@ -397,6 +400,7 @@ class Sandbox:
         env = env or {}
         metadata = metadata or {}
         resource = resource or {"cpu": "1", "memory": "2Gi"}
+        extensions = extensions or {}
 
         if isinstance(image, str):
             image = SandboxImageSpec(image=image)
@@ -418,6 +422,7 @@ class Sandbox:
                 metadata,
                 timeout,
                 resource,
+                extensions,
             )
             sandbox_id = response.id
 

--- a/sdks/sandbox/python/src/opensandbox/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/services/sandbox.py
@@ -49,17 +49,20 @@ class Sandboxes(Protocol):
         metadata: dict[str, str],
         timeout: timedelta,
         resource: dict[str, str],
+        extensions: dict[str, str],
     ) -> SandboxCreateResponse:
         """
         Create a new sandbox with the specified configuration.
 
         Args:
-            spec: Image specification for the sandbox
-            entrypoint: Command to run as entrypoint
-            env: Environment variables
-            metadata: Custom metadata
-            timeout: Sandbox timeout
-            resource: Resource limits
+            spec: Container image specification for provisioning the sandbox.
+            entrypoint: Command to run as the sandbox's main process.
+            env: Environment variables injected into the sandbox runtime.
+            metadata: User-defined metadata used for management and filtering.
+            timeout: Sandbox lifetime. The server may terminate the sandbox when it expires.
+            resource: Runtime resource limits (e.g. cpu/memory). Exact semantics are server-defined.
+            extensions: Opaque extension parameters passed through to the server as-is.
+                Prefer namespaced keys (e.g. ``storage.id``).
 
         Returns:
             Sandbox create response

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -91,6 +91,7 @@ class SandboxesAdapterSync(SandboxesSync):
         metadata: dict[str, str],
         timeout: timedelta,
         resource: dict[str, str],
+        extensions: dict[str, str],
     ) -> SandboxCreateResponse:
         logger.info("Creating sandbox with image: %s", spec.image)
         try:
@@ -100,7 +101,13 @@ class SandboxesAdapterSync(SandboxesSync):
             )
 
             create_request = SandboxModelConverter.to_api_create_sandbox_request(
-                spec, entrypoint, env, metadata, timeout, resource
+                spec=spec,
+                entrypoint=entrypoint,
+                env=env,
+                metadata=metadata,
+                timeout=timeout,
+                resource=resource,
+                extensions=extensions,
             )
             response_obj = post_sandboxes.sync_detailed(client=self._get_client(), body=create_request)
             handle_api_error(response_obj, "Create sandbox")

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -351,6 +351,7 @@ class SandboxSync:
         env: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
         resource: dict[str, str] | None = None,
+        extensions: dict[str, str] | None = None,
         entrypoint: list[str] | None = None,
         connection_config: ConnectionConfigSync | None = None,
         health_check: Callable[["SandboxSync"], bool] | None = None,
@@ -366,6 +367,8 @@ class SandboxSync:
             env: Environment variables for the sandbox
             metadata: Custom metadata for the sandbox
             resource: Resource limits (CPU, memory, etc.)
+            extensions: Opaque extension parameters passed through to the server as-is.
+                Prefer namespaced keys (e.g. ``storage.id``).
             entrypoint: Command to run as entrypoint
             connection_config: Connection configuration
             health_check: Custom sync health check function
@@ -382,6 +385,7 @@ class SandboxSync:
         env = env or {}
         metadata = metadata or {}
         resource = resource or {"cpu": "1", "memory": "2Gi"}
+        extensions = extensions or {}
 
         if isinstance(image, str):
             image = SandboxImageSpec(image=image)
@@ -399,7 +403,7 @@ class SandboxSync:
         try:
             sandbox_service = factory.create_sandbox_service()
             response = sandbox_service.create_sandbox(
-                image, entrypoint, env, metadata, timeout, resource
+                image, entrypoint, env, metadata, timeout, resource, extensions
             )
             sandbox_id = response.id
             execd_endpoint = sandbox_service.get_sandbox_endpoint(response.id, DEFAULT_EXECD_PORT)

--- a/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
@@ -50,6 +50,7 @@ class SandboxesSync(Protocol):
         metadata: dict[str, str],
         timeout: timedelta,
         resource: dict[str, str],
+        extensions: dict[str, str],
     ) -> SandboxCreateResponse:
         """
         Create a new sandbox with the specified configuration (blocking).
@@ -61,6 +62,8 @@ class SandboxesSync(Protocol):
             metadata: Custom metadata.
             timeout: Sandbox lifetime / expiration duration.
             resource: Resource limits.
+            extensions: Opaque extension parameters passed through to the server as-is.
+                Prefer namespaced keys (e.g. ``storage.id``).
 
         Returns:
             Sandbox create response.

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -138,6 +138,7 @@ def test_sandbox_model_converter_to_api_create_request_and_renew_tz() -> None:
         metadata={},
         timeout=timedelta(seconds=3),
         resource={"cpu": "100m"},
+        extensions={},
     )
     d = req.to_dict()
     assert d["image"]["uri"] == "python:3.11"

--- a/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
@@ -99,9 +99,11 @@ async def test_create_sandbox_success(monkeypatch: pytest.MonkeyPatch) -> None:
         metadata={},
         timeout=timedelta(seconds=3),
         resource={"cpu": "100m"},
+        extensions={"storage.id": "abc123", "debug": "true"},
     )
     assert isinstance(out.id, UUID)
     assert "image" in called["body"].to_dict()
+    assert called["body"].to_dict()["extensions"] == {"storage.id": "abc123", "debug": "true"}
 
 
 @pytest.mark.asyncio
@@ -123,6 +125,7 @@ async def test_create_sandbox_empty_response_raises(monkeypatch: pytest.MonkeyPa
             metadata={},
             timeout=timedelta(seconds=1),
             resource={"cpu": "100m"},
+            extensions={"debug": "true"},
         )
 
 


### PR DESCRIPTION
# Summary
- Support extensions in python sdk when creating sandbox
- See #37 for more context


# Testing
- [] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
