### PR TITLE
test(server): add create and delete route coverage

### DIFF
--- a/server/tests/test_routes_create_delete.py
+++ b/server/tests/test_routes_create_delete.py
@@ -1,0 +1,101 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from src.api import lifecycle
+from src.api.schema import CreateSandboxResponse, SandboxStatus
+
+
+def test_create_sandbox_returns_202_and_service_payload(
+    client: TestClient,
+    auth_headers: dict,
+    sample_sandbox_request: dict,
+    monkeypatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    calls: list[object] = []
+
+    class StubService:
+        @staticmethod
+        def create_sandbox(request) -> CreateSandboxResponse:
+            calls.append(request)
+            return CreateSandboxResponse(
+                id="sbx-001",
+                status=SandboxStatus(state="Pending"),
+                metadata={"project": "test-project"},
+                expiresAt=now + timedelta(hours=1),
+                createdAt=now,
+                entrypoint=["python", "-c", "print('Hello from sandbox')"],
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.post(
+        "/v1/sandboxes",
+        headers=auth_headers,
+        json=sample_sandbox_request,
+    )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["id"] == "sbx-001"
+    assert payload["status"]["state"] == "Pending"
+    assert payload["metadata"]["project"] == "test-project"
+    assert payload["entrypoint"] == ["python", "-c", "print('Hello from sandbox')"]
+    assert len(calls) == 1
+    assert calls[0].image.uri == "python:3.11"
+
+
+def test_create_sandbox_rejects_invalid_request(
+    client: TestClient,
+    auth_headers: dict,
+) -> None:
+    response = client.post(
+        "/v1/sandboxes",
+        headers=auth_headers,
+        json={"timeout": 10},
+    )
+
+    assert response.status_code == 422
+
+
+def test_delete_sandbox_returns_204_and_calls_service(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+
+    class StubService:
+        @staticmethod
+        def delete_sandbox(sandbox_id: str) -> None:
+            calls.append(sandbox_id)
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.delete("/v1/sandboxes/sbx-001", headers=auth_headers)
+
+    assert response.status_code == 204
+    assert response.text == ""
+    assert calls == ["sbx-001"]
+
+
+def test_delete_sandbox_requires_api_key(client: TestClient) -> None:
+    response = client.delete("/v1/sandboxes/sbx-001")
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "MISSING_API_KEY"


### PR DESCRIPTION
## Summary
- add route tests for sandbox create/delete endpoints in `server/tests/test_routes_create_delete.py`
- verify create route returns `202` and serializes service payload correctly
- verify create route rejects invalid request payloads
- verify delete route calls service and returns `204`
- verify auth enforcement for delete route

## Why
This adds practical coverage for core lifecycle entry points and reduces regression risk on request validation/response semantics.

## Validation
- `python3 -m pytest server/tests/test_routes_create_delete.py -q`
- `python3 -m ruff check server/tests/test_routes_create_delete.py`
