### PR TITLE
docs: add kubernetes code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 /components/execd/ @Pangjiping @hittyt
 /sandboxes/ @Pangjiping @ninan-nn @jwx0925 @hittyt @hellomypastor
 
+# Kubernetes controller
+/kubernetes/ @Spground @Generalwin
+
 # SDKs
 /sdks/ @ninan-nn @jwx0925 @hittyt @hellomypastor
 


### PR DESCRIPTION
# Summary
Added CODEOWNERS entry for kubernetes/ to include @Spground and @Generalwin so K8s changes request the right reviewers.

# Testing
- [x] Not run (only update docs)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
