### PR TITLE
fix(server): skip auth for proxy-to-sandbox paths; strict path matching

### DIFF
--- a/server/src/middleware/auth.py
+++ b/server/src/middleware/auth.py
@@ -19,6 +19,7 @@ This module implements API Key authentication as specified in the OpenAPI spec.
 API keys are configured via config.toml and validated against the OPEN-SANDBOX-API-KEY header.
 """
 
+import re
 from typing import Callable, Optional
 
 from fastapi import Request, Response, status
@@ -39,6 +40,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     # Paths that don't require authentication
     EXEMPT_PATHS = ["/health", "/docs", "/redoc", "/openapi.json"]
+
+    # Strict pattern for proxy-to-sandbox: only /sandboxes/{id}/proxy/... or /v1/sandboxes/{id}/proxy/...
+    # Reject path traversal (..) to avoid auth bypass.
+    _PROXY_PATH_RE = re.compile(r"^(/v1)?/sandboxes/[^/]+/proxy/")
+
+    @staticmethod
+    def _is_proxy_path(path: str) -> bool:
+        """True only for the exact proxy-route shape; rejects path traversal (..)."""
+        if ".." in path:
+            return False
+        return bool(AuthMiddleware._PROXY_PATH_RE.match(path))
 
     def __init__(self, app, config: Optional[AppConfig] = None):
         """
@@ -80,6 +92,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         # Skip authentication for exempt paths
         if any(request.url.path.startswith(path) for path in self.EXEMPT_PATHS):
+            return await call_next(request)
+
+        # Skip authentication only for the exact proxy-to-sandbox route shape
+        # (no path traversal, no loose substring match)
+        if self._is_proxy_path(request.url.path):
             return await call_next(request)
 
         # If no API keys are configured, skip authentication

--- a/server/src/middleware/auth.py
+++ b/server/src/middleware/auth.py
@@ -41,9 +41,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
     # Paths that don't require authentication
     EXEMPT_PATHS = ["/health", "/docs", "/redoc", "/openapi.json"]
 
-    # Strict pattern for proxy-to-sandbox: only /sandboxes/{id}/proxy/... or /v1/sandboxes/{id}/proxy/...
-    # Reject path traversal (..) to avoid auth bypass.
-    _PROXY_PATH_RE = re.compile(r"^(/v1)?/sandboxes/[^/]+/proxy/")
+    # Strict pattern for proxy-to-sandbox: /sandboxes/{id}/proxy/{port}/... with numeric port only.
+    # Matches the actual route in lifecycle.py; rejects path traversal (..) and malformed port.
+    _PROXY_PATH_RE = re.compile(r"^(/v1)?/sandboxes/[^/]+/proxy/\d+(/|$)")
 
     @staticmethod
     def _is_proxy_path(path: str) -> bool:

--- a/server/tests/test_auth_middleware.py
+++ b/server/tests/test_auth_middleware.py
@@ -53,3 +53,64 @@ def test_auth_middleware_accepts_valid_key():
     response = client.get("/secured", headers={"OPEN-SANDBOX-API-KEY": "secret-key"})
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+
+def test_auth_middleware_skips_validation_for_proxy_to_sandbox():
+    """Proxy-to-sandbox paths must not require API key; server only forwards to sandbox."""
+    app = _build_test_app()
+
+    @app.get("/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}")
+    def proxy_echo(sandbox_id: str, port: int, full_path: str):
+        return {"proxied": True, "sandbox_id": sandbox_id, "port": port, "path": full_path}
+
+    client = TestClient(app)
+    # No OPEN-SANDBOX-API-KEY header; should still succeed for proxy path
+    response = client.get("/sandboxes/abc-123/proxy/8080/foo/bar")
+    assert response.status_code == 200
+    assert response.json()["proxied"] is True
+    assert response.json()["sandbox_id"] == "abc-123"
+    assert response.json()["port"] == 8080
+    assert response.json()["path"] == "foo/bar"
+
+
+def test_auth_middleware_v1_proxy_path_exempt():
+    """V1 prefix proxy path is also exempt."""
+    app = _build_test_app()
+
+    @app.get("/v1/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}")
+    def proxy_echo(sandbox_id: str, port: int, full_path: str):
+        return {"proxied": True}
+
+    client = TestClient(app)
+    response = client.get("/v1/sandboxes/sid/proxy/443/")
+    assert response.status_code == 200
+    assert response.json()["proxied"] is True
+
+
+def test_auth_middleware_requires_key_for_non_proxy_paths_containing_proxy_and_sandboxes():
+    """Paths that contain both 'proxy' and 'sandboxes' but not in proxy-route shape still require auth."""
+    app = _build_test_app()
+
+    @app.get("/proxy/sandboxes/anything")
+    def fake_proxy():
+        return {"reached": True}
+
+    client = TestClient(app)
+    response = client.get("/proxy/sandboxes/anything")
+    assert response.status_code == 401
+    assert response.json()["code"] == "MISSING_API_KEY"
+
+
+def test_auth_middleware_is_proxy_path_rejects_traversal():
+    """Paths containing '..' are never considered proxy (no auth bypass)."""
+    assert AuthMiddleware._is_proxy_path("/sandboxes/abc/proxy/8080/../other") is False
+    assert AuthMiddleware._is_proxy_path("/sandboxes/../admin/proxy/8080") is False
+
+
+def test_auth_middleware_is_proxy_path_accepts_valid_shapes():
+    """Only exact proxy route shape is accepted."""
+    assert AuthMiddleware._is_proxy_path("/sandboxes/id/proxy/8080") is True
+    assert AuthMiddleware._is_proxy_path("/sandboxes/id/proxy/8080/") is True
+    assert AuthMiddleware._is_proxy_path("/v1/sandboxes/id/proxy/443/path") is True
+    assert AuthMiddleware._is_proxy_path("/proxy/sandboxes/x") is False
+    assert AuthMiddleware._is_proxy_path("/foo/sandboxes/id/proxy/8080") is False


### PR DESCRIPTION
# Summary
- Do not validate `OPEN-SANDBOX-API-KEY` when request is proxied to sandbox
  (/sandboxes/{id}/proxy/... or /v1/sandboxes/{id}/proxy/...).
- Use strict regex for exempt path to avoid false positives
  (e.g. /proxy/sandboxes/... no longer exempt).
- Reject paths containing '..' to prevent path traversal auth bypass.
- Add _is_proxy_path() and tests for exemption and security cases.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation. #248
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered