### PR TITLE
feat(examples): add Kimi Code CLI integration example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Examples for common OpenSandbox use cases. Each subdirectory contains runnable c
 - <img src="https://cli.iflow.cn/img/favicon.ico" alt="iFlow" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**iflow-cli**](iflow-cli): CLI invocation template for iFlow/custom HTTP LLM services
 - <img src="https://geminicli.com/favicon.ico" alt="Google Gemini" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**gemini-cli**](gemini-cli): Call Google Gemini within the sandbox
 - <img src="https://developers.openai.com/favicon.png" alt="OpenAI" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**codex-cli**](codex-cli): Call OpenAI/Codex-like models within the sandbox
+- <img src="https://www.kimi.com/favicon.ico" alt="Kimi" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**kimi-cli**](kimi-cli): Call Kimi Code CLI (Moonshot AI) within the sandbox
 - <img src="https://img.shields.io/badge/-%20-1C3C3C?logo=langgraph&logoColor=white&style=flat-square" alt="LangGraph" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**langgraph**](langgraph): LangGraph agent orchestrating sandbox lifecycle + tools
 - <img src="https://google.github.io/adk-docs/assets/agent-development-kit.png" alt="Google ADK" width="16" height="16" style="display:inline-block;width:16px;height:16px;vertical-align:middle;margin-right:4px;" /> [**google-adk**](google-adk): Google ADK agent calling OpenSandbox tools
 - 🦞 [**openclaw**](openclaw): Run an OpenClaw Gateway inside a sandbox
@@ -22,7 +23,7 @@ Examples for common OpenSandbox use cases. Each subdirectory contains runnable c
 
 ## How to Run
 - Set basic environment variables (e.g., `export SANDBOX_DOMAIN=...`, `export SANDBOX_API_KEY=...`)
-- Add provider-specific variables as needed (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `IFLOW_API_KEY`/`IFLOW_ENDPOINT`, etc.; model selection is optional)
+- Add provider-specific variables as needed (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `KIMI_API_KEY`, `IFLOW_API_KEY`/`IFLOW_ENDPOINT`, etc.; model selection is optional)
 - Navigate to the example directory and install dependencies: `pip install -r requirements.txt` (or refer to the Dockerfile in the directory)
 - Then execute: `python main.py`
 - To run in a container, build and run using the `Dockerfile` in the directory

--- a/examples/kimi-cli/README.md
+++ b/examples/kimi-cli/README.md
@@ -1,0 +1,48 @@
+# Kimi CLI Example
+
+Run [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) (Moonshot AI) inside an OpenSandbox container.
+
+## Start OpenSandbox server [local]
+
+Pre-pull the code-interpreter image (includes Python 3.12+):
+
+```shell
+docker pull sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.1
+
+# use docker hub
+# docker pull opensandbox/code-interpreter:v1.0.1
+```
+
+Then start the local OpenSandbox server, stdout logs will be visible in the terminal:
+
+```shell
+uv pip install opensandbox-server
+opensandbox-server init-config ~/.sandbox.toml --example docker
+opensandbox-server
+```
+
+## Create and Access the Kimi Sandbox
+
+```shell
+# Install OpenSandbox package
+uv pip install opensandbox
+
+# Run the example (requires SANDBOX_DOMAIN / SANDBOX_API_KEY / KIMI_API_KEY)
+uv run python examples/kimi-cli/main.py
+```
+
+The script installs Kimi Code CLI (`pip install kimi-cli`) at runtime (Python 3.12+ is already in the code-interpreter image), then sends a simple request `kimi -p "Compute 1+1=?."`. Auth is passed via `KIMI_API_KEY`, and you can override endpoint/model with `KIMI_BASE_URL` / `KIMI_MODEL_NAME`.
+
+## Environment Variables
+
+- `SANDBOX_DOMAIN`: Sandbox service address (default: `localhost:8080`)
+- `SANDBOX_API_KEY`: API key if your server requires authentication (optional for local)
+- `SANDBOX_IMAGE`: Sandbox image to use (default: `sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.1`)
+- `KIMI_API_KEY`: Your Moonshot AI / Kimi API key (required)
+- `KIMI_BASE_URL`: Kimi API endpoint (optional; defaults to Kimi's official endpoint)
+- `KIMI_MODEL_NAME`: Model to use (default: `kimi-k2.5`)
+
+## References
+- [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) - Official Kimi Code CLI repository
+- [Moonshot AI Platform](https://platform.moonshot.ai/) - API key management and documentation
+- [Kimi CLI Documentation](https://moonshotai.github.io/kimi-cli/en/) - Full CLI documentation

--- a/examples/kimi-cli/main.py
+++ b/examples/kimi-cli/main.py
@@ -1,0 +1,88 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+from datetime import timedelta
+
+from opensandbox import Sandbox
+from opensandbox.config import ConnectionConfig
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+async def _print_execution_logs(execution) -> None:
+    for msg in execution.logs.stdout:
+        print(f"[stdout] {msg.text}")
+    for msg in execution.logs.stderr:
+        print(f"[stderr] {msg.text}")
+    if execution.error:
+        print(f"[error] {execution.error.name}: {execution.error.value}")
+
+
+async def main() -> None:
+    domain = os.getenv("SANDBOX_DOMAIN", "localhost:8080")
+    api_key = os.getenv("SANDBOX_API_KEY")
+    kimi_api_key = _required_env("KIMI_API_KEY")
+    kimi_base_url = os.getenv("KIMI_BASE_URL")
+    kimi_model_name = os.getenv("KIMI_MODEL_NAME", "kimi-k2.5")
+    image = os.getenv(
+        "SANDBOX_IMAGE",
+        "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.1",
+    )
+
+    config = ConnectionConfig(
+        domain=domain,
+        api_key=api_key,
+        request_timeout=timedelta(seconds=60),
+    )
+
+    # Inject Kimi settings into container environment for CLI access
+    env = {
+        "KIMI_API_KEY": kimi_api_key,
+        "KIMI_BASE_URL": kimi_base_url,
+        "KIMI_MODEL_NAME": kimi_model_name,
+    }
+    # Drop None values to avoid overriding defaults inside CLI
+    env = {k: v for k, v in env.items() if v is not None}
+
+    sandbox = await Sandbox.create(
+        image,
+        connection_config=config,
+        env=env,
+    )
+
+    async with sandbox:
+        # Install Kimi CLI (Python 3.12+ is already in the code-interpreter image)
+        install_exec = await sandbox.commands.run(
+            "pip install kimi-cli"
+        )
+        await _print_execution_logs(install_exec)
+
+        # Use Kimi CLI to send a message in non-interactive mode
+        run_exec = await sandbox.commands.run(
+            'kimi -p "Compute 1+1=?."'
+        )
+        await _print_execution_logs(run_exec)
+
+        await sandbox.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Add **Kimi Code CLI** (Moonshot AI) sandbox example, following the same pattern as existing `claude-code`, `gemini-cli`, and `codex-cli` examples
- New `examples/kimi-cli/` directory with `main.py` and `README.md`
- Updated `examples/README.md` to include the Kimi CLI entry in the integration list

## Details

[Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) is Moonshot AI's open-source terminal coding agent (6.4k+ stars, Apache 2.0). It supports:
- Multiple models (Kimi K2.5 default)
- Non-interactive mode (`kimi -p "prompt"`)
- Environment-based configuration (`KIMI_API_KEY`, `KIMI_BASE_URL`, `KIMI_MODEL_NAME`)

The example installs `kimi-cli` via pip at runtime (Python 3.12+ is already available in the code-interpreter image) and demonstrates basic prompt execution inside a sandboxed environment.

## Testing
- [ ] Not run (requires KIMI_API_KEY and running OpenSandbox server)
- [x] Code follows existing example patterns (claude-code, gemini-cli, codex-cli)
- [x] README follows existing documentation format

## Breaking Changes
- [x] None

## Checklist
- [x] Clearly described motivation
- [x] Added/updated docs (examples/README.md updated)
- [x] Security impact considered (API key passed via env, not hardcoded)
- [x] Backward compatibility considered (additive change only)