### PR TITLE
Potential fix for code scanning alert no. 117: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sdk-unit-tests.yml
+++ b/.github/workflows/sdk-unit-tests.yml
@@ -28,6 +28,9 @@ on:
       - "sdks/code-interpreter/**"
       - "specs/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/117](https://github.com/alibaba/OpenSandbox/security/code-scanning/117)

In general, the fix is to explicitly set a minimal `permissions` block for the workflow or for individual jobs, instead of relying on repository defaults. Since all three jobs only need to read the repository contents (for checkout) and do not appear to write to the repo or interact with issues/PRs, a workflow-level `permissions: contents: read` is appropriate and preserves existing functionality.

The best single change is to add a top-level `permissions` block (applies to all jobs) near the top of `.github/workflows/sdk-unit-tests.yml`, after the `on:` triggers and before `concurrency:` (or before `jobs:`). This block should include `contents: read` as the minimal required permission; if in the future some job requires more, that job can define its own `permissions` block. No imports or additional definitions are required because this is just GitHub Actions YAML configuration.

Concretely, in `.github/workflows/sdk-unit-tests.yml`, between the existing `push:` block (line 24–29) and `concurrency:` (line 31–33), insert:

```yaml
permissions:
  contents: read
```

This will constrain the `GITHUB_TOKEN` used by all jobs in this workflow to read-only access to repository contents, aligning with least-privilege principles without changing any job behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
