### PR TITLE
fix(server): preserve proxy HTTP errors and add route coverage

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -475,6 +475,9 @@ async def proxy_sandbox_endpoint_request(request: Request, sandbox_id: str, port
             status_code=502,
             detail=f"Could not connect to the backend sandbox {endpoint}: {e}",
         )
+    except HTTPException:
+        # Preserve explicit HTTP exceptions raised above (e.g. websocket upgrade not supported).
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"An internal error occurred in the proxy: {e}"

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httpx
+from fastapi.testclient import TestClient
+
+from src.api import lifecycle
+from src.api.schema import Endpoint
+
+
+class _FakeStreamingResponse:
+    def __init__(self, status_code: int = 200, headers: dict | None = None, chunks: list[bytes] | None = None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks or []
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeAsyncClient:
+    def __init__(self):
+        self.built = None
+        self.response = _FakeStreamingResponse()
+        self.raise_connect_error = False
+        self.raise_generic_error = False
+
+    def build_request(self, method: str, url: str, headers: dict, content):
+        self.built = {
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "content": content,
+        }
+        return self.built
+
+    async def send(self, req, stream: bool = True):
+        if self.raise_connect_error:
+            raise httpx.ConnectError("connection refused")
+        if self.raise_generic_error:
+            raise RuntimeError("unexpected proxy error")
+        return self.response
+
+
+def test_proxy_forwards_filtered_headers_and_query(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            assert sandbox_id == "sbx-123"
+            assert port == 44772
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(
+        status_code=201,
+        headers={"x-backend": "yes"},
+        chunks=[b"proxy-ok"],
+    )
+    client.app.state.http_client = fake_client
+
+    headers = {
+        **auth_headers,
+        "Authorization": "Bearer top-secret",
+        "Cookie": "sid=secret",
+        "Connection": "keep-alive",
+        "Upgrade": "h2c",
+        "X-Trace": "trace-1",
+    }
+
+    response = client.post(
+        "/v1/sandboxes/sbx-123/proxy/44772/api/run",
+        params={"q": "search"},
+        headers=headers,
+        content=b'{"hello":"world"}',
+    )
+
+    assert response.status_code == 201
+    assert response.content == b"proxy-ok"
+    assert response.headers.get("x-backend") == "yes"
+
+    assert fake_client.built is not None
+    assert fake_client.built["method"] == "POST"
+    assert fake_client.built["url"] == "http://10.57.1.91:40109/api/run?q=search"
+    forwarded_headers = fake_client.built["headers"]
+    lowered_headers = {k.lower(): v for k, v in forwarded_headers.items()}
+    assert "host" not in lowered_headers
+    assert "connection" not in lowered_headers
+    assert "upgrade" not in lowered_headers
+    assert "authorization" not in lowered_headers
+    assert "cookie" not in lowered_headers
+    assert lowered_headers.get("x-trace") == "trace-1"
+
+
+def test_proxy_rejects_websocket_upgrade(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    client.app.state.http_client = _FakeAsyncClient()
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/ws",
+        headers={**auth_headers, "Upgrade": "websocket"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["message"] == "Websocket upgrade is not supported yet"
+
+
+def test_proxy_maps_connect_error_to_502(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    fake_client = _FakeAsyncClient()
+    fake_client.raise_connect_error = True
+    client.app.state.http_client = fake_client
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/healthz",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 502
+    assert "Could not connect to the backend sandbox" in response.json()["message"]
+
+
+def test_proxy_maps_unexpected_error_to_500(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    fake_client = _FakeAsyncClient()
+    fake_client.raise_generic_error = True
+    client.app.state.http_client = fake_client
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/healthz",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 500
+    assert "An internal error occurred in the proxy" in response.json()["message"]


### PR DESCRIPTION
## Summary
- add focused tests for sandbox proxy route behavior:
  - header filtering + query forwarding
  - websocket upgrade rejection
  - backend connect error mapping to 502
  - unexpected exception mapping to 500
- fix proxy exception handling so explicit `HTTPException` (e.g. websocket unsupported) is not swallowed and rewritten to 500

## Why
Current proxy handler catches broad `Exception`, which also catches `HTTPException`. This turns intended 4xx responses into 500s. The new tests expose this and lock expected behavior.

## Validation
- `pytest -q server/tests/test_routes_proxy.py`
- `pytest -q server/tests/test_routes_endpoint_behavior.py server/tests/test_routes_proxy.py`
