### PR TITLE
docs(kubernetes): clarify pause/resume API support status

### DIFF
--- a/kubernetes/README-ZH.md
+++ b/kubernetes/README-ZH.md
@@ -42,6 +42,12 @@ Pool 自定义资源维护一个预热的计算资源池，以实现快速沙箱
 - 池范围的容量限制，防止资源耗尽
 - 基于需求的自动扩展
 
+## 运行时 API 支持说明
+
+- Kubernetes 运行时当前**不支持** `pause` / `resume` 生命周期 API。
+- 对 Kubernetes 运行时调用这两个 API 会返回 `501 Not Implemented`。
+- OpenSandbox 的 pause/resume 语义是保留容器进程内存态后再恢复；当前 Kubernetes provider 主要覆盖 create/get/list/delete/renew 流程。
+
 
 ## 与 [kubernates-sigs/agent-sandbox](kubernates-sigs/agent-sandbox) 的关系
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -42,6 +42,12 @@ Intelligent resource management features:
 - Pool-wide capacity limits to prevent resource exhaustion
 - Automatic scaling based on demand
 
+## Runtime API Support Notes
+
+- `pause` / `resume` lifecycle APIs are currently **not supported** by the Kubernetes runtime.
+- Calling these APIs against Kubernetes runtime returns `501 Not Implemented`.
+- Pause/resume semantics in OpenSandbox mean preserving in-memory process state (container-level suspend/resume). Kubernetes provider currently focuses on create/get/list/delete/renew workflows.
+
 
 ## Relationship with [kubernates-sigs/agent-sandbox](kubernates-sigs/agent-sandbox)
 


### PR DESCRIPTION
## Summary
- add a dedicated runtime API support note in Kubernetes docs (EN/ZH)
- explicitly document that `pause`/`resume` APIs return `501 Not Implemented` in Kubernetes runtime
- clarify pause/resume semantics to avoid confusion with create/delete lifecycle

## Why
Issue #354 asks whether Kubernetes runtime supports pause/resume and what pause means. This documentation update makes current behavior explicit and reduces integration ambiguity.

## Testing
- docs-only change
- verified wording against current Kubernetes service behavior (`pause_sandbox`/`resume_sandbox` return 501)

Refs #354
