### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sandbox-k8s-test.yml
+++ b/.github/workflows/sandbox-k8s-test.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'kubernetes/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/63](https://github.com/alibaba/OpenSandbox/security/code-scanning/63)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow to the minimum needed. This is best done by adding a `permissions` block at the workflow root so it applies to all jobs (there is only one job, `test`). Since the workflow just checks out code and runs local build/test commands, it only needs read access to repository contents. Therefore we should set `permissions: contents: read`.

Concretely, edit `.github/workflows/sandbox-k8s-test.yml` and insert a `permissions` section near the top of the file, at the workflow level (same indentation as `on:` and `concurrency:`). For example, after the `on:` block (lines 3–8) and before `concurrency` is a clear and conventional place. No additional imports or methods are required; this is purely a YAML configuration change. The rest of the workflow (jobs, steps, `runs-on`) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
