### PR TITLE
feat(execd): support EXECD_ENVS env file injection

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -1,23 +1,35 @@
 #!/bin/sh
 
 # Copyright 2025 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
 EXECD="${EXECD:=/opt/opensandbox/execd}"
+
+if [ -z "${EXECD_ENVS:-}" ]; then
+	EXECD_ENVS="/opt/opensandbox/.env"
+fi
+# Best-effort ensure file exists.
+if ! mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null; then
+	echo "warning: failed to create dir for EXECD_ENVS=$EXECD_ENVS" >&2
+fi
+if ! touch "$EXECD_ENVS" 2>/dev/null; then
+	echo "warning: failed to touch EXECD_ENVS=$EXECD_ENVS" >&2
+fi
+export EXECD_ENVS
+
 echo "starting OpenSandbox execd daemon at $EXECD"
 $EXECD &
 

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -56,6 +56,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	cmd.Env = mergeEnvs(os.Environ(), loadExtraEnvFromFile())
 
 	done := make(chan struct{}, 1)
 	safego.Go(func() {
@@ -66,7 +67,6 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	})
 
 	cmd.Dir = request.Cwd
-	cmd.Env = os.Environ()
 	// use a dedicated process group so signals propagate to children.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
@@ -166,6 +166,7 @@ func (c *Controller) runBackgroundCommand(_ context.Context, request *ExecuteCod
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	cmd.Env = mergeEnvs(os.Environ(), loadExtraEnvFromFile())
 
 	// use DevNull as stdin so interactive programs exit immediately.
 	cmd.Stdin = os.NewFile(uintptr(syscall.Stdin), os.DevNull)

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -49,7 +49,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Dir = request.Cwd
-	cmd.Env = os.Environ()
+	cmd.Env = mergeEnvs(os.Environ(), loadExtraEnvFromFile())
 
 	done := make(chan struct{}, 1)
 	safego.Go(func() {
@@ -111,6 +111,7 @@ func (c *Controller) runBackgroundCommand(_ context.Context, request *ExecuteCod
 	cmd := exec.CommandContext(context.Background(), "cmd", "/C", request.Code)
 
 	cmd.Dir = request.Cwd
+	cmd.Env = mergeEnvs(os.Environ(), loadExtraEnvFromFile())
 
 	devNull, _ := os.OpenFile(os.DevNull, os.O_RDWR, 0) // best-effort, ignore error
 	cmd.Stdin = devNull

--- a/components/execd/pkg/runtime/env.go
+++ b/components/execd/pkg/runtime/env.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/beego/beego/v2/core/logs"
+)
+
+// loadExtraEnvFromFile reads key=value lines from EXECD_ENVS (if set).
+// Empty lines and lines starting with '#' are ignored.
+func loadExtraEnvFromFile() map[string]string {
+	path := os.Getenv("EXECD_ENVS")
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		logs.Warn("EXECD_ENVS: failed to read file %s: %v", path, err)
+		return nil
+	}
+
+	envs := make(map[string]string)
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			logs.Warn("EXECD_ENVS: skip malformed line: %s", line)
+			continue
+		}
+		envs[kv[0]] = os.ExpandEnv(kv[1])
+	}
+
+	return envs
+}
+
+// mergeEnvs overlays extra into base and returns a merged slice.
+func mergeEnvs(base []string, extra map[string]string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+
+	merged := make(map[string]string, len(base)+len(extra))
+	for _, kv := range base {
+		pair := strings.SplitN(kv, "=", 2)
+		if len(pair) == 2 {
+			merged[pair[0]] = pair[1]
+		}
+	}
+
+	for k, v := range extra {
+		merged[k] = v
+	}
+
+	out := make([]string, 0, len(merged))
+	for k, v := range merged {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return out
+}

--- a/components/execd/pkg/runtime/env_test.go
+++ b/components/execd/pkg/runtime/env_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExtraEnvFromFileUnset(t *testing.T) {
+	t.Setenv("EXECD_ENVS", "")
+	if got := loadExtraEnvFromFile(); got != nil {
+		t.Fatalf("expected nil when EXECD_ENVS unset, got %#v", got)
+	}
+}
+
+func TestLoadExtraEnvFromFileParsesAndExpands(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env")
+
+	t.Setenv("EXECD_ENVS", envFile)
+	t.Setenv("BASE_DIR", "/opt/base")
+
+	content := strings.Join([]string{
+		"# comment",
+		"FOO=bar",
+		"PATH=$BASE_DIR/bin",
+		"MALFORMED",
+		"EMPTY=",
+		"",
+	}, "\n")
+
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	got := loadExtraEnvFromFile()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %#v", got)
+	}
+
+	if got["FOO"] != "bar" {
+		t.Fatalf("FOO mismatch, got %q", got["FOO"])
+	}
+	if got["PATH"] != "/opt/base/bin" {
+		t.Fatalf("PATH expansion mismatch, got %q", got["PATH"])
+	}
+	if val, ok := got["EMPTY"]; !ok || val != "" {
+		t.Fatalf("EMPTY mismatch, got %q (present=%v)", val, ok)
+	}
+}
+
+func TestLoadExtraEnvFromFileMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "does-not-exist")
+	t.Setenv("EXECD_ENVS", envFile)
+
+	if got := loadExtraEnvFromFile(); got != nil {
+		t.Fatalf("expected nil for missing file, got %#v", got)
+	}
+}
+
+func TestMergeEnvsOverlaysExtra(t *testing.T) {
+	base := []string{"A=1", "B=2"}
+	extra := map[string]string{"B": "override", "C": "3"}
+
+	merged := mergeEnvs(base, extra)
+	got := make(map[string]string)
+	for _, kv := range merged {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			got[parts[0]] = parts[1]
+		}
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %#v", got)
+	}
+	if got["A"] != "1" {
+		t.Fatalf("A mismatch, got %q", got["A"])
+	}
+	if got["B"] != "override" {
+		t.Fatalf("B mismatch, got %q", got["B"])
+	}
+	if got["C"] != "3" {
+		t.Fatalf("C mismatch, got %q", got["C"])
+	}
+}

--- a/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
@@ -31,6 +31,17 @@ DEFAULT_JAVA_VERSION=${DEFAULT_JAVA_VERSION:-21}
 DEFAULT_NODE_VERSION=${DEFAULT_NODE_VERSION:-22}
 DEFAULT_GO_VERSION=${DEFAULT_GO_VERSION:-1.25}
 
+append_env_if_needed() {
+	local key=$1
+	local value=$2
+	if [ -z "${EXECD_ENVS:-}" ]; then
+		return
+	}
+	# Best-effort: ensure parent dir exists, ignore errors.
+	mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null || true
+	printf '%s=%s\n' "$key" "$value" >>"$EXECD_ENVS" 2>/dev/null || true
+}
+
 function switch_python() {
 	local version=$1
 	if [ -z "$version" ]; then
@@ -44,6 +55,7 @@ function switch_python() {
 
 	if [ -d "$target_dir" ]; then
 		export PATH="$target_dir/bin:$PATH"
+		append_env_if_needed PATH "$PATH"
 		echo "Switched to Python $(python3 --version)"
 	else
 		echo "Python version $version not found."
@@ -69,6 +81,8 @@ function switch_java() {
 	if [ -n "$java_home" ]; then
 		export JAVA_HOME="$java_home"
 		export PATH="$JAVA_HOME/bin:$PATH"
+		append_env_if_needed JAVA_HOME "$JAVA_HOME"
+		append_env_if_needed PATH "$PATH"
 		echo "Switched to Java $version ($JAVA_HOME)"
 	else
 		echo "Java version $version not found."
@@ -88,6 +102,7 @@ function switch_node() {
 
 	if [ -d "$target_dir" ]; then
 		export PATH="$target_dir/bin:$PATH"
+		append_env_if_needed PATH "$PATH"
 		echo "Switched to Node $(node --version)"
 	else
 		echo "Node version $version not found."
@@ -108,6 +123,8 @@ function switch_go() {
 	if [ -d "$target_dir" ]; then
 		export GOROOT="$target_dir"
 		export PATH="$GOROOT/bin:$PATH"
+		append_env_if_needed GOROOT "$GOROOT"
+		append_env_if_needed PATH "$PATH"
 		echo "Switched to Go $(go version)"
 	else
 		echo "Go version $version not found."

--- a/sandboxes/code-interpreter/scripts/code-interpreter.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter.sh
@@ -101,6 +101,10 @@ setup_bash() {
 
 # export go bin path
 export PATH="$(go env GOPATH)/bin:$PATH"
+if [ -n "${EXECD_ENVS:-}" ]; then
+	mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null || true
+	printf 'PATH=%s\n' "$PATH" >>"$EXECD_ENVS" 2>/dev/null || true
+fi
 
 setup_python &
 pids+=($!)


### PR DESCRIPTION
# Summary
- export `EXECD_ENVS` before execd start.
- append code-interpreter env to `EXECD_ENVS`

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
