### PR TITLE
chore(ingress): do not print request header to log

### DIFF
--- a/components/ingress/pkg/proxy/proxy.go
+++ b/components/ingress/pkg/proxy/proxy.go
@@ -74,7 +74,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.URL.Host = targetHost
 	r.Header.Del(SandboxIngress)
 
-	Logger.Infow("ingress requested", "target", targetHost, "client", p.getClientIP(r), "headers", r.Header, "uri", r.RequestURI, "method", r.Method)
+	Logger.Infow("ingress requested", "target", targetHost, "client", p.getClientIP(r), "uri", r.RequestURI, "method", r.Method)
 	p.serve(w, r)
 }
 


### PR DESCRIPTION
# Summary
- do not print request header to log
- fix for https://github.com/alibaba/OpenSandbox/security/code-scanning/99

# Testing
- [x] Not run (just logger)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered