### PR TITLE
feat(python-sdk): improve sandbox health timeout diagnostics

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -341,10 +341,26 @@ class Sandbox:
             if last_exception
             else "Health check returned false continuously"
         )
+        connection_detail = (
+            f"ConnectionConfig(domain={self.connection_config.get_domain()}, "
+            f"use_server_proxy={self.connection_config.use_server_proxy})"
+        )
+        if self.connection_config.use_server_proxy:
+            hint = (
+                "Hint: server proxy mode is enabled. Check server-to-sandbox connectivity "
+                "and server API key/auth configuration."
+            )
+        else:
+            hint = (
+                "Hint: direct sandbox endpoint access is enabled. If the SDK cannot directly "
+                "reach sandbox network/ports, set ConnectionConfig(use_server_proxy=True). "
+                "For Docker bridge deployments where server runs in a container, also configure "
+                "server [docker].host_ip to a host-reachable address."
+            )
 
         final_message = (
             f"Sandbox health check timed out after {timeout.total_seconds()}s "
-            f"({attempt} attempts). {error_detail}"
+            f"({attempt} attempts). {error_detail}. {connection_detail}. {hint}"
         )
 
         logger.error(final_message)

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -328,9 +328,30 @@ class SandboxSync:
 
             time.sleep(polling_interval.total_seconds())
 
-        error_detail = f"Last error: {last_exception}" if last_exception else "Health check returned false continuously"
+        error_detail = (
+            f"Last error: {last_exception}"
+            if last_exception
+            else "Health check returned false continuously"
+        )
+        connection_detail = (
+            f"ConnectionConfig(domain={self.connection_config.get_domain()}, "
+            f"use_server_proxy={self.connection_config.use_server_proxy})"
+        )
+        if self.connection_config.use_server_proxy:
+            hint = (
+                "Hint: server proxy mode is enabled. Check server-to-sandbox connectivity "
+                "and server API key/auth configuration."
+            )
+        else:
+            hint = (
+                "Hint: direct sandbox endpoint access is enabled. If the SDK cannot directly "
+                "reach sandbox network/ports, set ConnectionConfigSync(use_server_proxy=True). "
+                "For Docker bridge deployments where server runs in a container, also configure "
+                "server [docker].host_ip to a host-reachable address."
+            )
         final_message = (
-            f"Sandbox health check timed out after {timeout.total_seconds()}s ({attempt} attempts). {error_detail}"
+            f"Sandbox health check timed out after {timeout.total_seconds()}s "
+            f"({attempt} attempts). {error_detail}. {connection_detail}. {hint}"
         )
         logger.error(final_message)
         raise SandboxReadyTimeoutException(final_message)

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -49,7 +49,13 @@ class _Noop:
     pass
 
 
-def _make_sandbox(*, health_service, sandbox_service, custom_health_check=None) -> Sandbox:
+def _make_sandbox(
+    *,
+    health_service,
+    sandbox_service,
+    custom_health_check=None,
+    connection_config: ConnectionConfig | None = None,
+) -> Sandbox:
     return Sandbox(
         sandbox_id=str(uuid4()),
         sandbox_service=sandbox_service,
@@ -57,7 +63,7 @@ def _make_sandbox(*, health_service, sandbox_service, custom_health_check=None) 
         command_service=_Noop(),
         health_service=health_service,
         metrics_service=_Noop(),
-        connection_config=ConnectionConfig(),
+        connection_config=connection_config or ConnectionConfig(),
         custom_health_check=custom_health_check,
     )
 
@@ -108,6 +114,26 @@ async def test_check_ready_timeout_raises() -> None:
 
     with pytest.raises(SandboxReadyTimeoutException):
         await sbx.check_ready(timeout=timedelta(seconds=0.01), polling_interval=timedelta(seconds=0))
+
+
+@pytest.mark.asyncio
+async def test_check_ready_timeout_message_includes_troubleshooting_hints() -> None:
+    async def _always_false(_: Sandbox) -> bool:
+        return False
+
+    sbx = _make_sandbox(
+        health_service=_HealthServiceStub(),
+        sandbox_service=_SandboxServiceStub(),
+        custom_health_check=_always_false,
+        connection_config=ConnectionConfig(domain="10.0.0.1:8080", use_server_proxy=False),
+    )
+
+    with pytest.raises(SandboxReadyTimeoutException) as exc_info:
+        await sbx.check_ready(timeout=timedelta(seconds=0.01), polling_interval=timedelta(seconds=0))
+
+    message = str(exc_info.value)
+    assert "ConnectionConfig(domain=10.0.0.1:8080, use_server_proxy=False)" in message
+    assert "ConnectionConfig(use_server_proxy=True)" in message
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.exceptions import SandboxReadyTimeoutException
+from opensandbox.sync.sandbox import SandboxSync
+
+
+class _Noop:
+    pass
+
+
+def test_sync_check_ready_timeout_message_includes_troubleshooting_hints() -> None:
+    def _always_false(_: SandboxSync) -> bool:
+        return False
+
+    sbx = SandboxSync(
+        sandbox_id=str(uuid4()),
+        sandbox_service=_Noop(),
+        filesystem_service=_Noop(),
+        command_service=_Noop(),
+        health_service=_Noop(),
+        metrics_service=_Noop(),
+        connection_config=ConnectionConfigSync(
+            domain="10.0.0.2:8080",
+            use_server_proxy=False,
+        ),
+        custom_health_check=_always_false,
+    )
+
+    with pytest.raises(SandboxReadyTimeoutException) as exc_info:
+        sbx.check_ready(timeout=timedelta(seconds=0.01), polling_interval=timedelta(seconds=0))
+
+    message = str(exc_info.value)
+    assert "ConnectionConfig(domain=10.0.0.2:8080, use_server_proxy=False)" in message
+    assert "ConnectionConfigSync(use_server_proxy=True)" in message


### PR DESCRIPTION
## Summary
- improve `SandboxReadyTimeoutException` message in async/sync SDKs with actionable troubleshooting hints
- include connection context in timeout message (`domain`, `use_server_proxy`) for faster diagnosis
- add guidance in error text for common bridge-network reachability issues (`use_server_proxy=True`, server `[docker].host_ip`)
- add and update async/sync business-logic tests to lock the new behavior

## Why
Recent user reports show that health timeout errors are hard to diagnose in ECS/containerized bridge deployments. This change makes timeout errors self-diagnosing and directly points users to likely fixes.

Refs #297

## Validation
- `cd sdks/sandbox/python && PYTHONPATH=src python3 -m pytest tests/test_sandbox_business_logic.py tests/test_sandbox_sync_business_logic.py -q`
- `cd sdks/sandbox/python && python3 -m ruff check src/opensandbox/sandbox.py src/opensandbox/sync/sandbox.py tests/test_sandbox_business_logic.py tests/test_sandbox_sync_business_logic.py`
