### PR TITLE
test(server): add get-sandbox route coverage

### DIFF
--- a/server/tests/test_routes_get_sandbox.py
+++ b/server/tests/test_routes_get_sandbox.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
+
+from src.api import lifecycle
+from src.api.schema import ImageSpec, Sandbox, SandboxStatus
+
+
+def test_get_sandbox_returns_service_payload(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    class StubService:
+        @staticmethod
+        def get_sandbox(sandbox_id: str) -> Sandbox:
+            assert sandbox_id == "sbx-001"
+            return Sandbox(
+                id=sandbox_id,
+                image=ImageSpec(uri="python:3.11"),
+                status=SandboxStatus(state="Running"),
+                metadata={"team": "infra"},
+                entrypoint=["python", "-V"],
+                expiresAt=now + timedelta(hours=1),
+                createdAt=now,
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get("/v1/sandboxes/sbx-001", headers=auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == "sbx-001"
+    assert payload["status"]["state"] == "Running"
+    assert payload["image"]["uri"] == "python:3.11"
+
+
+def test_get_sandbox_propagates_not_found(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox(sandbox_id: str) -> Sandbox:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "SANDBOX_NOT_FOUND",
+                    "message": f"Sandbox {sandbox_id} not found",
+                },
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get("/v1/sandboxes/missing", headers=auth_headers)
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "code": "SANDBOX_NOT_FOUND",
+        "message": "Sandbox missing not found",
+    }
+
+
+def test_get_sandbox_requires_api_key(client: TestClient) -> None:
+    response = client.get("/v1/sandboxes/sbx-001")
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "MISSING_API_KEY"


### PR DESCRIPTION
## Summary
- add route tests for get-sandbox endpoint in `server/tests/test_routes_get_sandbox.py`
- verify successful payload passthrough from service layer
- verify service-layer `404` is propagated with standardized error schema
- verify auth enforcement on get-sandbox route

## Why
This closes another route-level testing gap and reduces regression risk for core sandbox retrieval behavior.

## Validation
- `python3 -m pytest server/tests/test_routes_get_sandbox.py -q`
- `python3 -m ruff check server/tests/test_routes_get_sandbox.py`
