### PR TITLE
fix: Replace bare except clauses with specific exception types

### DIFF
--- a/kubernetes/hack/pool-perf.py
+++ b/kubernetes/hack/pool-perf.py
@@ -31,7 +31,8 @@ class PoolPerformanceTester:
     def __init__(self, pool_name, pool_size, replicas_per_bsb, total_bsb_count, timeout):
         try:
             config.load_kube_config()
-        except:
+        except Exception:
+            # Fall back to in-cluster config if kube config is not available
             config.load_incluster_config()
         self.custom_api = client.CustomObjectsApi()
         self.pool_name = pool_name
@@ -176,10 +177,14 @@ class PoolPerformanceTester:
         for name in self.bsb_names:
             try:
                 self.custom_api.delete_namespaced_custom_object(GROUP, VERSION, NAMESPACE, BSB_PLURAL, name)
-            except: pass
+            except Exception as e:
+                # Silently ignore deletion errors during cleanup
+                pass
         try:
             self.custom_api.delete_namespaced_custom_object(GROUP, VERSION, NAMESPACE, POOL_PLURAL, self.pool_name)
-        except: pass
+        except Exception as e:
+            # Silently ignore deletion errors during cleanup
+            pass
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Pool Performance Tester")


### PR DESCRIPTION
## Summary

This PR fixes security and error handling issues in the Kubernetes pool performance testing script (`kubernetes/hack/pool-perf.py`) by replacing bare `except:` clauses with specific exception types.

## Problem

Bare `except:` clauses in Python are a security anti-pattern because they:
- Catch **all** exceptions including `SystemExit` and `KeyboardInterrupt`
- Prevent proper program termination
- Make debugging difficult by hiding critical errors
- Violate PEP 8 style guidelines

## Changes

### `kubernetes/hack/pool-perf.py`

1. **Line 34** - `__init__` method:
   - Changed: `except:` → `except Exception:`
   - Added: Explanatory comment about fallback behavior
   - Intent: Fall back to in-cluster config if kube config is not available

2. **Line 179** - `cleanup()` method (BatchSandbox deletion):
   - Changed: `except: pass` → `except Exception as e: pass`
   - Added: Explanatory comment about silent error handling
   - Intent: Ignore deletion errors during cleanup (resources may not exist)

3. **Line 182** - `cleanup()` method (Pool deletion):
   - Changed: `except: pass` → `except Exception as e: pass`
   - Added: Explanatory comment about silent error handling
   - Intent: Ignore deletion errors during cleanup (resources may not exist)

## Security Impact

- ✅ No longer catches `SystemExit` or `KeyboardInterrupt`
- ✅ Allows proper program termination on Ctrl+C or exit calls
- ✅ Follows Python best practices (PEP 8)
- ✅ Makes error handling intent explicit

## Testing

- ✅ Code review: Changes maintain existing behavior
- ✅ Cleanup errors are still silently ignored (as intended)
- ✅ Kube config fallback logic preserved

## Related

- PEP 8: Programming Recommendations - "A bare ``except:`` clause will catch SystemExit and KeyboardInterrupt exceptions"
- Python documentation: "Use ``except Exception`` instead of a bare ``except:``"

🤖 Generated with [Claude Code](https://claude.ai/code)