### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ingress-test.yaml
+++ b/.github/workflows/ingress-test.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/66](https://github.com/alibaba/OpenSandbox/security/code-scanning/66)

In general, this issue is fixed by explicitly declaring a `permissions` block for the workflow or for each job, restricting `GITHUB_TOKEN` to the minimal scopes required (typically `contents: read` for CI that only reads the repo). This avoids inheriting potentially broader repository/organization defaults.

For this specific workflow, the `test` job performs only read operations on the repository (`actions/checkout`) and local build/test commands. There is no evidence of any operation requiring write access. The safest and simplest fix is to add a job-level `permissions` block under `jobs.test`, with `contents: read`. This documents the requirement and prevents accidental elevation if repository defaults change or the workflow is copied elsewhere.

Concretely:
- Edit `.github/workflows/ingress-test.yaml`.
- Under `jobs:`, inside the `test:` job, add a `permissions:` section at the same indentation level as `runs-on`, before `runs-on` or immediately after, e.g.:

```yaml
  test:
    permissions:
      contents: read
    runs-on: ubuntu-latest
    steps:
      ...
```

No imports, methods, or other definitions are required since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
