### PR TITLE
fix(server): prefix agent-sandbox resource name for DNS-1035 compliance

### DIFF
--- a/server/src/services/k8s/agent_sandbox_provider.py
+++ b/server/src/services/k8s/agent_sandbox_provider.py
@@ -118,11 +118,13 @@ class AgentSandboxProvider(WorkloadProvider):
         if self.service_account:
             pod_spec["serviceAccountName"] = self.service_account
 
+        resource_name = self.legacy_resource_name(sandbox_id)
+
         runtime_manifest = {
             "apiVersion": f"{self.group}/{self.version}",
             "kind": "Sandbox",
             "metadata": {
-                "name": sandbox_id,
+                "name": resource_name,
                 "namespace": namespace,
                 "labels": labels,
             },
@@ -325,16 +327,18 @@ class AgentSandboxProvider(WorkloadProvider):
         informer = self._get_informer(namespace)
         cache_ready = informer.has_synced if informer else False
 
+        resource_name = self.legacy_resource_name(sandbox_id)
+
         if informer and cache_ready:
-            cached = informer.get(sandbox_id)
+            cached = informer.get(resource_name)
             if cached:
                 return cached
 
-            legacy_name = self.legacy_resource_name(sandbox_id)
-            if legacy_name != sandbox_id:
-                legacy_cached = informer.get(legacy_name)
-                if legacy_cached:
-                    return legacy_cached
+            # Fallback for sandboxes created with raw UUID naming
+            if resource_name != sandbox_id:
+                raw_cached = informer.get(sandbox_id)
+                if raw_cached:
+                    return raw_cached
 
         if informer and not cache_ready:
             logger.warning(
@@ -347,7 +351,7 @@ class AgentSandboxProvider(WorkloadProvider):
                 version=self.version,
                 namespace=namespace,
                 plural=self.plural,
-                name=sandbox_id,
+                name=resource_name,
             )
             if informer and workload:
                 informer.update_cache(workload)
@@ -357,16 +361,15 @@ class AgentSandboxProvider(WorkloadProvider):
                 logger.error(f"Unexpected error getting Sandbox for {sandbox_id}: {e}")
                 raise
 
-        # Fallback for pre-upgrade sandboxes that used "sandbox-<id>" naming
-        legacy_name = self.legacy_resource_name(sandbox_id)
-        if legacy_name != sandbox_id:
+        # Fallback for sandboxes created with raw UUID naming
+        if resource_name != sandbox_id:
             try:
                 workload = self.custom_api.get_namespaced_custom_object(
                     group=self.group,
                     version=self.version,
                     namespace=namespace,
                     plural=self.plural,
-                    name=legacy_name,
+                    name=sandbox_id,
                 )
                 if informer and workload:
                     informer.update_cache(workload)

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -51,7 +51,7 @@ class TestAgentSandboxProvider:
         )
         mock_api = mock_k8s_client.get_custom_objects_api()
         mock_api.create_namespaced_custom_object.return_value = {
-            "metadata": {"name": "test-id", "uid": "test-uid"}
+            "metadata": {"name": "sandbox-test-id", "uid": "test-uid"}
         }
 
         expires_at = datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc)
@@ -68,12 +68,12 @@ class TestAgentSandboxProvider:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid"}
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         assert body["apiVersion"] == "agents.x-k8s.io/v1alpha1"
         assert body["kind"] == "Sandbox"
-        assert body["metadata"]["name"] == "test-id"
+        assert body["metadata"]["name"] == "sandbox-test-id"
         assert body["metadata"]["namespace"] == "test-ns"
         assert body["spec"]["replicas"] == 1
         assert body["spec"]["shutdownTime"] == "2025-12-31T10:00:00+00:00"
@@ -98,22 +98,37 @@ class TestAgentSandboxProvider:
 
         assert result is None
 
-    def test_get_workload_falls_back_to_legacy_name(self, mock_k8s_client):
+    def test_get_workload_tries_prefixed_name_first(self, mock_k8s_client):
         """
-        Test case: Verify legacy sandbox-<id> name is used when primary lookup 404s
+        Test case: Verify sandbox-<id> prefixed name is tried first
+        """
+        provider = AgentSandboxProvider(mock_k8s_client)
+        mock_api = mock_k8s_client.get_custom_objects_api()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test-id"}
+        }
+
+        result = provider.get_workload("test-id", "test-ns")
+
+        assert result["metadata"]["name"] == "sandbox-test-id"
+        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "sandbox-test-id"
+
+    def test_get_workload_falls_back_to_raw_uuid(self, mock_k8s_client):
+        """
+        Test case: Verify raw UUID is used as fallback when prefixed name 404s
         """
         provider = AgentSandboxProvider(mock_k8s_client)
         mock_api = mock_k8s_client.get_custom_objects_api()
         mock_api.get_namespaced_custom_object.side_effect = [
             ApiException(status=404),
-            {"metadata": {"name": "sandbox-test-id"}},
+            {"metadata": {"name": "test-id"}},
         ]
 
         result = provider.get_workload("test-id", "test-ns")
 
-        assert result["metadata"]["name"] == "sandbox-test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[1].kwargs["name"] == "sandbox-test-id"
+        assert result["metadata"]["name"] == "test-id"
+        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "sandbox-test-id"
+        assert mock_api.get_namespaced_custom_object.call_args_list[1].kwargs["name"] == "test-id"
 
     def test_get_workload_reraises_non_404_exceptions(self, mock_k8s_client):
         """
@@ -132,7 +147,7 @@ class TestAgentSandboxProvider:
         """
         Test case: Use informer cache when already synced
         """
-        cached = {"metadata": {"name": "test-id"}}
+        cached = {"metadata": {"name": "sandbox-test-id"}}
 
         class FakeInformer:
             def __init__(self):
@@ -143,7 +158,7 @@ class TestAgentSandboxProvider:
                 self.started = True
 
             def get(self, name):
-                return cached if name == "test-id" else None
+                return cached if name == "sandbox-test-id" else None
 
             def update_cache(self, obj):
                 self.updated = obj


### PR DESCRIPTION
## Summary

- The agent-sandbox provider uses the raw sandbox UUID (`uuid4()`) as the Kubernetes resource name directly. UUIDs can start with a digit (e.g. `19fa7291-...`), which violates DNS-1035 naming rules. The agent-sandbox controller then fails when creating the backing Service with that name.
- Prefix the resource name with `sandbox-` via the existing `legacy_resource_name()` helper, and swap the lookup order in `get_workload` to try the prefixed name first, falling back to raw UUID for backward compatibility.

## Testing

- [x] Unit tests: updated `test_agent_sandbox_provider.py` — 23 tests all passing
- [x] Verified `create_workload` now generates DNS-1035-compliant names
- [x] Verified `get_workload` lookup order: prefixed name first, raw UUID fallback

## Breaking Changes

None. Existing sandboxes created with raw UUID names are still accessible via the fallback path.

## Checklist

- [x] Linked issue: Fixes #318
- [x] Tests added/updated
- [x] No security impact
- [x] Backward compatible