### PR TITLE
fix(components/execd): remove `omitempty` under FileInfo model

### DIFF
--- a/components/execd/pkg/web/model/filesystem.go
+++ b/components/execd/pkg/web/model/filesystem.go
@@ -19,7 +19,7 @@ import "time"
 // FileInfo represents file metadata including path and permissions
 type FileInfo struct {
 	Path       string    `json:"path,omitempty"`
-	Size       int64     `json:"size,omitempty"`
+	Size       int64     `json:"size"`
 	ModifiedAt time.Time `json:"modified_at,omitempty"`
 	CreatedAt  time.Time `json:"created_at,omitempty"`
 	Permission `json:",inline"`
@@ -32,9 +32,9 @@ type FileMetadata struct {
 
 // Permission represents file ownership and mode
 type Permission struct {
-	Owner string `json:"owner,omitempty"`
-	Group string `json:"group,omitempty"`
-	Mode  int    `json:"mode,omitempty"`
+	Owner string `json:"owner"`
+	Group string `json:"group"`
+	Mode  int    `json:"mode"`
 }
 
 // RenameFileItem represents a file rename operation


### PR DESCRIPTION
# Summary
- remove `omitempty` under FileInfo model, it's conflict with SDK design

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
