### PR TITLE
fix(server): validate list metadata query format strictly

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -149,7 +149,8 @@ async def list_sandboxes(
         from urllib.parse import parse_qsl
         try:
             # Parse query string format: key=value&key2=value2
-            parsed = parse_qsl(metadata)
+            # strict_parsing=True rejects malformed segments like "a=1&broken"
+            parsed = parse_qsl(metadata, keep_blank_values=True, strict_parsing=True)
             metadata_dict = dict(parsed)
         except Exception as e:
             from fastapi import HTTPException

--- a/server/tests/test_routes_list_sandboxes.py
+++ b/server/tests/test_routes_list_sandboxes.py
@@ -83,6 +83,55 @@ def test_list_sandboxes_parses_filters_and_pagination(
     assert captured_requests[0].pagination.page_size == 5
 
 
+def test_list_sandboxes_rejects_malformed_metadata_query(
+    client: TestClient,
+    auth_headers: dict,
+) -> None:
+    response = client.get(
+        "/v1/sandboxes",
+        params={"metadata": "team=infra&broken"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "INVALID_METADATA_FORMAT"
+    assert "bad query field" in response.json()["message"]
+
+
+def test_list_sandboxes_keeps_blank_metadata_values(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    captured_requests: list[object] = []
+
+    class StubService:
+        @staticmethod
+        def list_sandboxes(request) -> ListSandboxesResponse:
+            captured_requests.append(request)
+            return ListSandboxesResponse(
+                items=[],
+                pagination=PaginationInfo(
+                    page=1,
+                    pageSize=20,
+                    totalItems=0,
+                    totalPages=0,
+                    hasNextPage=False,
+                ),
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes",
+        params={"metadata": "team=infra&note="},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert captured_requests[0].filter.metadata == {"team": "infra", "note": ""}
+
+
 def test_list_sandboxes_validates_page_bounds(
     client: TestClient,
     auth_headers: dict,


### PR DESCRIPTION
## Summary
- switch `/v1/sandboxes` metadata parsing to strict query-string mode
- reject malformed metadata filters (e.g. `team=infra&broken`) with a clear `400 INVALID_METADATA_FORMAT`
- keep explicit blank values (e.g. `note=`) instead of dropping them implicitly
- add route tests for malformed metadata and blank-value metadata

## Why
`list_sandboxes` already had error handling intended for invalid metadata format, but default `parse_qsl` behavior silently tolerated malformed segments. This change aligns behavior with API expectations and makes client errors explicit.

## Testing
- `pytest -q server/tests/test_routes_list_sandboxes.py server/tests/test_routes_create_delete.py server/tests/test_routes_get_sandbox.py`
- result: 13 passed
