### PR TITLE
Potential fix for code scanning alert no. 114: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/egress-test.yaml.yml
+++ b/.github/workflows/egress-test.yaml.yml
@@ -7,6 +7,9 @@ on:
       - 'components/egress/**'
       - 'components/internal/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/114](https://github.com/alibaba/OpenSandbox/security/code-scanning/114)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow (either at the top level to apply to all jobs, or per job) that grants only the minimum required scopes. For a CI workflow that only checks out code, builds, tests, runs scripts, and uploads artifacts, `contents: read` is typically sufficient; artifact upload does not require any extra repository permissions.

The best fix here without changing functionality is to add a top‑level `permissions` block near the top of `.github/workflows/egress-test.yaml.yml`, right after the `name` or `on` section, setting `contents: read`. This will apply to all three jobs (`test`, `smoke`, and `bench`) since none of them define their own `permissions` block, and all they do is read repo contents and upload artifacts. No additional imports or methods are needed; this is purely a YAML configuration change within the shown workflow file.

Concretely, edit `.github/workflows/egress-test.yaml.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block (or immediately after `name:` if you prefer). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
