### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -1,5 +1,8 @@
 name: Real E2E Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/34](https://github.com/alibaba/OpenSandbox/security/code-scanning/34)

In general, to fix this issue you should explicitly define a `permissions` block for the workflow (or per job) that grants only the minimum `GITHUB_TOKEN` scopes needed. For workflows that only check out code, run tests, and upload artifacts, `contents: read` is usually sufficient; `id-token: write` or other scopes are only needed for more advanced use cases like OIDC-based deployments.

For this specific workflow in `.github/workflows/real-e2e.yml`, the jobs (`python-e2e`, `java-e2e`, and the elided `javascript-e2e`) only check out the repo, set up runtimes, run local scripts, and in one case upload an artifact. None of the shown steps require write access to repository contents, issues, pull requests, or other resources. The best fix, without changing functionality, is to add a single top-level `permissions` block right after the `name` (before `on:`) that sets `contents: read`. This applies to all jobs that do not override permissions, which covers all the shown jobs and documents the intended least-privilege behavior.

Concretely: edit `.github/workflows/real-e2e.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Real E2E Tests`) and before line 3 (`on:`). No other imports, methods, or definitions are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
