### PR TITLE
fix(python-sdk): propagate API key header for execd adapters in proxy mode

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -96,8 +96,12 @@ class CommandsAdapter(Commands):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
-        # Execd API does not require authentication
+        # Execd API typically does not require authentication.
+        # Keep API key header available for server-proxy mode.
         self._client = Client(
             base_url=base_url,
             timeout=timeout,

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -92,6 +92,9 @@ class FilesystemAdapter(Filesystem):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
         self._httpx_client = httpx.AsyncClient(
             base_url=base_url,
@@ -100,7 +103,8 @@ class FilesystemAdapter(Filesystem):
             transport=self.connection_config.transport,
         )
 
-        # Execd API does not require authentication
+        # Execd API typically does not require authentication.
+        # Keep API key header available for server-proxy mode.
         self._client = Client(
             base_url=base_url,
             timeout=timeout,

--- a/sdks/sandbox/python/src/opensandbox/adapters/health_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/health_adapter.py
@@ -66,8 +66,12 @@ class HealthAdapter(Health):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
-        # Execd API does not require authentication
+        # Execd API typically does not require authentication.
+        # Keep API key header available for server-proxy mode.
         self._client = Client(
             base_url=base_url,
             timeout=timeout,

--- a/sdks/sandbox/python/src/opensandbox/adapters/metrics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/metrics_adapter.py
@@ -75,8 +75,12 @@ class MetricsAdapter(Metrics):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
-        # Execd API does not require authentication
+        # Execd API typically does not require authentication.
+        # Keep API key header available for server-proxy mode.
         self._client = Client(
             base_url=base_url,
             timeout=timeout,

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -80,6 +80,9 @@ class CommandsAdapterSync(CommandsSync):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
         self._client = Client(base_url=base_url, timeout=timeout)
 

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -70,6 +70,9 @@ class FilesystemAdapterSync(FilesystemSync):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
         self._httpx_client = httpx.Client(
             base_url=base_url,

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/health_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/health_adapter.py
@@ -42,6 +42,9 @@ class HealthAdapterSync(HealthSync):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
         self._client = Client(base_url=base_url, timeout=timeout)
         self._httpx_client = httpx.Client(

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/metrics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/metrics_adapter.py
@@ -51,6 +51,9 @@ class MetricsAdapterSync(MetricsSync):
             **self.connection_config.headers,
             **self.execd_endpoint.headers,
         }
+        api_key = self.connection_config.get_api_key()
+        if api_key:
+            headers.setdefault("OPEN-SANDBOX-API-KEY", api_key)
 
         self._client = Client(base_url=base_url, timeout=timeout)
         self._httpx_client = httpx.Client(

--- a/sdks/sandbox/python/tests/test_adapters_eager_init.py
+++ b/sdks/sandbox/python/tests/test_adapters_eager_init.py
@@ -21,7 +21,12 @@ from opensandbox.adapters.health_adapter import HealthAdapter
 from opensandbox.adapters.metrics_adapter import MetricsAdapter
 from opensandbox.adapters.sandboxes_adapter import SandboxesAdapter
 from opensandbox.config import ConnectionConfig
+from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.models.sandboxes import SandboxEndpoint
+from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
+from opensandbox.sync.adapters.filesystem_adapter import FilesystemAdapterSync
+from opensandbox.sync.adapters.health_adapter import HealthAdapterSync
+from opensandbox.sync.adapters.metrics_adapter import MetricsAdapterSync
 
 
 def test_sandbox_service_adapter_eager_init() -> None:
@@ -48,3 +53,40 @@ async def test_execd_service_adapters_eager_init_and_urls() -> None:
     assert await fs._get_client() is not None
     assert await health._get_client() is not None
     assert await metrics._get_client() is not None
+
+
+@pytest.mark.asyncio
+async def test_execd_service_adapters_set_api_key_header() -> None:
+    cfg = ConnectionConfig(protocol="http", api_key="proxy-key")
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+
+    cmd = CommandsAdapter(cfg, endpoint)
+    fs = FilesystemAdapter(cfg, endpoint)
+    health = HealthAdapter(cfg, endpoint)
+    metrics = MetricsAdapter(cfg, endpoint)
+
+    for adapter in (cmd, fs, health, metrics):
+        assert adapter._httpx_client.headers.get("OPEN-SANDBOX-API-KEY") == "proxy-key"
+
+    await cmd._httpx_client.aclose()
+    await fs._httpx_client.aclose()
+    await health._httpx_client.aclose()
+    await metrics._httpx_client.aclose()
+
+
+def test_sync_execd_service_adapters_set_api_key_header() -> None:
+    cfg = ConnectionConfigSync(protocol="http", api_key="proxy-key")
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+
+    cmd = CommandsAdapterSync(cfg, endpoint)
+    fs = FilesystemAdapterSync(cfg, endpoint)
+    health = HealthAdapterSync(cfg, endpoint)
+    metrics = MetricsAdapterSync(cfg, endpoint)
+
+    for adapter in (cmd, fs, health, metrics):
+        assert adapter._httpx_client.headers.get("OPEN-SANDBOX-API-KEY") == "proxy-key"
+
+    cmd._httpx_client.close()
+    fs._httpx_client.close()
+    health._httpx_client.close()
+    metrics._httpx_client.close()


### PR DESCRIPTION
## Summary
- propagate `OPEN-SANDBOX-API-KEY` into execd adapter HTTP headers for async/sync adapters
- cover `CommandsAdapter`, `FilesystemAdapter`, `HealthAdapter`, and `MetricsAdapter`
- add async/sync tests to verify API key header is present in adapter-owned clients

## Why
When users enable server proxy mode, execd requests go through the OpenSandbox server and still require API key authentication. This ensures adapter requests carry the key consistently.

Closes #248

## Validation
- `cd sdks/sandbox/python && PYTHONPATH=src python3 -m pytest tests/test_adapters_eager_init.py -q`
- `cd sdks/sandbox/python && python3 -m ruff check src/opensandbox/adapters src/opensandbox/sync/adapters tests/test_adapters_eager_init.py`
