### PR TITLE
fix(ingress): set CGO_ENABLED=0 in Dockerfile

### DIFF
--- a/components/ingress/Dockerfile
+++ b/components/ingress/Dockerfile
@@ -36,7 +36,7 @@ COPY components/ingress/. ./components/ingress
 
 WORKDIR /build/components/ingress
 
-RUN go build \
+RUN CGO_ENABLED=0 go build \
     -ldflags "-X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \


### PR DESCRIPTION
# Summary
- closes #433
- ingress: ELF 64-bit LSB executable, x86-64, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered