### PR TITLE
docs(kubernetes): add C# SDK integration quickstart after controller setup

### DIFF
--- a/kubernetes/README-ZH.md
+++ b/kubernetes/README-ZH.md
@@ -261,6 +261,34 @@ kubectl get deployment -n opensandbox-system
 kubectl logs -n opensandbox-system -l control-plane=controller-manager -f
 ```
 
+**通过 C# SDK 接入（控制器就绪后）：**
+
+C# SDK 连接的是 **OpenSandbox 服务端 API**，而不是直接连接 controller Pod。
+当服务端已配置为 Kubernetes runtime 后，将 SDK `Domain` 指向服务端地址：
+
+```csharp
+using OpenSandbox;
+using OpenSandbox.Config;
+
+var config = new ConnectionConfig(new ConnectionConfigOptions
+{
+    Domain = "localhost:8080", // 替换为你的 OpenSandbox 服务端地址
+    ApiKey = "your-api-key",
+    UseServerProxy = true,     // 当客户端无法直连 sandbox endpoint 时建议开启
+});
+
+await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+{
+    ConnectionConfig = config,
+    Image = "python:3.11",
+});
+
+var execution = await sandbox.Commands.RunAsync("python -V");
+Console.WriteLine(execution.Logs.Stdout.FirstOrDefault()?.Text);
+```
+
+更多 C# SDK 细节请参考 [OpenSandbox C# SDK README](../sdks/sandbox/csharp/README_zh.md)。
+
 **升级：**
 
 ```sh

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -260,6 +260,34 @@ kubectl get deployment -n opensandbox-system
 kubectl logs -n opensandbox-system -l control-plane=controller-manager -f
 ```
 
+**Connect from C# SDK (after controller is ready):**
+
+The C# SDK talks to the **OpenSandbox server API**, not directly to the controller pod.
+After your server is configured to use Kubernetes runtime, point the SDK to the server domain:
+
+```csharp
+using OpenSandbox;
+using OpenSandbox.Config;
+
+var config = new ConnectionConfig(new ConnectionConfigOptions
+{
+    Domain = "localhost:8080", // Replace with your OpenSandbox server endpoint
+    ApiKey = "your-api-key",
+    UseServerProxy = true,     // Recommended when client cannot directly reach sandbox endpoints
+});
+
+await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+{
+    ConnectionConfig = config,
+    Image = "python:3.11",
+});
+
+var execution = await sandbox.Commands.RunAsync("python -V");
+Console.WriteLine(execution.Logs.Stdout.FirstOrDefault()?.Text);
+```
+
+For more C# SDK details, see [OpenSandbox C# SDK README](../sdks/sandbox/csharp/README.md).
+
 **Upgrade:**
 
 ```sh


### PR DESCRIPTION
## Summary
- add a C# SDK integration quickstart section to Kubernetes deployment docs (EN/ZH)
- clarify that C# SDK connects to OpenSandbox server API, not directly to controller pod
- include `UseServerProxy` guidance for environments where sandbox endpoints are not directly reachable

## Why
Issue #304 discussion asked how to integrate after controller startup (especially for C# users). This adds a copy-paste example in the Kubernetes deployment flow to reduce onboarding friction.

## Testing
- docs-only change
- manually reviewed markdown links and code snippet consistency with `sdks/sandbox/csharp/README.md`
