### PR TITLE
test(k8s): add 1.20.0, 1.21.1 k8s version in e2e

### DIFF
--- a/.github/workflows/sandbox-k8s-e2e.yml
+++ b/.github/workflows/sandbox-k8s-e2e.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.22.4", "1.24.4", "1.26.4", "1.28.6", "1.30.4", "1.32.2", "1.34.2"]
+        k8s-version: ["1.20.0", "1.21.1", "1.22.4", "1.24.4", "1.26.4", "1.28.6", "1.30.4", "1.32.2", "1.34.2"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Summary
- What is changing and why?

Add k8s 1.20.0, 1.21.1 version in e2e to coverage old k8s release.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
