### PR TITLE
feat(kotlin-sdk): enrich ready-timeout diagnostics

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -516,7 +516,16 @@ class Sandbox internal constructor(
                 "Check returned false continuously"
             }
 
-        val finalMessage = "Sandbox health check timed out after ${timeout.seconds}s ($attempt attempts). $errorDetail"
+        val context = "domain=${httpClientProvider.config.getDomain()}, useServerProxy=${httpClientProvider.config.useServerProxy}"
+        var suggestion =
+            "If this sandbox runs in Docker bridge or remote-network mode, consider enabling useServerProxy=true."
+        if (!httpClientProvider.config.useServerProxy) {
+            suggestion += " You can also configure server-side [docker].host_ip for direct endpoint access."
+        }
+
+        val finalMessage =
+            "Sandbox health check timed out after ${timeout.seconds}s ($attempt attempts). $errorDetail " +
+                "Connection context: $context. $suggestion"
 
         logger.error(finalMessage, lastException)
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
@@ -68,6 +68,14 @@ class SandboxTest {
 
     @BeforeEach
     fun setUp() {
+        every {
+            httpClientProvider.config
+        } returns
+            ConnectionConfig.builder()
+                .domain("localhost:8080")
+                .useServerProxy(false)
+                .build()
+
         sandbox =
             Sandbox(
                 id = sandboxId,
@@ -207,5 +215,39 @@ class SandboxTest {
         assertThrows(SandboxReadyTimeoutException::class.java) {
             sandbox.checkReady(Duration.ofMillis(100), Duration.ofMillis(10))
         }
+    }
+
+    @Test
+    fun `checkReady timeout should include connection context and bridge hint`() {
+        every { healthService.ping(sandboxId) } throws RuntimeException("connect ECONNREFUSED")
+
+        val ex =
+            assertThrows(SandboxReadyTimeoutException::class.java) {
+                sandbox.checkReady(Duration.ofMillis(100), Duration.ofMillis(10))
+            }
+
+        assertTrue(ex.message!!.contains("Connection context: domain=localhost:8080, useServerProxy=false"))
+        assertTrue(ex.message!!.contains("useServerProxy=true"))
+        assertTrue(ex.message!!.contains("[docker].host_ip"))
+        assertTrue(ex.message!!.contains("Last error: connect ECONNREFUSED"))
+    }
+
+    @Test
+    fun `checkReady timeout should omit host_ip hint when server proxy is enabled`() {
+        val proxyEnabledConfig =
+            ConnectionConfig.builder()
+                .domain("localhost:8080")
+                .useServerProxy(true)
+                .build()
+        every { httpClientProvider.config } returns proxyEnabledConfig
+        every { healthService.ping(sandboxId) } returns false
+
+        val ex =
+            assertThrows(SandboxReadyTimeoutException::class.java) {
+                sandbox.checkReady(Duration.ofMillis(100), Duration.ofMillis(10))
+            }
+
+        assertTrue(ex.message!!.contains("useServerProxy=true"))
+        assertFalse(ex.message!!.contains("[docker].host_ip"))
     }
 }


### PR DESCRIPTION
## Summary
- enrich Kotlin SDK `checkReady` timeout message with:
  - connection context (`domain`, `useServerProxy`)
  - actionable bridge-network hints
- extend `SandboxTest` with assertions for the new diagnostics behavior

## Why
This makes timeout errors more actionable in bridge/remote deployment scenarios and aligns Kotlin SDK troubleshooting with recent Python/JavaScript/C# improvements.

## Validation
- attempted: `cd sdks/sandbox/kotlin && ./gradlew :sandbox:test --tests com.alibaba.opensandbox.sandbox.SandboxTest`
- could not run locally because this environment does not have a Java runtime installed
