### PR TITLE
feat(components/execd): support parse sse api grace shutdown timeout from env

### DIFF
--- a/components/execd/README.md
+++ b/components/execd/README.md
@@ -227,6 +227,16 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:44772/code
 ```
 
+## Configuration
+
+### API graceful shutdown window
+
+- Env: `EXECD_API_GRACE_SHUTDOWN` (e.g. `500ms`, `2s`, `1m`)
+- Flag: `--graceful-shutdown-timeout`
+- Default: `1s`
+
+This controls how long execd keeps SSE responses (code/command runs) alive after sending the final chunk, so clients can drain tail output before the connection closes. Set to `0s` to disable the grace period.
+
 ## Observability
 
 ### Logging

--- a/components/execd/README_zh.md
+++ b/components/execd/README_zh.md
@@ -226,6 +226,16 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:44772/code
 ```
 
+## 配置
+
+### SSE API 优雅结束时间窗口
+
+- 环境变量：`EXECD_API_GRACE_SHUTDOWN`（如 `500ms`、`2s`、`1m`）
+- 命令行参数：`--graceful-shutdown-timeout`
+- 默认值：`1s`
+
+作用：控制 SSE 响应（代码/命令执行）在发送最后一块数据后，保持连接的宽限时间，方便客户端完全读到尾部输出再关闭。如果设置为 `0s` 则关闭这一等待。
+
 ## 可观测性
 
 ### 日志记录

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	jupyterHostEnv  = "JUPYTER_HOST"
-	jupyterTokenEnv = "JUPYTER_TOKEN"
+	jupyterHostEnv             = "JUPYTER_HOST"
+	jupyterTokenEnv            = "JUPYTER_TOKEN"
+	gracefulShutdownTimeoutEnv = "EXECD_API_GRACE_SHUTDOWN"
 )
 
 // InitFlags registers CLI flags and env overrides.
@@ -35,7 +36,7 @@ func InitFlags() {
 	ServerPort = 44772
 	ServerLogLevel = 6
 	ServerAccessToken = ""
-	ApiGracefulShutdownTimeout = time.Second * 3
+	ApiGracefulShutdownTimeout = time.Second * 1
 
 	// First, set default values from environment variables
 	if jupyterFromEnv := os.Getenv(jupyterHostEnv); jupyterFromEnv != "" {
@@ -55,6 +56,15 @@ func InitFlags() {
 	flag.IntVar(&ServerPort, "port", ServerPort, "Server listening port (default: 44772)")
 	flag.IntVar(&ServerLogLevel, "log-level", ServerLogLevel, "Server log level (0=LevelEmergency, 1=LevelAlert, 2=LevelCritical, 3=LevelError, 4=LevelWarning, 5=LevelNotice, 6=LevelInformational, 7=LevelDebug, default: 6)")
 	flag.StringVar(&ServerAccessToken, "access-token", ServerAccessToken, "Server access token for API authentication")
+
+	if graceShutdownTimeout := os.Getenv(gracefulShutdownTimeoutEnv); graceShutdownTimeout != "" {
+		duration, err := time.ParseDuration(graceShutdownTimeout)
+		if err != nil {
+			log.Panicf("Failed to parse graceful shutdown timeout from env: %v", err)
+		}
+		ApiGracefulShutdownTimeout = duration
+	}
+
 	flag.DurationVar(&ApiGracefulShutdownTimeout, "graceful-shutdown-timeout", ApiGracefulShutdownTimeout, "API graceful shutdown timeout duration (default: 3s)")
 
 	// Parse flags - these will override environment variables if provided

--- a/components/execd/tests/smoke.sh
+++ b/components/execd/tests/smoke.sh
@@ -19,4 +19,5 @@ set -euxo pipefail
 source tests/jupyter.sh
 install_jupyter
 
+export EXECD_API_GRACE_SHUTDOWN=500ms
 ./bin/execd -jupyter-host=http://127.0.0.1:${JUPYTER_PORT} --jupyter-token=${JUPYTER_TOKEN} --log-level=7 >execd.log 2>&1 &


### PR DESCRIPTION
# Summary
- support parse sse api grace shutdown timeout from env `EXECD_API_GRACE_SHUTDOWN`

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
