### PR TITLE
Potential fix for code scanning alert no. 92: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -19,6 +19,9 @@ on:
     tags:
       - 'server/v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish-pypi:
     if: startsWith(github.ref, 'refs/tags/server/v')


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/92](https://github.com/alibaba/OpenSandbox/security/code-scanning/92)

In general, this should be fixed by explicitly setting a `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the least privileges required. Because this workflow only needs to read the repository contents (for `actions/checkout`) and doesn’t use `GITHUB_TOKEN` to write anything, `contents: read` is sufficient. We can set this at the workflow root so it applies to both jobs.

The best minimally invasive fix is to add a root-level `permissions` block right after the `on:` trigger (or after `name:`) in `.github/workflows/publish-server.yml`:

```yaml
permissions:
  contents: read
```

This will apply to both `publish-pypi` and `publish-image` jobs, since they don’t define their own `permissions`. No changes are needed to steps, secrets, or external actions, and existing functionality (building and publishing to PyPI and Docker/ACR using secrets) will keep working because those operations don’t rely on elevated `GITHUB_TOKEN` scopes.

Concretely: in `.github/workflows/publish-server.yml`, between the `on:` block ending at line 20 and the `jobs:` key at line 22, insert a new `permissions` section with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
