### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting Security Issues
+
+The OpenSandbox team takes security seriously. If you discover a security vulnerability, please report it responsibly.
+
+### How to Report
+
+- **GitHub Security Advisories**: Open a private security advisory on GitHub
+- **Email**: Contact the maintainers directly with "[SECURITY]" in the subject
+
+### What to Include
+
+- Clear description of the vulnerability
+- Steps to reproduce
+- Potential impact and scope
+- Suggested remediation (if available)
+
+## Response Process
+
+1. Acknowledgment within 48 hours
+2. Investigation and validation
+3. Fix development and testing
+4. Coordinated disclosure
+
+## Supported Versions
+
+Only the latest release and main branch are actively supported with security updates.
+
+## Security Best Practices
+
+When deploying OpenSandbox:
+- Keep dependencies up to date
+- Use network policies to restrict sandbox egress
+- Monitor audit logs regularly
+- Follow principle of least privilege


### PR DESCRIPTION
Add a security policy with reporting guidelines, response process, and deployment best practices.