### PR TITLE
chore(server): extract egress configuration as an independent module for easier extension.

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -48,7 +48,8 @@ jobs:
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
-          egress_image = "opensandbox/egress:latest"
+          [egress]
+          image = "opensandbox/egress:latest"
           [docker]
           network_mode = "bridge"
           EOF
@@ -97,7 +98,8 @@ jobs:
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
-          egress_image = "opensandbox/egress:latest"
+          [egress]
+          image = "opensandbox/egress:latest"
           [docker]
           network_mode = "bridge"
           EOF
@@ -150,7 +152,8 @@ jobs:
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
-          egress_image = "opensandbox/egress:latest"
+          [egress]
+          image = "opensandbox/egress:latest"
           [docker]
           network_mode = "bridge"
           EOF

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -71,7 +71,8 @@ jobs:
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:latest"
-          egress_image = "opensandbox/egress:latest"
+          [egress]
+          image = "opensandbox/egress:latest"
           [docker]
           network_mode = "${{ matrix.network }}"
           EOF

--- a/server/DEVELOPMENT.md
+++ b/server/DEVELOPMENT.md
@@ -252,7 +252,7 @@ uv run python -m src.main
 
 ### Egress sidecar (bridge + `networkPolicy`)
 
-- Config: set `[runtime].egress_image`; sidecar starts only when the request carries `networkPolicy`. Requires Docker `network_mode="bridge"`.
+- Config: set `[egress].image`; sidecar starts only when the request carries `networkPolicy`. Requires Docker `network_mode="bridge"`.
 - Network & privileges: main container shares the sidecar netns (`network_mode=container:<sidecar>`); main container explicitly drops `NET_ADMIN`; sidecar keeps `NET_ADMIN` to manage iptables / DNS transparent redirect.
 - Ports: host port bindings live on the sidecar; main container labels record the mapped ports for upstream endpoint resolution.
 - Lifecycle: on create failure / delete / expiration / abnormal recovery, the sidecar is cleaned up; startup also removes orphaned sidecars.

--- a/server/README.md
+++ b/server/README.md
@@ -125,16 +125,18 @@ cp example.batchsandbox-template.yaml ~/batchsandbox-template.yaml
    ```
    Further reading on Docker container security: https://docs.docker.com/engine/security/
 
-### (Optional) Egress sidecar for `networkPolicy`
+### Egress sidecar for `networkPolicy`
 
-- Configure the sidecar image (used only when requests include `networkPolicy`):
+- **Required when using `networkPolicy`**: Configure the sidecar image. The `egress.image` setting is mandatory when requests include `networkPolicy`:
    ```toml
    [runtime]
    type = "docker"
    execd_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.3"
-   egress_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:latest"
+   
+   [egress]
+   image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:latest"
    ```
-- Supported only in Docker bridge mode; requests with `networkPolicy` are rejected when `network_mode=host`.
+- Supported only in Docker bridge mode; requests with `networkPolicy` are rejected when `network_mode=host` or when `egress.image` is not configured.
 - Main container shares the sidecar netns and explicitly drops `NET_ADMIN`; the sidecar keeps `NET_ADMIN` to manage iptables.
 - IPv6 is disabled in the shared namespace when the egress sidecar is injected to keep policy enforcement consistent.
 - Sidecar image is pulled before start; delete/expire/failure paths attempt to clean up the sidecar as well.
@@ -366,7 +368,12 @@ curl -X DELETE \
 |------------------------|--------|----------|-------------------------------------------------------|
 | `runtime.type`         | string | Yes      | Runtime implementation (`"docker"` or `"kubernetes"`) |
 | `runtime.execd_image`  | string | Yes      | Container image with execd binary                     |
-| `runtime.egress_image` | string | No       | Container image with egress binary                    |
+
+### Egress configuration
+
+| Key           | Type   | Required | Description                    |
+|---------------|--------|----------|--------------------------------|
+| `egress.image` | string | **Required when using `networkPolicy`** | Container image with egress binary. Must be configured when `networkPolicy` is provided in sandbox creation requests. |
 
 ### Docker configuration
 

--- a/server/example.config.toml
+++ b/server/example.config.toml
@@ -33,7 +33,11 @@ api_key = ""
 # -----------------------------------------------------------------
 type = "docker"
 execd_image = "opensandbox/execd:v1.0.5"
-egress_image = "opensandbox/egress:v1.0.0"
+
+[egress]
+# Egress configuration
+# -----------------------------------------------------------------
+image = "opensandbox/egress:v1.0.0"
 
 [docker]
 # Docker-specific knobs

--- a/server/example.config.zh.toml
+++ b/server/example.config.zh.toml
@@ -33,7 +33,11 @@ api_key = ""
 # -----------------------------------------------------------------
 type = "docker"
 execd_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.5"
-egress_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.0"
+
+[egress]
+# Egress configuration
+# -----------------------------------------------------------------
+image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.0"
 
 [docker]
 # Docker-specific knobs

--- a/server/src/cli.py
+++ b/server/src/cli.py
@@ -26,6 +26,7 @@ from src.config import (
     CONFIG_ENV_VAR,
     DEFAULT_CONFIG_PATH,
     DockerConfig,
+    EgressConfig,
     KubernetesRuntimeConfig,
     RouterConfig,
     RuntimeConfig,
@@ -167,6 +168,11 @@ def render_full_config(destination: str | Path | None = None, *, force: bool = F
         _render_section("server", ServerConfig),
         _render_section("runtime", RuntimeConfig),
         _render_section("docker", DockerConfig),
+        _render_section(
+            "egress",
+            EgressConfig,
+            extra_comments=["Used when networkPolicy is provided. Requires docker.network_mode = \"bridge\"."],
+        ),
         _render_section(
             "kubernetes",
             KubernetesRuntimeConfig,

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -131,6 +131,16 @@ class AgentSandboxRuntimeConfig(BaseModel):
     )
 
 
+class EgressConfig(BaseModel):
+    """Egress sidecar configuration."""
+
+    image: Optional[str] = Field(
+        default=None,
+        description="Container image for the egress sidecar (used when network policy is requested).",
+        min_length=1,
+    )
+
+
 class RuntimeConfig(BaseModel):
     """Runtime selection (docker, kubernetes, etc.)."""
 
@@ -141,11 +151,6 @@ class RuntimeConfig(BaseModel):
     execd_image: str = Field(
         ...,
         description="Container image that contains the execd binary for sandbox initialization.",
-        min_length=1,
-    )
-    egress_image: Optional[str] = Field(
-        default=None,
-        description="Container image for the egress sidecar (used when network policy is requested).",
         min_length=1,
     )
 
@@ -205,6 +210,7 @@ class AppConfig(BaseModel):
     agent_sandbox: Optional["AgentSandboxRuntimeConfig"] = None
     router: Optional[RouterConfig] = None
     docker: DockerConfig = Field(default_factory=DockerConfig)
+    egress: Optional[EgressConfig] = None
 
     @model_validator(mode="after")
     def validate_runtime_blocks(self) -> "AppConfig":
@@ -317,6 +323,7 @@ __all__ = [
     "RouterConfig",
     "DockerConfig",
     "KubernetesRuntimeConfig",
+    "EgressConfig",
     "DEFAULT_CONFIG_PATH",
     "CONFIG_ENV_VAR",
     "get_config",

--- a/server/tests/smoke.sh
+++ b/server/tests/smoke.sh
@@ -258,7 +258,7 @@ create_resp_body="${create_resp_with_status%$'\n'*}"
 
 if [[ "${status_code}" != "202" ]]; then
   warn "Skip egress sidecar smoke (status ${status_code}). Body: ${create_resp_body}"
-  warn "Likely network_mode=host or egress_image unset."
+  warn "Likely network_mode=host or egress.image unset."
 else
   SANDBOX_ID=$(python - <<'PY' "${create_resp_body}"
 import json,sys

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException, status
 
-from src.config import AppConfig, RouterConfig, RuntimeConfig, ServerConfig
+from src.config import AppConfig, EgressConfig, RouterConfig, RuntimeConfig, ServerConfig
 from src.services.constants import SANDBOX_ID_LABEL, SandboxErrorCodes
 from src.services.docker import DockerSandboxService, PendingSandbox
 from src.services.helpers import parse_memory_limit, parse_nano_cpus, parse_timestamp
@@ -182,7 +182,7 @@ def test_network_policy_rejected_on_host_mode(mock_docker):
 
     cfg = _app_config()
     cfg.docker.network_mode = "host"
-    cfg.runtime.egress_image = "egress:latest"
+    cfg.egress = EgressConfig(image="egress:latest")
     service = DockerSandboxService(config=cfg)
 
     request = CreateSandboxRequest(
@@ -210,7 +210,7 @@ def test_network_policy_requires_egress_image(mock_docker):
 
     cfg = _app_config()
     cfg.docker.network_mode = "bridge"
-    cfg.runtime.egress_image = None
+    cfg.egress = None
     service = DockerSandboxService(config=cfg)
 
     request = CreateSandboxRequest(
@@ -248,7 +248,7 @@ def test_egress_sidecar_injection_and_capabilities(mock_docker):
 
     cfg = _app_config()
     cfg.docker.network_mode = "bridge"
-    cfg.runtime.egress_image = "egress:latest"
+    cfg.egress = EgressConfig(image="egress:latest")
     service = DockerSandboxService(config=cfg)
 
     req = CreateSandboxRequest(


### PR DESCRIPTION
# Summary
- extract egress configuration as an independent module for easier extension.
- expect to release together with next version.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [ ] None
- [x] Yes, `egress_image` is not accepted

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
