### PR TITLE
feat(server): add server.eip config for endpoint host in Docker runtime

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -427,6 +427,7 @@ curl -X DELETE \
 | `server.port` | integer | `8080` | Port to listen on |
 | `server.log_level` | string | `"INFO"` | Python logging level |
 | `server.api_key` | string | `null` | API key for authentication |
+| `server.eip` | string | `null` | Bound public IP; when set, used as the host part when returning sandbox endpoints (Docker runtime) |
 
 ### Runtime configuration
 

--- a/server/README_zh.md
+++ b/server/README_zh.md
@@ -426,6 +426,7 @@ curl -X DELETE \
 | `server.port` | integer | `8080` | 监听端口 |
 | `server.log_level` | string | `"INFO"` | Python 日志级别 |
 | `server.api_key` | string | `null` | API 认证密钥 |
+| `server.eip` | string | `null` | 绑定的公网 IP；配置后，返回 sandbox endpoint 时作为地址的 host 部分（Docker 运行时） |
 
 ### 运行时配置
 

--- a/server/TROUBLESHOOTING.md
+++ b/server/TROUBLESHOOTING.md
@@ -28,3 +28,24 @@ If this still reproduces, collect:
 - `docker logs opensandbox-server`
 - `docker logs <sandbox-container>`
 - your `config.toml` (mask secrets)
+
+## Sandbox health check timed out (e.g. on Alibaba Cloud ECS)
+
+If the client reports:
+
+```text
+opensandbox.exceptions.sandbox.SandboxReadyTimeoutException: Sandbox health check timed out after 30.0s (2 attempts). Health check returned false continuously
+```
+
+when the server runs on a cloud VM (e.g. [Alibaba Cloud ECS](https://github.com/alibaba/OpenSandbox/issues/297)), the client is likely trying to reach the sandbox at an address it cannot access. The server may be returning a bind address such as `127.0.0.1` or an internal LAN IP in the endpoint URL, so the health check from the client side fails.
+
+**Solution:** Set the bound public IP so that the server returns a reachable address in the sandbox endpoint API. In your config (e.g. `~/.sandbox.toml`), under `[server]`, set `eip` to the VM’s public IP (or the hostname that clients use to reach the server):
+
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+eip = "47.x.x.x"   # Your ECS public IP, or the hostname clients use to reach this server
+```
+
+After restarting the server, the get-endpoint API will use `eip` as the host part of the returned URL, so the client can reach the sandbox for the health check. This applies to the Docker runtime; the server skips resolving `host` when `eip` is set.

--- a/server/TROUBLESHOOTING_zh.md
+++ b/server/TROUBLESHOOTING_zh.md
@@ -25,3 +25,24 @@ exec /opt/opensandbox/bootstrap.sh: operation not permitted
 - `docker logs opensandbox-server`
 - `docker logs <sandbox-container>`
 - `config.toml`（注意脱敏）
+
+## 沙箱健康检查超时（如阿里云 ECS）
+
+若服务端部署在云主机（例如 [阿里云 ECS](https://github.com/alibaba/OpenSandbox/issues/297)），客户端创建沙箱时出现：
+
+```text
+opensandbox.exceptions.sandbox.SandboxReadyTimeoutException: Sandbox health check timed out after 30.0s (2 attempts). Health check returned false continuously
+```
+
+通常是因为服务端返回的 endpoint 地址（如 `127.0.0.1` 或内网 IP）对客户端不可达，客户端无法完成健康检查。
+
+**解决办法：** 配置绑定的公网 IP，让服务端在返回 sandbox endpoint 时使用客户端可访问的地址。在配置文件（如 `~/.sandbox.toml`）的 `[server]` 下设置 `eip` 为云主机的公网 IP（或客户端访问该服务时使用的主机名）：
+
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+eip = "47.x.x.x"   # 你的 ECS 公网 IP，或客户端用来访问本机的主机名
+```
+
+重启服务后，获取 endpoint 的 API 会使用 `eip` 作为返回地址的 host 部分，客户端即可连通沙箱并通过健康检查。该行为针对 Docker 运行时；配置了 `eip` 后，服务端将不再根据 `host` 解析地址。

--- a/server/example.config.toml
+++ b/server/example.config.toml
@@ -23,6 +23,7 @@ host = "127.0.0.1"
 port = 8080
 log_level = "INFO"
 # api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
+# eip = "1.2.3.4"  # Optional: External IP/hostname for endpoint URLs when returning sandbox endpoints
 
 [runtime]
 # Runtime selection (docker | kubernetes)

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -181,6 +181,10 @@ class ServerConfig(BaseModel):
         default=None,
         description="Global API key for authenticating incoming lifecycle API calls.",
     )
+    eip: Optional[str] = Field(
+        default=None,
+        description="Bound public IP. When set, used as the host part when returning sandbox endpoints.",
+    )
 
 
 class KubernetesRuntimeConfig(BaseModel):

--- a/server/src/services/docker.py
+++ b/server/src/services/docker.py
@@ -1548,6 +1548,10 @@ class DockerSandboxService(SandboxService):
         return ip or None
 
     def _resolve_public_host(self) -> str:
+        """Resolve the host used in endpoint URLs. If [server].eip is set, use it directly without resolving host."""
+        eip_cfg = (self.app_config.server.eip or "").strip()
+        if eip_cfg:
+            return eip_cfg
         host_cfg = (self.app_config.server.host or "").strip()
         host_key = host_cfg.lower()
         if host_key in {"", "0.0.0.0", "::"}:


### PR DESCRIPTION
# Summary
- Add optional server.eip (bound public IP) in ServerConfig; when set,
  `_resolve_public_host()` returns eip directly and skips host resolution.
- Document server.eip in README and README_zh configuration reference.
- Add troubleshooting section for SandboxReadyTimeoutException on cloud
  VMs (e.g. Alibaba Cloud ECS #297) and fix via server.eip.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation. #297 
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered