### PR TITLE
test(k8s): update k8s version in e2e and README

### DIFF
--- a/.github/workflows/sandbox-k8s-e2e.yml
+++ b/.github/workflows/sandbox-k8s-e2e.yml
@@ -18,11 +18,29 @@ env:
 
 jobs:
   e2e-k8s:
-    name: E2E Tests (K8s v${{ matrix.k8s-version }})
+    name: E2E Tests (K8s v${{ matrix.k8s-version }}, Kind ${{ matrix.kind-version }})
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: ["1.20.0", "1.21.1", "1.22.4", "1.24.4", "1.26.4", "1.28.6", "1.30.4", "1.32.2", "1.34.2"]
+        include:
+          - k8s-version: "1.20.0"
+            kind-version: "v0.17.0" # to fix incompatibility
+          - k8s-version: "1.21.1"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.22.4"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.24.4"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.26.4"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.28.6"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.30.4"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.32.2"
+            kind-version: "v0.31.0"
+          - k8s-version: "1.34.2"
+            kind-version: "v0.31.0"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,4 +54,4 @@ jobs:
       - name: Run tests
         run: |
           cd kubernetes
-          make test-e2e KIND_K8S_VERSION=v${{ matrix.k8s-version }}
+          make test-e2e KIND_REINSTALL=true KIND_VERSION=${{ matrix.kind-version }} KIND_K8S_VERSION=v${{ matrix.k8s-version }}

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -125,13 +125,16 @@ KIND_CLUSTER ?= sandbox-k8s-test-e2e
 KIND_K8S_VERSION ?= v1.22.4
 GINKGO_ARGS ?=
 
+KIND_VERSION ?= v0.20.0
+KIND_REINSTALL ?= false
+
 .PHONY: install-kind
-install-kind: ## Install Kind using go install if not already installed
-	@if command -v kind >/dev/null 2>&1; then \
+install-kind: ## Install Kind using go install if not already installed. Set KIND_REINSTALL=true to force reinstall.
+	@if [ "$(KIND_REINSTALL)" != "true" ] && command -v kind >/dev/null 2>&1; then \
 		echo "Kind is already installed: $$(kind version)"; \
 	else \
-		echo "Installing Kind..."; \
-		go install sigs.k8s.io/kind@v0.20.0 && \
+		echo "Installing Kind $(KIND_VERSION)..."; \
+		go install sigs.k8s.io/kind@$(KIND_VERSION) && \
 		echo "Kind installed successfully: $$(kind version)"; \
 	fi
 

--- a/kubernetes/README-ZH.md
+++ b/kubernetes/README-ZH.md
@@ -107,7 +107,7 @@ BatchSandbox 与 Sig Agent-Sandbox 在吞吐量方面的性能对比测试。
 - go 版本 v1.24.0+
 - docker 版本 17.03+
 - kubectl 版本 v1.11.3+
-- 访问 Kubernetes v1.22.4+ 集群
+- 访问 Kubernetes v1.21.1+ 集群
 
 如果您没有 Kubernetes 集群的访问权限，可以使用 [kind](https://kind.sigs.k8s.io/) 创建一个本地 Kubernetes 集群进行测试。Kind 在 Docker 容器中运行 Kubernetes 节点，使得设置本地开发环境变得容易。
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -106,7 +106,7 @@ Core Difference: The time complexity of Sig Agent-Sandbox and BatchSandbox for b
 - go version v1.24.0+
 - docker version 17.03+
 - kubectl version v1.11.3+
-- Access to a Kubernetes v1.22.4+ cluster
+- Access to a Kubernetes v1.21.1+ cluster
 
 If you don't have access to a Kubernetes cluster, you can use [kind](https://kind.sigs.k8s.io/) to create a local Kubernetes cluster for testing purposes. Kind runs Kubernetes nodes in Docker containers, making it easy to set up a local development environment.
 


### PR DESCRIPTION
# Summary
- What is changing and why?

Remove k8s 1.20.0 version in e2e and update k8s component README.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
