### PR TITLE
fix(scripts): correct shell syntax typo in code-interpreter-env.sh

### DIFF
--- a/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
@@ -36,7 +36,7 @@ append_env_if_needed() {
 	local value=$2
 	if [ -z "${EXECD_ENVS:-}" ]; then
 		return
-	}
+	fi
 	# Best-effort: ensure parent dir exists, ignore errors.
 	mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null || true
 	printf '%s=%s\n' "$key" "$value" >>"$EXECD_ENVS" 2>/dev/null || true


### PR DESCRIPTION
# Summary

Fix a shell syntax typo in `sandboxes/code-interpreter/scripts/code-interpreter-env.sh`.

In the `append_env_if_needed` function, the closing keyword of an `if` block was incorrectly written as `}` (curly brace) instead of `fi`, which is invalid shell syntax.

# Changes

- Replace `}` with `fi` to correctly close the `if` statement in `append_env_if_needed`
