### PR TITLE
fix(server): reuse a single volume per claim_name and add multiple vo…

### DIFF
--- a/server/src/services/k8s/volume_helper.py
+++ b/server/src/services/k8s/volume_helper.py
@@ -56,6 +56,8 @@ def apply_volumes_to_pod_spec(
 
     # Collect existing volume names to prevent collisions with internal volumes
     existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
+    # One Kubernetes volume per unique PVC; multiple volumeMounts can reference it
+    pvc_to_volume_name: Dict[str, str] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -68,18 +70,25 @@ def apply_volumes_to_pod_spec(
             )
 
         if vol.pvc is not None:
-            # PVC backend: maps to PersistentVolumeClaim
+            # PVC backend: maps to Kubernetes PersistentVolumeClaim.
+            # Multiple Volume API objects sharing the same claim_name must produce
+            # a single Kubernetes volume and multiple volumeMounts (CSI drivers
+            # can fail when the same PVC is defined in multiple volume entries).
             pvc_claim_name = vol.pvc.claim_name
 
-            pod_volumes.append({
-                "name": vol_name,
-                "persistentVolumeClaim": {
-                    "claimName": pvc_claim_name,
-                },
-            })
+            if pvc_claim_name not in pvc_to_volume_name:
+                # First use of this PVC: create one volume, use current vol.name as volume name
+                pod_volumes.append({
+                    "name": vol_name,
+                    "persistentVolumeClaim": {
+                        "claimName": pvc_claim_name,
+                    },
+                })
+                pvc_to_volume_name[pvc_claim_name] = vol_name
+                existing_volume_names.add(vol_name)
 
             mount = {
-                "name": vol_name,
+                "name": pvc_to_volume_name[pvc_claim_name],
                 "mountPath": vol.mount_path,
                 "readOnly": vol.read_only,
             }
@@ -88,10 +97,7 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                "Added PVC volume '%s' (claim: %s) mounted at '%s' for sandbox",
-                vol_name,
-                pvc_claim_name,
-                vol.mount_path,
+                f"Added PVC volume '{vol_name}' (claim: {pvc_claim_name}) mounted at '{vol.mount_path}' for sandbox"
             )
         elif vol.host is not None:
             # Host backend: maps to hostPath volume
@@ -116,10 +122,7 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                "Added hostPath volume '%s' (path: %s) mounted at '%s' for sandbox",
-                vol_name,
-                host_path,
-                vol.mount_path,
+                f"Added hostPath volume '{vol_name}' (path: {host_path}) mounted at '{vol.mount_path}' for sandbox"
             )
         else:
             raise ValueError(

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -1972,3 +1972,48 @@ spec:
             apply_volumes_to_pod_spec(pod_spec, volumes)
 
         assert "conflicts with an internal volume" in str(exc_info.value)
+
+    def test_apply_volumes_to_pod_spec_same_pvc_multiple_mounts(self, mock_k8s_client):
+        """
+        When multiple Volume API objects share the same claim_name, only one
+        Kubernetes volume is created; multiple volumeMounts reference it (avoids
+        CSI driver issues from duplicate PVC volume definitions).
+        """
+        from src.api.schema import Volume, PVC
+
+        pod_spec = {
+            "containers": [{"name": "main", "volumeMounts": []}],
+            "volumes": [],
+        }
+        volumes = [
+            Volume(
+                name="skills",
+                pvc=PVC(claim_name="oss-pvc-r"),
+                mount_path="/path/to/skills",
+                sub_path="skill-hub/publish",
+                read_only=True,
+            ),
+            Volume(
+                name="draft",
+                pvc=PVC(claim_name="oss-pvc-r"),
+                mount_path="/path/to/draft",
+                sub_path="skill-hub/draft",
+                read_only=True,
+            ),
+        ]
+
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        # One volume definition for the shared PVC (first Volume name used)
+        assert len(pod_spec["volumes"]) == 1
+        assert pod_spec["volumes"][0]["name"] == "skills"
+        assert pod_spec["volumes"][0]["persistentVolumeClaim"]["claimName"] == "oss-pvc-r"
+
+        # Two volumeMounts, both referencing the same volume name
+        mounts = pod_spec["containers"][0]["volumeMounts"]
+        assert len(mounts) == 2
+        by_path = {m["mountPath"]: m for m in mounts}
+        assert by_path["/path/to/skills"]["name"] == "skills"
+        assert by_path["/path/to/skills"].get("subPath") == "skill-hub/publish"
+        assert by_path["/path/to/draft"]["name"] == "skills"
+        assert by_path["/path/to/draft"].get("subPath") == "skill-hub/draft"


### PR DESCRIPTION
# Summary
- reuse a single volume per claim_name and add multiple volumeMounts instead of one volume per Volume object.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
