### PR TITLE
fix(server): reject websocket upgrades before proxying

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -441,6 +441,10 @@ async def proxy_sandbox_endpoint_request(request: Request, sandbox_id: str, port
     client: httpx.AsyncClient = request.app.state.http_client
 
     try:
+        upgrade_header = request.headers.get("Upgrade", "")
+        if upgrade_header.lower() == "websocket":
+            raise HTTPException(status_code=400, detail="Websocket upgrade is not supported yet")
+
         # Filter headers
         headers = {}
         for key, value in request.headers.items():
@@ -458,13 +462,6 @@ async def proxy_sandbox_endpoint_request(request: Request, sandbox_id: str, port
             headers=headers,
             content=request.stream(),
         )
-
-        # TODO: support websocket protocol?
-        # since execd component does not have websocket handler currently, we just raise an error here
-        if request.method == "GET" and request.headers.get("Upgrade") == "websocket":
-            raise HTTPException(
-                status_code=400, detail="Websocket upgrade is not supported yet"
-            )
 
         resp = await client.send(req, stream=True)
 

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -131,6 +131,29 @@ def test_proxy_rejects_websocket_upgrade(
     assert response.json()["message"] == "Websocket upgrade is not supported yet"
 
 
+def test_proxy_rejects_websocket_upgrade_for_post_and_mixed_case_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    client.app.state.http_client = _FakeAsyncClient()
+
+    response = client.post(
+        "/v1/sandboxes/sbx-123/proxy/44772/ws",
+        headers={**auth_headers, "Upgrade": "WebSocket"},
+        content=b"{}",
+    )
+
+    assert response.status_code == 400
+    assert response.json()["message"] == "Websocket upgrade is not supported yet"
+
+
 def test_proxy_maps_connect_error_to_502(
     client: TestClient,
     auth_headers: dict,


### PR DESCRIPTION
## Summary
- reject websocket upgrade attempts before building the proxied backend request instead of only blocking `GET` requests with exact lowercase `Upgrade: websocket`
- make the guard case-insensitive so mixed-case upgrade headers are rejected consistently
- add regression coverage for a `POST` websocket upgrade request

## Testing
- `uv run pytest tests/test_routes_proxy.py -q`