### PR TITLE
Potential fix for code scanning alert no. 97: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/egress-test.yaml.yml
+++ b/.github/workflows/egress-test.yaml.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'components/egress/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/97](https://github.com/alibaba/OpenSandbox/security/code-scanning/97)

In general, the problem is fixed by adding an explicit `permissions` block that grants only the minimal required scopes to `GITHUB_TOKEN`. Since the jobs here only need to check out code and run local builds/tests, they only require read access to repository contents. They do not need to write to the repo, create statuses, or modify issues/PRs.

The best minimal fix without changing existing functionality is to add a workflow‑level `permissions` block near the top of `.github/workflows/egress-test.yaml.yml`, immediately after the `name:` line or after the `on:` block. Setting `permissions: contents: read` at the root will apply to both `test` and `smoke` jobs, satisfying the CodeQL rule and enforcing least privilege. No imports or additional methods are needed, just the YAML configuration change.

Concretely: in `.github/workflows/egress-test.yaml.yml`, insert:

```yaml
permissions:
  contents: read
```

so that it appears between the `on:` block and `concurrency:` (or right after `name:`), ensuring the entire workflow uses read‑only `contents` permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
