### PR TITLE
feat(js-sdk): improve sandbox ready-timeout diagnostics

### DIFF
--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -511,24 +511,43 @@ export class Sandbox {
     healthCheck?: (sbx: Sandbox) => boolean | Promise<boolean>;
   }): Promise<void> {
     const deadline = Date.now() + opts.readyTimeoutSeconds * 1000;
+    let attempt = 0;
+    let errorDetail = "Health check returned false continuously.";
+
+    const buildTimeoutMessage = () => {
+      const context = `domain=${this.connectionConfig.domain}, useServerProxy=${this.connectionConfig.useServerProxy}`;
+      let suggestion =
+        "If this sandbox runs in Docker bridge or remote-network mode, consider enabling useServerProxy=true.";
+      if (!this.connectionConfig.useServerProxy) {
+        suggestion += " You can also configure server-side [docker].host_ip for direct endpoint access.";
+      }
+      return `Sandbox health check timed out after ${opts.readyTimeoutSeconds}s (${attempt} attempts). ${errorDetail} Connection context: ${context}. ${suggestion}`;
+    };
 
     // Wait until execd becomes reachable and passes health check.
     while (true) {
       if (Date.now() > deadline) {
         throw new SandboxReadyTimeoutException({
-          message: `Sandbox not ready: timed out waiting for health check (timeoutSeconds=${opts.readyTimeoutSeconds})`,
+          message: buildTimeoutMessage(),
         });
       }
+      attempt++;
       try {
         if (opts.healthCheck) {
           const ok = await opts.healthCheck(this);
-          if (ok) return;
+          if (ok) {
+            return;
+          }
         } else {
           const ok = await this.health.ping();
-          if (ok) return;
+          if (ok) {
+            return;
+          }
         }
-      } catch {
-        // ignore and retry
+        errorDetail = "Health check returned false continuously.";
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errorDetail = `Last health check error: ${message}`;
       }
       await sleep(opts.pollingIntervalMillis);
     }

--- a/tests/javascript/tests/test_wait_until_ready_diagnostics.test.ts
+++ b/tests/javascript/tests/test_wait_until_ready_diagnostics.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "vitest";
+
+import { Sandbox, SandboxReadyTimeoutException } from "@alibaba-group/opensandbox";
+
+test("waitUntilReady timeout includes last health-check error and connection context", async () => {
+  const fakeSandbox = {
+    connectionConfig: {
+      domain: "localhost:8080",
+      useServerProxy: false,
+    },
+    health: {
+      ping: async () => {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:8080");
+      },
+    },
+  } as unknown as Sandbox;
+
+  let thrown: unknown;
+  try {
+    await Sandbox.prototype.waitUntilReady.call(fakeSandbox, {
+      readyTimeoutSeconds: 0.01,
+      pollingIntervalMillis: 1,
+    });
+  } catch (err) {
+    thrown = err;
+  }
+
+  expect(thrown).toBeInstanceOf(SandboxReadyTimeoutException);
+  const message = (thrown as Error).message;
+  expect(message).toContain("Sandbox health check timed out");
+  expect(message).toContain("Last health check error");
+  expect(message).toContain("domain=localhost:8080");
+  expect(message).toContain("useServerProxy=false");
+  expect(message).toContain("useServerProxy=true");
+});
+
+test("waitUntilReady timeout includes false-continuously hint when ping returns false", async () => {
+  let pingCalls = 0;
+  const fakeSandbox = {
+    connectionConfig: {
+      domain: "localhost:8080",
+      useServerProxy: true,
+    },
+    health: {
+      ping: async () => {
+        pingCalls++;
+        return false;
+      },
+    },
+  } as unknown as Sandbox;
+
+  let thrown: unknown;
+  try {
+    await Sandbox.prototype.waitUntilReady.call(fakeSandbox, {
+      readyTimeoutSeconds: 0.01,
+      pollingIntervalMillis: 1,
+    });
+  } catch (err) {
+    thrown = err;
+  }
+
+  expect(thrown).toBeInstanceOf(SandboxReadyTimeoutException);
+  expect((thrown as Error).message).toContain("Health check returned false continuously.");
+  expect(pingCalls).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- improve JavaScript SDK `waitUntilReady` timeout message with:
  - timeout attempts count
  - last health-check error detail (when available)
  - connection context (`domain`, `useServerProxy`)
  - actionable suggestion for bridge/remote networking cases
- add focused JS tests for the new timeout diagnostics behavior

## Why
Users hitting readiness timeout (for example in bridge network setups) need immediate, actionable diagnostics instead of a generic timeout error.
This aligns JavaScript SDK ergonomics with the improved troubleshooting direction already added in Python SDK.

## Validation
- `pnpm -C sdks/sandbox/javascript run lint`
- `pnpm -C tests/javascript run lint`
- `cd tests/javascript && pnpm run prep:sdk && pnpm exec vitest run tests/test_wait_until_ready_diagnostics.test.ts`
