### PR TITLE
refactor(sdk-python): replace exception name matching with type checks

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
@@ -30,6 +30,18 @@ import json
 import logging
 from typing import Any
 
+from httpx import (
+    ConnectError,
+    HTTPStatusError,
+    NetworkError,
+    ReadTimeout,
+    TimeoutException,
+    WriteTimeout,
+)
+from opensandbox.api.execd.errors import UnexpectedStatus as ExecdUnexpectedStatus
+from opensandbox.api.lifecycle.errors import (
+    UnexpectedStatus as LifecycleUnexpectedStatus,
+)
 from opensandbox.exceptions import (
     InvalidArgumentException,
     SandboxApiException,
@@ -39,6 +51,15 @@ from opensandbox.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+UNEXPECTED_STATUS_TYPES = (LifecycleUnexpectedStatus, ExecdUnexpectedStatus)
+HTTPX_NETWORK_ERROR_TYPES = (
+    ConnectError,
+    TimeoutException,
+    NetworkError,
+    ReadTimeout,
+    WriteTimeout,
+)
 
 
 class ExceptionConverter:
@@ -124,24 +145,17 @@ class ExceptionConverter:
 
 def _is_unexpected_status_error(e: Exception) -> bool:
     """Check if exception is an openapi-python-client UnexpectedStatus error."""
-    return type(e).__name__ == "UnexpectedStatus"
+    return isinstance(e, UNEXPECTED_STATUS_TYPES)
 
 
 def _is_httpx_status_error(e: Exception) -> bool:
     """Check if exception is an httpx HTTPStatusError."""
-    return type(e).__name__ == "HTTPStatusError"
+    return isinstance(e, HTTPStatusError)
 
 
 def _is_httpx_network_error(e: Exception) -> bool:
     """Check if exception is an httpx network-related error."""
-    error_types = (
-        "ConnectError",
-        "TimeoutException",
-        "NetworkError",
-        "ReadTimeout",
-        "WriteTimeout",
-    )
-    return type(e).__name__ in error_types
+    return isinstance(e, HTTPX_NETWORK_ERROR_TYPES)
 
 
 def _convert_unexpected_status_to_api_exception(e: Exception) -> SandboxApiException:

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
@@ -38,6 +38,7 @@ from httpx import (
     TimeoutException,
     WriteTimeout,
 )
+
 from opensandbox.api.execd.errors import UnexpectedStatus as ExecdUnexpectedStatus
 from opensandbox.api.lifecycle.errors import (
     UnexpectedStatus as LifecycleUnexpectedStatus,

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 import pytest
+from httpx import HTTPStatusError, Request, Response
 
+from opensandbox.api.lifecycle.errors import UnexpectedStatus
 from opensandbox.adapters.converter.exception_converter import (
     ExceptionConverter,
     parse_sandbox_error,
@@ -94,6 +96,34 @@ def test_exception_converter_maps_common_types() -> None:
 
     se2 = ExceptionConverter.to_sandbox_exception(OSError("x"))
     assert isinstance(se2, SandboxInternalException)
+
+
+def test_exception_converter_maps_generated_unexpected_status_to_api_exception() -> (
+    None
+):
+    err = UnexpectedStatus(400, b'{"code":"X","message":"bad"}')
+
+    converted = ExceptionConverter.to_sandbox_exception(err)
+
+    assert isinstance(converted, SandboxApiException)
+    assert converted.status_code == 400
+    assert converted.error is not None
+    assert converted.error.code == "X"
+
+
+def test_exception_converter_maps_httpx_status_error_to_api_exception() -> None:
+    request = Request("GET", "https://example.test")
+    response = Response(
+        502, request=request, content=b'{"code":"UPSTREAM","message":"gateway"}'
+    )
+    err = HTTPStatusError("bad gateway", request=request, response=response)
+
+    converted = ExceptionConverter.to_sandbox_exception(err)
+
+    assert isinstance(converted, SandboxApiException)
+    assert converted.status_code == 502
+    assert converted.error is not None
+    assert converted.error.code == "UPSTREAM"
 
 
 def test_execution_converter_to_api_run_command_request() -> None:

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta
 import pytest
 from httpx import HTTPStatusError, Request, Response
 
-from opensandbox.api.lifecycle.errors import UnexpectedStatus
 from opensandbox.adapters.converter.exception_converter import (
     ExceptionConverter,
     parse_sandbox_error,
@@ -38,6 +37,7 @@ from opensandbox.adapters.converter.response_handler import handle_api_error
 from opensandbox.adapters.converter.sandbox_model_converter import (
     SandboxModelConverter,
 )
+from opensandbox.api.lifecycle.errors import UnexpectedStatus
 from opensandbox.exceptions import (
     InvalidArgumentException,
     SandboxApiException,


### PR DESCRIPTION
## Summary
- replace string-based exception name checks in the Python SDK exception converter with direct `isinstance()` checks against generated `UnexpectedStatus` types and httpx exception classes
- keep behavior unchanged while making the converter more robust to refactors and easier to reason about
- add regression coverage for generated `UnexpectedStatus` and `HTTPStatusError` conversion paths

## Testing
- `uv run pytest tests/test_converters_and_error_handling.py -q`
- `uv run pyright src/opensandbox/adapters/converter/exception_converter.py`