### PR TITLE
fix(k8s): ensure agent sandbox names are DNS-1035 compatible

### DIFF
--- a/server/src/services/k8s/agent_sandbox_provider.py
+++ b/server/src/services/k8s/agent_sandbox_provider.py
@@ -17,6 +17,7 @@ Agent-sandbox workload provider implementation.
 """
 
 import logging
+import re
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Callable
 from threading import Lock
@@ -45,6 +46,7 @@ from src.services.k8s.workload_provider import WorkloadProvider
 from src.services.runtime_resolver import SecureRuntimeResolver
 
 logger = logging.getLogger(__name__)
+DNS_1035_LABEL_RE = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
 
 
 class AgentSandboxProvider(WorkloadProvider):
@@ -122,6 +124,10 @@ class AgentSandboxProvider(WorkloadProvider):
                 sandbox_id,
             )
 
+        # agent-sandbox controller creates a Service with the same name.
+        # Ensure the workload name is DNS-1035 compatible to avoid service creation failures.
+        workload_name = self._resolve_workload_name(sandbox_id)
+
         pod_spec = self._build_pod_spec(
             image_spec=image_spec,
             entrypoint=entrypoint,
@@ -139,7 +145,7 @@ class AgentSandboxProvider(WorkloadProvider):
             "apiVersion": f"{self.group}/{self.version}",
             "kind": "Sandbox",
             "metadata": {
-                "name": sandbox_id,
+                "name": workload_name,
                 "namespace": namespace,
                 "labels": labels,
             },
@@ -177,6 +183,11 @@ class AgentSandboxProvider(WorkloadProvider):
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
         }
+
+    def _resolve_workload_name(self, sandbox_id: str) -> str:
+        if DNS_1035_LABEL_RE.match(sandbox_id):
+            return sandbox_id
+        return self.legacy_resource_name(sandbox_id)
 
     def _build_pod_spec(
         self,
@@ -599,4 +610,3 @@ class AgentSandboxProvider(WorkloadProvider):
             return Endpoint(endpoint=f"{service_fqdn}:{port}")
 
         return None
-

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -84,6 +84,35 @@ class TestAgentSandboxProvider:
         assert "containers" in body["spec"]["podTemplate"]["spec"]
         assert "volumes" in body["spec"]["podTemplate"]["spec"]
 
+    def test_create_workload_prefixes_name_when_sandbox_id_is_not_dns_1035(
+        self, mock_k8s_client
+    ):
+        provider = AgentSandboxProvider(mock_k8s_client)
+        mock_api = mock_k8s_client.get_custom_objects_api()
+        sandbox_id = "19fa7291-431b-4636-8251-e8d8e2646f35"
+        prefixed_name = f"sandbox-{sandbox_id}"
+        mock_api.create_namespaced_custom_object.return_value = {
+            "metadata": {"name": prefixed_name, "uid": "test-uid"}
+        }
+
+        expires_at = datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc)
+
+        result = provider.create_workload(
+            sandbox_id=sandbox_id,
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={"FOO": "bar"},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": sandbox_id},
+            expires_at=expires_at,
+            execd_image="execd:latest",
+        )
+
+        assert result == {"name": prefixed_name, "uid": "test-uid"}
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        assert body["metadata"]["name"] == prefixed_name
+
     def test_get_workload_returns_none_on_404(self, mock_k8s_client):
         """
         Test case: Verify None returned on 404 exception


### PR DESCRIPTION
## Summary
- ensure AgentSandbox workload names are DNS-1035 compatible before create
- when `sandbox_id` is not DNS-1035 compliant (e.g. starts with a digit), fallback to `sandbox-<id>` naming
- add regression test for digit-prefixed UUID sandbox IDs

## Why
Issue #318 reports agent-sandbox creation failure when generated sandbox IDs start with a digit. The controller creates a Service with the same name, and Kubernetes rejects DNS-1035-invalid names.

## Testing
- `pytest -q server/tests/k8s/test_agent_sandbox_provider.py`
- `pytest -q server/tests/k8s/test_kubernetes_service.py`

Closes #318
