### PR TITLE
fix(execd): Add fallback from bash to sh for Alpine-based images

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -35,6 +35,15 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/util/safego"
 )
 
+// getShell returns the preferred shell, falling back to sh if bash is not available.
+// This is needed for Alpine-based Docker images that only have sh by default.
+func getShell() string {
+	if _, err := exec.LookPath("bash"); err == nil {
+		return "bash"
+	}
+	return "sh"
+}
+
 func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 	if uid == nil && gid == nil {
 		return nil, nil
@@ -93,7 +102,8 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
-	cmd := exec.CommandContext(ctx, "bash", "-c", request.Code)
+	shell := getShell()
+	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -218,7 +228,8 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
-	cmd := exec.CommandContext(ctx, "bash", "-c", request.Code)
+	shell := getShell()
+	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
 
 	cmd.Dir = request.Cwd
 


### PR DESCRIPTION
## Summary
This PR addresses issue #405 by adding a fallback from bash to sh for Alpine-based Docker images.

## Problem
In a lot of Docker images like Alpine-based images, they only contain `sh`. They do not contain `bash` by default, making it impossible to run any command using the execd.

## Solution
Added a `getShell()` helper function that:
1. First tries to find `bash` using `exec.LookPath`
2. Falls back to `sh` if bash is not available

This change has been applied to both locations where shell commands are executed (lines ~96 and ~231).

## Testing
The fix is backward compatible - on systems with bash (like Ubuntu, Debian), it will continue to use bash. On Alpine-based images, it will automatically fall back to sh.