### PR TITLE
fix(docs): resolve dead link breaking Deploy Docs Pages CI

### DIFF
--- a/docs/secure-container.md
+++ b/docs/secure-container.md
@@ -740,4 +740,4 @@ sudo systemctl restart containerd
 
 - **Documentation**: [OpenSandbox GitHub](https://github.com/alibaba/OpenSandbox)
 - **Issues**: Report bugs via [GitHub Issues](https://github.com/alibaba/OpenSandbox/issues)
-- **Design Document**: See [OSEP-0004](../oseps/0004-secure-container-runtime.md) for complete design details
+- **Design Document**: See [OSEP-0004](/oseps/0004-secure-container-runtime) for complete design details


### PR DESCRIPTION
`Deploy Docs Pages` has been failing on main since the secure-container guide landed — 4 runs in a row, all the same error:

```
(!) Found dead link ./../oseps/0004-secure-container-runtime in file secure-container.md
[vitepress] 1 dead link(s) found.
```

The relative path `../oseps/...` escapes the VitePress source root (`docs/`), so vitepress can't resolve it. Since docs-manifest already generates OSEP pages into the site (under `oseps/` route), switched to the internal VitePress route instead — keeps readers within the docs site rather than bouncing them to raw GitHub.

Failing runs for reference: [#22714648602](https://github.com/alibaba/OpenSandbox/actions/runs/22714648602), [#22709156607](https://github.com/alibaba/OpenSandbox/actions/runs/22709156607), [#22709110171](https://github.com/alibaba/OpenSandbox/actions/runs/22709110171), [#22706379595](https://github.com/alibaba/OpenSandbox/actions/runs/22706379595)