### PR TITLE
feat(server): support no-timeout (manual cleanup) in Kubernetes sandbox service

### DIFF
--- a/server/src/services/k8s/agent_sandbox_provider.py
+++ b/server/src/services/k8s/agent_sandbox_provider.py
@@ -128,7 +128,7 @@ class AgentSandboxProvider(WorkloadProvider):
         env: Dict[str, str],
         resource_limits: Dict[str, str],
         labels: Dict[str, str],
-        expires_at: datetime,
+        expires_at: Optional[datetime],
         execd_image: str,
         extensions: Optional[Dict[str, str]] = None,
         network_policy: Optional[NetworkPolicy] = None,
@@ -162,6 +162,19 @@ class AgentSandboxProvider(WorkloadProvider):
 
         resource_name = self._resource_name(sandbox_id)
 
+        # When expires_at is None (manual cleanup), omit shutdownTime so controller does not auto-expire
+        spec = {
+            "replicas": 1,
+            "shutdownPolicy": self.shutdown_policy,
+            "podTemplate": {
+                "metadata": {
+                    "labels": labels,
+                },
+                "spec": pod_spec,
+            },
+        }
+        if expires_at is not None:
+            spec["shutdownTime"] = expires_at.isoformat()
         runtime_manifest = {
             "apiVersion": f"{self.group}/{self.version}",
             "kind": "Sandbox",
@@ -170,17 +183,7 @@ class AgentSandboxProvider(WorkloadProvider):
                 "namespace": namespace,
                 "labels": labels,
             },
-            "spec": {
-                "replicas": 1,
-                "shutdownTime": expires_at.isoformat(),
-                "shutdownPolicy": self.shutdown_policy,
-                "podTemplate": {
-                    "metadata": {
-                        "labels": labels,
-                    },
-                    "spec": pod_spec,
-                },
-            },
+            "spec": spec,
         }
 
         sandbox = self.template_manager.merge_with_runtime_values(runtime_manifest)

--- a/server/src/services/k8s/batchsandbox_provider.py
+++ b/server/src/services/k8s/batchsandbox_provider.py
@@ -107,7 +107,7 @@ class BatchSandboxProvider(WorkloadProvider):
         env: Dict[str, str],
         resource_limits: Dict[str, str],
         labels: Dict[str, str],
-        expires_at: datetime,
+        expires_at: Optional[datetime],
         execd_image: str,
         extensions: Optional[Dict[str, str]] = None,
         network_policy: Optional[NetworkPolicy] = None,
@@ -227,7 +227,15 @@ class BatchSandboxProvider(WorkloadProvider):
             apply_volumes_to_pod_spec(pod_spec, volumes)
 
         # Build runtime-generated BatchSandbox manifest
-        # This contains only the essential runtime fields
+        # When expires_at is None (manual cleanup), omit expireTime so controller does not auto-expire
+        spec: Dict[str, Any] = {
+            "replicas": 1,
+            "template": {
+                "spec": pod_spec,
+            },
+        }
+        if expires_at is not None:
+            spec["expireTime"] = expires_at.isoformat()
         runtime_manifest = {
             "apiVersion": f"{self.group}/{self.version}",
             "kind": "BatchSandbox",
@@ -236,13 +244,7 @@ class BatchSandboxProvider(WorkloadProvider):
                 "namespace": namespace,
                 "labels": labels,
             },
-            "spec": {
-                "replicas": 1,
-                "expireTime": expires_at.isoformat(),
-                "template": {
-                    "spec": pod_spec,
-                },
-            },
+            "spec": spec,
         }
         
         # Merge with template to get final manifest
@@ -297,7 +299,7 @@ class BatchSandboxProvider(WorkloadProvider):
         namespace: str,
         labels: Dict[str, str],
         pool_ref: str,
-        expires_at: datetime,
+        expires_at: Optional[datetime],
         entrypoint: List[str],
         env: Dict[str, str],
     ) -> Dict[str, Any]:
@@ -323,6 +325,13 @@ class BatchSandboxProvider(WorkloadProvider):
         Raises:
             SandboxError: If required parameters are invalid
         """
+        spec: Dict[str, Any] = {
+            "replicas": 1,
+            "poolRef": pool_ref,
+            "taskTemplate": self._build_task_template(entrypoint, env),
+        }
+        if expires_at is not None:
+            spec["expireTime"] = expires_at.isoformat()
         runtime_manifest = {
             "apiVersion": f"{self.group}/{self.version}",
             "kind": "BatchSandbox",
@@ -331,12 +340,7 @@ class BatchSandboxProvider(WorkloadProvider):
                 "namespace": namespace,
                 "labels": labels,
             },
-            "spec": {
-                "replicas": 1,
-                "poolRef": pool_ref,
-                "expireTime": expires_at.isoformat(),
-                "taskTemplate": self._build_task_template(entrypoint, env),
-            },
+            "spec": spec,
         }
         
         # Pool-based creation does not need template merging
@@ -734,7 +738,7 @@ class BatchSandboxProvider(WorkloadProvider):
         except (ValueError, TypeError) as e:
             logger.warning("Invalid expireTime format: %s, error: %s", expire_time_str, e)
             return None
-    
+
     def _parse_pod_ip(self, workload: Dict[str, Any]) -> Optional[str]:
         """Parse the first Pod IP from the endpoints annotation.
 

--- a/server/src/services/k8s/kubernetes_service.py
+++ b/server/src/services/k8s/kubernetes_service.py
@@ -42,6 +42,7 @@ from src.api.schema import (
 from src.config import AppConfig, get_config
 from src.services.constants import (
     SANDBOX_ID_LABEL,
+    SANDBOX_MANUAL_CLEANUP_LABEL,
     SandboxErrorCodes,
 )
 from src.services.helpers import matches_filter
@@ -274,26 +275,18 @@ class KubernetesSandboxService(SandboxService):
         # Generate sandbox ID
         sandbox_id = self.generate_sandbox_id()
         
-        # Calculate expiration time
+        # Calculate expiration time (None = no TTL, manual cleanup only; same as Docker)
         created_at = datetime.now(timezone.utc)
         expires_at = None
         if request.timeout is not None:
             expires_at = calculate_expiration_or_raise(created_at, request.timeout)
-        elif not self.workload_provider.supports_manual_cleanup():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "code": SandboxErrorCodes.INVALID_PARAMETER,
-                    "message": (
-                        "Manual cleanup mode is not supported by the current Kubernetes workload provider."
-                    ),
-                },
-            )
-        
+
         # Build labels
         labels = {
             SANDBOX_ID_LABEL: sandbox_id,
         }
+        if expires_at is None:
+            labels[SANDBOX_MANUAL_CLEANUP_LABEL] = "true"
         
         # Add user metadata as labels
         if request.metadata:

--- a/server/src/services/k8s/workload_provider.py
+++ b/server/src/services/k8s/workload_provider.py
@@ -41,7 +41,7 @@ class WorkloadProvider(ABC):
         env: Dict[str, str],
         resource_limits: Dict[str, str],
         labels: Dict[str, str],
-        expires_at: datetime,
+        expires_at: Optional[datetime],
         execd_image: str,
         extensions: Optional[Dict[str, str]] = None,
         network_policy: Optional[NetworkPolicy] = None,
@@ -59,7 +59,7 @@ class WorkloadProvider(ABC):
             env: Environment variables
             resource_limits: Resource limits (cpu, memory)
             labels: Labels to apply to the workload
-            expires_at: Expiration time
+            expires_at: Expiration time, or None for manual cleanup (no TTL)
             execd_image: execd daemon image
             extensions: General extension field for passing additional configuration.
                 This is a flexible field for various use cases (e.g., ``poolRef`` for pool-based creation).
@@ -180,15 +180,6 @@ class WorkloadProvider(ABC):
 
         Providers that implement imagePullSecrets injection should override
         this method to return True.
-        """
-        return False
-
-    def supports_manual_cleanup(self) -> bool:
-        """
-        Whether this provider can represent a non-expiring sandbox.
-
-        Providers should override this only after their backing CRD semantics
-        are verified to support omitting expiration fields safely.
         """
         return False
 

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 
 from src.services.k8s.kubernetes_service import KubernetesSandboxService
-from src.services.constants import SandboxErrorCodes
+from src.services.constants import SANDBOX_MANUAL_CLEANUP_LABEL, SandboxErrorCodes
 from src.api.schema import ImageAuth, ListSandboxesRequest
 
 
@@ -194,19 +194,26 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.create_sandbox(create_sandbox_request)
         k8s_service.workload_provider.create_workload.assert_called_once()
 
-    def test_create_sandbox_rejects_manual_cleanup_when_provider_not_supported(
+    def test_create_sandbox_with_no_timeout_calls_provider_with_expires_at_none_and_manual_cleanup_label(
         self, k8s_service, create_sandbox_request
     ):
+        """When timeout is None (manual cleanup), provider receives expires_at=None and manual-cleanup label."""
         create_sandbox_request.timeout = None
-        k8s_service.workload_provider.supports_manual_cleanup.return_value = False
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-id", "uid": "uid-1"
+        }
+        k8s_service.workload_provider.get_workload.return_value = MagicMock()
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running", "reason": "", "message": "",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
 
-        with pytest.raises(HTTPException) as exc_info:
-            k8s_service.create_sandbox(create_sandbox_request)
+        k8s_service.create_sandbox(create_sandbox_request)
 
-        assert exc_info.value.status_code == 400
-        assert exc_info.value.detail["code"] == SandboxErrorCodes.INVALID_PARAMETER
-        assert "Manual cleanup mode is not supported" in exc_info.value.detail["message"]
-        k8s_service.workload_provider.create_workload.assert_not_called()
+        k8s_service.workload_provider.create_workload.assert_called_once()
+        _, kwargs = k8s_service.workload_provider.create_workload.call_args
+        assert kwargs["expires_at"] is None
+        assert kwargs["labels"].get(SANDBOX_MANUAL_CLEANUP_LABEL) == "true"
 
     def test_create_sandbox_rejects_timeout_above_configured_maximum(
         self, k8s_service, create_sandbox_request
@@ -578,3 +585,19 @@ class TestRenewExpiration:
             k8s_service.renew_expiration("test-sandbox-id", request)
         
         assert exc_info.value.status_code == 400
+
+    def test_renew_returns_409_when_sandbox_has_no_expiration(self, k8s_service):
+        """Renew is rejected with 409 when sandbox has no TTL (manual cleanup)."""
+        k8s_service.workload_provider.get_workload.return_value = MagicMock()
+        k8s_service.workload_provider.get_expiration.return_value = None
+        from src.api.schema import RenewSandboxExpirationRequest
+        request = RenewSandboxExpirationRequest(
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service.renew_expiration("no-ttl-sandbox", request)
+
+        assert exc_info.value.status_code == 409
+        assert "does not have automatic expiration" in exc_info.value.detail["message"]
+        k8s_service.workload_provider.update_expiration.assert_not_called()


### PR DESCRIPTION
# Summary
- Allow create_sandbox with `timeout=null`: set `expires_at=None` and add `opensandbox.io/manual-cleanup` label; BatchSandbox/AgentSandbox omit `spec.expireTime/spec.shutdownTime` when `expires_at` is None
- Align renew behavior with Docker: return 409 "does not have automatic expiration enabled" when `get_expiration(workload)` is None
- Drop `supports_manual_cleanup()`; support is implied by `create_workload(expires_at: Optional[datetime])`

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered