### PR TITLE
docs: fix Execution class import path in Kotlin SDK READMEs

### DIFF
--- a/sdks/code-interpreter/kotlin/README.md
+++ b/sdks/code-interpreter/kotlin/README.md
@@ -35,7 +35,7 @@ The following example demonstrates how to initialize the client with a specific 
 ```java
 import com.alibaba.opensandbox.codeinterpreter.CodeInterpreter;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.CodeContext;
-import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.Execution;
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.RunCodeRequest;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.SupportedLanguage;
 import com.alibaba.opensandbox.sandbox.Sandbox;

--- a/sdks/code-interpreter/kotlin/README_zh.md
+++ b/sdks/code-interpreter/kotlin/README_zh.md
@@ -35,7 +35,7 @@ dependencies {
 ```java
 import com.alibaba.opensandbox.codeinterpreter.CodeInterpreter;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.CodeContext;
-import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.Execution;
+import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.RunCodeRequest;
 import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.SupportedLanguage;
 import com.alibaba.opensandbox.sandbox.Sandbox;


### PR DESCRIPTION
# Summary
- docs: fix Execution class import path in Kotlin SDK READMEs

# Testing
- [x] Not run (only update docs)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
