### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-python-sdks.yml
+++ b/.github/workflows/publish-python-sdks.yml
@@ -14,6 +14,9 @@
 
 name: Publish Python SDKs
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/31](https://github.com/alibaba/OpenSandbox/security/code-scanning/31)

In general, the fix is to explicitly define a `permissions:` block granting only the minimal GITHUB_TOKEN scopes required. This workflow only needs to read the repository contents (for `actions/checkout`) and does not interact with issues, PRs, or other GitHub write APIs, so `contents: read` at the workflow level is sufficient. Setting it at the top level applies to all jobs unless overridden.

The best minimal fix without changing functionality is to add a root‑level `permissions:` block just below the `name:` (or just below `on:`) specifying `contents: read`. No existing jobs or steps need modification, and no additional permissions (e.g., `packages`, `id-token`) are required by the code shown. Specifically, in `.github/workflows/publish-python-sdks.yml`, add:

```yaml
permissions:
  contents: read
```

indented to align with `name:` and `on:`. No imports or further definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
