### PR TITLE
fix(server): use internal endpoint resolution for proxy route

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -428,7 +428,7 @@ async def proxy_sandbox_endpoint_request(request: Request, sandbox_id: str, port
     and asynchronously proxies the request to it.
     """
 
-    endpoint = sandbox_service.get_endpoint(sandbox_id, port)
+    endpoint = sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
 
     target_host = endpoint.endpoint
     query_string = request.url.query

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -61,9 +61,10 @@ def test_proxy_forwards_filtered_headers_and_query(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
             assert sandbox_id == "sbx-123"
             assert port == 44772
+            assert resolve_internal is True
             return Endpoint(endpoint="10.57.1.91:40109")
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
@@ -116,7 +117,7 @@ def test_proxy_rejects_websocket_upgrade(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
             return Endpoint(endpoint="10.57.1.91:40109")
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
@@ -138,7 +139,7 @@ def test_proxy_rejects_websocket_upgrade_for_post_and_mixed_case_header(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
             return Endpoint(endpoint="10.57.1.91:40109")
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
@@ -161,7 +162,7 @@ def test_proxy_maps_connect_error_to_502(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
             return Endpoint(endpoint="10.57.1.91:40109")
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
@@ -185,7 +186,7 @@ def test_proxy_maps_unexpected_error_to_500(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
             return Endpoint(endpoint="10.57.1.91:40109")
 
     monkeypatch.setattr(lifecycle, "sandbox_service", StubService())


### PR DESCRIPTION
Fixes #402

# Summary
This PR fixes proxy endpoint resolution in `proxy_sandbox_endpoint_request`.

Previously, the proxy route called:
`get_endpoint(sandbox_id, port)`

That could return a non-internal/proxied endpoint depending on runtime config, which is not suitable for server-side forwarding.  
Now the proxy route explicitly calls:
`get_endpoint(sandbox_id, port, resolve_internal=True)`

This ensures proxy requests are always forwarded to the sandbox internal endpoint.

In addition, proxy route tests were updated to accept the `resolve_internal` argument and assert that `resolve_internal=True` is passed in the proxy path.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Executed:
- `uv run pytest tests/test_routes_proxy.py`
- `uv run pytest tests/test_routes_endpoint_behavior.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)  <!-- N/A: internal behavior fix, no public API/doc change -->
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
