### PR TITLE
docs(oseps): add fqdn-based egress control proposal

### DIFF
--- a/oseps/0001-fqdn-based-egress-control.md
+++ b/oseps/0001-fqdn-based-egress-control.md
@@ -3,8 +3,8 @@ title: FQDN-based Egress Control
 authors:
   - "@hittyt"
 creation-date: 2025-12-27
-last-updated: 2025-12-27
-status: draft
+last-updated: 2025-12-30
+status: provisional
 ---
 
 # OSEP-0001: FQDN-based Egress Control


### PR DESCRIPTION
# Summary
- What is changing and why?

Add new OSEP proposal: FQDN-based Egress Control with two-layer DNS proxy + nftables design.
Clarify privilege model: requires CAP_NET_ADMIN; without it the policy is disabled with warning (no resolv.conf fallback).
Refine diagrams and notes to reflect enforcement modes, graceful degradation, and bypass caveats.

# Testing
- [ ] Not run (Docs-only change)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation  Closes #56 
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
