### PR TITLE
fix: revert header route mode from RuntimeError to return None

### DIFF
--- a/server/src/services/helpers.py
+++ b/server/src/services/helpers.py
@@ -181,7 +181,8 @@ def format_ingress_endpoint(
 
     if route_mode == GATEWAY_ROUTE_MODE_HEADER:
         # TODO(Pangjiping): Header mode intentionally not emitted until Endpoint schema supports headers.
-        raise RuntimeError(f"Unsupported route mode: {route_mode}")
+        # Return None (skip header mode) until the Endpoint schema supports headers.
+        return None
 
     return None
 
@@ -193,3 +194,4 @@ __all__ = [
     "format_ingress_endpoint",
     "matches_filter",
 ]
+


### PR DESCRIPTION
## Summary

- Gateway ingress with `header` route mode causes a 500 Internal Server Error for any endpoint resolution request
- The function `format_ingress_endpoint()` was changed in commit 69d369d6 to raise `RuntimeError` instead of silently returning `None`
- Both `AgentSandboxProvider` and `BatchSandboxProvider` call this function without catching `RuntimeError`

## Root Cause

In commit `69d369d6` (2026-02-04), the function `format_ingress_endpoint()` in `server/src/services/helpers.py` was changed so that configuring ingress gateway route mode `header` raises a `RuntimeError` instead of silently returning `None`. The config validator (`GatewayRouteModeConfig`) still accepts `header` as a valid value, so operators can configure it without any warning at startup. At runtime, every call to `get_endpoint_info()` in both `AgentSandboxProvider` (line 535) and `BatchSandboxProvider` (line 802) invokes `format_ingress_endpoint()` without a `try/except`, causing the `RuntimeError` to propagate unhandled and crash endpoint resolution with a 500 error.

## What This PR Changes

Reverts the single-line change in `server/src/services/helpers.py` for the `GATEWAY_ROUTE_MODE_HEADER` branch:

- **Before:** `raise RuntimeError(f"Unsupported route mode: {route_mode}")`
- **After:** `return None` (safe, silent skip — falls through to direct pod/service endpoint resolution)

This is the minimal safe hotfix. Header mode support can be properly implemented in a follow-up PR once the Endpoint schema supports headers.

