### PR TITLE
fix(server): put force-include inline table on single line to fix TOML parse error

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -85,13 +85,7 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
-force-include = {
-    "example.config.toml" = "example.config.toml",
-    "example.config.zh.toml" = "example.config.zh.toml",
-    "example.config.k8s.toml" = "example.config.k8s.toml",
-    "example.config.k8s.zh.toml" = "example.config.k8s.zh.toml",
-    "example.batchsandbox-template.yaml" = "example.batchsandbox-template.yaml",
-}
+force-include = { "example.config.toml" = "example.config.toml", "example.config.zh.toml" = "example.config.zh.toml", "example.config.k8s.toml" = "example.config.k8s.toml", "example.config.k8s.zh.toml" = "example.config.k8s.zh.toml", "example.batchsandbox-template.yaml" = "example.batchsandbox-template.yaml" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# Summary
- put force-include inline table on single line to fix TOML parse error

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
