### PR TITLE
fix(components/execd): support chained bootstrap commands via -c or `BOOTSTRAP_CMD`

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -33,5 +33,25 @@ export EXECD_ENVS
 echo "starting OpenSandbox execd daemon at $EXECD"
 $EXECD &
 
+# Allow chained shell commands (e.g., /test1.sh && /test2.sh)
+# Usage:
+#   bootstrap.sh -c "/test1.sh && /test2.sh"
+# Or set BOOTSTRAP_CMD="/test1.sh && /test2.sh"
+CMD=""
+if [ "${BOOTSTRAP_CMD:-}" != "" ]; then
+	CMD="$BOOTSTRAP_CMD"
+elif [ $# -ge 1 ] && [ "$1" = "-c" ]; then
+	shift
+	CMD="$*"
+fi
+
 set -x
+if [ "$CMD" != "" ]; then
+	exec /bin/sh -c "$CMD"
+fi
+
+if [ $# -eq 0 ]; then
+	exec /bin/sh
+fi
+
 exec "$@"


### PR DESCRIPTION
# Summary
- fix #127 

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
