### PR TITLE
Fix batch sandbox provider

### DIFF
--- a/server/src/config.py
+++ b/server/src/config.py
@@ -26,7 +26,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
@@ -231,6 +231,36 @@ class KubernetesRuntimeConfig(BaseModel):
     batchsandbox_template_file: Optional[str] = Field(
         default=None,
         description="Path to BatchSandbox CR YAML template file. Used when workload_provider is 'batchsandbox'.",
+    )
+    sandbox_create_timeout_seconds: int = Field(
+        default=60,
+        ge=1,
+        description="Timeout in seconds to wait for a sandbox to become ready (IP assigned) after creation.",
+    )
+    sandbox_create_poll_interval_seconds: float = Field(
+        default=1.0,
+        gt=0,
+        description="Polling interval in seconds when waiting for a sandbox to become ready after creation.",
+    )
+    execd_init_resources: Optional["ExecdInitResources"] = Field(
+        default=None,
+        description=(
+            "Resource requests/limits for the execd init container. "
+            "If unset, no resource constraints are applied."
+        ),
+    )
+
+
+class ExecdInitResources(BaseModel):
+    """Resource requests and limits for the execd init container."""
+
+    limits: Optional[Dict[str, str]] = Field(
+        default=None,
+        description='Resource limits, e.g. {cpu = "100m", memory = "128Mi"}.',
+    )
+    requests: Optional[Dict[str, str]] = Field(
+        default=None,
+        description='Resource requests, e.g. {cpu = "50m", memory = "64Mi"}.',
     )
 
 

--- a/server/src/services/k8s/agent_sandbox_provider.py
+++ b/server/src/services/k8s/agent_sandbox_provider.py
@@ -29,7 +29,7 @@ from kubernetes.client import (
     ApiException,
 )
 
-from src.config import AppConfig, IngressConfig
+from src.config import AppConfig, IngressConfig, ExecdInitResources
 from src.services.helpers import format_ingress_endpoint
 from src.api.schema import Endpoint, ImageSpec, NetworkPolicy
 from src.services.k8s.agent_sandbox_template import AgentSandboxTemplateManager
@@ -64,6 +64,7 @@ class AgentSandboxProvider(WorkloadProvider):
         informer_resync_seconds: int = 300,
         informer_watch_timeout_seconds: int = 60,
         app_config: Optional[AppConfig] = None,
+        execd_init_resources: Optional[ExecdInitResources] = None,
     ):
         self.k8s_client = k8s_client
         self.custom_api = k8s_client.get_custom_objects_api()
@@ -77,6 +78,7 @@ class AgentSandboxProvider(WorkloadProvider):
         self.service_account = service_account
         self.template_manager = AgentSandboxTemplateManager(template_file_path)
         self.ingress_config = ingress_config
+        self.execd_init_resources = execd_init_resources
         self._enable_informer = enable_informer
         self._informer_factory = informer_factory or (
             lambda ns: WorkloadInformer(
@@ -213,7 +215,7 @@ class AgentSandboxProvider(WorkloadProvider):
         # Inject runtimeClassName if secure runtime is configured
         if self.runtime_class:
             pod_spec["runtimeClassName"] = self.runtime_class
-        
+
         # Add egress sidecar if network policy is provided
         apply_egress_to_spec(
             pod_spec=pod_spec,
@@ -232,6 +234,13 @@ class AgentSandboxProvider(WorkloadProvider):
             "chmod +x /opt/opensandbox/bin/bootstrap.sh"
         )
 
+        resources = None
+        if self.execd_init_resources:
+            resources = V1ResourceRequirements(
+                limits=self.execd_init_resources.limits,
+                requests=self.execd_init_resources.requests,
+            )
+
         return V1Container(
             name="execd-installer",
             image=execd_image,
@@ -243,6 +252,7 @@ class AgentSandboxProvider(WorkloadProvider):
                     mount_path="/opt/opensandbox/bin",
                 )
             ],
+            resources=resources,
         )
 
     def _build_main_container(
@@ -516,6 +526,14 @@ class AgentSandboxProvider(WorkloadProvider):
         }
 
     def _pod_state_from_selector(self, workload: Dict[str, Any]) -> Optional[tuple[str, str, str]]:
+        """Resolve state from Pod list via label selector.
+
+        Returns three-state tuple (state, reason, message):
+        - Running: Pod phase Running and has IP
+        - Allocated: Pod has IP assigned but not Running yet
+        - Pending: Pod scheduled but no IP yet
+        Returns None if selector/namespace missing or API call fails.
+        """
         status = workload.get("status", {})
         selector = status.get("selector")
         namespace = workload.get("metadata", {}).get("namespace")
@@ -531,17 +549,23 @@ class AgentSandboxProvider(WorkloadProvider):
             return None
 
         for pod in pods:
-            if pod.status and pod.status.phase == "Running":
-                if pod.status.pod_ip:
+            if pod.status:
+                if pod.status.pod_ip and pod.status.phase == "Running":
                     return (
                         "Running",
                         "POD_READY",
                         "Pod is running with IP assigned",
                     )
+                if pod.status.pod_ip:
+                    return (
+                        "Allocated",
+                        "IP_ASSIGNED",
+                        "Pod has IP assigned but not running yet",
+                    )
                 return (
                     "Pending",
-                    "POD_READY_NO_IP",
-                    "Pod is running but waiting for IP assignment",
+                    "POD_SCHEDULED",
+                    "Pod is scheduled but waiting for IP assignment",
                 )
 
         if pods:

--- a/server/src/services/k8s/batchsandbox_provider.py
+++ b/server/src/services/k8s/batchsandbox_provider.py
@@ -16,6 +16,7 @@
 BatchSandbox-based workload provider implementation.
 """
 
+import json
 import logging
 import shlex
 from datetime import datetime
@@ -30,7 +31,7 @@ from kubernetes.client import (
     ApiException,
 )
 
-from src.config import AppConfig, IngressConfig, INGRESS_MODE_GATEWAY
+from src.config import AppConfig, IngressConfig, INGRESS_MODE_GATEWAY, ExecdInitResources
 from src.services.helpers import format_ingress_endpoint
 from src.api.schema import Endpoint, ImageSpec, NetworkPolicy
 from src.services.k8s.batchsandbox_template import BatchSandboxTemplateManager
@@ -66,6 +67,7 @@ class BatchSandboxProvider(WorkloadProvider):
         informer_resync_seconds: int = 300,
         informer_watch_timeout_seconds: int = 60,
         app_config: Optional[AppConfig] = None,
+        execd_init_resources: Optional[ExecdInitResources] = None,
     ):
         """
         Initialize BatchSandbox provider.
@@ -84,7 +86,7 @@ class BatchSandboxProvider(WorkloadProvider):
         self.runtime_class = (
             self.resolver.get_k8s_runtime_class() if self.resolver else None
         )
-        
+
         # CRD constants
         self.group = "sandbox.opensandbox.io"
         self.version = "v1alpha1"
@@ -92,6 +94,7 @@ class BatchSandboxProvider(WorkloadProvider):
         
         # Template manager
         self.template_manager = BatchSandboxTemplateManager(template_file_path)
+        self.execd_init_resources = execd_init_resources
         self._enable_informer = enable_informer
         self._informer_factory = informer_factory or (
             lambda ns: WorkloadInformer(
@@ -204,7 +207,7 @@ class BatchSandboxProvider(WorkloadProvider):
         # Inject runtimeClassName if secure runtime is configured
         if self.runtime_class:
             pod_spec["runtimeClassName"] = self.runtime_class
-        
+
         # Add egress sidecar if network policy is provided
         apply_egress_to_spec(
             pod_spec=pod_spec,
@@ -468,7 +471,14 @@ class BatchSandboxProvider(WorkloadProvider):
             "chmod +x /opt/opensandbox/bin/execd && "
             "chmod +x /opt/opensandbox/bin/bootstrap.sh"
         )
-        
+
+        resources = None
+        if self.execd_init_resources:
+            resources = V1ResourceRequirements(
+                limits=self.execd_init_resources.limits,
+                requests=self.execd_init_resources.requests,
+            )
+
         return V1Container(
             name="execd-installer",
             image=execd_image,
@@ -480,6 +490,7 @@ class BatchSandboxProvider(WorkloadProvider):
                     mount_path="/opt/opensandbox/bin"
                 )
             ],
+            resources=resources,
         )
     
     def _build_main_container(
@@ -760,6 +771,24 @@ class BatchSandboxProvider(WorkloadProvider):
             logger.warning(f"Invalid expireTime format: {expire_time_str}, error: {e}")
             return None
     
+    def _parse_pod_ip(self, workload: Dict[str, Any]) -> Optional[str]:
+        """Parse the first Pod IP from the endpoints annotation.
+
+        Returns the IP string if the annotation exists and contains a non-empty
+        JSON array, otherwise returns None.
+        """
+        annotations = workload.get("metadata", {}).get("annotations", {})
+        endpoints_str = annotations.get("sandbox.opensandbox.io/endpoints")
+        if not endpoints_str:
+            return None
+        try:
+            endpoints = json.loads(endpoints_str)
+            if endpoints and len(endpoints) > 0:
+                return endpoints[0]
+        except (json.JSONDecodeError, IndexError, TypeError):
+            pass
+        return None
+
     def get_status(self, workload: Dict[str, Any]) -> Dict[str, Any]:
         """
         Get status from BatchSandbox.
@@ -774,32 +803,29 @@ class BatchSandboxProvider(WorkloadProvider):
         replicas = status.get("replicas", 0)
         ready = status.get("ready", 0)
         allocated = status.get("allocated", 0)
-        
-        # Get annotations for endpoint information
-        annotations = workload.get("metadata", {}).get("annotations", {})
-        endpoints_str = annotations.get("sandbox.opensandbox.io/endpoints")
-        
-        # Determine state based on ready status and endpoint availability
-        if ready == 1 and endpoints_str:
-            # Pod is ready and has an IP address assigned
+
+        pod_ip = self._parse_pod_ip(workload)
+
+        # Determine state: Pending -> Allocated (IP assigned) -> Running (Pod ready)
+        if ready == 1 and pod_ip:
+            # Pod is ready and has IP
             state = "Running"
-            reason = "READY_WITH_IP"
-            message = f"Pod is ready with IP assigned ({ready}/{replicas} ready)"
-        elif ready > 0:
-            # Pod is ready but no IP yet - still pending
-            state = "Pending"
-            reason = "POD_READY_NO_IP"
-            message = f"Pod is ready but waiting for IP assignment ({ready}/{replicas} ready)"
-        elif allocated > 0:
-            # Pod is allocated/scheduled but not ready yet
-            state = "Pending"
-            reason = "POD_SCHEDULED"
-            message = f"Pod is scheduled but not ready ({allocated}/{replicas} allocated, {ready} ready)"
+            reason = "POD_READY_WITH_IP"
+            message = f"Pod is ready with IP ({ready}/{replicas} ready)"
+        elif pod_ip:
+            # Pod has IP assigned but not ready yet
+            state = "Allocated"
+            reason = "IP_ASSIGNED"
+            message = f"Pod has IP assigned but not ready ({allocated}/{replicas} allocated, {ready} ready)"
         else:
-            # Pod is not allocated yet
+            # Pod is not allocated yet or allocated but no IP
             state = "Pending"
-            reason = "BATCHSANDBOX_PENDING"
-            message = "BatchSandbox is pending allocation"
+            reason = "POD_SCHEDULED" if allocated > 0 else "BATCHSANDBOX_PENDING"
+            message = (
+                f"Pod is scheduled but waiting for IP ({allocated}/{replicas} allocated, {ready} ready)"
+                if allocated > 0
+                else "BatchSandbox is pending allocation"
+            )
         
         # Get creation timestamp
         creation_timestamp = workload.get("metadata", {}).get("creationTimestamp")
@@ -817,26 +843,10 @@ class BatchSandboxProvider(WorkloadProvider):
         - gateway mode: use ingress config to format endpoint
         - direct/default: resolve Pod IP from annotation
         """
-        import json
-
         if self.ingress_config and self.ingress_config.mode == INGRESS_MODE_GATEWAY:
             return format_ingress_endpoint(self.ingress_config, sandbox_id, port)
 
-        annotations = workload.get("metadata", {}).get("annotations", {})
-        
-        # Get endpoints from annotation
-        endpoints_str = annotations.get("sandbox.opensandbox.io/endpoints")
-        if not endpoints_str:
+        pod_ip = self._parse_pod_ip(workload)
+        if not pod_ip:
             return None
-
-        try:
-            # Parse JSON array of IPs
-            endpoints = json.loads(endpoints_str)
-            if endpoints and len(endpoints) > 0:
-                # Use the first IP
-                pod_ip = endpoints[0]
-                return Endpoint(endpoint=f"{pod_ip}:{port}")
-        except (json.JSONDecodeError, IndexError, TypeError):
-            return None
-
-        return None
+        return Endpoint(endpoint=f"{pod_ip}:{port}")

--- a/server/src/services/k8s/kubernetes_service.py
+++ b/server/src/services/k8s/kubernetes_service.py
@@ -188,18 +188,8 @@ class KubernetesSandboxService(SandboxService):
                     last_state = current_state
                     last_message = current_message
                 
-                # Check if Failed
-                if current_state == "Failed":
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail={
-                            "code": SandboxErrorCodes.K8S_POD_FAILED,
-                            "message": f"Pod failed: {current_message}",
-                        },
-                    )
-                
-                # Check if Running
-                if current_state == "Running":
+                # Check if Running or Allocated (IP assigned)
+                if current_state in ("Running", "Allocated"):
                     return workload
                 
             except HTTPException:
@@ -308,8 +298,8 @@ class KubernetesSandboxService(SandboxService):
             try:
                 workload = self._wait_for_sandbox_ready(
                     sandbox_id=sandbox_id,
-                    timeout_seconds=60,
-                    poll_interval_seconds=1.0,
+                    timeout_seconds=self.app_config.kubernetes.sandbox_create_timeout_seconds,
+                    poll_interval_seconds=self.app_config.kubernetes.sandbox_create_poll_interval_seconds,
                 )
                 
                 # Get final status

--- a/server/src/services/k8s/provider_factory.py
+++ b/server/src/services/k8s/provider_factory.py
@@ -100,6 +100,7 @@ def create_workload_provider(
             informer_resync_seconds=k8s_config.informer_resync_seconds,
             informer_watch_timeout_seconds=k8s_config.informer_watch_timeout_seconds,
             app_config=app_config,
+            execd_init_resources=k8s_config.execd_init_resources if k8s_config else None,
         )
 
     # Special handling for AgentSandboxProvider - pass agent-specific settings
@@ -119,6 +120,7 @@ def create_workload_provider(
                 k8s_config.informer_watch_timeout_seconds if k8s_config else 60
             ),
             app_config=app_config,
+            execd_init_resources=k8s_config.execd_init_resources if k8s_config else None,
         )
 
     # Providers without ingress-specific needs

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -24,6 +24,7 @@ import pytest
 from kubernetes.client import ApiException
 
 from src.api.schema import ImageSpec, NetworkPolicy, NetworkRule
+from src.config import ExecdInitResources
 from src.services.k8s.agent_sandbox_provider import AgentSandboxProvider
 
 
@@ -316,7 +317,7 @@ class TestAgentSandboxProvider:
 
     def test_get_status_falls_back_to_pod_state(self, mock_k8s_client):
         """
-        Test case: Verify status fallback uses pod selector state
+        Test case: Verify status fallback uses pod selector state (Running + IP = Running)
         """
         provider = AgentSandboxProvider(mock_k8s_client)
         core_api = mock_k8s_client.get_core_v1_api()
@@ -336,6 +337,29 @@ class TestAgentSandboxProvider:
 
         assert result["state"] == "Running"
         assert result["reason"] == "POD_READY"
+
+    def test_get_status_falls_back_to_allocated_when_ip_assigned_not_running(self, mock_k8s_client):
+        """
+        Test case: Verify Allocated state when Pod has IP but is not Running yet
+        """
+        provider = AgentSandboxProvider(mock_k8s_client)
+        core_api = mock_k8s_client.get_core_v1_api()
+        core_api.list_namespaced_pod.return_value = MagicMock(
+            items=[
+                SimpleNamespace(
+                    status=SimpleNamespace(phase="Pending", pod_ip="10.0.0.2")
+                )
+            ]
+        )
+        workload = {
+            "status": {"conditions": [], "selector": "app=sandbox"},
+            "metadata": {"creationTimestamp": "2025-12-31T09:00:00Z", "namespace": "test-ns"},
+        }
+
+        result = provider.get_status(workload)
+
+        assert result["state"] == "Allocated"
+        assert result["reason"] == "IP_ASSIGNED"
 
     def test_get_endpoint_info_prefers_running_pod(self, mock_k8s_client):
         """
@@ -376,6 +400,70 @@ class TestAgentSandboxProvider:
 
         assert endpoint.endpoint == "svc.example.com:9000"
         assert endpoint.headers is None
+
+
+class TestAgentSandboxProviderExecdInit:
+    """AgentSandboxProvider execd init container resource tests"""
+
+    def test_init_container_has_no_resources_when_not_configured(self, mock_k8s_client):
+        """
+        Test case: Verify init container has no resources when execd_init_resources is not set
+        """
+        provider = AgentSandboxProvider(mock_k8s_client)
+        mock_api = mock_k8s_client.get_custom_objects_api()
+        mock_api.create_namespaced_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        init_containers = body["spec"]["podTemplate"]["spec"]["initContainers"]
+        assert len(init_containers) == 1
+        assert "resources" not in init_containers[0]
+
+    def test_init_container_has_resources_when_configured(self, mock_k8s_client):
+        """
+        Test case: Verify init container applies resources when execd_init_resources is set
+        """
+        provider = AgentSandboxProvider(
+            mock_k8s_client,
+            execd_init_resources=ExecdInitResources(
+                limits={"cpu": "100m", "memory": "128Mi"},
+                requests={"cpu": "50m", "memory": "64Mi"},
+            ),
+        )
+        mock_api = mock_k8s_client.get_custom_objects_api()
+        mock_api.create_namespaced_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        init_containers = body["spec"]["podTemplate"]["spec"]["initContainers"]
+        assert init_containers[0]["resources"]["limits"] == {"cpu": "100m", "memory": "128Mi"}
+        assert init_containers[0]["resources"]["requests"] == {"cpu": "50m", "memory": "64Mi"}
 
 
 class TestAgentSandboxProviderEgress:

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 from kubernetes.client import ApiException
 
 from src.api.schema import ImageSpec, NetworkPolicy, NetworkRule
+from src.config import ExecdInitResources
 from src.services.k8s.batchsandbox_provider import BatchSandboxProvider
 
 
@@ -108,7 +109,7 @@ class TestBatchSandboxProvider:
     
     def test_create_workload_builds_execd_init_container(self, mock_k8s_client):
         """
-        Test case: Verify execd init container built correctly
+        Test case: Verify execd init container built correctly without resources when not configured
         """
         provider = BatchSandboxProvider(mock_k8s_client)
         mock_api = mock_k8s_client.get_custom_objects_api()
@@ -136,6 +137,41 @@ class TestBatchSandboxProvider:
         assert init_container["command"] == ["/bin/sh", "-c"]
         assert "bootstrap.sh" in init_container["args"][0]
         assert init_container["volumeMounts"][0]["name"] == "opensandbox-bin"
+        # No resources configured: resources field should be absent
+        assert "resources" not in init_container
+
+    def test_create_workload_init_container_with_configured_resources(self, mock_k8s_client):
+        """
+        Test case: Verify init container applies resources when execd_init_resources is configured
+        """
+        provider = BatchSandboxProvider(
+            mock_k8s_client,
+            execd_init_resources=ExecdInitResources(
+                limits={"cpu": "100m", "memory": "128Mi"},
+                requests={"cpu": "50m", "memory": "64Mi"},
+            ),
+        )
+        mock_api = mock_k8s_client.get_custom_objects_api()
+        mock_api.create_namespaced_custom_object.return_value = {
+            "metadata": {"name": "test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:test",
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        init_container = body["spec"]["template"]["spec"]["initContainers"][0]
+        assert init_container["resources"]["limits"] == {"cpu": "100m", "memory": "128Mi"}
+        assert init_container["resources"]["requests"] == {"cpu": "50m", "memory": "64Mi"}
     
     def test_create_workload_wraps_entrypoint_with_bootstrap(self, mock_k8s_client):
         """
@@ -741,23 +777,28 @@ spec:
         result = provider.get_status(workload)
         
         assert result["state"] == "Running"
-        assert result["reason"] == "READY_WITH_IP"
-        assert "IP assigned" in result["message"]
+        assert result["reason"] == "POD_READY_WITH_IP"
+        assert "IP" in result["message"]
     
-    def test_get_status_pending_ready_without_ip(self):
+    def test_get_status_allocated_with_ip_not_ready(self):
         """
-        Test case: Verify status when Pod is Ready but has no IP (should be Pending)
+        Test case: Verify status when IP is assigned but Pod is not Ready (Allocated state)
         """
         provider = BatchSandboxProvider(MagicMock())
         workload = {
-            "status": {"replicas": 1, "ready": 1, "allocated": 1},
-            "metadata": {"creationTimestamp": "2025-12-24T10:00:00Z"}
+            "status": {"replicas": 1, "ready": 0, "allocated": 1},
+            "metadata": {
+                "annotations": {
+                    "sandbox.opensandbox.io/endpoints": '["10.0.0.1"]'
+                },
+                "creationTimestamp": "2025-12-24T10:00:00Z"
+            }
         }
         
         result = provider.get_status(workload)
         
-        assert result["state"] == "Pending"
-        assert result["reason"] == "POD_READY_NO_IP"
+        assert result["state"] == "Allocated"
+        assert result["reason"] == "IP_ASSIGNED"
     
     def test_get_status_pending_scheduled(self):
         """
@@ -771,6 +812,46 @@ spec:
         
         result = provider.get_status(workload)
         
+        assert result["state"] == "Pending"
+        assert result["reason"] == "POD_SCHEDULED"
+    
+    def test_get_status_pending_when_endpoints_invalid_json(self):
+        """
+        Test case: Verify Pending when endpoints annotation contains invalid JSON
+        """
+        provider = BatchSandboxProvider(MagicMock())
+        workload = {
+            "status": {"replicas": 1, "ready": 0, "allocated": 1},
+            "metadata": {
+                "annotations": {
+                    "sandbox.opensandbox.io/endpoints": "invalid-json"
+                },
+                "creationTimestamp": "2025-12-24T10:00:00Z"
+            }
+        }
+
+        result = provider.get_status(workload)
+
+        assert result["state"] == "Pending"
+        assert result["reason"] == "POD_SCHEDULED"
+
+    def test_get_status_pending_when_endpoints_empty_array(self):
+        """
+        Test case: Verify Pending when endpoints annotation is empty array
+        """
+        provider = BatchSandboxProvider(MagicMock())
+        workload = {
+            "status": {"replicas": 1, "ready": 0, "allocated": 1},
+            "metadata": {
+                "annotations": {
+                    "sandbox.opensandbox.io/endpoints": "[]"
+                },
+                "creationTimestamp": "2025-12-24T10:00:00Z"
+            }
+        }
+
+        result = provider.get_status(workload)
+
         assert result["state"] == "Pending"
         assert result["reason"] == "POD_SCHEDULED"
     

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -121,6 +121,42 @@ class TestKubernetesSandboxServiceCreate:
         assert response.status.state == "Running"
         k8s_service.workload_provider.create_workload.assert_called_once()
 
+    def test_create_sandbox_uses_configured_timeout_and_poll_interval(
+        self, k8s_service, create_sandbox_request, mock_workload
+    ):
+        """
+        Test case: create_sandbox uses timeout and poll_interval from config
+
+        Purpose: Verify that sandbox_create_timeout_seconds and
+        sandbox_create_poll_interval_seconds are read from KubernetesRuntimeConfig
+        and forwarded to _wait_for_sandbox_ready.
+        """
+        from unittest.mock import patch
+
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-123",
+            "uid": "abc-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Pod is running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+
+        # Override config values
+        k8s_service.app_config.kubernetes.sandbox_create_timeout_seconds = 120
+        k8s_service.app_config.kubernetes.sandbox_create_poll_interval_seconds = 0.5
+
+        with patch.object(k8s_service, "_wait_for_sandbox_ready", wraps=k8s_service._wait_for_sandbox_ready) as mock_wait:
+            k8s_service.create_sandbox(create_sandbox_request)
+
+        mock_wait.assert_called_once()
+        _, kwargs = mock_wait.call_args
+        assert kwargs["timeout_seconds"] == 120
+        assert kwargs["poll_interval_seconds"] == 0.5
+
 
 class TestWaitForSandboxReady:
     """_wait_for_sandbox_ready method tests"""
@@ -145,14 +181,14 @@ class TestWaitForSandboxReady:
     
     def test_wait_for_pending_then_running_succeeds(self, k8s_service, mock_workload):
         """
-        Test case: Successfully wait from Pending to Running
+        Test case: Successfully wait from Pending to Allocated to Running
         
-        Purpose: Verify normal waiting when Pod transitions from Pending to Running state
+        Purpose: Verify normal waiting when Pod transitions through Pending -> Allocated -> Running
         """
-        # Mock state transition: Pending -> Running
+        # Mock state transition: Pending -> Allocated -> Running
         status_sequence = [
             {"state": "Pending", "reason": "", "message": "Pending", "last_transition_at": datetime.now(timezone.utc)},
-            {"state": "Pending", "reason": "", "message": "Pulling image", "last_transition_at": datetime.now(timezone.utc)},
+            {"state": "Allocated", "reason": "IP_ASSIGNED", "message": "IP assigned", "last_transition_at": datetime.now(timezone.utc)},
             {"state": "Running", "reason": "", "message": "Running", "last_transition_at": datetime.now(timezone.utc)},
         ]
         
@@ -162,27 +198,25 @@ class TestWaitForSandboxReady:
         result = k8s_service._wait_for_sandbox_ready("test-sandbox-id", timeout_seconds=10, poll_interval_seconds=0.1)
         
         assert result == mock_workload
-        assert k8s_service.workload_provider.get_status.call_count == 3
+        assert k8s_service.workload_provider.get_status.call_count == 2
     
-    def test_wait_for_failed_pod_raises_exception(self, k8s_service, mock_workload):
+    def test_wait_for_allocated_pod_returns_immediately(self, k8s_service, mock_workload):
         """
-        Test case: Raises exception for Failed Pod
+        Test case: Returns immediately when Pod reaches Allocated state (IP assigned)
         
-        Purpose: Verify that HTTPException is raised when Pod enters Failed state
+        Purpose: Verify that Allocated state (IP assigned) is treated as ready
         """
         k8s_service.workload_provider.get_workload.return_value = mock_workload
         k8s_service.workload_provider.get_status.return_value = {
-            "state": "Failed",
-            "reason": "ImagePullBackOff",
-            "message": "Failed to pull image",
+            "state": "Allocated",
+            "reason": "IP_ASSIGNED",
+            "message": "Pod has IP assigned",
             "last_transition_at": datetime.now(timezone.utc),
         }
         
-        with pytest.raises(HTTPException) as exc_info:
-            k8s_service._wait_for_sandbox_ready("test-sandbox-id", timeout_seconds=10)
+        result = k8s_service._wait_for_sandbox_ready("test-sandbox-id", timeout_seconds=10)
         
-        assert exc_info.value.status_code == 500
-        assert "Failed to pull image" in exc_info.value.detail["message"]
+        assert result == mock_workload
     
     def test_wait_timeout_raises_exception(self, k8s_service, mock_workload):
         """


### PR DESCRIPTION
# Summary
  (1) Fix create sandbox timeout in k8s service. No need to wait pod running when create sandbox.
  (2) Add configurable resources in execd init container.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [x] Backward compatibility considered
