### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'components/execd/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/29](https://github.com/alibaba/OpenSandbox/security/code-scanning/29)

In general, the fix is to explicitly declare a `permissions` block in the workflow (at the top level or per job) that grants only the minimal required privileges to `GITHUB_TOKEN`. For this workflow, the steps only need to read repository contents to run builds and tests; they do not push changes, comment on PRs, or modify any GitHub resources. Therefore, setting `permissions: contents: read` at the workflow root is sufficient and will apply to both `test` and `smoke` jobs.

The best minimal change is to add a top-level `permissions` block just after the `on:` section and before `concurrency:` in `.github/workflows/execd-test.yml`. This keeps existing behavior while ensuring the token is limited to read-only access to repository contents. No other imports, methods, or YAML keys are required, and we do not need per-job overrides since both jobs share the same needs.

Concretely, modify `.github/workflows/execd-test.yml` by inserting:

```yaml
permissions:
  contents: read
```

between line 8 and line 9 (between the `on:` block and the `concurrency:` block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
