### PR TITLE
fix(k8s): reject unsupported image.auth with actionable error

### DIFF
--- a/server/src/services/k8s/kubernetes_service.py
+++ b/server/src/services/k8s/kubernetes_service.py
@@ -224,6 +224,26 @@ class KubernetesSandboxService(SandboxService):
         """
         # Common validation: egress.image must be configured
         ensure_egress_configured(request.network_policy, self.app_config.egress)
+
+    def _ensure_image_auth_support(self, request: CreateSandboxRequest) -> None:
+        """
+        Validate image auth support for Kubernetes runtime.
+
+        K8s runtime currently does not map per-request image.auth to imagePullSecrets.
+        """
+        if request.image.auth is None:
+            return
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "image.auth is not supported in Kubernetes runtime yet. "
+                    "Use imagePullSecrets via Kubernetes ServiceAccount or sandbox template."
+                ),
+            },
+        )
     
     def create_sandbox(self, request: CreateSandboxRequest) -> CreateSandboxResponse:
         """
@@ -244,6 +264,7 @@ class KubernetesSandboxService(SandboxService):
         ensure_entrypoint(request.entrypoint)
         ensure_metadata_labels(request.metadata)
         self._ensure_network_policy_support(request)
+        self._ensure_image_auth_support(request)
         
         # Generate sandbox ID
         sandbox_id = self.generate_sandbox_id()

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -23,7 +23,7 @@ from fastapi import HTTPException
 
 from src.services.k8s.kubernetes_service import KubernetesSandboxService
 from src.services.constants import SandboxErrorCodes
-from src.api.schema import ListSandboxesRequest
+from src.api.schema import ImageAuth, ListSandboxesRequest
 
 
 class TestKubernetesSandboxServiceInit:
@@ -156,6 +156,22 @@ class TestKubernetesSandboxServiceCreate:
         _, kwargs = mock_wait.call_args
         assert kwargs["timeout_seconds"] == 120
         assert kwargs["poll_interval_seconds"] == 0.5
+
+    def test_create_sandbox_rejects_image_auth_for_k8s_runtime(
+        self, k8s_service, create_sandbox_request
+    ):
+        create_sandbox_request.image.auth = ImageAuth(
+            username="registry-user",
+            password="registry-pass",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service.create_sandbox(create_sandbox_request)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == SandboxErrorCodes.INVALID_PARAMETER
+        assert "imagePullSecrets" in exc_info.value.detail["message"]
+        k8s_service.workload_provider.create_workload.assert_not_called()
 
 
 class TestWaitForSandboxReady:


### PR DESCRIPTION
## Summary
- add explicit validation in Kubernetes runtime to reject per-request `image.auth`
- return `400 INVALID_PARAMETER` with actionable guidance to use `imagePullSecrets`
- add unit test to verify fail-fast behavior and ensure no workload is created

## Why
Issue #328 shows user confusion when private images fail in K8s mode. Today `image.auth` is silently ignored in K8s runtime, which leads to late timeout errors and poor debuggability. Failing fast with a clear message prevents misconfiguration.

## Testing
- `pytest -q server/tests/k8s/test_kubernetes_service.py`
- result: 20 passed

Refs #328
