### PR TITLE
feat(example): add google adk example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Examples for common OpenSandbox use cases. Each subdirectory contains runnable c
 - [**iflow-cli**](iflow-cli): CLI invocation template for iFlow/custom HTTP LLM services
 - [**gemini-cli**](gemini-cli): Call Google Gemini within the sandbox
 - [**codex-cli**](codex-cli): Call OpenAI/Codex-like models within the sandbox
+- [**google-adk**](google-adk): Google ADK agent calling OpenSandbox tools
 - [**desktop**](desktop): Launch VNC desktop (Xvfb + x11vnc) for VNC client connections
 - [**playwright**](playwright): Launch headless browser (Playwright + Chromium) to scrape web content
 - [**vscode**](vscode): Launch code-server (VS Code Web) to provide browser access

--- a/examples/google-adk/README.md
+++ b/examples/google-adk/README.md
@@ -1,0 +1,50 @@
+# Google ADK + OpenSandbox Example
+
+Integrate Google Agent Development Kit (ADK) with OpenSandbox. The ADK agent
+drives tool calls that execute inside a sandbox.
+
+## Start OpenSandbox server [local]
+
+Pre-pull the code-interpreter image (includes Python):
+
+```shell
+docker pull sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:latest
+
+# use docker hub
+# docker pull opensandbox/code-interpreter:latest
+```
+
+Start the local OpenSandbox server, logs will be visible in the terminal:
+
+```shell
+git clone git@github.com:alibaba/OpenSandbox.git
+cd OpenSandbox/server
+cp example.config.toml ~/.sandbox.toml
+uv sync
+uv run python -m src.main
+```
+
+## Run the example
+
+```shell
+# Install OpenSandbox + Google ADK deps
+uv pip install opensandbox google-adk
+
+# Run the example (requires SANDBOX_DOMAIN / SANDBOX_API_KEY / GOOGLE_API_KEY)
+uv run python examples/google-adk/main.py
+```
+
+The script uses ADK to create an agent with OpenSandbox tools (`write_file`,
+`read_file`, `run_in_sandbox`). It runs a few prompts, prints tool events, and
+cleans up the sandbox.
+
+## Environment Variables
+
+- `SANDBOX_DOMAIN`: Sandbox service address (default: `localhost:8080`)
+- `SANDBOX_API_KEY`: API key if your server requires authentication (optional for local)
+- `SANDBOX_IMAGE`: Sandbox image to use (default: `sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:latest`)
+- `GOOGLE_API_KEY`: Gemini API key (required)
+- `GOOGLE_ADK_MODEL`: Gemini model name (default: `gemini-2.5-flash`)
+
+## References
+- [Google ADK](https://google.github.io/adk-docs/) - Agent Development Kit

--- a/examples/google-adk/main.py
+++ b/examples/google-adk/main.py
@@ -1,0 +1,135 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from datetime import timedelta
+
+from google.adk.agents import Agent
+from google.adk.apps import App
+from google.adk.runners import Runner
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.utils._debug_output import print_event
+from google.adk.utils.context_utils import Aclosing
+from google.genai import types
+from opensandbox import Sandbox
+from opensandbox.config import ConnectionConfig
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+async def main() -> None:
+    _required_env("GOOGLE_API_KEY")
+    domain = os.getenv("SANDBOX_DOMAIN", "localhost:8080")
+    api_key = os.getenv("SANDBOX_API_KEY")
+    image = os.getenv(
+        "SANDBOX_IMAGE",
+        "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:latest",
+    )
+    model_name = os.getenv("GOOGLE_ADK_MODEL", "gemini-2.5-flash")
+
+    config = ConnectionConfig(
+        domain=domain,
+        api_key=api_key,
+        request_timeout=timedelta(seconds=120),
+    )
+
+    sandbox = await Sandbox.create(
+        image,
+        connection_config=config,
+    )
+
+    async def run_in_sandbox(command: str) -> str:
+        """Run a shell command in OpenSandbox and return the output."""
+
+        execution = await sandbox.commands.run(command)
+        stdout = "\n".join(msg.text for msg in execution.logs.stdout)
+        stderr = "\n".join(msg.text for msg in execution.logs.stderr)
+        if execution.error:
+            stderr = "\n".join(
+                [
+                    stderr,
+                    f"[error] {execution.error.name}: {execution.error.value}",
+                ]
+            ).strip()
+
+        output = stdout.strip()
+        if stderr:
+            output = "\n".join([output, f"[stderr]\n{stderr}"]).strip()
+        return output or "(no output)"
+
+    async def write_file(path: str, content: str) -> str:
+        """Write a file inside the sandbox."""
+
+        await sandbox.files.write_file(path, content)
+        return f"wrote {len(content)} bytes to {path}"
+
+    async def read_file(path: str) -> str:
+        """Read a file from the sandbox."""
+
+        return await sandbox.files.read_file(path)
+
+    agent = Agent(
+        name="opensandbox_adk",
+        model=model_name,
+        instruction=(
+            "You have access to OpenSandbox tools. Use write_file to create or "
+            "update files, read_file to read files, and run_in_sandbox to run "
+            "commands."
+        ),
+        tools=[run_in_sandbox, write_file, read_file],
+    )
+
+    app = App(name="opensandbox_adk", root_agent=agent)
+    session_service = InMemorySessionService()
+    runner = Runner(app=app, session_service=session_service)
+    session = await session_service.create_session(
+        app_name=app.name,
+        user_id="local-user",
+    )
+
+    prompts = [
+        "Use write_file to save /tmp/math.py that prints 137 * 42.",
+        "Run the script using run_in_sandbox and report the result.",
+        "Write /tmp/notes.txt with 'ADK + OpenSandbox', then read it back.",
+    ]
+
+    try:
+        for prompt in prompts:
+            content = types.Content(
+                role="user",
+                parts=[types.Part(text=prompt)],
+            )
+            async with Aclosing(
+                runner.run_async(
+                    user_id=session.user_id,
+                    session_id=session.id,
+                    new_message=content,
+                )
+            ) as agen:
+                async for event in agen:
+                    print_event(event, verbose=True)
+    finally:
+        await sandbox.kill()
+        await sandbox.close()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
# Summary

  - Add a Google ADK + OpenSandbox example with ADK Agent/Runner wiring, OpenSandbox tools, and documentation so users can try ADK-based tool calls inside a sandbox.

  # Testing

  - [x] Not run (example-only change; requires external API keys)
  - [ ] Unit tests
  - [ ] Integration tests
  - [ ] e2e / manual verification

  # Breaking Changes

  - [x] None
  - [ ] Yes (describe impact and migration path)

  # Checklist

  - [x] Linked Issue or clearly described motivation
  - [x] Added/updated docs (if needed)
  - [ ] Added/updated tests (if needed)
  - [x] Security impact considered
  - [x] Backward compatibility considered