### PR TITLE
docs(server): add bootstrap operation-not-permitted troubleshooting

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -126,32 +126,7 @@ Before you start the server, edit the configuration file to suit your environmen
    ```
    Further reading on Docker container security: https://docs.docker.com/engine/security/
 
-**Troubleshooting: `exec /opt/opensandbox/bootstrap.sh: operation not permitted`**
-
-If sandbox logs show:
-
-```text
-exec /opt/opensandbox/bootstrap.sh: operation not permitted
-```
-
-check the following first:
-
-1. Verify the script exists and is executable inside the sandbox container:
-   ```bash
-   docker exec -it <sandbox-container> ls -l /opt/opensandbox/bootstrap.sh
-   ```
-2. Verify runtime security/mount constraints are not blocking execution (for example strict
-   confinement or `noexec` mount behavior in host/container runtime setup).
-3. If you are running Docker from Snap-based environments (for example Ubuntu Core), prefer
-   Docker CE package deployments for production OpenSandbox workloads, because strict runtime
-   confinement may block this bootstrap execution path in some setups.
-4. Re-run with the latest server and execd images to ensure you include the latest runtime fixes.
-
-If this still reproduces, collect:
-- `docker info`
-- `docker logs opensandbox-server`
-- `docker logs <sandbox-container>`
-- your `config.toml` (mask secrets)
+For common issues and solutions, see [Troubleshooting](TROUBLESHOOTING.md).
 
 **Ingress exposure (direct | gateway)**
    ```toml

--- a/server/README_zh.md
+++ b/server/README_zh.md
@@ -127,29 +127,7 @@ opensandbox-server init-config ~/.sandbox.toml --example k8s-zh
    ```
    更多 Docker 容器安全参考：https://docs.docker.com/engine/security/
 
-**故障排查：`exec /opt/opensandbox/bootstrap.sh: operation not permitted`**
-
-如果沙箱日志出现：
-
-```text
-exec /opt/opensandbox/bootstrap.sh: operation not permitted
-```
-
-建议先检查：
-
-1. 确认脚本在沙箱容器内存在且可执行：
-   ```bash
-   docker exec -it <sandbox-container> ls -l /opt/opensandbox/bootstrap.sh
-   ```
-2. 检查运行时安全策略和挂载约束是否阻止执行（例如严格沙箱约束或 `noexec` 挂载行为）。
-3. 如果使用 Snap 版本 Docker（如 Ubuntu Core 场景），生产环境建议优先使用 Docker CE 安装方式，因为部分严格约束环境会影响该 bootstrap 执行路径。
-4. 升级并复现：使用最新 server / execd 镜像确认是否已包含修复。
-
-如果仍可复现，建议附带以下信息提 issue：
-- `docker info`
-- `docker logs opensandbox-server`
-- `docker logs <sandbox-container>`
-- `config.toml`（注意脱敏）
+常见问题及解决方案请参阅 [故障排查](TROUBLESHOOTING_zh.md)。
 
 **Ingress 暴露（direct | gateway）**
 ```toml

--- a/server/TROUBLESHOOTING.md
+++ b/server/TROUBLESHOOTING.md
@@ -1,0 +1,30 @@
+# Troubleshooting
+
+English | [中文](TROUBLESHOOTING_zh.md)
+
+## `exec /opt/opensandbox/bootstrap.sh: operation not permitted`
+
+If sandbox logs show:
+
+```text
+exec /opt/opensandbox/bootstrap.sh: operation not permitted
+```
+
+check the following first:
+
+1. Verify the script exists and is executable inside the sandbox container:
+   ```bash
+   docker exec -it <sandbox-container> ls -l /opt/opensandbox/bootstrap.sh
+   ```
+2. Verify runtime security/mount constraints are not blocking execution (for example strict
+   confinement or `noexec` mount behavior in host/container runtime setup).
+3. If you are running Docker from Snap-based environments (for example Ubuntu Core), prefer
+   Docker CE package deployments for production OpenSandbox workloads, because strict runtime
+   confinement may block this bootstrap execution path in some setups.
+4. Re-run with the latest server and execd images to ensure you include the latest runtime fixes.
+
+If this still reproduces, collect:
+- `docker info`
+- `docker logs opensandbox-server`
+- `docker logs <sandbox-container>`
+- your `config.toml` (mask secrets)

--- a/server/TROUBLESHOOTING_zh.md
+++ b/server/TROUBLESHOOTING_zh.md
@@ -1,0 +1,27 @@
+# 故障排查
+
+[English](TROUBLESHOOTING.md) | 中文
+
+## `exec /opt/opensandbox/bootstrap.sh: operation not permitted`
+
+如果沙箱日志出现：
+
+```text
+exec /opt/opensandbox/bootstrap.sh: operation not permitted
+```
+
+建议先检查：
+
+1. 确认脚本在沙箱容器内存在且可执行：
+   ```bash
+   docker exec -it <sandbox-container> ls -l /opt/opensandbox/bootstrap.sh
+   ```
+2. 检查运行时安全策略和挂载约束是否阻止执行（例如严格沙箱约束或 `noexec` 挂载行为）。
+3. 如果使用 Snap 版本 Docker（如 Ubuntu Core 场景），生产环境建议优先使用 Docker CE 安装方式，因为部分严格约束环境会影响该 bootstrap 执行路径。
+4. 升级并复现：使用最新 server / execd 镜像确认是否已包含修复。
+
+如果仍可复现，建议附带以下信息提 issue：
+- `docker info`
+- `docker logs opensandbox-server`
+- `docker logs <sandbox-container>`
+- `config.toml`（注意脱敏）


### PR DESCRIPTION
## Summary
- add troubleshooting guidance for `exec /opt/opensandbox/bootstrap.sh: operation not permitted`
- include a quick diagnosis checklist and required debug information for issue reports
- document Snap-based Docker caveat for strict confinement environments
- update both English and Chinese server README files

## Why
Issue #263 reports sandbox startup failures with `operation not permitted`. This PR adds concrete troubleshooting guidance for operators and maintainers.

Closes #263

## Validation
- documentation-only change
