### PR TITLE
Potential fix for code scanning alert no. 91: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -1,5 +1,8 @@
 name: Publish Components Image
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/91](https://github.com/alibaba/OpenSandbox/security/code-scanning/91)

In general, the fix is to add a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. Since this workflow only needs to read the repository contents (for `actions/checkout`) and does not appear to modify anything via the GitHub API, `contents: read` at the workflow or job level is sufficient.

The best minimal fix without changing functionality is to add a top-level `permissions` section right under the workflow `name:` (before `on:`). This will apply to all jobs that do not override `permissions`, including the `publish` job. Concretely, in `.github/workflows/publish-components.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Publish Components Image`). No additional imports, methods, or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
