### PR TITLE
fix(tests/javascript): retry directory deletion verification

### DIFF
--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -409,13 +409,13 @@ test("01f sandbox create with PVC named volume subPath mount", async () => {
     );
     expect(writeResult.error).toBeUndefined();
 
-    let readBack;
+    let readBack: Awaited<ReturnType<typeof subpathSandbox.commands.run>> | undefined;
     for (let attempt = 0; attempt < 3; attempt++) {
       readBack = await subpathSandbox.commands.run(
         `cat ${containerMountPath}/output.txt`
       );
       if (readBack.logs.stdout.length > 0) break;
-      await new Promise((r) => setTimeout(r, 1000));
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
     }
     expect(readBack!.error).toBeUndefined();
     expect(readBack!.logs.stdout).toHaveLength(1);
@@ -550,7 +550,7 @@ test("02a command status + background logs", async () => {
     logsText += logs.content;
     cursor = logs.cursor ?? cursor;
     if (logsText.includes("log-line-2")) break;
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000));
   }
 
   expect(logsText.includes("log-line-1")).toBe(true);
@@ -679,14 +679,14 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
     { workingDirectory: "/tmp" }
   );
   for (let attempt = 0; attempt < 3; attempt++) {
-    expect(verify.error).toBeUndefined();
-    if (verify.logs.stdout[0]?.text === "OK") break;
+    if (!verify.error && verify.logs.stdout[0]?.text === "OK") break;
     await new Promise((r) => setTimeout(r, 1000));
     verify = await sandbox.commands.run(
       `test ! -d ${dir1} && test ! -d ${dir2} && echo OK`,
       { workingDirectory: "/tmp" }
     );
   }
+  expect(verify.error).toBeUndefined();
   expect(verify.logs.stdout[0]?.text).toBe("OK");
 });
 


### PR DESCRIPTION
## Summary
- retry the final `deleteDirectories` verification when the sandbox command stdout lags behind directory removal
- keep the fix scoped to the JavaScript E2E filesystem test without changing runtime behavior

## Validation
- `npx -y pnpm@9.15.0 -C tests/javascript exec eslint tests/test_sandbox_e2e.test.ts`
- `npx -y pnpm@9.15.0 -C tests/javascript exec tsc --noEmit`
- `npx -y pnpm@9.15.0 -C tests/javascript exec vitest run tests/test_sandbox_e2e.test.ts -t \"03 filesystem operations\"` (3 consecutive passes with local server on 127.0.0.1:8080 and `OPENSANDBOX_SANDBOX_DEFAULT_IMAGE=public.ecr.aws/docker/library/node:22-bookworm`)