### PR TITLE
test(k8s): add e2e test workflow to cover k8s version range 1.22-1.32

### DIFF
--- a/.github/workflows/sandbox-k8s-e2e.yml
+++ b/.github/workflows/sandbox-k8s-e2e.yml
@@ -1,0 +1,36 @@
+name: Sandbox K8S E2E Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'kubernetes/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.24'
+
+jobs:
+  e2e-k8s:
+    name: E2E Tests (K8s v${{ matrix.k8s-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: ["1.22.4", "1.24.4", "1.26.4", "1.28.6", "1.30.4", "1.32.2", "1.34.2"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run tests
+        run: |
+          cd kubernetes
+          make test-e2e KIND_K8S_VERSION=v${{ matrix.k8s-version }}


### PR DESCRIPTION
# Summary
- What is changing and why?

Add e2e test workflow to cover k8s version range 1.22-1.32

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
