### PR TITLE
docs: add Kimi CLI to README Coding Agent Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ OpenSandbox provides rich examples demonstrating sandbox usage in different scen
 - **[claude-code](examples/claude-code/README.md)** - Run Claude Code inside OpenSandbox.
 - **[gemini-cli](examples/gemini-cli/README.md)** - Run Google Gemini CLI inside OpenSandbox.
 - **[codex-cli](examples/codex-cli/README.md)** - Run OpenAI Codex CLI inside OpenSandbox.
+- **[kimi-cli](examples/kimi-cli/README.md)** - Run [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) (Moonshot AI) inside OpenSandbox.
 - **[iflow-cli](examples/iflow-cli/README.md)** - Run iFLow CLI inside OpenSandbox.
 - **[langgraph](examples/langgraph/README.md)** - LangGraph state-machine workflow that creates/runs a sandbox job with fallback retry.
 - **[google-adk](examples/google-adk/README.md)** - Google ADK agent using OpenSandbox tools to write/read files and run commands.

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -152,11 +152,12 @@ OpenSandbox 提供了丰富的示例来演示不同场景下的沙箱使用方�
 
 #### 🤖 Coding Agent 集成
 
-在 OpenSandbox 中，集成各类 Coding Agent，包括 Claude Code、Google Gemini、OpenAI Codex 等。
+在 OpenSandbox 中，集成各类 Coding Agent，包括 Claude Code、Google Gemini、OpenAI Codex、Kimi CLI 等。
 
 - **[claude-code](../examples/claude-code/README.md)** - 在 OpenSandbox 中运行 Claude Code。
 - **[gemini-cli](../examples/gemini-cli/README.md)** - 在 OpenSandbox 中运行 Google Gemini CLI。
 - **[codex-cli](../examples/codex-cli/README.md)** - 在 OpenSandbox 中运行 OpenAI Codex CLI。
+- **[kimi-cli](../examples/kimi-cli/README.md)** - 在 OpenSandbox 中运行 [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)（Moonshot AI）。
 - **[iflow-cli](../examples/iflow-cli/README.md)** - 在 OpenSandbox 中运行 iFlow CLI。
 - **[langgraph](../examples/langgraph/README.md)** - 基于 LangGraph 状态机编排沙箱任务与回退重试。
 - **[google-adk](../examples/google-adk/README.md)** - 使用 Google ADK 通过 OpenSandbox 工具读写文件并执行命令。


### PR DESCRIPTION
## Summary
- Add [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) (Moonshot AI) entry to the **Coding Agent Integrations** section in both English (`README.md`) and Chinese (`docs/README_zh.md`)
- Follows the merge of #275 which added the `examples/kimi-cli` integration example

## Changes
- `README.md`: Added kimi-cli line between codex-cli and iflow-cli
- `docs/README_zh.md`: Added kimi-cli line + updated intro text to mention Kimi CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)