### PR TITLE
docs: update sdk adapters dev conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@
 - Kotlin: Kotlin Coding Conventions, `ktlint` where configured.
 - Naming: classes `PascalCase`, functions `snake_case` (Python) / `camelCase` (Go/Kotlin), constants `UPPER_SNAKE_CASE`.
 
+## SDK API Implementation Conventions
+- Keep a clear split between generated API transport code and handwritten SDK business/adaptor code.
+- In adapter/infrastructure layers, default to integrating through generated API clients instead of handcrafted request wiring.
+- Prefer generated OpenAPI clients for standard request/response endpoints; use handwritten transport only for streaming or protocol-specific paths (for example SSE).
+- Do not manually edit generated client files. When specs change, regenerate first, then adapt handwritten layers.
+- For handwritten streaming paths, keep wire contracts aligned with OpenAPI field names/models and cover behavior with focused tests (especially parsing and error mapping).
+
 ## Testing Guidelines
 - Python tests use `pytest` (async tests common).
 - Go tests use `go test` under `components/execd/pkg/...`.


### PR DESCRIPTION
# Summary
- Clarify SDK API implementation conventions in `AGENTS.md` with stable, general rules.
- Emphasize that adapter/infrastructure layers should default to integrating through OpenAPI-generated clients.
- Keep handcrafted transport limited to streaming/protocol-specific paths (for example SSE).
- Reinforce regeneration-first workflow for spec changes and alignment/testing requirements for handwritten streaming paths.

# Testing
- [x] Not run (docs-only change)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
