### PR TITLE
ci(release): auto-generate Helm chart release notes

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -151,10 +151,12 @@ jobs:
             
             ${{ steps.parse_tag.outputs.component == 'opensandbox' && '**Note**: This is an all-in-one chart that bundles controller and server. The packaged chart already includes all dependencies, no need to run `helm dependency build` when installing from release.' || '' }}
             
-            ### What's Changed
+            ### Release Metadata
             
             - Chart version: ${{ steps.chart_version.outputs.version }}
             - App version: ${{ steps.parse_tag.outputs.app_version }}
+            - Detailed code changes are auto-generated from merged pull requests below
+          generate_release_notes: true
           files: |
             ${{ steps.parse_tag.outputs.component }}-*.tgz
           draft: false


### PR DESCRIPTION
## Summary
- enable GitHub auto-generated release notes for Helm chart releases
- keep the existing installation and version metadata while appending merged PR summaries below
- make release pages show actual change details instead of only chart/app version bullets

Closes #355

## Testing
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/publish-helm-chart.yml') ...` (workflow YAML parses successfully)
- reviewed the release action inputs to ensure `generate_release_notes: true` is enabled alongside the custom body
