### PR TITLE
feat(code-interpreter): add .NET 10 SDK to base image

### DIFF
--- a/sandboxes/code-interpreter/Dockerfile_base
+++ b/sandboxes/code-interpreter/Dockerfile_base
@@ -25,6 +25,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     MAVEN_VERSION=3.9.2 \
     MAVEN_HOME=/opt/maven \
+    DOTNET_ROOT=/opt/dotnet \
+    DOTNET_CHANNEL=10.0 \
     UV_PYTHON_INSTALL_DIR=/opt/python/versions \
     NODE_ROOT=/opt/node \
     GO_ROOT=/opt/go \
@@ -60,7 +62,15 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv python install 3.10 3.11 3.12 3.13 && \
     (uv python install 3.14 || echo "Python 3.14 skipped")
 
-# 5. Install Node.js (18, 20, 22)
+# 5. Install .NET SDK 10
+RUN mkdir -p ${DOTNET_ROOT} && \
+    curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
+    chmod +x /tmp/dotnet-install.sh && \
+    /tmp/dotnet-install.sh --channel ${DOTNET_CHANNEL} --install-dir ${DOTNET_ROOT} && \
+    ${DOTNET_ROOT}/dotnet --version && \
+    rm -f /tmp/dotnet-install.sh
+
+# 6. Install Node.js (18, 20, 22)
 RUN mkdir -p ${NODE_ROOT} && \
     ARCH="" && \
     if [ -z "${TARGETARCH}" ]; then \
@@ -81,7 +91,7 @@ RUN mkdir -p ${NODE_ROOT} && \
         mv node-v${v}-linux-${ARCH} v${v}; \
     done
 
-# 6. Install Go (latest three major versions)
+# 7. Install Go (latest three major versions)
 RUN mkdir -p ${GO_ROOT} && \
     ARCH="" && \
     if [ -z "${TARGETARCH}" ]; then \
@@ -102,9 +112,9 @@ RUN mkdir -p ${GO_ROOT} && \
         mv go ${v}; \
     done
 
-# 7. Configure defaults & env script
+# 8. Configure defaults & env script
 ENV GOROOT=${GO_ROOT}/${GO_V1_25} \
-    PATH="${NODE_ROOT}/v${NODE_V22}/bin:${GO_ROOT}/${GO_V1_25}/bin:${PATH}"
+    PATH="${DOTNET_ROOT}:${NODE_ROOT}/v${NODE_V22}/bin:${GO_ROOT}/${GO_V1_25}/bin:${PATH}"
 
 RUN mkdir -p /opt/opensandbox
 COPY scripts/code-interpreter-env.sh /opt/opensandbox/code-interpreter-env.sh

--- a/sandboxes/code-interpreter/README.md
+++ b/sandboxes/code-interpreter/README.md
@@ -8,7 +8,7 @@ provide an out-of-the-box multi-language code execution environment.
 
 ## Features
 
-- **Multi-Language Support**: Pre-installed Python, Java, Node.js, and Go with multiple versions
+- **Multi-Language Support**: Pre-installed Python, Java, Node.js, Go, and .NET tooling for common sandbox workloads
 - **Version Switching**: Easy runtime version switching without rebuilding
 - **Jupyter Integration**: Built-in Jupyter Notebook with multi-language kernels
 - **Multi-Architecture**: Supports both amd64 and arm64 architectures
@@ -24,8 +24,12 @@ The image comes pre-installed with the following languages and versions:
 | **Java**    | 8, 11, 17, 21                 | `/usr/lib/jvm`         | OpenJDK; includes Maven 3.9.2            |
 | **Node.js** | v18, v20, v22                 | `/opt/node`            | Official Linux binaries                  |
 | **Go**      | 1.23, 1.24, 1.25              | `/opt/go`              | Official Linux binaries                  |
+| **.NET SDK** | 10.0 channel                 | `/opt/dotnet`          | Installed via `dotnet-install.sh`        |
 
 *> Note: Version numbers may be updated to the latest patch versions at build time.*
+
+The .NET SDK is preinstalled as a single `10.0` channel and is available directly from `PATH`; it does not use the
+runtime version switching helper.
 
 ## Quick Start
 
@@ -204,6 +208,13 @@ go install github.com/user/package@latest
 
 ```bash
 mvn install dependency:copy-dependencies
+```
+
+**.NET SDK:**
+
+```bash
+dotnet --version
+dotnet new console --framework net10.0
 ```
 
 ## Architecture

--- a/sandboxes/code-interpreter/README_zh.md
+++ b/sandboxes/code-interpreter/README_zh.md
@@ -7,7 +7,7 @@
 
 ## 特性
 
-- **多语言支持**：预装 Python、Java、Node.js 和 Go 及其多个版本
+- **多语言支持**：预装 Python、Java、Node.js、Go 和 .NET 工具链，覆盖常见沙箱工作负载
 - **版本切换**：无需重新构建，支持运行时快速切换版本
 - **Jupyter 集成**：内置 Jupyter Notebook 并支持多语言内核
 - **多架构支持**：同时支持 amd64 和 arm64 架构
@@ -23,8 +23,11 @@
 | **Java**    | 8, 11, 17, 21                 | `/usr/lib/jvm`         | OpenJDK; 含 Maven 3.9.2 |
 | **Node.js** | v18, v20, v22                 | `/opt/node`            | 官方 Linux 二进制包          |
 | **Go**      | 1.23, 1.24, 1.25              | `/opt/go`              | 官方 Linux 二进制包          |
+| **.NET SDK** | 10.0 通道                     | `/opt/dotnet`          | 通过 `dotnet-install.sh` 安装 |
 
 *> 注意: 版本号可能会随构建时间更新至小版本的最新版。*
+
+.NET SDK 以单一 `10.0` 通道预装，可直接通过 `PATH` 使用；当前不走运行时版本切换脚本。
 
 ## 快速开始
 
@@ -202,6 +205,13 @@ go install github.com/user/package@latest
 
 ```bash
 mvn install dependency:copy-dependencies
+```
+
+**.NET SDK：**
+
+```bash
+dotnet --version
+dotnet new console --framework net10.0
 ```
 
 ## 架构说明


### PR DESCRIPTION
## Summary
- install the .NET 10 SDK into the code-interpreter base image via `dotnet-install.sh`
- expose `dotnet` from `PATH` so sandbox workloads can use it without extra setup
- document the new runtime availability in the code-interpreter environment docs (EN/ZH)

Closes #324

## Testing
- `git diff --check`
- `bash dotnet-install.sh --help | rg -- '--dry-run|--channel|--install-dir'`
- `bash dotnet-install.sh --channel 10.0 --install-dir <tmp> --dry-run`

## Notes
- The dry-run resolves the concrete SDK payload URL for the current platform, which validates the install channel/configuration without waiting for a full SDK download in this environment.
