### PR TITLE
docs(examples): add inline-block and margin-right to icon styles

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,21 +4,21 @@ Examples for common OpenSandbox use cases. Each subdirectory contains runnable c
 
 ## Integrations / Sandboxes
 - 🧰 [**aio-sandbox**](aio-sandbox): All-in-one sandbox setup using OpenSandbox SDK and agent-sandbox
-- <img src="https://kubernetes.io/icons/favicon-32.png" alt="Kubernetes" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**agent-sandbox**](agent-sandbox): Create a kubernetes-sigs/agent-sandbox instance and run a command
+- <img src="https://kubernetes.io/icons/favicon-32.png" alt="Kubernetes" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**agent-sandbox**](agent-sandbox): Create a kubernetes-sigs/agent-sandbox instance and run a command
 - 🧪 [**code-interpreter**](code-interpreter): Code Interpreter SDK singleton example
 - 💾 [**host-volume-mount**](host-volume-mount): Mount host directories into sandboxes (read-write, read-only, subpath)
 - 🎯 [**rl-training**](rl-training): Reinforcement learning training loop inside a sandbox
-- <img src="https://img.shields.io/badge/-%20-D97757?logo=claude&logoColor=white&style=flat-square" alt="Claude" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**claude-code**](claude-code): Call Claude (Anthropic) API/CLI within the sandbox
-- <img src="https://cli.iflow.cn/img/favicon.ico" alt="iFlow" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**iflow-cli**](iflow-cli): CLI invocation template for iFlow/custom HTTP LLM services
-- <img src="https://geminicli.com/favicon.ico" alt="Google Gemini" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**gemini-cli**](gemini-cli): Call Google Gemini within the sandbox
-- <img src="https://developers.openai.com/favicon.png" alt="OpenAI" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**codex-cli**](codex-cli): Call OpenAI/Codex-like models within the sandbox
-- <img src="https://img.shields.io/badge/-%20-1C3C3C?logo=langgraph&logoColor=white&style=flat-square" alt="LangGraph" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**langgraph**](langgraph): LangGraph agent orchestrating sandbox lifecycle + tools
-- <img src="https://google.github.io/adk-docs/assets/agent-development-kit.png" alt="Google ADK" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**google-adk**](google-adk): Google ADK agent calling OpenSandbox tools
+- <img src="https://img.shields.io/badge/-%20-D97757?logo=claude&logoColor=white&style=flat-square" alt="Claude" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**claude-code**](claude-code): Call Claude (Anthropic) API/CLI within the sandbox
+- <img src="https://cli.iflow.cn/img/favicon.ico" alt="iFlow" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**iflow-cli**](iflow-cli): CLI invocation template for iFlow/custom HTTP LLM services
+- <img src="https://geminicli.com/favicon.ico" alt="Google Gemini" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**gemini-cli**](gemini-cli): Call Google Gemini within the sandbox
+- <img src="https://developers.openai.com/favicon.png" alt="OpenAI" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**codex-cli**](codex-cli): Call OpenAI/Codex-like models within the sandbox
+- <img src="https://img.shields.io/badge/-%20-1C3C3C?logo=langgraph&logoColor=white&style=flat-square" alt="LangGraph" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**langgraph**](langgraph): LangGraph agent orchestrating sandbox lifecycle + tools
+- <img src="https://google.github.io/adk-docs/assets/agent-development-kit.png" alt="Google ADK" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**google-adk**](google-adk): Google ADK agent calling OpenSandbox tools
 - 🦞 [**openclaw**](openclaw): Run an OpenClaw Gateway inside a sandbox
 - 🖥️ [**desktop**](desktop): Launch VNC desktop (Xvfb + x11vnc) for VNC client connections
-- <img src="https://playwright.dev/img/playwright-logo.svg" alt="Playwright" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**playwright**](playwright): Launch headless browser (Playwright + Chromium) to scrape web content
-- <img src="https://code.visualstudio.com/assets/favicon.ico" alt="VS Code" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**vscode**](vscode): Launch code-server (VS Code Web) to provide browser access
-- <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Google Chrome" width="16" height="16" style="width:16px;height:16px;vertical-align:middle;" /> [**chrome**](chrome): Launch headless Chromium with DevTools port exposed for remote debugging
+- <img src="https://playwright.dev/img/playwright-logo.svg" alt="Playwright" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**playwright**](playwright): Launch headless browser (Playwright + Chromium) to scrape web content
+- <img src="https://code.visualstudio.com/assets/favicon.ico" alt="VS Code" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**vscode**](vscode): Launch code-server (VS Code Web) to provide browser access
+- <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Google Chrome" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**chrome**](chrome): Launch headless Chromium with DevTools port exposed for remote debugging
 
 ## How to Run
 - Set basic environment variables (e.g., `export SANDBOX_DOMAIN=...`, `export SANDBOX_API_KEY=...`)


### PR DESCRIPTION
# Summary
- docs(examples): add inline-block and margin-right to icon styles to fix the icon line break issue
<img width="1928" height="1594" alt="image" src="https://github.com/user-attachments/assets/8c39b450-8a84-4c04-a17c-52ce77868f6f" />


# Testing
- [x] Not run (only update doc)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
