### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-license.yml
+++ b/.github/workflows/verify-license.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   verify-license:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/25](https://github.com/alibaba/OpenSandbox/security/code-scanning/25)

In general, to fix this class of problem you explicitly declare a `permissions` block for the workflow or each job, granting only the scopes that are actually needed (often just `contents: read` for simple CI checks). This prevents the `GITHUB_TOKEN` from inheriting potentially broader default permissions from the repository or organization.

For this specific workflow, the `verify-license` job only checks out the repository and runs a local shell script; it does not appear to require any write access to the repository or other resources. The minimal appropriate permissions are therefore `contents: read`. The best fix, without changing any existing behavior, is to add a `permissions` block at the job level under `verify-license:` (or at the root if you preferred). This will limit the `GITHUB_TOKEN` for this job to read-only repository contents while leaving all existing steps unchanged.

Concretely:
- Edit `.github/workflows/verify-license.yml`.
- Under `jobs:`, in the `verify-license:` job, add:
  ```yaml
  permissions:
    contents: read
  ```
- Place this block after `runs-on: ubuntu-latest` (or before `steps:`) with correct indentation.

No additional methods, imports, or definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
