### PR TITLE
feat(components/execd): replace sh to bash under bootstrap

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2025 Alibaba Group Holding Ltd.
 #
@@ -47,11 +47,11 @@ fi
 
 set -x
 if [ "$CMD" != "" ]; then
-	exec /bin/sh -c "$CMD"
+	exec bash -c "$CMD"
 fi
 
 if [ $# -eq 0 ]; then
-	exec /bin/sh
+	exec bash
 fi
 
 exec "$@"


### PR DESCRIPTION
# Summary
- Replace sh to bash under bootstrap
- At the beginning we used `sh` for maximum compatibility, but I noticed that `run_command` in `execd` is still invoked via `bash`, so we’ve effectively been assuming that the user’s base image includes `bash` all along. Therefore I’m going to change the shebang in `bootstrap.sh` to `bash` as well, so we can use more modern syntax.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
