### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-docs-pages.yml
+++ b/.github/workflows/deploy-docs-pages.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/.vitepress/dist
 

--- a/.github/workflows/publish-java-sdks.yml
+++ b/.github/workflows/publish-java-sdks.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Publish to Maven Central
         working-directory: ${{ matrix.sdk.workingDirectory }}

--- a/.github/workflows/publish-python-sdks.yml
+++ b/.github/workflows/publish-python-sdks.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -72,7 +72,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/sdk-unit-tests.yml
+++ b/.github/workflows/sdk-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -75,7 +75,7 @@ jobs:
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run tests
         working-directory: sdks/sandbox/kotlin


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | deploy-docs-pages.yml |
| `astral-sh/setup-uv` | [`v5`](https://github.com/astral-sh/setup-uv/releases/tag/v5) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Release](https://github.com/astral-sh/setup-uv/releases/tag/v7) | publish-python-sdks.yml, publish-server.yml, sdk-unit-tests.yml |
| `gradle/actions/setup-gradle` | [`v4`](https://github.com/gradle/actions/setup-gradle/releases/tag/v4) | [`v5`](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | [Release](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | publish-java-sdks.yml, sdk-unit-tests.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **actions/upload-pages-artifact** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/actions/upload-pages-artifact/releases) for breaking changes
- **gradle/actions/setup-gradle** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/gradle/actions/releases) for breaking changes
- **astral-sh/setup-uv** (v5 → v7): Major version upgrade — review the [release notes](https://github.com/astral-sh/setup-uv/releases) for breaking changes
  - ⚠️ Input `pyproject-file` was **removed** — if your workflow uses it, the step may fail
  - ⚠️ Input `uv-file` was **removed** — if your workflow uses it, the step may fail

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
