### PR TITLE
fix(readme): repair invalid LICENSE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
   </a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0.html">
-    <img src="https://img.shields.io/github/license/alibaba/OpenSandbox.svg" alt="license" />
+    <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="license" />
   </a>
   <a href="https://badge.fury.io/py/opensandbox">
     <img src="https://badge.fury.io/py/opensandbox.svg" alt="PyPI version" />
@@ -230,4 +230,3 @@ This project is open source under the [Apache 2.0 License](LICENSE).
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=alibaba/OpenSandbox&type=date&legend=top-left)](https://www.star-history.com/#alibaba/OpenSandbox&type=date&legend=top-left)
-

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -11,7 +11,7 @@
     <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
   </a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0.html">
-    <img src="https://img.shields.io/github/license/alibaba/OpenSandbox.svg" alt="license" />
+    <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="license" />
   </a>
   <a href="https://badge.fury.io/py/opensandbox">
     <img src="https://badge.fury.io/py/opensandbox.svg" alt="PyPI version" />


### PR DESCRIPTION
## Summary
- replace the dynamic GitHub license badge that shows `invalid`
- use a stable Apache 2.0 shields badge in both README files

## Testing
- manual verification of README badge links