### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'server/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/27](https://github.com/alibaba/OpenSandbox/security/code-scanning/27)

In general, the fix is to add an explicit `permissions` block that scopes down the default `GITHUB_TOKEN` permissions to the minimum needed. Since this workflow only checks out code and runs local Python/Docker commands, it only requires read access to repository contents.

The single best fix is to add a root‑level `permissions` block (applies to all jobs) just after the `on:` block. Set `contents: read`, which is sufficient for `actions/checkout@v4`. No job appears to need write access to issues, PRs, etc., so we do not grant any additional scopes. This keeps functionality unchanged while enforcing least privilege and satisfying CodeQL.

Concretely, in `.github/workflows/server-test.yml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` section (lines 3–8) and the existing `concurrency:` block (lines 9–11). No imports or additional methods are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
