### PR TITLE
feat(server): refactor k8s client and add limiter

### DIFF
--- a/server/src/config.py
+++ b/server/src/config.py
@@ -216,6 +216,38 @@ class KubernetesRuntimeConfig(BaseModel):
             "[Beta] Watch timeout (seconds) before restarting the informer stream."
         ),
     )
+    read_qps: float = Field(
+        default=0.0,
+        ge=0,
+        description=(
+            "Maximum read requests per second to the Kubernetes API (get/list). "
+            "0 means unlimited (no rate limiting)."
+        ),
+    )
+    read_burst: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Burst size for the read rate limiter. "
+            "0 means use read_qps as burst (minimum 1)."
+        ),
+    )
+    write_qps: float = Field(
+        default=0.0,
+        ge=0,
+        description=(
+            "Maximum write requests per second to the Kubernetes API (create/delete/patch). "
+            "0 means unlimited (no rate limiting)."
+        ),
+    )
+    write_burst: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Burst size for the write rate limiter. "
+            "0 means use write_qps as burst (minimum 1)."
+        ),
+    )
     namespace: Optional[str] = Field(
         default=None,
         description="Namespace used for sandbox workloads.",

--- a/server/src/services/k8s/agent_sandbox_provider.py
+++ b/server/src/services/k8s/agent_sandbox_provider.py
@@ -20,18 +20,16 @@ import hashlib
 import logging
 import re
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Callable
-from threading import Lock
+from typing import Dict, List, Any, Optional
 
 from kubernetes.client import (
     V1Container,
     V1EnvVar,
     V1ResourceRequirements,
     V1VolumeMount,
-    ApiException,
 )
 
-from src.config import AppConfig, IngressConfig, ExecdInitResources
+from src.config import AppConfig
 from src.services.helpers import format_ingress_endpoint
 from src.api.schema import Endpoint, ImageSpec, NetworkPolicy, Volume
 from src.services.k8s.agent_sandbox_template import AgentSandboxTemplateManager
@@ -42,7 +40,6 @@ from src.services.k8s.egress_helper import (
     build_security_context_from_dict,
     serialize_security_context_to_dict,
 )
-from src.services.k8s.informer import WorkloadInformer
 from src.services.k8s.volume_helper import apply_volumes_to_pod_spec
 from src.services.k8s.workload_provider import WorkloadProvider
 from src.services.runtime_resolver import SecureRuntimeResolver
@@ -83,44 +80,24 @@ class AgentSandboxProvider(WorkloadProvider):
     def __init__(
         self,
         k8s_client: K8sClient,
-        template_file_path: Optional[str] = None,
-        shutdown_policy: str = "Delete",
-        service_account: Optional[str] = None,
-        ingress_config: Optional[IngressConfig] = None,
-        enable_informer: bool = True,
-        informer_factory: Optional[Callable[[str], WorkloadInformer]] = None,
-        informer_resync_seconds: int = 300,
-        informer_watch_timeout_seconds: int = 60,
         app_config: Optional[AppConfig] = None,
-        execd_init_resources: Optional[ExecdInitResources] = None,
     ):
         self.k8s_client = k8s_client
-        self.custom_api = k8s_client.get_custom_objects_api()
-        self.core_api = k8s_client.get_core_v1_api()
 
         self.group = "agents.x-k8s.io"
         self.version = "v1alpha1"
         self.plural = "sandboxes"
 
-        self.shutdown_policy = shutdown_policy
-        self.service_account = service_account
-        self.template_manager = AgentSandboxTemplateManager(template_file_path)
-        self.ingress_config = ingress_config
-        self.execd_init_resources = execd_init_resources
-        self._enable_informer = enable_informer
-        self._informer_factory = informer_factory or (
-            lambda ns: WorkloadInformer(
-                custom_api=self.custom_api,
-                group=self.group,
-                version=self.version,
-                plural=self.plural,
-                namespace=ns,
-                resync_period_seconds=informer_resync_seconds,
-                watch_timeout_seconds=informer_watch_timeout_seconds,
-            )
+        k8s_config = app_config.kubernetes if app_config else None
+        agent_config = app_config.agent_sandbox if app_config else None
+
+        self.shutdown_policy = agent_config.shutdown_policy if agent_config else "Delete"
+        self.service_account = k8s_config.service_account if k8s_config else None
+        self.template_manager = AgentSandboxTemplateManager(
+            agent_config.template_file if agent_config else None
         )
-        self._informers: Dict[str, WorkloadInformer] = {}
-        self._informers_lock = Lock()
+        self.ingress_config = app_config.ingress if app_config else None
+        self.execd_init_resources = k8s_config.execd_init_resources if k8s_config else None
 
         # Initialize secure runtime resolver
         self.resolver = SecureRuntimeResolver(app_config) if app_config else None
@@ -158,14 +135,7 @@ class AgentSandboxProvider(WorkloadProvider):
         egress_image: Optional[str] = None,
         volumes: Optional[List[Volume]] = None,
     ) -> Dict[str, Any]:
-        # Pool mode does not support volumes
-        if extensions and extensions.get("poolRef"):
-            if volumes:
-                raise ValueError(
-                    "Pool mode does not support volumes. "
-                    "Remove 'volumes' from request or use template mode."
-                )
-
+        """Create an agent-sandbox Sandbox CRD workload."""
         if self.runtime_class:
             logger.info(
                 "Using Kubernetes RuntimeClass '%s' for sandbox %s",
@@ -215,20 +185,13 @@ class AgentSandboxProvider(WorkloadProvider):
 
         sandbox = self.template_manager.merge_with_runtime_values(runtime_manifest)
 
-        created = self.custom_api.create_namespaced_custom_object(
+        created = self.k8s_client.create_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
             plural=self.plural,
             body=sandbox,
         )
-
-        informer = self._get_informer(namespace)
-        if informer:
-            try:
-                informer.update_cache(created)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to update informer cache for %s: %s", sandbox_id, exc)
 
         return {
             "name": created["metadata"]["name"],
@@ -245,6 +208,7 @@ class AgentSandboxProvider(WorkloadProvider):
         network_policy: Optional[NetworkPolicy] = None,
         egress_image: Optional[str] = None,
     ) -> Dict[str, Any]:
+        """Build pod spec dict for the Sandbox CRD."""
         init_container = self._build_execd_init_container(execd_image)
         main_container = self._build_main_container(
             image_spec=image_spec,
@@ -284,6 +248,7 @@ class AgentSandboxProvider(WorkloadProvider):
         return pod_spec
 
     def _build_execd_init_container(self, execd_image: str) -> V1Container:
+        """Build init container that copies execd binary to the shared volume."""
         script = (
             "cp ./execd /opt/opensandbox/bin/execd && "
             "cp ./bootstrap.sh /opt/opensandbox/bin/bootstrap.sh && "
@@ -359,6 +324,7 @@ class AgentSandboxProvider(WorkloadProvider):
         )
 
     def _container_to_dict(self, container: V1Container) -> Dict[str, Any]:
+        """Convert a V1Container object to a plain dict for CRD body."""
         result: Dict[str, Any] = {
             "name": container.name,
             "image": container.image,
@@ -388,70 +354,30 @@ class AgentSandboxProvider(WorkloadProvider):
 
         return result
 
-    def _get_informer(self, namespace: str) -> Optional[WorkloadInformer]:
-        if not self._enable_informer:
-            return None
-
-        with self._informers_lock:
-            informer = self._informers.get(namespace)
-            if informer is None:
-                informer = self._informer_factory(namespace)
-                self._informers[namespace] = informer
-                try:
-                    informer.start()
-                except Exception as exc:  # pragma: no cover - defensive
-                    logger.warning(
-                        "Failed to start informer for namespace %s: %s", namespace, exc
-                    )
-                    self._informers.pop(namespace, None)
-                    return None
-        return informer
-
     def get_workload(self, sandbox_id: str, namespace: str) -> Optional[Dict[str, Any]]:
-        informer = self._get_informer(namespace)
-        cache_ready = informer.has_synced if informer else False
-
+        """Get Sandbox CRD by sandbox ID, trying all candidate resource names."""
         candidates = self._resource_name_candidates(sandbox_id)
 
-        if informer and cache_ready:
-            for name in candidates:
-                cached = informer.get(name)
-                if cached:
-                    return cached
-
-        if informer and not cache_ready:
-            logger.warning(
-                f"Informer cache not synced for namespace {namespace}; falling back to direct API get."
-            )
-
         for name in candidates:
-            try:
-                workload = self.custom_api.get_namespaced_custom_object(
-                    group=self.group,
-                    version=self.version,
-                    namespace=namespace,
-                    plural=self.plural,
-                    name=name,
-                )
-                if informer and workload:
-                    informer.update_cache(workload)
+            workload = self.k8s_client.get_custom_object(
+                group=self.group,
+                version=self.version,
+                namespace=namespace,
+                plural=self.plural,
+                name=name,
+            )
+            if workload:
                 return workload
-            except ApiException as e:
-                if e.status != 404:
-                    logger.error(f"Unexpected error getting Sandbox for {sandbox_id}: {e}")
-                    raise
-            except Exception as e:
-                logger.error(f"Unexpected error getting Sandbox for {sandbox_id}: {e}")
-                raise
 
         return None
 
     def delete_workload(self, sandbox_id: str, namespace: str) -> None:
+        """Delete the Sandbox CRD for the given sandbox ID."""
         sandbox = self.get_workload(sandbox_id, namespace)
         if not sandbox:
             raise Exception(f"Sandbox for sandbox {sandbox_id} not found")
 
-        self.custom_api.delete_namespaced_custom_object(
+        self.k8s_client.delete_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -461,24 +387,17 @@ class AgentSandboxProvider(WorkloadProvider):
         )
 
     def list_workloads(self, namespace: str, label_selector: str) -> List[Dict[str, Any]]:
-        try:
-            sandbox_list = self.custom_api.list_namespaced_custom_object(
-                group=self.group,
-                version=self.version,
-                namespace=namespace,
-                plural=self.plural,
-                label_selector=label_selector,
-            )
-            return sandbox_list.get("items", [])
-        except ApiException as e:
-            if e.status == 404:
-                return []
-            raise
-        except Exception as e:
-            logger.error(f"Unexpected error listing Sandboxes: {e}")
-            raise
+        """List Sandbox CRDs matching the given label selector."""
+        return self.k8s_client.list_custom_objects(
+            group=self.group,
+            version=self.version,
+            namespace=namespace,
+            plural=self.plural,
+            label_selector=label_selector,
+        )
 
     def update_expiration(self, sandbox_id: str, namespace: str, expires_at: datetime) -> None:
+        """Patch the Sandbox CRD shutdownTime field."""
         sandbox = self.get_workload(sandbox_id, namespace)
         if not sandbox:
             raise Exception(f"Sandbox for sandbox {sandbox_id} not found")
@@ -489,7 +408,7 @@ class AgentSandboxProvider(WorkloadProvider):
             }
         }
 
-        self.custom_api.patch_namespaced_custom_object(
+        self.k8s_client.patch_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -499,6 +418,7 @@ class AgentSandboxProvider(WorkloadProvider):
         )
 
     def get_expiration(self, workload: Dict[str, Any]) -> Optional[datetime]:
+        """Parse shutdownTime from Sandbox CRD spec."""
         spec = workload.get("spec", {})
         shutdown_time_str = spec.get("shutdownTime")
 
@@ -508,10 +428,11 @@ class AgentSandboxProvider(WorkloadProvider):
         try:
             return datetime.fromisoformat(shutdown_time_str.replace("Z", "+00:00"))
         except (ValueError, TypeError) as e:
-            logger.warning(f"Invalid shutdownTime format: {shutdown_time_str}, error: {e}")
+            logger.warning("Invalid shutdownTime format: %s, error: %s", shutdown_time_str, e)
             return None
 
     def get_status(self, workload: Dict[str, Any]) -> Dict[str, Any]:
+        """Derive sandbox state from the Sandbox CRD status conditions."""
         status = workload.get("status", {})
         conditions = status.get("conditions", [])
 
@@ -577,10 +498,10 @@ class AgentSandboxProvider(WorkloadProvider):
             return None
 
         try:
-            pods = self.core_api.list_namespaced_pod(
+            pods = self.k8s_client.list_pods(
                 namespace=namespace,
                 label_selector=selector,
-            ).items
+            )
         except Exception:
             return None
 
@@ -620,15 +541,15 @@ class AgentSandboxProvider(WorkloadProvider):
         namespace = workload.get("metadata", {}).get("namespace")
         if selector and namespace:
             try:
-                pods = self.core_api.list_namespaced_pod(
+                pods = self.k8s_client.list_pods(
                     namespace=namespace,
                     label_selector=selector,
-                ).items
+                )
                 for pod in pods:
                     if pod.status and pod.status.pod_ip and pod.status.phase == "Running":
                         return Endpoint(endpoint=f"{pod.status.pod_ip}:{port}")
             except Exception as e:
-                logger.warning(f"Failed to resolve pod endpoint: {e}")
+                logger.warning("Failed to resolve pod endpoint: %s", e)
 
         service_fqdn = status.get("serviceFQDN")
         if service_fqdn:

--- a/server/src/services/k8s/batchsandbox_provider.py
+++ b/server/src/services/k8s/batchsandbox_provider.py
@@ -20,18 +20,16 @@ import logging
 import json
 import shlex
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Callable
-from threading import Lock
+from typing import Dict, List, Any, Optional
 
 from kubernetes.client import (
     V1Container,
     V1EnvVar,
     V1ResourceRequirements,
     V1VolumeMount,
-    ApiException,
 )
 
-from src.config import AppConfig, IngressConfig, INGRESS_MODE_GATEWAY, ExecdInitResources
+from src.config import AppConfig, INGRESS_MODE_GATEWAY
 from src.services.helpers import format_ingress_endpoint
 from src.api.schema import Endpoint, ImageSpec, NetworkPolicy, Volume
 from src.services.k8s.image_pull_secret_helper import (
@@ -46,7 +44,6 @@ from src.services.k8s.egress_helper import (
     build_security_context_from_dict,
     serialize_security_context_to_dict,
 )
-from src.services.k8s.informer import WorkloadInformer
 from src.services.k8s.volume_helper import apply_volumes_to_pod_spec
 from src.services.k8s.workload_provider import WorkloadProvider
 from src.services.runtime_resolver import SecureRuntimeResolver
@@ -65,26 +62,23 @@ class BatchSandboxProvider(WorkloadProvider):
     def __init__(
         self,
         k8s_client: K8sClient,
-        template_file_path: Optional[str] = None,
-        ingress_config: Optional[IngressConfig] = None,
-        enable_informer: bool = True,
-        informer_factory: Optional[Callable[[str], WorkloadInformer]] = None,
-        informer_resync_seconds: int = 300,
-        informer_watch_timeout_seconds: int = 60,
         app_config: Optional[AppConfig] = None,
-        execd_init_resources: Optional[ExecdInitResources] = None,
     ):
         """
         Initialize BatchSandbox provider.
 
         Args:
             k8s_client: Kubernetes client wrapper
-            template_file_path: Optional path to BatchSandbox CR YAML template file
-            app_config: Optional application config for secure runtime
+            app_config: Application config; kubernetes/ingress sub-configs are read from it directly.
         """
         self.k8s_client = k8s_client
-        self.custom_api = k8s_client.get_custom_objects_api()
-        self.ingress_config = ingress_config
+        self.ingress_config = app_config.ingress if app_config else None
+
+        k8s_config = app_config.kubernetes if app_config else None
+        template_file_path = k8s_config.batchsandbox_template_file if k8s_config else None
+        if template_file_path:
+            logger.info("Using BatchSandbox template file: %s", template_file_path)
+        self.execd_init_resources = k8s_config.execd_init_resources if k8s_config else None
 
         # Initialize secure runtime resolver
         self.resolver = SecureRuntimeResolver(app_config) if app_config else None
@@ -99,21 +93,6 @@ class BatchSandboxProvider(WorkloadProvider):
         
         # Template manager
         self.template_manager = BatchSandboxTemplateManager(template_file_path)
-        self.execd_init_resources = execd_init_resources
-        self._enable_informer = enable_informer
-        self._informer_factory = informer_factory or (
-            lambda ns: WorkloadInformer(
-                custom_api=self.custom_api,
-                group=self.group,
-                version=self.version,
-                plural=self.plural,
-                namespace=ns,
-                resync_period_seconds=informer_resync_seconds,
-                watch_timeout_seconds=informer_watch_timeout_seconds,
-            )
-        )
-        self._informers: Dict[str, WorkloadInformer] = {}
-        self._informers_lock = Lock()
 
     def supports_image_auth(self) -> bool:
         """BatchSandbox supports image pull auth via imagePullSecrets injection."""
@@ -271,7 +250,7 @@ class BatchSandboxProvider(WorkloadProvider):
         self._merge_pod_spec_extras(batchsandbox, extra_volumes, extra_mounts)
         
         # Create BatchSandbox
-        created = self.custom_api.create_namespaced_custom_object(
+        created = self.k8s_client.create_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -290,12 +269,12 @@ class BatchSandboxProvider(WorkloadProvider):
                 owner_kind="BatchSandbox",
             )
             try:
-                self.k8s_client.get_core_v1_api().create_namespaced_secret(namespace=namespace, body=secret)
+                self.k8s_client.create_secret(namespace=namespace, body=secret)
                 logger.info("Created imagePullSecret for sandbox %s", sandbox_id)
             except Exception:
                 logger.warning("Failed to create imagePullSecret for sandbox %s, rolling back BatchSandbox", sandbox_id)
                 try:
-                    self.custom_api.delete_namespaced_custom_object(
+                    self.k8s_client.delete_custom_object(
                         group=self.group,
                         version=self.version,
                         namespace=namespace,
@@ -306,13 +285,6 @@ class BatchSandboxProvider(WorkloadProvider):
                 except Exception as del_exc:
                     logger.warning("Failed to rollback BatchSandbox %s: %s", sandbox_id, del_exc)
                 raise
-
-        informer = self._get_informer(namespace)
-        if informer:
-            try:
-                informer.update_cache(created)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to update informer cache for %s: %s", sandbox_id, exc)
 
         return {
             "name": created["metadata"]["name"],
@@ -369,7 +341,7 @@ class BatchSandboxProvider(WorkloadProvider):
         
         # Pool-based creation does not need template merging
         # Create BatchSandbox directly
-        created = self.custom_api.create_namespaced_custom_object(
+        created = self.k8s_client.create_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -462,7 +434,7 @@ class BatchSandboxProvider(WorkloadProvider):
                 existing.add(name)
             main_container["volumeMounts"] = mounts
 
-    # Todo support empty cmd or env
+    # TODO: support empty cmd or env
     def _build_task_template(
         self,
         entrypoint: List[str],
@@ -660,83 +632,28 @@ class BatchSandboxProvider(WorkloadProvider):
         
         return result
 
-    def _get_informer(self, namespace: str) -> Optional[WorkloadInformer]:
-        if not self._enable_informer:
-            return None
-
-        with self._informers_lock:
-            informer = self._informers.get(namespace)
-            if informer is None:
-                informer = self._informer_factory(namespace)
-                self._informers[namespace] = informer
-                try:
-                    informer.start()
-                except Exception as exc:  # pragma: no cover - defensive
-                    logger.warning(
-                        "Failed to start informer for namespace %s: %s", namespace, exc
-                    )
-                    self._informers.pop(namespace, None)
-                    return None
-        return informer
-
     def get_workload(self, sandbox_id: str, namespace: str) -> Optional[Dict[str, Any]]:
         """Get BatchSandbox by sandbox ID."""
-        informer = self._get_informer(namespace)
-        cache_ready = informer.has_synced if informer else False
-
-        if informer and cache_ready:
-            cached = informer.get(sandbox_id)
-            if cached:
-                return cached
-
-            legacy_name = self.legacy_resource_name(sandbox_id)
-            if legacy_name != sandbox_id:
-                legacy_cached = informer.get(legacy_name)
-                if legacy_cached:
-                    return legacy_cached
-
-        if informer and not cache_ready:
-            logger.warning(
-                f"Informer cache not synced for namespace {namespace}; falling back to direct API get."
-            )
-
-        try:
-            workload = self.custom_api.get_namespaced_custom_object(
-                group=self.group,
-                version=self.version,
-                namespace=namespace,
-                plural=self.plural,
-                name=sandbox_id,
-            )
-            if informer and workload:
-                informer.update_cache(workload)
+        workload = self.k8s_client.get_custom_object(
+            group=self.group,
+            version=self.version,
+            namespace=namespace,
+            plural=self.plural,
+            name=sandbox_id,
+        )
+        if workload:
             return workload
-        except ApiException as e:
-            if e.status != 404:
-                logger.error(f"Unexpected error getting BatchSandbox for {sandbox_id}: {e}")
-                raise
 
         # Fallback for pre-upgrade sandboxes that used "sandbox-<id>" naming
         legacy_name = self.legacy_resource_name(sandbox_id)
         if legacy_name != sandbox_id:
-            try:
-                workload = self.custom_api.get_namespaced_custom_object(
-                    group=self.group,
-                    version=self.version,
-                    namespace=namespace,
-                    plural=self.plural,
-                    name=legacy_name,
-                )
-                if informer and workload:
-                    informer.update_cache(workload)
-                return workload
-            except ApiException as e:
-                if e.status == 404:
-                    return None
-                raise
-            except Exception as e:
-                logger.error(f"Unexpected error getting BatchSandbox for {sandbox_id}: {e}")
-                raise
+            return self.k8s_client.get_custom_object(
+                group=self.group,
+                version=self.version,
+                namespace=namespace,
+                plural=self.plural,
+                name=legacy_name,
+            )
 
         return None
     
@@ -746,7 +663,7 @@ class BatchSandboxProvider(WorkloadProvider):
         if not batchsandbox:
             raise Exception(f"BatchSandbox for sandbox {sandbox_id} not found")
         
-        self.custom_api.delete_namespaced_custom_object(
+        self.k8s_client.delete_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -757,25 +674,13 @@ class BatchSandboxProvider(WorkloadProvider):
     
     def list_workloads(self, namespace: str, label_selector: str) -> List[Dict[str, Any]]:
         """List BatchSandboxes matching label selector."""
-        try:
-            batchsandbox_list = self.custom_api.list_namespaced_custom_object(
-                group=self.group,
-                version=self.version,
-                namespace=namespace,
-                plural=self.plural,
-                label_selector=label_selector,
-            )
-            return batchsandbox_list.get("items", [])
-        except ApiException as e:
-            # Handle 404 when CRD doesn't exist
-            if e.status == 404:
-                return []
-            # Re-raise other API exceptions
-            raise
-        except Exception as e:
-            # Log and re-raise unexpected errors
-            logger.error(f"Unexpected error listing BatchSandboxes: {e}")
-            raise
+        return self.k8s_client.list_custom_objects(
+            group=self.group,
+            version=self.version,
+            namespace=namespace,
+            plural=self.plural,
+            label_selector=label_selector,
+        )
     
     def update_expiration(self, sandbox_id: str, namespace: str, expires_at: datetime) -> None:
         """Update BatchSandbox expiration time.
@@ -799,7 +704,7 @@ class BatchSandboxProvider(WorkloadProvider):
             }
         }
         
-        self.custom_api.patch_namespaced_custom_object(
+        self.k8s_client.patch_custom_object(
             group=self.group,
             version=self.version,
             namespace=namespace,
@@ -827,7 +732,7 @@ class BatchSandboxProvider(WorkloadProvider):
             # Parse ISO format datetime
             return datetime.fromisoformat(expire_time_str.replace('Z', '+00:00'))
         except (ValueError, TypeError) as e:
-            logger.warning(f"Invalid expireTime format: {expire_time_str}, error: {e}")
+            logger.warning("Invalid expireTime format: %s, error: %s", expire_time_str, e)
             return None
     
     def _parse_pod_ip(self, workload: Dict[str, Any]) -> Optional[str]:

--- a/server/src/services/k8s/client.py
+++ b/server/src/services/k8s/client.py
@@ -13,102 +13,285 @@
 # limitations under the License.
 
 """
-Kubernetes client wrapper for managing cluster connections and API access.
+Kubernetes client wrapper that provides a unified interface for all K8s resource
+operations. All API access goes through this class.
 """
 
-from typing import Optional
+import logging
+import threading
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
+
 from kubernetes import client, config
-from kubernetes.client import CoreV1Api, CustomObjectsApi, NodeV1Api
+from kubernetes.client import ApiException, CoreV1Api, CustomObjectsApi, NodeV1Api
 
 from src.config import KubernetesRuntimeConfig
+from src.services.k8s.informer import WorkloadInformer
+from src.services.k8s.rate_limiter import TokenBucketRateLimiter
+
+logger = logging.getLogger(__name__)
+
+# Type alias for informer cache key
+_InformerKey = Tuple[str, str, str, str]  # (group, version, plural, namespace)
 
 
 class K8sClient:
     """
-    Wrapper for Kubernetes API client with configuration management.
-    
-    Handles both in-cluster and kubeconfig-based authentication.
+    Unified Kubernetes API client.
+
+    Encapsulates all cluster resource operations (CustomObject, Secret, Pod,
+    RuntimeClass). Callers never hold raw API handles directly.
     """
-    
+
     def __init__(self, k8s_config: KubernetesRuntimeConfig):
-        """
-        Initialize Kubernetes client.
-
-        Args:
-            k8s_config: Kubernetes runtime configuration
-
-        Raises:
-            Exception: If unable to load Kubernetes configuration
-        """
         self.config = k8s_config
         self._load_config()
         self._core_v1_api: Optional[CoreV1Api] = None
         self._custom_objects_api: Optional[CustomObjectsApi] = None
         self._node_v1_api: Optional[NodeV1Api] = None
-    
+        # Informer pool: key -> WorkloadInformer
+        self._informers: Dict[_InformerKey, WorkloadInformer] = {}
+        self._informers_lock = threading.Lock()
+        # Rate limiters (None = unlimited)
+        self._read_limiter: Optional[TokenBucketRateLimiter] = (
+            TokenBucketRateLimiter(qps=k8s_config.read_qps, burst=k8s_config.read_burst)
+            if k8s_config.read_qps > 0
+            else None
+        )
+        self._write_limiter: Optional[TokenBucketRateLimiter] = (
+            TokenBucketRateLimiter(qps=k8s_config.write_qps, burst=k8s_config.write_burst)
+            if k8s_config.write_qps > 0
+            else None
+        )
+
+    # ------------------------------------------------------------------
+    # Internal API handle accessors (lazy singletons)
+    # ------------------------------------------------------------------
+
     def _load_config(self) -> None:
-        """
-        Load Kubernetes configuration from kubeconfig or in-cluster.
-        
-        Raises:
-            Exception: If configuration loading fails
-        """
+        """Load kubeconfig from file path or in-cluster service account."""
         try:
             if self.config.kubeconfig_path:
-                # Load from kubeconfig file
                 config.load_kube_config(config_file=self.config.kubeconfig_path)
             else:
-                # Load in-cluster config (when running inside K8s)
                 config.load_incluster_config()
         except Exception as e:
             raise Exception(f"Failed to load Kubernetes configuration: {e}") from e
-    
+
     def get_core_v1_api(self) -> CoreV1Api:
-        """
-        Get CoreV1Api client instance.
-        
-        Returns:
-            CoreV1Api: Kubernetes Core V1 API client
-        """
         if self._core_v1_api is None:
             self._core_v1_api = client.CoreV1Api()
         return self._core_v1_api
-    
-    def get_custom_objects_api(self) -> CustomObjectsApi:
-        """
-        Get CustomObjectsApi client instance for CRD operations.
 
-        Returns:
-            CustomObjectsApi: Kubernetes Custom Objects API client
-        """
+    def get_custom_objects_api(self) -> CustomObjectsApi:
         if self._custom_objects_api is None:
             self._custom_objects_api = client.CustomObjectsApi()
         return self._custom_objects_api
 
     def get_node_v1_api(self) -> NodeV1Api:
-        """
-        Get NodeV1Api client instance for RuntimeClass operations.
-
-        Returns:
-            NodeV1Api: Kubernetes Node V1 API client
-        """
         if self._node_v1_api is None:
             self._node_v1_api = client.NodeV1Api()
         return self._node_v1_api
 
-    async def read_runtime_class(self, name: str):
+    # ------------------------------------------------------------------
+    # Internal informer pool management
+    # ------------------------------------------------------------------
+
+    def _get_informer(self, group: str, version: str, plural: str, namespace: str) -> Optional[WorkloadInformer]:
+        """Return the informer for this resource+namespace, starting it lazily."""
+        if not self.config.informer_enabled:
+            return None
+
+        key: _InformerKey = (group, version, plural, namespace)
+        with self._informers_lock:
+            informer = self._informers.get(key)
+            if informer is None:
+                list_fn = partial(
+                    self.get_custom_objects_api().list_namespaced_custom_object,
+                    group=group,
+                    version=version,
+                    namespace=namespace,
+                    plural=plural,
+                )
+                informer = WorkloadInformer(
+                    list_fn=list_fn,
+                    resync_period_seconds=self.config.informer_resync_seconds,
+                    watch_timeout_seconds=self.config.informer_watch_timeout_seconds,
+                    thread_name=f"workload-informer-{plural}-{namespace}",
+                )
+                self._informers[key] = informer
+                try:
+                    informer.start()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("Failed to start informer for %s/%s: %s", plural, namespace, exc)
+                    self._informers.pop(key, None)
+                    return None
+        return informer
+
+    # ------------------------------------------------------------------
+    # CustomObject operations
+    # ------------------------------------------------------------------
+
+    def create_custom_object(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        body: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Create a namespaced custom resource."""
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        return self.get_custom_objects_api().create_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            body=body,
+        )
+
+    def get_custom_object(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        name: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a namespaced custom resource by name.
+
+        Tries the informer cache first when available and synced.
+        Returns None on 404.
         """
-        Read a RuntimeClass from the cluster.
+        informer = self._get_informer(group, version, plural, namespace)
+        if informer and informer.has_synced:
+            cached = informer.get(name)
+            if cached is not None:
+                return cached
 
-        Args:
-            name: RuntimeClass name
+        if self._read_limiter:
+            self._read_limiter.acquire()
+        try:
+            obj = self.get_custom_objects_api().get_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name,
+            )
+            if informer:
+                informer.update_cache(obj)
+            return obj
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
 
-        Returns:
-            The RuntimeClass object
+    def list_custom_objects(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        label_selector: str = "",
+    ) -> List[Dict[str, Any]]:
+        """List namespaced custom resources, returning the items list."""
+        if self._read_limiter:
+            self._read_limiter.acquire()
+        try:
+            resp = self.get_custom_objects_api().list_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                label_selector=label_selector,
+            )
+            return resp.get("items", [])
+        except ApiException as e:
+            if e.status == 404:
+                return []
+            raise
 
-        Raises:
-            ApiException: If the RuntimeClass does not exist
-        """
-        # Note: Kubernetes client is synchronous, but we wrap it in an async method
-        # for compatibility with async contexts
+    def delete_custom_object(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        name: str,
+        grace_period_seconds: int = 0,
+    ) -> None:
+        """Delete a namespaced custom resource."""
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        self.get_custom_objects_api().delete_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            name=name,
+            grace_period_seconds=grace_period_seconds,
+        )
+
+    def patch_custom_object(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        name: str,
+        body: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Patch a namespaced custom resource."""
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        return self.get_custom_objects_api().patch_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            name=name,
+            body=body,
+        )
+
+    # ------------------------------------------------------------------
+    # Secret operations
+    # ------------------------------------------------------------------
+
+    def create_secret(self, namespace: str, body: Any) -> Any:
+        """Create a namespaced Secret."""
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        return self.get_core_v1_api().create_namespaced_secret(
+            namespace=namespace,
+            body=body,
+        )
+
+    # ------------------------------------------------------------------
+    # Pod operations
+    # ------------------------------------------------------------------
+
+    def list_pods(
+        self,
+        namespace: str,
+        label_selector: str = "",
+    ) -> List[Any]:
+        """List pods in a namespace, returning the items list."""
+        if self._read_limiter:
+            self._read_limiter.acquire()
+        resp = self.get_core_v1_api().list_namespaced_pod(
+            namespace=namespace,
+            label_selector=label_selector,
+        )
+        return resp.items
+
+    # ------------------------------------------------------------------
+    # RuntimeClass operations
+    # ------------------------------------------------------------------
+
+    def read_runtime_class(self, name: str) -> Any:
+        """Read a RuntimeClass from the cluster."""
+        if self._read_limiter:
+            self._read_limiter.acquire()
         return self.get_node_v1_api().read_runtime_class(name)

--- a/server/src/services/k8s/informer.py
+++ b/server/src/services/k8s/informer.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Alibaba Group Holding Ltd.
+# Copyright 2025 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 import logging
 import threading
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from kubernetes import watch
-from kubernetes.client import ApiException, CustomObjectsApi
+from kubernetes.client import ApiException
 
 logger = logging.getLogger(__name__)
 
@@ -29,23 +29,28 @@ class WorkloadInformer:
 
     def __init__(
         self,
-        custom_api: CustomObjectsApi,
-        group: str,
-        version: str,
-        plural: str,
-        namespace: str,
+        list_fn: Callable[..., Any],
         resync_period_seconds: int = 300,
         watch_timeout_seconds: int = 60,
         enable_watch: bool = True,
+        thread_name: str = "workload-informer",
     ):
-        self.custom_api = custom_api
-        self.group = group
-        self.version = version
-        self.plural = plural
-        self.namespace = namespace
+        """
+        Args:
+            list_fn: Callable that lists the custom resource, with signature
+                     ``list_fn(**kwargs) -> dict``.  Typically a bound method
+                     like ``custom_api.list_namespaced_custom_object``.
+            resync_period_seconds: Full-resync interval when watch is disabled.
+            watch_timeout_seconds: Per-stream watch timeout before restart.
+            enable_watch: When False only the initial list is performed.
+            thread_name: Name for the background thread, used in stack traces
+                         and debuggers.  Should be unique per informer instance.
+        """
+        self.list_fn = list_fn
         self.resync_period_seconds = resync_period_seconds
         self.watch_timeout_seconds = watch_timeout_seconds
         self.enable_watch = enable_watch
+        self._thread_name = thread_name
 
         self._cache: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.RLock()
@@ -66,7 +71,7 @@ class WorkloadInformer:
 
         self._thread = threading.Thread(
             target=self._run,
-            name=f"workload-informer-{self.plural}-{self.namespace}",
+            name=self._thread_name,
             daemon=True,
         )
         self._thread.start()
@@ -78,13 +83,14 @@ class WorkloadInformer:
     def get(self, name: str) -> Optional[Dict[str, Any]]:
         """Return cached object by name, if present."""
         with self._lock:
-            obj = self._cache.get(name)
-            if obj:
-                return obj
-        return None
+            return self._cache.get(name)
 
     def update_cache(self, obj: Dict[str, Any]) -> None:
-        """Upsert a single object into the cache."""
+        """Upsert a single object into the cache.
+
+        Only advances ``_resource_version`` if the incoming version is strictly
+        newer, preventing a stale API response from rolling back the watch cursor.
+        """
         metadata = obj.get("metadata", {})
         name = metadata.get("name")
         if not name:
@@ -92,8 +98,28 @@ class WorkloadInformer:
 
         with self._lock:
             self._cache[name] = obj
-            if metadata.get("resourceVersion"):
-                self._resource_version = metadata["resourceVersion"]
+            self._advance_resource_version(metadata.get("resourceVersion"))
+
+    def _advance_resource_version(self, rv: Optional[str]) -> None:
+        """Advance ``_resource_version`` only when *rv* is strictly newer.
+
+        K8s resourceVersions are opaque strings but etcd encodes them as
+        monotonically increasing integers.  If the conversion fails we skip the
+        update (conservative: keep the current, newer cursor).
+
+        Must be called with ``self._lock`` already held.
+        """
+        if not rv:
+            return
+        if self._resource_version is None:
+            self._resource_version = rv
+            return
+        try:
+            if int(rv) > int(self._resource_version):
+                self._resource_version = rv
+        except ValueError:
+            # Non-integer resourceVersion — skip to avoid downgrade.
+            pass
 
     def _run(self) -> None:
         backoff = 1.0
@@ -105,6 +131,7 @@ class WorkloadInformer:
 
                 if not self.enable_watch:
                     self._stop_event.wait(self.resync_period_seconds)
+                    self._has_synced = False  # trigger a fresh list on next loop
                     continue
 
                 self._run_watch_loop()
@@ -115,28 +142,19 @@ class WorkloadInformer:
                     self._resource_version = None
                     self._has_synced = False
                 else:
-                    logger.warning(
-                        "Informer watch error for %s: %s", self.plural, exc, exc_info=True
-                    )
+                    logger.warning("Informer watch error: %s", exc, exc_info=True)
                     self._has_synced = False
                     self._stop_event.wait(min(backoff, 30.0))
                     backoff = min(backoff * 2, 30.0)
             except Exception as exc:  # pragma: no cover - defensive
-                logger.warning(
-                    "Unexpected informer error for %s: %s", self.plural, exc, exc_info=True
-                )
+                logger.warning("Unexpected informer error: %s", exc, exc_info=True)
                 self._has_synced = False
                 self._stop_event.wait(min(backoff, 30.0))
                 backoff = min(backoff * 2, 30.0)
 
     def _full_resync(self) -> None:
         """Perform a full list to refresh the cache."""
-        resp = self.custom_api.list_namespaced_custom_object(
-            group=self.group,
-            version=self.version,
-            namespace=self.namespace,
-            plural=self.plural,
-        )
+        resp = self.list_fn()
 
         # list response is a dict for CustomObjectsApi
         items = resp.get("items", []) if isinstance(resp, dict) else []
@@ -152,8 +170,7 @@ class WorkloadInformer:
 
         with self._lock:
             self._cache = new_cache
-            if resource_version:
-                self._resource_version = resource_version
+            self._advance_resource_version(resource_version)
             self._has_synced = True
 
     def _run_watch_loop(self) -> None:
@@ -161,11 +178,7 @@ class WorkloadInformer:
         w = watch.Watch()
         try:
             for event in w.stream(
-                self.custom_api.list_namespaced_custom_object,
-                group=self.group,
-                version=self.version,
-                namespace=self.namespace,
-                plural=self.plural,
+                self.list_fn,
                 resource_version=self._resource_version,
                 timeout_seconds=self.watch_timeout_seconds,
             ):
@@ -197,5 +210,4 @@ class WorkloadInformer:
                 self._cache.pop(name, None)
             else:
                 self._cache[name] = obj
-            if metadata.get("resourceVersion"):
-                self._resource_version = metadata["resourceVersion"]
+            self._advance_resource_version(metadata.get("resourceVersion"))

--- a/server/src/services/k8s/kubernetes_service.py
+++ b/server/src/services/k8s/kubernetes_service.py
@@ -30,6 +30,7 @@ from src.api.schema import (
     CreateSandboxRequest,
     CreateSandboxResponse,
     Endpoint,
+    ImageSpec,
     ListSandboxesRequest,
     ListSandboxesResponse,
     PaginationInfo,
@@ -89,7 +90,6 @@ class KubernetesSandboxService(SandboxService):
 
         self.namespace = self.app_config.kubernetes.namespace
         self.execd_image = runtime_config.execd_image
-        self.service_account = self.app_config.kubernetes.service_account
         
         # Initialize Kubernetes client
         try:
@@ -111,9 +111,6 @@ class KubernetesSandboxService(SandboxService):
             self.workload_provider = create_workload_provider(
                 provider_type=provider_type,
                 k8s_client=self.k8s_client,
-                k8s_config=self.app_config.kubernetes,
-                agent_sandbox_config=self.app_config.agent_sandbox,
-                ingress_config=self.ingress_config,
                 app_config=self.app_config,
             )
             logger.info(
@@ -743,8 +740,6 @@ class KubernetesSandboxService(SandboxService):
                 image_uri = container.image or ""
                 entrypoint = container.command or []
         
-        # Create ImageSpec object
-        from src.api.schema import ImageSpec
         image_spec = ImageSpec(uri=image_uri) if image_uri else ImageSpec(uri="unknown")
         
         return Sandbox(

--- a/server/src/services/k8s/provider_factory.py
+++ b/server/src/services/k8s/provider_factory.py
@@ -19,7 +19,7 @@ Factory for creating WorkloadProvider instances.
 import logging
 from typing import Dict, Type, Optional
 
-from src.config import AppConfig, KubernetesRuntimeConfig, AgentSandboxRuntimeConfig, IngressConfig
+from src.config import AppConfig
 from src.services.k8s.workload_provider import WorkloadProvider
 from src.services.k8s.batchsandbox_provider import BatchSandboxProvider
 from src.services.k8s.agent_sandbox_provider import AgentSandboxProvider
@@ -43,9 +43,6 @@ _PROVIDER_REGISTRY: Dict[str, Type[WorkloadProvider]] = {
 def create_workload_provider(
     provider_type: str | None,
     k8s_client: K8sClient,
-    k8s_config: Optional[KubernetesRuntimeConfig] = None,
-    agent_sandbox_config: Optional[AgentSandboxRuntimeConfig] = None,
-    ingress_config: Optional[IngressConfig] = None,
     app_config: Optional[AppConfig] = None,
 ) -> WorkloadProvider:
     """
@@ -55,9 +52,8 @@ def create_workload_provider(
         provider_type: Type of provider (e.g., 'batchsandbox', 'pod', 'job').
                       If None, uses the first registered provider.
         k8s_client: Kubernetes client instance
-        k8s_config: Optional Kubernetes runtime configuration (for template file paths, etc.)
-        agent_sandbox_config: Optional agent-sandbox configuration (for template/shutdown policy)
-        app_config: Optional application config for secure runtime
+        app_config: Application config; kubernetes/agent_sandbox/ingress sub-configs
+                    are read from it directly.
 
     Returns:
         WorkloadProvider instance
@@ -87,43 +83,11 @@ def create_workload_provider(
     provider_class = _PROVIDER_REGISTRY[provider_type_lower]
     logger.info(f"Creating workload provider: {provider_class.__name__}")
 
-    # Special handling for BatchSandboxProvider - pass template file path
-    if provider_type_lower == PROVIDER_TYPE_BATCHSANDBOX:
-        template_file = k8s_config.batchsandbox_template_file if k8s_config else None
-        if template_file:
-            logger.info(f"Using BatchSandbox template file: {template_file}")
-        return provider_class(
-            k8s_client,
-            template_file_path=template_file,
-            ingress_config=ingress_config,
-            enable_informer=k8s_config.informer_enabled,
-            informer_resync_seconds=k8s_config.informer_resync_seconds,
-            informer_watch_timeout_seconds=k8s_config.informer_watch_timeout_seconds,
-            app_config=app_config,
-            execd_init_resources=k8s_config.execd_init_resources if k8s_config else None,
-        )
+    # BatchSandboxProvider and AgentSandboxProvider read all sub-configs from app_config.
+    if provider_type_lower in (PROVIDER_TYPE_BATCHSANDBOX, PROVIDER_TYPE_AGENT_SANDBOX):
+        return provider_class(k8s_client, app_config=app_config)
 
-    # Special handling for AgentSandboxProvider - pass agent-specific settings
-    if provider_type_lower == PROVIDER_TYPE_AGENT_SANDBOX:
-        agent_config = agent_sandbox_config or AgentSandboxRuntimeConfig()
-        return provider_class(
-            k8s_client,
-            template_file_path=agent_config.template_file,
-            shutdown_policy=agent_config.shutdown_policy,
-            service_account=k8s_config.service_account if k8s_config else None,
-            ingress_config=ingress_config,
-            enable_informer=k8s_config.informer_enabled if k8s_config else True,
-            informer_resync_seconds=(
-                k8s_config.informer_resync_seconds if k8s_config else 300
-            ),
-            informer_watch_timeout_seconds=(
-                k8s_config.informer_watch_timeout_seconds if k8s_config else 60
-            ),
-            app_config=app_config,
-            execd_init_resources=k8s_config.execd_init_resources if k8s_config else None,
-        )
-
-    # Providers without ingress-specific needs
+    # Providers that do not accept app_config
     return provider_class(k8s_client)
 
 

--- a/server/src/services/k8s/rate_limiter.py
+++ b/server/src/services/k8s/rate_limiter.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generic token-bucket rate limiter.
+
+Usage example::
+
+    limiter = TokenBucketRateLimiter(qps=10.0, burst=20)
+    limiter.acquire()   # blocks until a token is available
+    do_something()
+"""
+
+import threading
+import time
+
+
+class TokenBucketRateLimiter:
+    """Thread-safe token-bucket rate limiter.
+
+    Tokens refill at ``qps`` tokens per second up to a maximum of ``burst``.
+    Calling :meth:`acquire` consumes one token, blocking if the bucket is empty.
+
+    Args:
+        qps: Sustained request rate in requests per second.
+        burst: Maximum burst size (bucket capacity). Defaults to ``qps``,
+               with a minimum of 1 to ensure at least one token is always
+               available regardless of qps.
+    """
+
+    def __init__(self, qps: float, burst: float = 0.0) -> None:
+        if qps <= 0:
+            raise ValueError(f"qps must be > 0, got {qps}")
+        self._qps = qps
+        self._burst = max(burst if burst > 0 else qps, 1.0)
+        self._tokens = self._burst
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def acquire(self) -> None:
+        """Acquire one token, blocking until one is available."""
+        while True:
+            wait = self._try_acquire()
+            if wait <= 0.0:
+                return
+            # Clamp to a minimum of 1 ms to avoid a busy-loop caused by
+            # floating-point imprecision when the deficit is near-zero.
+            time.sleep(max(wait, 0.001))
+
+    def try_acquire(self) -> bool:
+        """Try to acquire one token without blocking.
+
+        Returns:
+            ``True`` if a token was consumed, ``False`` if the bucket is empty.
+        """
+        return self._try_acquire() <= 0.0
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _try_acquire(self) -> float:
+        """Attempt to take a token.
+
+        Returns:
+            0.0 if a token was consumed successfully, otherwise the approximate
+            number of seconds to wait before retrying.
+        """
+        with self._lock:
+            self._refill()
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return 0.0
+            # Time until one token is available
+            return (1.0 - self._tokens) / self._qps
+
+    def _refill(self) -> None:
+        """Add tokens proportional to elapsed time (call with lock held)."""
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        self._tokens = min(self._burst, self._tokens + elapsed * self._qps)
+        self._last_refill = now

--- a/server/src/services/runtime_resolver.py
+++ b/server/src/services/runtime_resolver.py
@@ -23,6 +23,7 @@ This module provides:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Optional
 
@@ -233,8 +234,8 @@ async def _validate_k8s_runtime_class(
         return
 
     try:
-        # Use the K8sClient's read_runtime_class method
-        await k8s_client.read_runtime_class(runtime_class_name)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, k8s_client.read_runtime_class, runtime_class_name)
         logger.info("Kubernetes RuntimeClass '%s' is available.", runtime_class_name)
     except ApiException as exc:
         if exc.status == 404:

--- a/server/tests/k8s/conftest.py
+++ b/server/tests/k8s/conftest.py
@@ -26,10 +26,9 @@ def stub_workload_informer(monkeypatch):
     """
     Prevent real informer threads in unit tests.
     
-    Default informer behavior is enabled in production, but for unit tests we
-    stub it out so that API calls are still exercised without starting watch
-    threads or requiring cluster connections. Tests that need informer behavior
-    can supply a custom informer_factory explicitly.
+    Stubs the WorkloadInformer used inside K8sClient so that watch threads are
+    not started during unit tests. Cache is always empty (has_synced=False),
+    so get_custom_object falls through to the mocked API call.
     """
 
     class _FakeInformer:
@@ -49,8 +48,5 @@ def stub_workload_informer(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "src.services.k8s.agent_sandbox_provider.WorkloadInformer", _FakeInformer
-    )
-    monkeypatch.setattr(
-        "src.services.k8s.batchsandbox_provider.WorkloadInformer", _FakeInformer
+        "src.services.k8s.client.WorkloadInformer", _FakeInformer
     )

--- a/server/tests/k8s/fixtures/k8s_fixtures.py
+++ b/server/tests/k8s/fixtures/k8s_fixtures.py
@@ -37,6 +37,14 @@ def mock_k8s_client():
     client.get_core_v1_api.return_value = mock_core_api
     client.custom_api = mock_custom_api
     client.core_api = mock_core_api
+    # Unified resource operation methods
+    client.create_custom_object = MagicMock(return_value={"metadata": {"name": "test", "uid": "uid"}})
+    client.get_custom_object = MagicMock(return_value=None)
+    client.list_custom_objects = MagicMock(return_value=[])
+    client.delete_custom_object = MagicMock()
+    client.patch_custom_object = MagicMock()
+    client.create_secret = MagicMock()
+    client.list_pods = MagicMock(return_value=[])
     return client
 
 

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -24,8 +24,22 @@ import pytest
 from kubernetes.client import ApiException
 
 from src.api.schema import ImageSpec, NetworkPolicy, NetworkRule
-from src.config import ExecdInitResources
+from src.config import AppConfig, ExecdInitResources, KubernetesRuntimeConfig, AgentSandboxRuntimeConfig, RuntimeConfig
 from src.services.k8s.agent_sandbox_provider import AgentSandboxProvider
+
+
+def _app_config(shutdown_policy: str = "Delete", service_account: str | None = None, execd_init_resources: ExecdInitResources | None = None) -> AppConfig:
+    """Build an AppConfig for AgentSandboxProvider tests."""
+    return AppConfig(
+        runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+        kubernetes=KubernetesRuntimeConfig(
+            namespace="test-ns",
+            service_account=service_account,
+            workload_provider="agent-sandbox",
+            execd_init_resources=execd_init_resources,
+        ),
+        agent_sandbox=AgentSandboxRuntimeConfig(shutdown_policy=shutdown_policy),
+    )
 
 
 class TestAgentSandboxProvider:
@@ -47,11 +61,9 @@ class TestAgentSandboxProvider:
         """
         provider = AgentSandboxProvider(
             mock_k8s_client,
-            shutdown_policy="Delete",
-            service_account="agent-sa",
+            _app_config(shutdown_policy="Delete", service_account="agent-sa"),
         )
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -71,7 +83,7 @@ class TestAgentSandboxProvider:
 
         assert result == {"name": "test-id", "uid": "test-uid"}
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["apiVersion"] == "agents.x-k8s.io/v1alpha1"
         assert body["kind"] == "Sandbox"
         assert body["metadata"]["name"] == "test-id"
@@ -89,8 +101,7 @@ class TestAgentSandboxProvider:
         Test case: Ensure sandbox names are DNS-1035 compliant when IDs start with digits
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-1234", "uid": "test-uid"}
         }
 
@@ -109,7 +120,7 @@ class TestAgentSandboxProvider:
         )
 
         assert result == {"name": "sandbox-1234", "uid": "test-uid"}
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["metadata"]["name"] == "sandbox-1234"
 
     def test_resource_name_uses_hash_when_id_has_no_alnum(self, mock_k8s_client):
@@ -127,14 +138,10 @@ class TestAgentSandboxProvider:
 
     def test_get_workload_returns_none_on_404(self, mock_k8s_client):
         """
-        Test case: Verify None returned on 404 exception
+        Test case: Verify None returned when not found
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
-            ApiException(status=404),
-        ]
+        mock_k8s_client.get_custom_object.return_value = None
 
         result = provider.get_workload("test-id", "test-ns")
 
@@ -145,104 +152,67 @@ class TestAgentSandboxProvider:
         Test case: Ensure DNS-1035 resource name is tried before raw id
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
+        mock_k8s_client.get_custom_object.side_effect = [
+            None,
             {"metadata": {"name": "1234"}},
         ]
 
         result = provider.get_workload("1234", "test-ns")
 
         assert result["metadata"]["name"] == "1234"
-        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "sandbox-1234"
-        assert mock_api.get_namespaced_custom_object.call_args_list[1].kwargs["name"] == "1234"
+        assert mock_k8s_client.get_custom_object.call_args_list[0].kwargs["name"] == "sandbox-1234"
+        assert mock_k8s_client.get_custom_object.call_args_list[1].kwargs["name"] == "1234"
 
     def test_get_workload_falls_back_to_legacy_name(self, mock_k8s_client):
         """
-        Test case: Verify legacy sandbox-<id> name is used when primary lookup 404s
+        Test case: Verify legacy sandbox-<id> name is used when primary lookup returns None
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
+        mock_k8s_client.get_custom_object.side_effect = [
+            None,
             {"metadata": {"name": "sandbox-test-id"}},
         ]
 
         result = provider.get_workload("test-id", "test-ns")
 
         assert result["metadata"]["name"] == "sandbox-test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[1].kwargs["name"] == "sandbox-test-id"
+        assert mock_k8s_client.get_custom_object.call_args_list[0].kwargs["name"] == "test-id"
+        assert mock_k8s_client.get_custom_object.call_args_list[1].kwargs["name"] == "sandbox-test-id"
 
     def test_get_workload_reraises_non_404_exceptions(self, mock_k8s_client):
         """
         Test case: Verify non-404 exceptions are re-raised
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = ApiException(status=500)
+        mock_k8s_client.get_custom_object.side_effect = ApiException(status=500)
 
         with pytest.raises(ApiException) as exc_info:
             provider.get_workload("test-id", "test-ns")
 
         assert exc_info.value.status == 500
 
-    def test_get_workload_prefers_informer_cache(self, mock_k8s_client, monkeypatch):
+    def test_get_workload_prefers_informer_cache(self, mock_k8s_client):
         """
-        Test case: Use informer cache when already synced
+        Test case: get_workload calls k8s_client.get_custom_object and returns result
         """
         cached = {"metadata": {"name": "test-id"}}
+        mock_k8s_client.get_custom_object.return_value = cached
 
-        class FakeInformer:
-            def __init__(self):
-                self.started = False
-                self.has_synced = True
-
-            def start(self):
-                self.started = True
-
-            def get(self, name):
-                return cached if name == "test-id" else None
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        fake_informer = FakeInformer()
-        provider = AgentSandboxProvider(
-            mock_k8s_client,
-            informer_factory=lambda ns: fake_informer,
-        )
+        provider = AgentSandboxProvider(mock_k8s_client)
 
         result = provider.get_workload("test-id", "test-ns")
 
         assert result == cached
-        assert fake_informer.started is True
-        mock_k8s_client.get_custom_objects_api().get_namespaced_custom_object.assert_not_called()
+        mock_k8s_client.get_custom_object.assert_called()
 
     def test_create_workload_updates_informer_cache(self, mock_k8s_client):
         """
-        Test case: informer cache is updated immediately after create
+        Test case: create_workload returns name and uid from created resource
         """
         created_body = {"metadata": {"name": "test-id", "uid": "test-uid"}}
+        mock_k8s_client.create_custom_object.return_value = created_body
 
-        class FakeInformer:
-            def __init__(self):
-                self.started = False
-                self.updated = None
-
-            def start(self):
-                self.started = True
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        fake_informer = FakeInformer()
-        provider = AgentSandboxProvider(
-            mock_k8s_client,
-            informer_factory=lambda ns: fake_informer,
-        )
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = created_body
+        provider = AgentSandboxProvider(mock_k8s_client)
 
         expires_at = datetime(2025, 12, 31, 10, 0, 0, tzinfo=timezone.utc)
 
@@ -259,54 +229,18 @@ class TestAgentSandboxProvider:
         )
 
         assert result == {"name": "test-id", "uid": "test-uid"}
-        assert fake_informer.updated == created_body
-        assert fake_informer.started is True
-
-    def test_get_informer_single_instance_per_namespace(self, mock_k8s_client):
-        """
-        Test case: informer is created only once per namespace even with repeated calls
-        """
-
-        class FakeInformer:
-            def __init__(self):
-                self.started = 0
-
-            def start(self):
-                self.started += 1
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        factory_calls = {"count": 0}
-
-        def factory(ns):
-            factory_calls["count"] += 1
-            return FakeInformer()
-
-        provider = AgentSandboxProvider(
-            mock_k8s_client,
-            informer_factory=factory,
-        )
-
-        informer1 = provider._get_informer("test-ns")
-        informer2 = provider._get_informer("test-ns")
-
-        assert informer1 is informer2
-        assert factory_calls["count"] == 1
-        assert informer1.started == 1
 
     def test_update_expiration_patches_spec(self, mock_k8s_client):
         """
         Test case: Verify expiration time update
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.return_value = {"metadata": {"name": "sandbox-test-id"}}
+        mock_k8s_client.get_custom_object.return_value = {"metadata": {"name": "sandbox-test-id"}}
 
         expires_at = datetime(2025, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
         provider.update_expiration("test-id", "test-ns", expires_at)
 
-        call_kwargs = mock_api.patch_namespaced_custom_object.call_args.kwargs
+        call_kwargs = mock_k8s_client.patch_custom_object.call_args.kwargs
         assert call_kwargs["body"] == {
             "spec": {"shutdownTime": "2025-12-31T00:00:00+00:00"}
         }
@@ -378,14 +312,11 @@ class TestAgentSandboxProvider:
         Test case: Verify status fallback uses pod selector state (Running + IP = Running)
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        core_api = mock_k8s_client.get_core_v1_api()
-        core_api.list_namespaced_pod.return_value = MagicMock(
-            items=[
-                SimpleNamespace(
-                    status=SimpleNamespace(phase="Running", pod_ip="10.0.0.2")
-                )
-            ]
-        )
+        mock_k8s_client.list_pods.return_value = [
+            SimpleNamespace(
+                status=SimpleNamespace(phase="Running", pod_ip="10.0.0.2")
+            )
+        ]
         workload = {
             "status": {"conditions": [], "selector": "app=sandbox"},
             "metadata": {"creationTimestamp": "2025-12-31T09:00:00Z", "namespace": "test-ns"},
@@ -401,14 +332,11 @@ class TestAgentSandboxProvider:
         Test case: Verify Allocated state when Pod has IP but is not Running yet
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        core_api = mock_k8s_client.get_core_v1_api()
-        core_api.list_namespaced_pod.return_value = MagicMock(
-            items=[
-                SimpleNamespace(
-                    status=SimpleNamespace(phase="Pending", pod_ip="10.0.0.2")
-                )
-            ]
-        )
+        mock_k8s_client.list_pods.return_value = [
+            SimpleNamespace(
+                status=SimpleNamespace(phase="Pending", pod_ip="10.0.0.2")
+            )
+        ]
         workload = {
             "status": {"conditions": [], "selector": "app=sandbox"},
             "metadata": {"creationTimestamp": "2025-12-31T09:00:00Z", "namespace": "test-ns"},
@@ -424,14 +352,11 @@ class TestAgentSandboxProvider:
         Test case: Verify endpoint uses running pod IP
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        core_api = mock_k8s_client.get_core_v1_api()
-        core_api.list_namespaced_pod.return_value = MagicMock(
-            items=[
-                SimpleNamespace(
-                    status=SimpleNamespace(phase="Running", pod_ip="10.0.0.9")
-                )
-            ]
-        )
+        mock_k8s_client.list_pods.return_value = [
+            SimpleNamespace(
+                status=SimpleNamespace(phase="Running", pod_ip="10.0.0.9")
+            )
+        ]
         workload = {
             "status": {"selector": "app=sandbox"},
             "metadata": {"namespace": "test-ns"},
@@ -447,8 +372,7 @@ class TestAgentSandboxProvider:
         Test case: Verify endpoint falls back to serviceFQDN on pod lookup failure
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        core_api = mock_k8s_client.get_core_v1_api()
-        core_api.list_namespaced_pod.side_effect = Exception("boom")
+        mock_k8s_client.list_pods.side_effect = Exception("boom")
         workload = {
             "status": {"selector": "app=sandbox", "serviceFQDN": "svc.example.com"},
             "metadata": {"namespace": "test-ns"},
@@ -468,8 +392,7 @@ class TestAgentSandboxProviderExecdInit:
         Test case: Verify init container has no resources when execd_init_resources is not set
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -485,7 +408,7 @@ class TestAgentSandboxProviderExecdInit:
             execd_image="execd:latest",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         init_containers = body["spec"]["podTemplate"]["spec"]["initContainers"]
         assert len(init_containers) == 1
         assert "resources" not in init_containers[0]
@@ -496,13 +419,12 @@ class TestAgentSandboxProviderExecdInit:
         """
         provider = AgentSandboxProvider(
             mock_k8s_client,
-            execd_init_resources=ExecdInitResources(
+            _app_config(execd_init_resources=ExecdInitResources(
                 limits={"cpu": "100m", "memory": "128Mi"},
                 requests={"cpu": "50m", "memory": "64Mi"},
-            ),
+            )),
         )
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -518,7 +440,7 @@ class TestAgentSandboxProviderExecdInit:
             execd_image="execd:latest",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         init_containers = body["spec"]["podTemplate"]["spec"]["initContainers"]
         assert init_containers[0]["resources"]["limits"] == {"cpu": "100m", "memory": "128Mi"}
         assert init_containers[0]["resources"]["requests"] == {"cpu": "50m", "memory": "64Mi"}
@@ -532,8 +454,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify no sidecar is added when network_policy is None
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -553,7 +474,7 @@ class TestAgentSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         
@@ -568,8 +489,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify egress sidecar is added when network_policy is provided
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -593,7 +513,7 @@ class TestAgentSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         
@@ -620,8 +540,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify IPv6 disable sysctls are added to Pod spec
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -645,7 +564,7 @@ class TestAgentSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         
         # Verify securityContext with sysctls exists
@@ -669,8 +588,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify main container drops NET_ADMIN when network_policy is enabled
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -694,7 +612,7 @@ class TestAgentSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         
@@ -713,8 +631,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify no sidecar is added when egress_image is None even if network_policy exists
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -738,7 +655,7 @@ class TestAgentSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         
@@ -751,8 +668,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify sidecar environment variable contains serialized network policy
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -779,7 +695,7 @@ class TestAgentSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         
@@ -802,8 +718,7 @@ class TestAgentSandboxProviderEgress:
         Test case: Verify main container has no securityContext when network_policy is None
         """
         provider = AgentSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -823,7 +738,7 @@ class TestAgentSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["podTemplate"]["spec"]
         containers = pod_spec["containers"]
         

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -22,10 +22,32 @@ from unittest.mock import MagicMock
 from kubernetes.client import ApiException
 
 from src.api.schema import ImageSpec, ImageAuth, NetworkPolicy, NetworkRule
-from src.config import ExecdInitResources
+from src.config import AppConfig, ExecdInitResources, KubernetesRuntimeConfig, RuntimeConfig
 from src.services.k8s.batchsandbox_provider import BatchSandboxProvider
 from src.services.k8s.image_pull_secret_helper import IMAGE_AUTH_SECRET_PREFIX
 from src.services.k8s.volume_helper import apply_volumes_to_pod_spec
+
+
+def _app_config_with_template(template_file_path: str) -> AppConfig:
+    """Build an AppConfig with a batchsandbox_template_file set."""
+    return AppConfig(
+        runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+        kubernetes=KubernetesRuntimeConfig(
+            namespace="test-ns",
+            batchsandbox_template_file=template_file_path,
+        ),
+    )
+
+
+def _app_config_with_execd_resources(execd_init_resources: ExecdInitResources) -> AppConfig:
+    """Build an AppConfig with execd_init_resources set."""
+    return AppConfig(
+        runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+        kubernetes=KubernetesRuntimeConfig(
+            namespace="test-ns",
+            execd_init_resources=execd_init_resources,
+        ),
+    )
 
 
 class TestBatchSandboxProvider:
@@ -37,7 +59,7 @@ class TestBatchSandboxProvider:
         """
         Test case: Verify normal initialization without template
         """
-        provider = BatchSandboxProvider(mock_k8s_client, template_file_path=None)
+        provider = BatchSandboxProvider(mock_k8s_client)
         
         assert provider.k8s_client == mock_k8s_client
         assert provider.template_manager._template is None
@@ -52,7 +74,7 @@ class TestBatchSandboxProvider:
         template_file = tmp_path / "template.yaml"
         template_file.write_text("spec:\n  replicas: 1")
         
-        provider = BatchSandboxProvider(mock_k8s_client, str(template_file))
+        provider = BatchSandboxProvider(mock_k8s_client, _app_config_with_template(str(template_file)))
         
         assert provider.template_manager._template is not None
     
@@ -73,8 +95,7 @@ class TestBatchSandboxProvider:
         Test case: Verify created manifest structure is correct
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
         
@@ -95,7 +116,7 @@ class TestBatchSandboxProvider:
         assert result == {"name": "test-id", "uid": "test-uid"}
         
         # Verify API call
-        call_args = mock_api.create_namespaced_custom_object.call_args
+        call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
         
         assert body["apiVersion"] == "sandbox.opensandbox.io/v1alpha1"
@@ -114,8 +135,7 @@ class TestBatchSandboxProvider:
         Test case: Verify execd init container built correctly without resources when not configured
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test", "uid": "uid"}
         }
         
@@ -131,7 +151,7 @@ class TestBatchSandboxProvider:
             execd_image="execd:test"
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         init_container = body["spec"]["template"]["spec"]["initContainers"][0]
         
         assert init_container["name"] == "execd-installer"
@@ -148,13 +168,12 @@ class TestBatchSandboxProvider:
         """
         provider = BatchSandboxProvider(
             mock_k8s_client,
-            execd_init_resources=ExecdInitResources(
+            _app_config_with_execd_resources(ExecdInitResources(
                 limits={"cpu": "100m", "memory": "128Mi"},
                 requests={"cpu": "50m", "memory": "64Mi"},
-            ),
+            )),
         )
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test", "uid": "uid"}
         }
 
@@ -170,7 +189,7 @@ class TestBatchSandboxProvider:
             execd_image="execd:test",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         init_container = body["spec"]["template"]["spec"]["initContainers"][0]
         assert init_container["resources"]["limits"] == {"cpu": "100m", "memory": "128Mi"}
         assert init_container["resources"]["requests"] == {"cpu": "50m", "memory": "64Mi"}
@@ -180,8 +199,7 @@ class TestBatchSandboxProvider:
         Test case: Verify user entrypoint is wrapped with bootstrap
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
         
@@ -197,7 +215,7 @@ class TestBatchSandboxProvider:
             execd_image="execd:latest"
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         main_container = body["spec"]["template"]["spec"]["containers"][0]
         
         assert main_container["command"] == [
@@ -212,8 +230,7 @@ class TestBatchSandboxProvider:
         Also verifies EXECD environment variable is automatically injected.
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
         
@@ -229,7 +246,7 @@ class TestBatchSandboxProvider:
             execd_image="execd:latest"
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         env_vars = body["spec"]["template"]["spec"]["containers"][0]["env"]
         
         # Should have user env vars plus EXECD
@@ -261,9 +278,8 @@ spec:
               mountPath: /data
 """
         )
-        provider = BatchSandboxProvider(mock_k8s_client, str(template_file))
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        provider = BatchSandboxProvider(mock_k8s_client, _app_config_with_template(str(template_file)))
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
 
@@ -279,7 +295,7 @@ spec:
             execd_image="execd:latest"
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         spec = body["spec"]["template"]["spec"]
 
         volume_names = [v["name"] for v in spec["volumes"]]
@@ -319,9 +335,8 @@ spec:
               mountPath: /data
 """
         )
-        provider = BatchSandboxProvider(mock_k8s_client, str(template_file))
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        provider = BatchSandboxProvider(mock_k8s_client, _app_config_with_template(str(template_file)))
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
 
@@ -337,7 +352,7 @@ spec:
             execd_image="execd:latest"
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         spec = body["spec"]["template"]["spec"]
 
         volume_names = [v["name"] for v in spec["volumes"]]
@@ -353,8 +368,7 @@ spec:
         Test case: Verify resource limits set correctly
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
         
@@ -370,7 +384,7 @@ spec:
             execd_image="execd:latest"
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         resources = body["spec"]["template"]["spec"]["containers"][0]["resources"]
         
         assert resources["limits"] == {"cpu": "1", "memory": "1Gi"}
@@ -381,8 +395,7 @@ spec:
         Test case: Verify resources not set when resource limits are empty
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test", "uid": "uid"}
         }
         
@@ -398,7 +411,7 @@ spec:
             execd_image="execd:latest"
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         container = body["spec"]["template"]["spec"]["containers"][0]
         
         assert "resources" not in container
@@ -412,8 +425,7 @@ spec:
         Test case: Verify successfully querying existing sandbox
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
+        mock_k8s_client.get_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
         
         result = provider.get_workload("test-id", "test-ns")
         
@@ -425,11 +437,7 @@ spec:
         Test case: Verify None returned when not found
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
-            ApiException(status=404),
-        ]
+        mock_k8s_client.get_custom_object.return_value = None
         
         result = provider.get_workload("test-id", "test-ns")
         
@@ -437,31 +445,27 @@ spec:
 
     def test_get_workload_falls_back_to_legacy_name(self, mock_k8s_client):
         """
-        Test case: Verify legacy sandbox-<id> name is used when primary lookup 404s
+        Test case: Verify legacy sandbox-<id> name is used when primary lookup returns None
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
+        mock_k8s_client.get_custom_object.side_effect = [
+            None,
             {"metadata": {"name": "sandbox-test-id"}},
         ]
         
         result = provider.get_workload("test-id", "test-ns")
         
         assert result["metadata"]["name"] == "sandbox-test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[0].kwargs["name"] == "test-id"
-        assert mock_api.get_namespaced_custom_object.call_args_list[1].kwargs["name"] == "sandbox-test-id"
+        assert mock_k8s_client.get_custom_object.call_args_list[0].kwargs["name"] == "test-id"
+        assert mock_k8s_client.get_custom_object.call_args_list[1].kwargs["name"] == "sandbox-test-id"
     
     def test_get_workload_handles_404_gracefully(self, mock_k8s_client):
         """
-        Test case: Verify None returned on 404 exception
+        Test case: Verify None returned when not found
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
         
-        # Mock 404 exception
-        error = ApiException(status=404)
-        mock_api.get_namespaced_custom_object.side_effect = [error, error]
+        mock_k8s_client.get_custom_object.return_value = None
         
         result = provider.get_workload("test-id", "test-ns")
         
@@ -472,86 +476,48 @@ spec:
         Test case: Verify non-404 exceptions are re-raised
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
         
         # Mock 500 exception
         error = ApiException(status=500)
-        mock_api.get_namespaced_custom_object.side_effect = error
+        mock_k8s_client.get_custom_object.side_effect = error
         
         with pytest.raises(ApiException) as exc_info:
             provider.get_workload("test-id", "test-ns")
         
         assert exc_info.value.status == 500
 
-    def test_get_workload_prefers_informer_cache(self, mock_k8s_client, monkeypatch):
+    def test_get_workload_prefers_informer_cache(self, mock_k8s_client):
         """
-        Test case: Use informer cache when synced to avoid direct API call
+        Test case: get_workload calls k8s_client.get_custom_object and returns result
         """
         cached = {"metadata": {"name": "test-id"}}
+        mock_k8s_client.get_custom_object.return_value = cached
 
-        class FakeInformer:
-            def __init__(self):
-                self.started = False
-                self.has_synced = True
-
-            def start(self):
-                self.started = True
-
-            def get(self, name):
-                return cached if name == "test-id" else None
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        fake_informer = FakeInformer()
-        provider = BatchSandboxProvider(
-            mock_k8s_client,
-            enable_informer=True,
-            informer_factory=lambda ns: fake_informer,
-        )
+        provider = BatchSandboxProvider(mock_k8s_client)
 
         result = provider.get_workload("test-id", "test-ns")
 
         assert result == cached
-        assert fake_informer.started is True
-        mock_k8s_client.get_custom_objects_api().get_namespaced_custom_object.assert_not_called()
+        mock_k8s_client.get_custom_object.assert_called()
     
     def test_get_workload_logs_unexpected_errors(self, mock_k8s_client):
         """
         Test case: Verify unexpected errors are re-raised
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = RuntimeError("Unexpected")
+        mock_k8s_client.get_custom_object.side_effect = RuntimeError("Unexpected")
         
         with pytest.raises(RuntimeError, match="Unexpected"):
             provider.get_workload("test-id", "test-ns")
 
     def test_create_workload_updates_informer_cache(self, mock_k8s_client):
         """
-        Test case: informer cache is updated immediately after create
+        Test case: create_workload returns name and uid from created resource
         """
         created_body = {"metadata": {"name": "test-id", "uid": "test-uid"}}
+        mock_k8s_client.create_custom_object.return_value = created_body
 
-        class FakeInformer:
-            def __init__(self):
-                self.started = False
-                self.updated = None
-
-            def start(self):
-                self.started = True
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        fake_informer = FakeInformer()
-        provider = BatchSandboxProvider(
-            mock_k8s_client,
-            enable_informer=True,
-            informer_factory=lambda ns: fake_informer,
-        )
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = created_body
+        provider = BatchSandboxProvider(mock_k8s_client)
 
         expires_at = datetime(2025, 12, 31, tzinfo=timezone.utc)
 
@@ -568,42 +534,6 @@ spec:
         )
 
         assert result == {"name": "test-id", "uid": "test-uid"}
-        assert fake_informer.updated == created_body
-        assert fake_informer.started is True
-
-    def test_get_informer_single_instance_per_namespace(self, mock_k8s_client):
-        """
-        Test case: informer is created only once per namespace even with repeated calls
-        """
-
-        class FakeInformer:
-            def __init__(self):
-                self.started = 0
-
-            def start(self):
-                self.started += 1
-
-            def update_cache(self, obj):
-                self.updated = obj
-
-        factory_calls = {"count": 0}
-
-        def factory(ns):
-            factory_calls["count"] += 1
-            return FakeInformer()
-
-        provider = BatchSandboxProvider(
-            mock_k8s_client,
-            enable_informer=True,
-            informer_factory=factory,
-        )
-
-        informer1 = provider._get_informer("test-ns")
-        informer2 = provider._get_informer("test-ns")
-
-        assert informer1 is informer2
-        assert factory_calls["count"] == 1
-        assert informer1.started == 1
     
     # ===== Workload List Tests =====
     
@@ -614,8 +544,7 @@ spec:
         Test case: Verify list query returns results
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.list_namespaced_custom_object.return_value = mock_batchsandbox_list_response
+        mock_k8s_client.list_custom_objects.return_value = mock_batchsandbox_list_response["items"]
         
         result = provider.list_workloads("test-ns", "opensandbox.io/id")
         
@@ -624,11 +553,10 @@ spec:
     
     def test_list_workloads_returns_empty_on_404(self, mock_k8s_client):
         """
-        Test case: Verify empty list returned on 404
+        Test case: Verify empty list returned when no items
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.list_namespaced_custom_object.side_effect = ApiException(status=404)
+        mock_k8s_client.list_custom_objects.return_value = []
         
         result = provider.list_workloads("test-ns", "opensandbox.io/id")
         
@@ -643,12 +571,11 @@ spec:
         Test case: Verify successfully deleting existing sandbox
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
+        mock_k8s_client.get_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
         
         provider.delete_workload("test-id", "test-ns")
         
-        mock_api.delete_namespaced_custom_object.assert_called_once_with(
+        mock_k8s_client.delete_custom_object.assert_called_once_with(
             group="sandbox.opensandbox.io",
             version="v1alpha1",
             namespace="test-ns",
@@ -662,11 +589,7 @@ spec:
         Test case: Verify exception raised when not found
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.side_effect = [
-            ApiException(status=404),
-            ApiException(status=404),
-        ]
+        mock_k8s_client.get_custom_object.return_value = None
         
         with pytest.raises(Exception) as exc_info:
             provider.delete_workload("test-id", "test-ns")
@@ -680,12 +603,11 @@ spec:
         Test case: Verify immediate deletion (grace period = 0)
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
+        mock_k8s_client.get_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
         
         provider.delete_workload("test-id", "test-ns")
         
-        call_kwargs = mock_api.delete_namespaced_custom_object.call_args.kwargs
+        call_kwargs = mock_k8s_client.delete_custom_object.call_args.kwargs
         assert call_kwargs["grace_period_seconds"] == 0
     
     # ===== Expiration Time Management Tests =====
@@ -697,13 +619,12 @@ spec:
         Test case: Verify expiration time update
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.get_namespaced_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
+        mock_k8s_client.get_custom_object.return_value = mock_batchsandbox_list_response["items"][0]
         
         expires_at = datetime(2025, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
         provider.update_expiration("test-id", "test-ns", expires_at)
         
-        call_kwargs = mock_api.patch_namespaced_custom_object.call_args.kwargs
+        call_kwargs = mock_k8s_client.patch_custom_object.call_args.kwargs
         assert call_kwargs["body"] == {
             "spec": {"expireTime": "2025-12-31T00:00:00+00:00"}
         }
@@ -965,8 +886,7 @@ spec:
         This verifies backward compatibility - no error is raised.
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test-id", "uid": "test-uid"}
         }
         
@@ -987,7 +907,7 @@ spec:
         assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
         
         # Verify poolRef is used
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
     
     def test_create_workload_poolref_ignores_resource_limits(self, mock_k8s_client):
@@ -998,8 +918,7 @@ spec:
         This verifies backward compatibility - no error is raised.
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test-id", "uid": "test-uid"}
         }
         
@@ -1020,7 +939,7 @@ spec:
         assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
         
         # Verify poolRef is used
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
     
     def test_create_workload_poolref_allows_entrypoint_and_env(self, mock_k8s_client):
@@ -1030,8 +949,7 @@ spec:
         Verifies taskTemplate structure is correctly generated with user's entrypoint and env.
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "sandbox-test-id", "uid": "test-uid"}
         }
         
@@ -1051,7 +969,7 @@ spec:
         assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
         
         # Verify the call
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
         assert "taskTemplate" in body["spec"]
         
@@ -1197,8 +1115,7 @@ spec:
         - No template field (pool mode doesn't use pod template)
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
         
@@ -1217,7 +1134,7 @@ spec:
             extensions={"poolRef": "test-pool"}
         )
         
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         
         # Verify basic structure
         assert body["apiVersion"] == "sandbox.opensandbox.io/v1alpha1"
@@ -1243,8 +1160,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify no sidecar is added when network_policy is None
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1264,7 +1180,7 @@ class TestBatchSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1279,8 +1195,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify egress sidecar is added when network_policy is provided
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1304,7 +1219,7 @@ class TestBatchSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1331,8 +1246,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify IPv6 disable sysctls are added to Pod spec
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1356,7 +1270,7 @@ class TestBatchSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         
         # Verify securityContext with sysctls exists
@@ -1380,8 +1294,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify main container drops NET_ADMIN when network_policy is enabled
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1405,7 +1318,7 @@ class TestBatchSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1424,8 +1337,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify no sidecar is added when egress_image is None even if network_policy exists
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1449,7 +1361,7 @@ class TestBatchSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1462,8 +1374,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify sidecar environment variable contains serialized network policy
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1490,7 +1401,7 @@ class TestBatchSandboxProviderEgress:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1513,8 +1424,7 @@ class TestBatchSandboxProviderEgress:
         Test case: Verify main container has no securityContext when network_policy is None
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1534,7 +1444,7 @@ class TestBatchSandboxProviderEgress:
             egress_image=None,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1557,9 +1467,8 @@ spec:
           emptyDir: {}
 """
         )
-        provider = BatchSandboxProvider(mock_k8s_client, str(template_file))
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        provider = BatchSandboxProvider(mock_k8s_client, _app_config_with_template(str(template_file)))
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1583,7 +1492,7 @@ spec:
             egress_image="opensandbox/egress:v1.0.3",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
         containers = pod_spec["containers"]
         
@@ -1617,8 +1526,7 @@ spec:
         Test case: imagePullSecrets is injected into pod spec when image auth is provided
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "uid-123"}
         }
 
@@ -1637,7 +1545,7 @@ spec:
             execd_image="execd:latest",
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pull_secrets = body["spec"]["template"]["spec"].get("imagePullSecrets")
         assert pull_secrets == [{"name": f"{IMAGE_AUTH_SECRET_PREFIX}-test-id"}]
 
@@ -1646,11 +1554,9 @@ spec:
         Test case: a kubernetes.io/dockerconfigjson Secret is created with correct ownerReference
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "uid-abc"}
         }
-        mock_core_api = mock_k8s_client.get_core_v1_api()
 
         provider.create_workload(
             sandbox_id="test-id",
@@ -1667,8 +1573,8 @@ spec:
             execd_image="execd:latest",
         )
 
-        mock_core_api.create_namespaced_secret.assert_called_once()
-        call_kwargs = mock_core_api.create_namespaced_secret.call_args.kwargs
+        mock_k8s_client.create_secret.assert_called_once()
+        call_kwargs = mock_k8s_client.create_secret.call_args.kwargs
         assert call_kwargs["namespace"] == "test-ns"
         secret = call_kwargs["body"]
         assert secret.type == "kubernetes.io/dockerconfigjson"
@@ -1682,11 +1588,9 @@ spec:
         Test case: no Secret is created when image auth is absent
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "uid-123"}
         }
-        mock_core_api = mock_k8s_client.get_core_v1_api()
 
         provider.create_workload(
             sandbox_id="test-id",
@@ -1700,8 +1604,8 @@ spec:
             execd_image="execd:latest",
         )
 
-        mock_core_api.create_namespaced_secret.assert_not_called()
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        mock_k8s_client.create_secret.assert_not_called()
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert "imagePullSecrets" not in body["spec"]["template"]["spec"]
 
     def test_create_workload_with_image_auth_secret_failure_rolls_back_batchsandbox(self, mock_k8s_client):
@@ -1709,12 +1613,10 @@ spec:
         Test case: BatchSandbox is deleted when Secret creation fails
         """
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "uid-123"}
         }
-        mock_core_api = mock_k8s_client.get_core_v1_api()
-        mock_core_api.create_namespaced_secret.side_effect = ApiException(status=403)
+        mock_k8s_client.create_secret.side_effect = ApiException(status=403)
 
         with pytest.raises(ApiException):
             provider.create_workload(
@@ -1732,7 +1634,7 @@ spec:
                 execd_image="execd:latest",
             )
 
-        mock_api.delete_namespaced_custom_object.assert_called_once_with(
+        mock_k8s_client.delete_custom_object.assert_called_once_with(
             group=provider.group,
             version=provider.version,
             namespace="test-ns",
@@ -1755,8 +1657,7 @@ spec:
         from src.api.schema import Volume, PVC
 
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1787,8 +1688,7 @@ spec:
         assert result == {"name": "test-id", "uid": "test-uid"}
 
         # Verify API call
-        call_args = mock_api.create_namespaced_custom_object.call_args
-        body = call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
 
         # Check volume definition
@@ -1812,8 +1712,7 @@ spec:
         from src.api.schema import Volume, PVC
 
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1839,7 +1738,7 @@ spec:
             volumes=volumes,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
 
         main_container = pod_spec["containers"][0]
@@ -1855,8 +1754,7 @@ spec:
         from src.api.schema import Volume, PVC
 
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1883,7 +1781,7 @@ spec:
             volumes=volumes,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
 
         main_container = pod_spec["containers"][0]
@@ -1899,8 +1797,7 @@ spec:
         from src.api.schema import Volume, Host
 
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1926,7 +1823,7 @@ spec:
             volumes=volumes,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
 
         # Check volume definition
@@ -1951,8 +1848,7 @@ spec:
         from src.api.schema import Volume, PVC, Host
 
         provider = BatchSandboxProvider(mock_k8s_client)
-        mock_api = mock_k8s_client.get_custom_objects_api()
-        mock_api.create_namespaced_custom_object.return_value = {
+        mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
         }
 
@@ -1984,7 +1880,7 @@ spec:
             volumes=volumes,
         )
 
-        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         pod_spec = body["spec"]["template"]["spec"]
 
         # Check both volumes exist

--- a/server/tests/k8s/test_informer.py
+++ b/server/tests/k8s/test_informer.py
@@ -1,0 +1,271 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for WorkloadInformer."""
+
+import time
+from unittest.mock import MagicMock
+
+from src.services.k8s.informer import WorkloadInformer
+
+
+def _make_informer(**kwargs) -> WorkloadInformer:
+    """Return a WorkloadInformer with a mocked list_fn (watch disabled)."""
+    list_fn = kwargs.pop("list_fn", MagicMock(return_value={"items": [], "metadata": {}}))
+    return WorkloadInformer(list_fn=list_fn, enable_watch=False, **kwargs)
+
+
+def _list_response(*names: str) -> dict:
+    """Build a fake CustomObjects list API response."""
+    return {
+        "metadata": {"resourceVersion": "42"},
+        "items": [{"metadata": {"name": n, "resourceVersion": "1"}} for n in names],
+    }
+
+
+class TestWorkloadInformerInit:
+    """Construction and property defaults."""
+
+    def test_has_synced_is_false_before_start(self):
+        """has_synced starts as False before the first list completes."""
+        informer = _make_informer()
+        assert informer.has_synced is False
+
+    def test_get_returns_none_before_sync(self):
+        """get() returns None before the cache is populated."""
+        informer = _make_informer()
+        assert informer.get("anything") is None
+
+    def test_resync_and_watch_params_stored(self):
+        """Constructor stores resync and watch timeout parameters."""
+        informer = _make_informer(resync_period_seconds=120, watch_timeout_seconds=30)
+        assert informer.resync_period_seconds == 120
+        assert informer.watch_timeout_seconds == 30
+
+    def test_custom_thread_name_is_stored(self):
+        """thread_name parameter is stored and used when start() is called."""
+        informer = _make_informer(thread_name="informer-foos-default")
+        assert informer._thread_name == "informer-foos-default"
+
+    def test_default_thread_name(self):
+        """Default thread_name is 'workload-informer' when not specified."""
+        informer = _make_informer()
+        assert informer._thread_name == "workload-informer"
+
+
+class TestWorkloadInformerFullResync:
+    """_full_resync populates the cache correctly."""
+
+    def test_full_resync_populates_cache(self):
+        """After _full_resync, objects from list_fn are accessible via get()."""
+        list_fn = MagicMock(return_value=_list_response("alpha", "beta"))
+        informer = _make_informer(list_fn=list_fn)
+        informer._full_resync()
+
+        assert informer.get("alpha") is not None
+        assert informer.get("beta") is not None
+        assert informer.get("gamma") is None
+
+    def test_full_resync_sets_has_synced(self):
+        """_full_resync marks the informer as synced."""
+        list_fn = MagicMock(return_value=_list_response("x"))
+        informer = _make_informer(list_fn=list_fn)
+        informer._full_resync()
+        assert informer.has_synced is True
+
+    def test_full_resync_stores_resource_version(self):
+        """_full_resync saves the resourceVersion from the list metadata."""
+        list_fn = MagicMock(return_value=_list_response("x"))
+        informer = _make_informer(list_fn=list_fn)
+        informer._full_resync()
+        assert informer._resource_version == "42"
+
+    def test_full_resync_replaces_stale_cache(self):
+        """A second _full_resync replaces the previous cache contents."""
+        list_fn = MagicMock(return_value=_list_response("old"))
+        informer = _make_informer(list_fn=list_fn)
+        informer._full_resync()
+        assert informer.get("old") is not None
+
+        list_fn.return_value = _list_response("new")
+        informer._full_resync()
+        assert informer.get("old") is None
+        assert informer.get("new") is not None
+
+
+class TestWorkloadInformerUpdateCache:
+    """update_cache upserts objects into the cache."""
+
+    def test_update_cache_adds_new_object(self):
+        """update_cache makes a previously missing object retrievable."""
+        informer = _make_informer()
+        obj = {"metadata": {"name": "foo", "resourceVersion": "5"}}
+        informer.update_cache(obj)
+        assert informer.get("foo") == obj
+
+    def test_update_cache_overwrites_existing_object(self):
+        """update_cache replaces the cached version of an object."""
+        informer = _make_informer()
+        informer.update_cache({"metadata": {"name": "foo", "resourceVersion": "1"}})
+        updated = {"metadata": {"name": "foo", "resourceVersion": "2"}}
+        informer.update_cache(updated)
+        assert informer.get("foo") == updated
+
+    def test_update_cache_ignores_object_without_name(self):
+        """update_cache silently ignores objects that lack a metadata.name."""
+        informer = _make_informer()
+        informer.update_cache({"metadata": {}})
+        # Cache remains empty — no exception raised
+        assert informer._cache == {}
+
+    def test_update_cache_updates_resource_version(self):
+        """update_cache advances _resource_version from object metadata."""
+        informer = _make_informer()
+        informer.update_cache({"metadata": {"name": "foo", "resourceVersion": "99"}})
+        assert informer._resource_version == "99"
+
+    def test_update_cache_does_not_downgrade_resource_version(self):
+        """update_cache never rolls back _resource_version to an older value."""
+        informer = _make_informer()
+        informer._resource_version = "200"
+        informer.update_cache({"metadata": {"name": "foo", "resourceVersion": "100"}})
+        assert informer._resource_version == "200"
+
+    def test_update_cache_advances_resource_version_when_newer(self):
+        """update_cache advances _resource_version when the incoming value is strictly newer."""
+        informer = _make_informer()
+        informer._resource_version = "50"
+        informer.update_cache({"metadata": {"name": "foo", "resourceVersion": "99"}})
+        assert informer._resource_version == "99"
+
+
+class TestWorkloadInformerHandleEvent:
+    """_handle_event applies watch events to the cache."""
+
+    def test_handle_added_event_inserts_object(self):
+        """ADDED event inserts the object into the cache."""
+        informer = _make_informer()
+        obj = {"metadata": {"name": "bar", "resourceVersion": "10"}}
+        informer._handle_event({"type": "ADDED", "object": obj})
+        assert informer.get("bar") == obj
+
+    def test_handle_modified_event_replaces_object(self):
+        """MODIFIED event replaces the cached object."""
+        informer = _make_informer()
+        informer._cache["bar"] = {"metadata": {"name": "bar", "resourceVersion": "1"}}
+        updated = {"metadata": {"name": "bar", "resourceVersion": "2"}}
+        informer._handle_event({"type": "MODIFIED", "object": updated})
+        assert informer.get("bar") == updated
+
+    def test_handle_deleted_event_removes_object(self):
+        """DELETED event removes the object from the cache."""
+        informer = _make_informer()
+        informer._cache["bar"] = {"metadata": {"name": "bar"}}
+        informer._handle_event({"type": "DELETED", "object": {"metadata": {"name": "bar"}}})
+        assert informer.get("bar") is None
+
+    def test_handle_event_ignores_none_object(self):
+        """Events with a None object are silently ignored."""
+        informer = _make_informer()
+        informer._handle_event({"type": "ADDED", "object": None})
+        assert informer._cache == {}
+
+    def test_handle_event_ignores_object_without_name(self):
+        """Events whose object has no metadata.name are silently ignored."""
+        informer = _make_informer()
+        informer._handle_event({"type": "ADDED", "object": {"metadata": {}}})
+        assert informer._cache == {}
+
+    def test_handle_event_converts_non_dict_object(self):
+        """Non-dict objects are converted via to_dict() before caching."""
+        informer = _make_informer()
+        sdk_obj = MagicMock()
+        sdk_obj.to_dict.return_value = {"metadata": {"name": "sdk-obj", "resourceVersion": "3"}}
+        informer._handle_event({"type": "ADDED", "object": sdk_obj})
+        assert informer.get("sdk-obj") is not None
+
+    def test_handle_event_updates_resource_version(self):
+        """_handle_event advances _resource_version from the object metadata."""
+        informer = _make_informer()
+        informer._handle_event({
+            "type": "ADDED",
+            "object": {"metadata": {"name": "foo", "resourceVersion": "77"}},
+        })
+        assert informer._resource_version == "77"
+
+    def test_handle_event_does_not_downgrade_resource_version(self):
+        """_handle_event never rolls back _resource_version to an older value."""
+        informer = _make_informer()
+        informer._resource_version = "200"
+        informer._handle_event({
+            "type": "MODIFIED",
+            "object": {"metadata": {"name": "foo", "resourceVersion": "50"}},
+        })
+        assert informer._resource_version == "200"
+
+
+class TestWorkloadInformerStartStop:
+    """start/stop thread lifecycle."""
+
+    def test_start_launches_daemon_thread(self):
+        """start() spawns a daemon thread that is alive."""
+        list_fn = MagicMock(return_value={"items": [], "metadata": {}})
+        informer = WorkloadInformer(list_fn=list_fn, enable_watch=False,
+                                    resync_period_seconds=9999)
+        informer.start()
+        assert informer._thread is not None
+        assert informer._thread.is_alive()
+        informer.stop()
+
+    def test_start_is_idempotent(self):
+        """Calling start() twice does not create a second thread."""
+        list_fn = MagicMock(return_value={"items": [], "metadata": {}})
+        informer = WorkloadInformer(list_fn=list_fn, enable_watch=False,
+                                    resync_period_seconds=9999)
+        informer.start()
+        first_thread = informer._thread
+        informer.start()
+        assert informer._thread is first_thread
+        informer.stop()
+
+    def test_stop_signals_stop_event(self):
+        """stop() sets the internal stop event."""
+        informer = _make_informer()
+        informer.stop()
+        assert informer._stop_event.is_set()
+
+    def test_poll_mode_resets_has_synced_after_wait(self):
+        """In poll mode (enable_watch=False), _has_synced is reset after each wait so the
+        cache is refreshed on the next loop iteration."""
+        call_count = 0
+
+        def list_fn():
+            nonlocal call_count
+            call_count += 1
+            return {"items": [], "metadata": {"resourceVersion": str(call_count)}}
+
+        informer = WorkloadInformer(
+            list_fn=list_fn,
+            enable_watch=False,
+            resync_period_seconds=0,  # no wait, loop immediately
+        )
+        informer.start()
+
+        # Give the thread time to execute at least two full loops
+        deadline = time.monotonic() + 2.0
+        while call_count < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        informer.stop()
+        assert call_count >= 2, "list_fn should be called more than once in poll mode"

--- a/server/tests/k8s/test_k8s_client.py
+++ b/server/tests/k8s/test_k8s_client.py
@@ -16,8 +16,10 @@
 Unit tests for K8sClient.
 """
 
-from unittest.mock import patch, MagicMock
 import pytest
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client import ApiException
 
 from src.config import KubernetesRuntimeConfig
 from src.services.k8s.client import K8sClient
@@ -27,105 +29,350 @@ class TestK8sClient:
     """K8sClient unit tests"""
     
     def test_init_with_kubeconfig_loads_successfully(self, k8s_runtime_config):
-        """
-        Test case: Verify successful initialization with kubeconfig path
-        """
+        """Verify successful initialization with kubeconfig path."""
         with patch('kubernetes.config.load_kube_config') as mock_load:
             client = K8sClient(k8s_runtime_config)
-            
+
             assert client.config == k8s_runtime_config
             mock_load.assert_called_once_with(
                 config_file=k8s_runtime_config.kubeconfig_path
             )
-    
+
     def test_init_with_incluster_config_loads_successfully(self):
-        """
-        Test case: Verify successful initialization with in-cluster config
-        """
+        """Verify successful initialization with in-cluster config."""
         config = KubernetesRuntimeConfig(
             kubeconfig_path=None,
             namespace="test-ns"
         )
-        
+
         with patch('kubernetes.config.load_incluster_config') as mock_load:
             client = K8sClient(config)
-            
+
             assert client.config == config
             mock_load.assert_called_once()
-    
+
     def test_init_with_invalid_kubeconfig_raises_exception(self):
-        """
-        Test case: Verify exception raised with invalid config file
-        """
+        """Verify exception raised with invalid config file."""
         config = KubernetesRuntimeConfig(
             kubeconfig_path="/invalid/path",
             namespace="test-ns"
         )
-        
+
         with patch('kubernetes.config.load_kube_config') as mock_load:
             mock_load.side_effect = Exception("Config file not found")
-            
+
             with pytest.raises(Exception) as exc_info:
                 K8sClient(config)
-            
+
             assert "Failed to load Kubernetes configuration" in str(exc_info.value)
-    
+
     def test_get_core_v1_api_returns_singleton(self, k8s_runtime_config):
-        """
-        Test case: Verify CoreV1Api returns singleton
-        """
+        """Verify CoreV1Api returns singleton."""
         with patch('kubernetes.config.load_kube_config'), \
              patch('kubernetes.client.CoreV1Api') as mock_api_class:
-            
+
             mock_api_instance = MagicMock()
             mock_api_class.return_value = mock_api_instance
-            
+
             client = K8sClient(k8s_runtime_config)
-            
-            # First call
+
             api1 = client.get_core_v1_api()
-            # Second call
             api2 = client.get_core_v1_api()
-            
-            # Should return same instance
+
             assert api1 is api2
-            # API should be created only once
             assert mock_api_class.call_count == 1
-    
+
     def test_get_custom_objects_api_returns_singleton(self, k8s_runtime_config):
-        """
-        Test case: Verify CustomObjectsApi returns singleton
-        """
+        """Verify CustomObjectsApi returns singleton."""
         with patch('kubernetes.config.load_kube_config'), \
              patch('kubernetes.client.CustomObjectsApi') as mock_api_class:
-            
+
             mock_api_instance = MagicMock()
             mock_api_class.return_value = mock_api_instance
-            
+
             client = K8sClient(k8s_runtime_config)
-            
-            # First call
+
             api1 = client.get_custom_objects_api()
-            # Second call
             api2 = client.get_custom_objects_api()
-            
-            # Should return same instance
+
             assert api1 is api2
-            # API should be created only once
             assert mock_api_class.call_count == 1
     
     def test_get_core_v1_api_creates_on_first_call(self, k8s_runtime_config):
-        """
-        Test case: Verify API client is created on first call
-        """
+        """Verify API client is created on first call, not at init time."""
         with patch('kubernetes.config.load_kube_config'), \
              patch('kubernetes.client.CoreV1Api') as mock_api_class:
-            
+
             client = K8sClient(k8s_runtime_config)
-            
-            # Should not create API on initialization
+
             assert mock_api_class.call_count == 0
-            
-            # Create on first call
             client.get_core_v1_api()
             assert mock_api_class.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Rate limiter initialization
+    # ------------------------------------------------------------------
+
+    def test_no_rate_limiters_when_qps_is_zero(self, k8s_runtime_config):
+        """read_qps=0 and write_qps=0 means no rate limiters are created."""
+        with patch('kubernetes.config.load_kube_config'):
+            client = K8sClient(k8s_runtime_config)
+            assert client._read_limiter is None
+            assert client._write_limiter is None
+
+    def test_read_limiter_created_when_read_qps_set(self):
+        """read_qps > 0 creates a read rate limiter."""
+        config = KubernetesRuntimeConfig(read_qps=10.0, read_burst=20)
+        with patch('kubernetes.config.load_incluster_config'):
+            client = K8sClient(config)
+            assert client._read_limiter is not None
+            assert client._write_limiter is None
+
+    def test_write_limiter_created_when_write_qps_set(self):
+        """write_qps > 0 creates a write rate limiter."""
+        config = KubernetesRuntimeConfig(write_qps=5.0, write_burst=10)
+        with patch('kubernetes.config.load_incluster_config'):
+            client = K8sClient(config)
+            assert client._read_limiter is None
+            assert client._write_limiter is not None
+
+    # ------------------------------------------------------------------
+    # CustomObject CRUD
+    # ------------------------------------------------------------------
+
+    def _make_client(self, k8s_runtime_config):
+        """Return a K8sClient with mocked kubeconfig and raw API handles."""
+        with patch('kubernetes.config.load_kube_config'):
+            c = K8sClient(k8s_runtime_config)
+        c._custom_objects_api = MagicMock()
+        c._core_v1_api = MagicMock()
+        c._node_v1_api = MagicMock()
+        return c
+
+    def test_create_custom_object_delegates_to_api(self, k8s_runtime_config):
+        """create_custom_object forwards arguments to the raw API."""
+        c = self._make_client(k8s_runtime_config)
+        body = {"metadata": {"name": "foo"}}
+        c.create_custom_object("g", "v1", "ns", "foos", body)
+        c._custom_objects_api.create_namespaced_custom_object.assert_called_once_with(
+            group="g", version="v1", namespace="ns", plural="foos", body=body
+        )
+
+    def test_get_custom_object_returns_none_on_404(self, k8s_runtime_config):
+        """get_custom_object returns None when the API raises a 404."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.get_namespaced_custom_object.side_effect = ApiException(status=404)
+        result = c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+        assert result is None
+
+    def test_get_custom_object_returns_object(self, k8s_runtime_config):
+        """get_custom_object returns the object from the API on a successful call."""
+        c = self._make_client(k8s_runtime_config)
+        obj = {"metadata": {"name": "foo-1"}}
+        c._custom_objects_api.get_namespaced_custom_object.return_value = obj
+        result = c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+        assert result == obj
+
+    def test_get_custom_object_updates_informer_cache_on_api_hit(self, k8s_runtime_config):
+        """get_custom_object calls informer.update_cache with the returned object."""
+        c = self._make_client(k8s_runtime_config)
+        obj = {"metadata": {"name": "foo-1", "resourceVersion": "10"}}
+        c._custom_objects_api.get_namespaced_custom_object.return_value = obj
+        fake_informer = MagicMock()
+        fake_informer.has_synced = False
+        c._informers[("g", "v1", "foos", "ns")] = fake_informer
+        c.config = MagicMock(informer_enabled=True,
+                             informer_resync_seconds=300,
+                             informer_watch_timeout_seconds=60,
+                             read_qps=0.0, write_qps=0.0)
+        c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+        fake_informer.update_cache.assert_called_once_with(obj)
+
+    def test_get_custom_object_reraises_non_404(self, k8s_runtime_config):
+        """get_custom_object re-raises non-404 API exceptions."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.get_namespaced_custom_object.side_effect = ApiException(status=500)
+        with pytest.raises(ApiException):
+            c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+
+    def test_get_custom_object_returns_cached_when_synced(self, k8s_runtime_config):
+        """get_custom_object returns cached value and skips API when informer is synced."""
+        c = self._make_client(k8s_runtime_config)
+        cached_obj = {"metadata": {"name": "foo-1"}}
+        fake_informer = MagicMock()
+        fake_informer.has_synced = True
+        fake_informer.get.return_value = cached_obj
+        c._informers[("g", "v1", "foos", "ns")] = fake_informer
+        # Disable real informer creation
+        c.config = MagicMock(informer_enabled=True,
+                             informer_resync_seconds=300,
+                             informer_watch_timeout_seconds=60,
+                             read_qps=0.0, write_qps=0.0)
+
+        result = c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+
+        assert result is cached_obj
+        c._custom_objects_api.get_namespaced_custom_object.assert_not_called()
+
+    def test_get_custom_object_skips_informer_when_disabled(self, k8s_runtime_config):
+        """get_custom_object bypasses informer and calls API when informer_enabled=False."""
+        c = self._make_client(k8s_runtime_config)
+        c.config = MagicMock(informer_enabled=False, read_qps=0.0)
+        obj = {"metadata": {"name": "foo-1"}}
+        c._custom_objects_api.get_namespaced_custom_object.return_value = obj
+        result = c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+        assert result == obj
+        c._custom_objects_api.get_namespaced_custom_object.assert_called_once()
+
+    def test_list_custom_objects_returns_items(self, k8s_runtime_config):
+        """list_custom_objects returns the items list from the API response."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": [{"metadata": {"name": "a"}}, {"metadata": {"name": "b"}}]
+        }
+        result = c.list_custom_objects("g", "v1", "ns", "foos")
+        assert len(result) == 2
+
+    def test_list_custom_objects_returns_empty_on_404(self, k8s_runtime_config):
+        """list_custom_objects returns [] when the API raises a 404."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.list_namespaced_custom_object.side_effect = ApiException(status=404)
+        result = c.list_custom_objects("g", "v1", "ns", "foos")
+        assert result == []
+
+    def test_list_custom_objects_reraises_non_404(self, k8s_runtime_config):
+        """list_custom_objects re-raises non-404 API exceptions."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.list_namespaced_custom_object.side_effect = ApiException(status=500)
+        with pytest.raises(ApiException):
+            c.list_custom_objects("g", "v1", "ns", "foos")
+
+    def test_delete_custom_object_delegates_to_api(self, k8s_runtime_config):
+        """delete_custom_object forwards arguments to the raw API."""
+        c = self._make_client(k8s_runtime_config)
+        c.delete_custom_object("g", "v1", "ns", "foos", "foo-1", grace_period_seconds=0)
+        c._custom_objects_api.delete_namespaced_custom_object.assert_called_once_with(
+            group="g", version="v1", namespace="ns", plural="foos",
+            name="foo-1", grace_period_seconds=0
+        )
+
+    def test_patch_custom_object_delegates_to_api(self, k8s_runtime_config):
+        """patch_custom_object forwards arguments to the raw API."""
+        c = self._make_client(k8s_runtime_config)
+        body = {"spec": {"replicas": 2}}
+        c.patch_custom_object("g", "v1", "ns", "foos", "foo-1", body)
+        c._custom_objects_api.patch_namespaced_custom_object.assert_called_once_with(
+            group="g", version="v1", namespace="ns", plural="foos",
+            name="foo-1", body=body
+        )
+
+    # ------------------------------------------------------------------
+    # Secret / Pod / RuntimeClass
+    # ------------------------------------------------------------------
+
+    def test_create_secret_delegates_to_api(self, k8s_runtime_config):
+        """create_secret forwards to CoreV1Api.create_namespaced_secret."""
+        c = self._make_client(k8s_runtime_config)
+        body = {"metadata": {"name": "my-secret"}}
+        c.create_secret("ns", body)
+        c._core_v1_api.create_namespaced_secret.assert_called_once_with(
+            namespace="ns", body=body
+        )
+
+    def test_list_pods_returns_items(self, k8s_runtime_config):
+        """list_pods returns the items attribute from the API response."""
+        c = self._make_client(k8s_runtime_config)
+        mock_pod = MagicMock()
+        c._core_v1_api.list_namespaced_pod.return_value = MagicMock(items=[mock_pod])
+        result = c.list_pods("ns", label_selector="app=foo")
+        assert result == [mock_pod]
+        c._core_v1_api.list_namespaced_pod.assert_called_once_with(
+            namespace="ns", label_selector="app=foo"
+        )
+
+    def test_list_pods_returns_empty_list_on_exception(self, k8s_runtime_config):
+        """list_pods re-raises exceptions from the API."""
+        c = self._make_client(k8s_runtime_config)
+        c._core_v1_api.list_namespaced_pod.side_effect = Exception("network error")
+        with pytest.raises(Exception, match="network error"):
+            c.list_pods("ns")
+
+    def test_read_runtime_class_delegates_to_api(self, k8s_runtime_config):
+        """read_runtime_class forwards to NodeV1Api.read_runtime_class."""
+        c = self._make_client(k8s_runtime_config)
+        c._node_v1_api.read_runtime_class.return_value = MagicMock(metadata=MagicMock(name="gvisor"))
+        result = c.read_runtime_class("gvisor")
+        c._node_v1_api.read_runtime_class.assert_called_once_with("gvisor")
+        assert result is not None
+
+    # ------------------------------------------------------------------
+    # Write limiter integration
+    # ------------------------------------------------------------------
+
+    def test_write_limiter_called_on_create(self, k8s_runtime_config):
+        """create_custom_object acquires the write limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._write_limiter = mock_limiter
+        c.create_custom_object("g", "v1", "ns", "foos", {})
+        mock_limiter.acquire.assert_called_once()
+
+    def test_write_limiter_called_on_delete(self, k8s_runtime_config):
+        """delete_custom_object acquires the write limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._write_limiter = mock_limiter
+        c.delete_custom_object("g", "v1", "ns", "foos", "foo-1")
+        mock_limiter.acquire.assert_called_once()
+
+    def test_write_limiter_called_on_patch(self, k8s_runtime_config):
+        """patch_custom_object acquires the write limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._write_limiter = mock_limiter
+        c.patch_custom_object("g", "v1", "ns", "foos", "foo-1", {})
+        mock_limiter.acquire.assert_called_once()
+
+    def test_write_limiter_called_on_create_secret(self, k8s_runtime_config):
+        """create_secret acquires the write limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._write_limiter = mock_limiter
+        c.create_secret("ns", {})
+        mock_limiter.acquire.assert_called_once()
+
+    def test_read_limiter_called_on_get(self, k8s_runtime_config):
+        """get_custom_object acquires the read limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        c.config = MagicMock(informer_enabled=False, read_qps=0.0)
+        c._custom_objects_api.get_namespaced_custom_object.return_value = {}
+        mock_limiter = MagicMock()
+        c._read_limiter = mock_limiter
+        c.get_custom_object("g", "v1", "ns", "foos", "foo-1")
+        mock_limiter.acquire.assert_called_once()
+
+    def test_read_limiter_called_on_list(self, k8s_runtime_config):
+        """list_custom_objects acquires the read limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        c._custom_objects_api.list_namespaced_custom_object.return_value = {"items": []}
+        mock_limiter = MagicMock()
+        c._read_limiter = mock_limiter
+        c.list_custom_objects("g", "v1", "ns", "foos")
+        mock_limiter.acquire.assert_called_once()
+
+    def test_read_limiter_called_on_list_pods(self, k8s_runtime_config):
+        """list_pods acquires the read limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        c._core_v1_api.list_namespaced_pod.return_value = MagicMock(items=[])
+        mock_limiter = MagicMock()
+        c._read_limiter = mock_limiter
+        c.list_pods("ns")
+        mock_limiter.acquire.assert_called_once()
+
+    def test_read_limiter_called_on_read_runtime_class(self, k8s_runtime_config):
+        """read_runtime_class acquires the read limiter before calling the API."""
+        c = self._make_client(k8s_runtime_config)
+        mock_limiter = MagicMock()
+        c._read_limiter = mock_limiter
+        c.read_runtime_class("gvisor")
+        mock_limiter.acquire.assert_called_once()

--- a/server/tests/k8s/test_provider_factory.py
+++ b/server/tests/k8s/test_provider_factory.py
@@ -38,16 +38,15 @@ from src.services.k8s.agent_sandbox_provider import AgentSandboxProvider
 class TestProviderFactory:
     """provider_factory unit tests"""
     
-    def test_register_and_create_batchsandbox_provider(self, mock_k8s_client, k8s_runtime_config):
-        """
-        Test case: Register and create BatchSandbox provider
-        
+    def test_register_and_create_batchsandbox_provider(self, mock_k8s_client, k8s_app_config):
+        """Test case: Register and create BatchSandbox provider
+
         Purpose: Verify that BatchSandbox provider can be created through factory method
         """
         provider = create_workload_provider(
             PROVIDER_TYPE_BATCHSANDBOX,
             mock_k8s_client,
-            k8s_runtime_config
+            k8s_app_config,
         )
         
         assert isinstance(provider, BatchSandboxProvider)
@@ -56,11 +55,10 @@ class TestProviderFactory:
     def test_register_and_create_agent_sandbox_provider(
         self,
         mock_k8s_client,
-        agent_sandbox_runtime_config,
+        agent_sandbox_app_config,
         tmp_path,
     ):
-        """
-        Test case: Register and create agent-sandbox provider
+        """Test case: Register and create agent-sandbox provider
 
         Purpose: Verify that AgentSandbox provider can be created through factory method
         """
@@ -83,40 +81,37 @@ spec:
             shutdown_policy="Retain",
             ingress_enabled=True,
         )
+        agent_sandbox_app_config.agent_sandbox = agent_config
         provider = create_workload_provider(
             PROVIDER_TYPE_AGENT_SANDBOX,
             mock_k8s_client,
-            agent_sandbox_runtime_config,
-            agent_config,
+            agent_sandbox_app_config,
         )
 
         assert isinstance(provider, AgentSandboxProvider)
         assert provider.k8s_client == mock_k8s_client
         assert provider.shutdown_policy == "Retain"
-        assert provider.service_account == agent_sandbox_runtime_config.service_account
-        assert provider._enable_informer is True
+        assert provider.service_account == agent_sandbox_app_config.kubernetes.service_account
     
-    def test_create_provider_case_insensitive(self, mock_k8s_client, k8s_runtime_config):
-        """
-        Test case: Case-insensitive provider creation
-        
+    def test_create_provider_case_insensitive(self, mock_k8s_client, k8s_app_config):
+        """Test case: Case-insensitive provider creation
+
         Purpose: Verify that provider type name is case-insensitive
         """
-        provider1 = create_workload_provider("BatchSandbox", mock_k8s_client, k8s_runtime_config)
-        provider2 = create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_runtime_config)
-        provider3 = create_workload_provider("BATCHSANDBOX", mock_k8s_client, k8s_runtime_config)
+        provider1 = create_workload_provider("BatchSandbox", mock_k8s_client, k8s_app_config)
+        provider2 = create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_app_config)
+        provider3 = create_workload_provider("BATCHSANDBOX", mock_k8s_client, k8s_app_config)
         
         assert isinstance(provider1, BatchSandboxProvider)
         assert isinstance(provider2, BatchSandboxProvider)
         assert isinstance(provider3, BatchSandboxProvider)
     
-    def test_create_provider_with_none_type_uses_default(self, mock_k8s_client, k8s_runtime_config):
-        """
-        Test case: None type uses default provider
-        
+    def test_create_provider_with_none_type_uses_default(self, mock_k8s_client, k8s_app_config):
+        """Test case: None type uses default provider
+
         Purpose: Verify that the first registered provider is used when provider_type is None
         """
-        provider = create_workload_provider(None, mock_k8s_client, k8s_runtime_config)
+        provider = create_workload_provider(None, mock_k8s_client, k8s_app_config)
         
         # Should use the first registered provider (batchsandbox)
         assert isinstance(provider, BatchSandboxProvider)
@@ -130,16 +125,13 @@ spec:
         with pytest.raises(ValueError, match="Unsupported workload provider type"):
             create_workload_provider("invalid", mock_k8s_client)
     
-    def test_create_batchsandbox_with_template_file(self, mock_k8s_client, k8s_runtime_config, tmp_path):
-        """
-        Test case: Create BatchSandbox provider with template file
-        
+    def test_create_batchsandbox_with_template_file(self, mock_k8s_client, k8s_app_config, tmp_path):
+        """Test case: Create BatchSandbox provider with template file
+
         Purpose: Verify that factory method correctly passes template file path to BatchSandboxProvider
         """
-        # Create temporary template file
         template_file = tmp_path / "test_template.yaml"
-        template_file.write_text("""
-apiVersion: execution.alibaba-inc.com/v1alpha1
+        template_file.write_text("""apiVersion: execution.alibaba-inc.com/v1alpha1
 kind: BatchSandbox
 metadata:
   name: test-template
@@ -149,20 +141,16 @@ spec:
       nodeSelector:
         gpu: "true"
 """)
-        
-        k8s_runtime_config.batchsandbox_template_file = str(template_file)
-        
+
+        k8s_app_config.kubernetes.batchsandbox_template_file = str(template_file)
+
         with patch.object(BatchSandboxProvider, '__init__', return_value=None) as mock_init:
-            create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_runtime_config)
+            create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_app_config)
             
-            # Verify that template_file_path parameter was passed
+            # Verify that app_config carrying the template path was passed
             mock_init.assert_called_once()
             call_kwargs = mock_init.call_args.kwargs
-            assert 'template_file_path' in call_kwargs
-            assert call_kwargs['template_file_path'] == str(template_file)
-            assert call_kwargs['enable_informer'] is True
-            assert call_kwargs['informer_resync_seconds'] == k8s_runtime_config.informer_resync_seconds
-            assert call_kwargs['informer_watch_timeout_seconds'] == k8s_runtime_config.informer_watch_timeout_seconds
+            assert call_kwargs['app_config'].kubernetes.batchsandbox_template_file == str(template_file)
     
     def test_list_available_providers(self):
         """
@@ -221,13 +209,12 @@ spec:
         # Verify it's registered
         assert "custom" in list_available_providers()
     
-    def test_create_batchsandbox_with_config(self, mock_k8s_client, k8s_runtime_config):
-        """
-        Test case: Create BatchSandbox provider with explicit config
-        
+    def test_create_batchsandbox_with_config(self, mock_k8s_client, k8s_app_config):
+        """Test case: Create BatchSandbox provider with explicit config
+
         Purpose: Verify that provider creation works when k8s_config is provided
         """
-        provider = create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_runtime_config)
+        provider = create_workload_provider(PROVIDER_TYPE_BATCHSANDBOX, mock_k8s_client, k8s_app_config)
         
         assert isinstance(provider, BatchSandboxProvider)
         assert provider.k8s_client == mock_k8s_client

--- a/server/tests/k8s/test_rate_limiter.py
+++ b/server/tests/k8s/test_rate_limiter.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TokenBucketRateLimiter."""
+
+import time
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from src.services.k8s.rate_limiter import TokenBucketRateLimiter
+
+
+class TestTokenBucketRateLimiter:
+    """Tests for the token-bucket rate limiter."""
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def test_invalid_qps_raises_value_error(self):
+        """qps <= 0 must raise ValueError."""
+        with pytest.raises(ValueError, match="qps must be > 0"):
+            TokenBucketRateLimiter(qps=0)
+
+    def test_negative_qps_raises_value_error(self):
+        """Negative qps must raise ValueError."""
+        with pytest.raises(ValueError):
+            TokenBucketRateLimiter(qps=-1.0)
+
+    def test_burst_defaults_to_qps_when_zero(self):
+        """burst=0 means the bucket capacity equals qps (minimum 1)."""
+        limiter = TokenBucketRateLimiter(qps=5.0, burst=0)
+        assert limiter._burst == 5.0
+
+    def test_explicit_burst_is_respected(self):
+        """Explicit burst value sets bucket capacity independently from qps."""
+        limiter = TokenBucketRateLimiter(qps=5.0, burst=20)
+        assert limiter._burst == 20.0
+
+    def test_burst_minimum_is_one_when_qps_below_one(self):
+        """burst is clamped to 1 when qps < 1 and burst is not set."""
+        limiter = TokenBucketRateLimiter(qps=0.5)
+        assert limiter._burst == 1.0
+
+    def test_low_qps_limiter_can_acquire(self):
+        """A limiter with qps < 1 and default burst must be able to issue a token."""
+        limiter = TokenBucketRateLimiter(qps=0.5)
+        assert limiter.try_acquire() is True
+
+    # ------------------------------------------------------------------
+    # try_acquire
+    # ------------------------------------------------------------------
+
+    def test_try_acquire_succeeds_when_bucket_full(self):
+        """try_acquire returns True when tokens are available."""
+        limiter = TokenBucketRateLimiter(qps=10.0, burst=10)
+        assert limiter.try_acquire() is True
+
+    def test_try_acquire_fails_when_bucket_empty(self):
+        """try_acquire returns False after exhausting all tokens."""
+        limiter = TokenBucketRateLimiter(qps=1.0, burst=1)
+        limiter.try_acquire()  # consume the only token
+        assert limiter.try_acquire() is False
+
+    def test_try_acquire_consumes_token(self):
+        """Each successful try_acquire reduces available tokens by one."""
+        limiter = TokenBucketRateLimiter(qps=10.0, burst=3)
+        assert limiter.try_acquire() is True
+        assert limiter.try_acquire() is True
+        assert limiter.try_acquire() is True
+        assert limiter.try_acquire() is False
+
+    # ------------------------------------------------------------------
+    # acquire (blocking)
+    # ------------------------------------------------------------------
+
+    def test_acquire_succeeds_immediately_when_tokens_available(self):
+        """acquire completes without sleeping when the bucket has tokens."""
+        limiter = TokenBucketRateLimiter(qps=100.0, burst=10)
+        start = time.monotonic()
+        limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1  # should be essentially instant
+
+    def test_acquire_blocks_until_token_available(self):
+        """acquire blocks and returns only after a token refills."""
+        limiter = TokenBucketRateLimiter(qps=10.0, burst=1)
+        limiter.try_acquire()  # drain the bucket
+
+        start = time.monotonic()
+        limiter.acquire()  # should wait ~0.1s for next token
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 0.05  # some delay occurred
+
+    def test_acquire_minimum_sleep_prevents_busy_loop(self):
+        """acquire sleeps at least 1 ms even when wait is near-zero."""
+        limiter = TokenBucketRateLimiter(qps=1.0, burst=1)
+        # Manually set tokens to just below 1 to produce a near-zero wait
+        with limiter._lock:
+            limiter._tokens = 1.0 - 1e-10
+
+        with patch("src.services.k8s.rate_limiter.time.sleep") as mock_sleep:
+            # _try_acquire will succeed on first or second call; we only care
+            # that if sleep is called, the argument is >= 0.001.
+            limiter.acquire()
+            for call in mock_sleep.call_args_list:
+                assert call.args[0] >= 0.001
+
+    # ------------------------------------------------------------------
+    # Token refill
+    # ------------------------------------------------------------------
+
+    def test_tokens_refill_over_time(self):
+        """Tokens are replenished proportional to elapsed time."""
+        limiter = TokenBucketRateLimiter(qps=100.0, burst=10)
+        # Drain all tokens
+        for _ in range(10):
+            limiter.try_acquire()
+        assert limiter.try_acquire() is False
+
+        time.sleep(0.05)  # wait for ~5 tokens to refill at 100 qps
+
+        assert limiter.try_acquire() is True
+
+    def test_tokens_capped_at_burst(self):
+        """Token count never exceeds burst capacity."""
+        limiter = TokenBucketRateLimiter(qps=10.0, burst=5)
+        time.sleep(0.5)  # wait long enough to overflow if cap not applied
+        # Force a refill by calling _try_acquire internals
+        with limiter._lock:
+            limiter._refill()
+        assert limiter._tokens <= 5.0
+
+    # ------------------------------------------------------------------
+    # Thread safety
+    # ------------------------------------------------------------------
+
+    def test_concurrent_acquires_do_not_exceed_burst(self):
+        """Concurrent threads must not collectively acquire more than burst tokens."""
+        burst = 5
+        limiter = TokenBucketRateLimiter(qps=1000.0, burst=burst)
+        successes = []
+        lock = threading.Lock()
+
+        # Freeze time so _refill() never adds extra tokens during the test
+        fixed_time = limiter._last_refill
+
+        def worker():
+            with patch("src.services.k8s.rate_limiter.time.monotonic", return_value=fixed_time):
+                if limiter.try_acquire():
+                    with lock:
+                        successes.append(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(successes) <= burst

--- a/server/tests/test_agent_sandbox_service.py
+++ b/server/tests/test_agent_sandbox_service.py
@@ -126,9 +126,9 @@ class TestAgentSandboxServiceInit:
             mock_provider_factory.assert_called_once()
             call_kwargs = mock_provider_factory.call_args.kwargs
             assert call_kwargs["provider_type"] == "agent-sandbox"
-            assert call_kwargs["agent_sandbox_config"].template_file == "/tmp/template.yaml"
-            assert call_kwargs["agent_sandbox_config"].shutdown_policy == "Retain"
-            assert call_kwargs["k8s_config"] == agent_sandbox_runtime_config
+            assert call_kwargs["app_config"].agent_sandbox.template_file == "/tmp/template.yaml"
+            assert call_kwargs["app_config"].agent_sandbox.shutdown_policy == "Retain"
+            assert call_kwargs["app_config"].kubernetes == agent_sandbox_runtime_config
 
     def test_init_without_kubernetes_config_raises_error(self):
         """


### PR DESCRIPTION
# Summary
（1）重构了server中k8s client的时候，把对api server交互细节都封装到client内部，比如informer等。降低priverder层对复杂度。
（2）统一对client访问api server进行了限流。

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
