### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sandbox-k8s-e2e.yml
+++ b/.github/workflows/sandbox-k8s-e2e.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'kubernetes/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/64](https://github.com/alibaba/OpenSandbox/security/code-scanning/64)

In general, the problem is fixed by explicitly specifying a minimal `permissions` block so the `GITHUB_TOKEN` only has the access this workflow needs. For a typical test-only workflow using `actions/checkout` and running tests, `contents: read` is sufficient. Adding this block prevents the job from inheriting potentially broader repository/organization defaults (like `contents: write`).

For this specific file `.github/workflows/sandbox-k8s-e2e.yml`, the best fix without changing functionality is to add a root-level `permissions:` block just after the `on:` section. Root-level permissions apply to all jobs unless overridden, and here there is only one job (`e2e-k8s`) that only reads repository contents. We therefore set:
```yaml
permissions:
  contents: read
```
No additional imports or methods are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
