### PR TITLE
fix(execd): encode non-ASCII filenames in Content-Disposition header

### DIFF
--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -55,7 +56,7 @@ func (c *FilesystemController) DownloadFile() {
 	}
 
 	c.ctx.Header("Content-Type", "application/octet-stream")
-	c.ctx.Header("Content-Disposition", "attachment; filename="+filepath.Base(filePath))
+	c.ctx.Header("Content-Disposition", formatContentDisposition(filepath.Base(filePath)))
 	c.ctx.Header("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
 
 	if rangeHeader := c.ctx.GetHeader("Range"); rangeHeader != "" {
@@ -80,4 +81,26 @@ func (c *FilesystemController) DownloadFile() {
 	}
 
 	http.ServeContent(c.ctx.Writer, c.ctx.Request, filepath.Base(filePath), fileInfo.ModTime(), file)
+}
+
+// formatContentDisposition formats the Content-Disposition header value with proper
+// encoding for non-ASCII filenames according to RFC 6266 and RFC 5987.
+func formatContentDisposition(filename string) string {
+	// Check if filename contains non-ASCII characters
+	needsEncoding := false
+	for _, r := range filename {
+		if r > 127 {
+			needsEncoding = true
+			break
+		}
+	}
+
+	if !needsEncoding {
+		return "attachment; filename=\"" + filename + "\""
+	}
+
+	// Use RFC 5987 encoding for non-ASCII filenames
+	// Format: attachment; filename="fallback"; filename*=UTF-8''encoded_name
+	encodedFilename := url.PathEscape(filename)
+	return "attachment; filename=\"" + encodedFilename + "\"; filename*=UTF-8''" + encodedFilename
 }

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -118,3 +118,44 @@ func TestReplaceContentFailsUnknownFile(t *testing.T) {
 
 	require.Contains(t, []int{http.StatusNotFound, http.StatusInternalServerError}, rec.Code, "expected failure status")
 }
+
+func TestFormatContentDisposition(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "ASCII filename",
+			filename: "test.txt",
+			want:     "attachment; filename=\"test.txt\"",
+		},
+		{
+			name:     "Chinese filename",
+			filename: "测试文件.txt",
+			want:     "attachment; filename=\"%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.txt\"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.txt",
+		},
+		{
+			name:     "Japanese filename",
+			filename: "テスト.txt",
+			want:     "attachment; filename=\"%E3%83%86%E3%82%B9%E3%83%88.txt\"; filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.txt",
+		},
+		{
+			name:     "Special characters in filename",
+			filename: "file with spaces.txt",
+			want:     "attachment; filename=\"file with spaces.txt\"",
+		},
+		{
+			name:     "Mixed ASCII and non-ASCII",
+			filename: "report-报告.pdf",
+			want:     "attachment; filename=\"report-%E6%8A%A5%E5%91%8A.pdf\"; filename*=UTF-8''report-%E6%8A%A5%E5%91%8A.pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatContentDisposition(tt.filename)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Use RFC 6266 and RFC 5987 encoding for filenames containing non-ASCII characters (e.g., Chinese, Japanese) in file download responses.

- Add formatContentDisposition function to properly encode filenames
- Add unit tests for ASCII and non-ASCII filename scenarios

# Summary
- What is changing and why?

**What**: 修复 `FilesystemController.DownloadFile` 方法中 `Content-Disposition` 响应头对非ASCII文件名（如中文、日文）编码不正确的问题。

**Why**: 原代码直接拼接文件名到 Header 中，当文件名包含非ASCII字符时会导致客户端（浏览器）无法正确解析文件名，出现乱码或下载失败。现按照 RFC 6266 和 RFC 5987 规范对非ASCII文件名进行 URL 编码，确保跨浏览器兼容性。

**Changes**:
- `components/execd/pkg/web/controller/filesystem_download.go`: 新增 `formatContentDisposition` 函数
- `components/execd/pkg/web/controller/filesystem_test.go`: 新增单元测试

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

**Unit tests**: 新增 `TestFormatContentDisposition` 测试用例，覆盖以下场景：
- 纯 ASCII 文件名（`test.txt`）
- 中文文件名（`测试文件.txt`）
- 日文文件名（`テスト.txt`）
- 包含空格的文件名（`file with spaces.txt`）
- 混合 ASCII 和非 ASCII 文件名（`report-报告.pdf`）

所有测试均通过。

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

此修改仅为内部实现优化，API 行为保持向后兼容。

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

**Security**: 无安全影响，仅涉及响应头编码格式。

**Backward Compatibility**: 完全向后兼容，纯 ASCII 文件名行为不变，非 ASCII 文件名获得正确编码。