### PR TITLE
docs: rename README doc links for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <hr />
 </div>
 
-[Document](https://open-sandbox.ai/) | [文档](https://open-sandbox.ai/zh/)
+[Documentation](https://open-sandbox.ai/) | [中文文档](https://open-sandbox.ai/zh/)
 
 OpenSandbox is a **general-purpose sandbox platform** for AI applications, offering multi-language SDKs, unified sandbox APIs, and Docker/Kubernetes runtimes for scenarios like Coding Agents, GUI Agents, Agent Evaluation, AI Code Execution, and RL Training.
 


### PR DESCRIPTION
## Summary
- change `Document` to `Documentation`
- change Chinese label to `中文文档`

## Why
The top-level language switch reads more naturally and is easier for users to scan.

## Testing
- [x] README markdown render check
