### PR TITLE
fix(server): forward query string in sandbox proxy handler

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -430,7 +430,10 @@ async def proxy_sandbox_endpoint_request(request: Request, sandbox_id: str, port
     endpoint = sandbox_service.get_endpoint(sandbox_id, port)
 
     target_host = endpoint.endpoint
+    query_string = request.url.query
     target_url = f"http://{target_host}/{full_path}"
+    if query_string:
+        target_url = f"{target_url}?{query_string}"
 
     client: httpx.AsyncClient = request.app.state.http_client
 


### PR DESCRIPTION
# Summary
- Forward the original query string when proxying requests to sandbox endpoints.
- The proxy handler in `server/src/api/lifecycle.py` was constructing the target URL using only the path component (`full_path`), silently dropping the query string. This caused `/files/download?path=...` requests to reach the sandbox execd daemon without the `path` parameter, resulting in a `400 MISSING_QUERY` error.

# Testing
- [x] e2e / manual verification
  - Reproduced the error by calling `sandbox.files.read_bytes()` via the Python SDK with `use_server_proxy=True`
  - Confirmed fix by re-running the same scenario after patching; file download succeeded

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
