### PR TITLE
fix(server): restore port allocation for user-defined Docker networks

### DIFF
--- a/server/src/services/docker.py
+++ b/server/src/services/docker.py
@@ -990,7 +990,7 @@ class DockerSandboxService(OSSFSMixin, SandboxService):
                 host_config_kwargs = self._base_host_config_kwargs(
                     mem_limit, nano_cpus, self.network_mode
                 )
-                if self.network_mode == BRIDGE_NETWORK_MODE:
+                if self.network_mode != HOST_NETWORK_MODE:
                     host_execd_port, host_http_port = self._allocate_distinct_host_ports()
                     port_bindings = {
                         "44772": ("0.0.0.0", host_execd_port),


### PR DESCRIPTION
## Summary                                                                                                                                                                                      
                                                                                                                                                                                            
After commit `74d3dbb`, sandboxes using a user-defined Docker network (e.g. `network_mode = "foo_network"`) fail with:                                                                       

code: 'DOCKER::NETWORK_MODE_ENDPOINT_UNAVAILABLE'                                                                                                                                           
message: 'Missing host port mapping for execd proxy port 44772.'                                                                                                                            
                                                                                                                                                                                            
## Root Cause                                                                                                                                                                               

Commit `55690af` correctly changed the port-allocation condition in `_provision_sandbox` to cover user-defined networks:

```python
# 55690af: correct
if self.network_mode != HOST_NETWORK_MODE:
```
But 74d3dbb accidentally reverted it during the ossfs refactor:
```python
# 74d3dbb: regression
if self.network_mode == BRIDGE_NETWORK_MODE:
```
User-defined network containers are now created without host port bindings or port labels. When get_endpoint reads those labels, it finds nothing and raises the error.

Fix

server/src/services/docker.py line 993:
```python
# before (broken)
if self.network_mode == BRIDGE_NETWORK_MODE:

# after
if self.network_mode != HOST_NETWORK_MODE:
```

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
