### PR TITLE
fix(server): cleanup container when runtime prep fails

### DIFF
--- a/server/src/services/docker.py
+++ b/server/src/services/docker.py
@@ -1828,7 +1828,7 @@ class DockerSandboxService(SandboxService):
             with self._docker_operation("start sandbox container", sandbox_id):
                 container.start()
             return container
-        except DockerException as exc:
+        except Exception as exc:
             if container is not None:
                 try:
                     with self._docker_operation("cleanup sandbox container", sandbox_id):
@@ -1849,6 +1849,10 @@ class DockerSandboxService(SandboxService):
                         sandbox_id,
                         cleanup_exc,
                     )
+
+            if isinstance(exc, HTTPException):
+                raise exc
+
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail={

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -128,6 +128,62 @@ def test_create_sandbox_applies_security_defaults(mock_docker):
     assert host_config.get("pids_limit") == service.app_config.docker.pids_limit
 
 
+@pytest.mark.parametrize(
+    "runtime_exc, expected_status, expect_wrapped_error",
+    [
+        (
+            RuntimeError("tarfile error"),
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            True,
+        ),
+        (
+            HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "CONFLICT", "message": "conflict error"},
+            ),
+            status.HTTP_409_CONFLICT,
+            False,
+        ),
+    ],
+)
+@patch("src.services.docker.docker")
+def test_prepare_runtime_failure_triggers_cleanup(
+    mock_docker, runtime_exc, expected_status, expect_wrapped_error
+):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_client.api.create_container.return_value = {"Id": "cid"}
+    mock_container = MagicMock()
+    mock_client.containers.get.return_value = mock_container
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    request = CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.11"),
+        timeout=120,
+        resourceLimits=ResourceLimits(root={}),
+        env={},
+        metadata={},
+        entrypoint=["python"],
+    )
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime", side_effect=runtime_exc),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            service.create_sandbox(request)
+
+    mock_container.remove.assert_called_with(force=True)
+
+    assert exc.value.status_code == expected_status
+
+    if expect_wrapped_error:
+        assert str(runtime_exc) in str(exc.value.detail["message"])
+    else:
+        assert exc.value.detail["message"] == runtime_exc.detail["message"]
+
+
 @patch("src.services.docker.docker")
 def test_create_sandbox_rejects_invalid_metadata(mock_docker):
     mock_client = MagicMock()


### PR DESCRIPTION
Thank you for open-sourcing such a nice project; we really need it.

# Summary
- This PR fixes a container cleanup bug in the Docker runtime provisioning flow.
- 
`DockerSandboxService._create_and_start_container()` only handled `DockerException`. However, `_prepare_sandbox_runtime()` can raise `HTTPException`.In that case, the exception bypassed the cleanup path.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
