### PR TITLE
refactor(sdk-python): hoist HTTPX network error names in exception converter

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
@@ -40,6 +40,14 @@ from opensandbox.exceptions import (
 
 logger = logging.getLogger(__name__)
 
+HTTPX_NETWORK_ERROR_TYPES = {
+    "ConnectError",
+    "TimeoutException",
+    "NetworkError",
+    "ReadTimeout",
+    "WriteTimeout",
+}
+
 
 class ExceptionConverter:
     """
@@ -134,14 +142,7 @@ def _is_httpx_status_error(e: Exception) -> bool:
 
 def _is_httpx_network_error(e: Exception) -> bool:
     """Check if exception is an httpx network-related error."""
-    error_types = (
-        "ConnectError",
-        "TimeoutException",
-        "NetworkError",
-        "ReadTimeout",
-        "WriteTimeout",
-    )
-    return type(e).__name__ in error_types
+    return type(e).__name__ in HTTPX_NETWORK_ERROR_TYPES
 
 
 def _convert_unexpected_status_to_api_exception(e: Exception) -> SandboxApiException:


### PR DESCRIPTION
## Summary
- move the static HTTPX network error names from `_is_httpx_network_error` into a module-level constant
- reuse that constant for membership checks instead of constructing a tuple on every invocation
- keep exception mapping behavior unchanged

## Why
`_is_httpx_network_error` sits on the exception conversion path and can be called repeatedly under transient/network-failure conditions. Hoisting the constant removes repeated tuple construction and centralizes the canonical list of supported HTTPX network error names.

## Testing
- `python3 -m py_compile sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py`
- `python3 -m pytest tests/test_converters_and_error_handling.py -q`

## Compatibility
- no API or behavior changes
- same recognized error names, only storage location changed