### PR TITLE
fix(helm): replace --v with --zap-log-level for controller

### DIFF
--- a/kubernetes/README-ZH.md
+++ b/kubernetes/README-ZH.md
@@ -200,7 +200,7 @@ helm install opensandbox \
   https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
   --namespace opensandbox-system \
   --create-namespace \
-  --set controller.logLevel=5
+  --set controller.logLevel=debug
 ```
 
 或使用 values 文件进行复杂配置：
@@ -217,7 +217,7 @@ controller:
     requests:
       cpu: 100m
       memory: 128Mi
-  logLevel: 5
+  logLevel: debug
 EOF
 
 # 使用自定义 values 安装

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -199,7 +199,7 @@ helm install opensandbox \
   https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
   --namespace opensandbox-system \
   --create-namespace \
-  --set controller.logLevel=5
+  --set controller.logLevel=debug
 ```
 
 Or use a values file for complex configurations:
@@ -216,7 +216,7 @@ controller:
     requests:
       cpu: 100m
       memory: 128Mi
-  logLevel: 5
+  logLevel: debug
 EOF
 
 # Install with custom values

--- a/kubernetes/charts/opensandbox-controller/README.md
+++ b/kubernetes/charts/opensandbox-controller/README.md
@@ -70,7 +70,7 @@ kubectl delete crd pools.sandbox.opensandbox.io
 | `controller.resources.limits.memory` | Memory resource limits | `128Mi` |
 | `controller.resources.requests.cpu` | CPU resource requests | `10m` |
 | `controller.resources.requests.memory` | Memory resource requests | `64Mi` |
-| `controller.logLevel` | Log level (0-5, higher is more verbose) | `3` |
+| `controller.logLevel` | Log level passed to `--zap-log-level` (e.g. debug/info/error) | `info` |
 | `controller.leaderElection.enabled` | Enable leader election | `true` |
 | `controller.nodeSelector` | Node labels for pod assignment | `{}` |
 | `controller.tolerations` | Tolerations for pod assignment | `[]` |

--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - --leader-elect
         {{- end }}
         - --health-probe-bind-address=:8081
-        - --v={{ .Values.controller.logLevel }}
+        - --zap-log-level={{ .Values.controller.logLevel }}
         ports:
         - name: health
           containerPort: 8081

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -34,8 +34,8 @@ controller:
       cpu: 10m
       memory: 64Mi
   
-  # -- Log level (0-5, higher is more verbose)
-  logLevel: 3
+  # -- Log level for --zap-log-level (e.g. debug, info, error)
+  logLevel: info
   
   # -- Enable leader election for controller manager
   leaderElection:

--- a/kubernetes/docs/HELM-DEPLOYMENT.md
+++ b/kubernetes/docs/HELM-DEPLOYMENT.md
@@ -122,7 +122,7 @@ controller:
       cpu: 100m
       memory: 128Mi
   
-  logLevel: 5
+  logLevel: debug
 
 imagePullSecrets:
   - name: myregistrykey
@@ -365,7 +365,7 @@ helm upgrade opensandbox ./charts/opensandbox-controller \
 #### values-dev.yaml
 ```yaml
 controller:
-  logLevel: 5
+  logLevel: debug
   resources:
     limits:
       cpu: 200m
@@ -375,7 +375,7 @@ controller:
 #### values-prod.yaml
 ```yaml
 controller:
-  logLevel: 2
+  logLevel: info
   replicaCount: 3
   resources:
     limits:


### PR DESCRIPTION
## Summary
- switch Helm chart controller arg from `--v={{ .Values.controller.logLevel }}` to `--zap-log-level={{ .Values.controller.logLevel }}`
- update default `controller.logLevel` from numeric style to zap style (`info`)
- align Helm docs/examples (EN/ZH) to use `debug/info` values

## Why
The controller binds zap flags (`opts.BindFlags(flag.CommandLine)`), so using `--v` in chart deployment is inconsistent and can confuse users.
Maintainer feedback in issue #304 also calls out replacing `--v=3` with `--zap-log-level=3`.

## Validation
- checked chart template + values + docs consistency in repo
- `git diff --check` clean
- `helm` binary is not available in this environment, so `helm template/lint` could not be executed locally
