### PR TITLE
docs: add OpenSandbox offical documentation to github homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <hr />
 </div>
 
-English | [中文](docs/README_zh.md)
+[Document](https://open-sandbox.ai/) | [文档](https://open-sandbox.ai/zh/)
 
 OpenSandbox is a **general-purpose sandbox platform** for AI applications, offering multi-language SDKs, unified sandbox APIs, and Docker/Kubernetes runtimes for scenarios like Coding Agents, GUI Agents, Agent Evaluation, AI Code Execution, and RL Training.
 


### PR DESCRIPTION
# Summary
- add OpenSandbox offical documentation to github homepage

# Testing
- [x] Not run (only update doc)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
