### PR TITLE
docs: update project structure and roadmap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,24 +168,20 @@ For more details, please refer to [examples](examples/README.md) and the README 
 
 ## Project Structure
 
-```bash
-OpenSandbox/
-├── sdks/                     # Multi-language SDKs
-│   ├── code-interpreter/     # Code Interpreter SDK
-│   └── sandbox/              # Sandbox base SDK
-├── specs/                    # OpenAPI specifications
-│   ├── execd-api.yaml        # Command execution and file operations API specification
-│   └── sandbox-lifecycle.yml # Sandbox lifecycle API specification
-├── server/                   # Sandbox server
-├── components/               # Core components
-│   └── execd/                # Command execution and file operations component (Go)
-├── docs/                     # Documentation
-├── examples/                 # Example integrations and use cases
-├── sandboxes/                # Sandbox implementations
-│   └── code-interpreter/     # Code Interpreter sandbox implementation
-├── scripts/                  # Build and utility scripts
-└── tests                     # End-to-end tests
-```
+| Directory | Description |
+|-----------|-------------|
+| [`server/`](server/README.md) | Python FastAPI sandbox lifecycle server |
+| [`components/execd/`](components/execd/README.md) | Go execution daemon for commands and file operations |
+| [`sdks/`](sdks/) | Multi-language SDKs (Python, Kotlin) |
+| [`sandboxes/`](sandboxes/) | Sandbox runtime images (e.g., code-interpreter) |
+| [`kubernetes/`](kubernetes/README.md) | Kubernetes operator and batch sandbox support |
+| [`specs/`](specs/README.md) | OpenAPI specifications |
+| [`examples/`](examples/README.md) | Integration examples and use cases |
+| [`oseps/`](oseps/README.md) | OpenSandbox Enhancement Proposals |
+| [`docs/`](docs/) | Architecture and design documentation |
+| [`tests/`](tests/) | Cross-component E2E tests |
+
+For detailed architecture, see [docs/architecture.md](docs/architecture.md).
 
 ## Documentation
 
@@ -206,14 +202,14 @@ You can use OpenSandbox for personal or commercial projects in compliance with t
 
 ### SDK
 
-- [ ] **TypeScript SDK** - TypeScript/JavaScript client SDK for sandbox lifecycle management and command execution、file operations.
-- [ ] **Go SDK** - Go client SDK for sandbox lifecycle management and command execution、file operations.
+- [ ] **TypeScript SDK** - TypeScript/JavaScript client SDK for sandbox lifecycle management and command execution, file operations.
+- [ ] **Go SDK** - Go client SDK for sandbox lifecycle management and command execution, file operations.
 
 ### Server Runtime
 
-- [ ] **OpenSandbox Kubernetes Runtime** - High-performance sandbox scheduling implementation
+- [x] **OpenSandbox Kubernetes Runtime** - High-performance sandbox scheduling implementation (see [`kubernetes/`](kubernetes/README.md))
 - [ ] **kubernetes-sigs/agent-sandbox Support** - Integration with [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
-- [ ] **Declarative Network Isolation** - Network egress control with allow/deny rules for specific domains
+- [ ] **Declarative Network Isolation** - Network egress control with allow/deny rules for specific domains (see [OSEP-0001](oseps/0001-fqdn-based-egress-control.md))
 
 ## Contact and Discussion
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -168,24 +168,20 @@ OpenSandbox 提供了丰富的示例来演示不同场景下的沙箱使用方�
 
 ## 项目结构
 
-```bash
-OpenSandbox/
-├── sdks/                     # 多语言 SDK
-│   ├── code-interpreter/     # Code Interpreter SDK
-│   └── sandbox/              # Sandbox 基础 SDK
-├── specs/                    # OpenAPI 规范
-│   ├── execd-api.yaml        # 命令执行和文件操作 API 规范
-│   └── sandbox-lifecycle.yml # 沙箱生命周期 API 规范
-├── server/                   # 沙箱服务端
-├── components/               # 核心组件
-│   └── execd/                # 命令执行和文件操作组件(Go)
-├── docs/                     # 文档
-├── examples/                 # 示例集成和使用案例
-├── sandboxes/                # 沙箱实现
-│   └── code-interpreter/     # Code Interpreter 沙箱实现
-├── scripts/                  # 构建和工具脚本
-└── e2e/                      # 端到端测试
-```
+| 目录 | 说明 |
+|------|------|
+| [`server/`](../server/README_zh.md) | Python FastAPI 沙箱生命周期服务 |
+| [`components/execd/`](../components/execd/README_zh.md) | Go 执行守护进程，负责命令和文件操作 |
+| [`sdks/`](../sdks/) | 多语言 SDK（Python、Kotlin） |
+| [`sandboxes/`](../sandboxes/) | 沙箱运行时镜像（如 code-interpreter） |
+| [`kubernetes/`](../kubernetes/README-ZH.md) | Kubernetes Operator 和批量沙箱支持 |
+| [`specs/`](../specs/README_zh.md) | OpenAPI 规范 |
+| [`examples/`](../examples/README.md) | 集成示例和使用案例 |
+| [`oseps/`](../oseps/README.md) | OpenSandbox Enhancement Proposals |
+| [`docs/`](../docs/) | 架构和设计文档 |
+| [`tests/`](../tests/) | 跨组件端到端测试 |
+
+详细架构请参阅 [docs/architecture.md](architecture.md)。
 
 ## 文档
 
@@ -211,10 +207,9 @@ OpenSandbox/
 
 ### Server Runtime
 
-- [ ] **自研 Kubernetes 沙箱调度器** - 高性能沙箱调度实现
+- [x] **自研 Kubernetes 沙箱调度器** - 高性能沙箱调度实现（见 [`kubernetes/`](../kubernetes/README-ZH.md)）
 - [ ] **kubernetes-sigs/agent-sandbox 支持** - 集成 [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) 沙箱调度能力
-- [ ] **声明式网络隔离** - 支持允许/禁止特定域名规则的网络 egress 访问控制
-- [ ] **沙箱路由器 Ingress** - Kubernetes 版本中的专用 ingress 组件（sandbox-router），用于将流量路由到沙箱
+- [ ] **声明式网络隔离** - 支持允许/禁止特定域名规则的网络 egress 访问控制（见 [OSEP-0001](../oseps/0001-fqdn-based-egress-control.md)）
 
 ## 联系与讨论
 


### PR DESCRIPTION
# Summary
- Replace tree-style project structure with table format for easier maintenance
- Add missing directories: kubernetes/, oseps/
- Mark Kubernetes Runtime as completed in Roadmap
- Add links to OSEP-0001 for network isolation proposal
- Sync changes between English and Chinese versions

# Testing
- [x] Not run (only update docs)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
