### PR TITLE
feat(controller): add kube client rate limiter flags and configuratio…

### DIFF
--- a/kubernetes/charts/opensandbox-controller/README.md
+++ b/kubernetes/charts/opensandbox-controller/README.md
@@ -71,6 +71,8 @@ kubectl delete crd pools.sandbox.opensandbox.io
 | `controller.resources.requests.cpu` | CPU resource requests | `10m` |
 | `controller.resources.requests.memory` | Memory resource requests | `64Mi` |
 | `controller.logLevel` | Can be one of 'debug', 'info', 'error' | `info` |
+| `controller.kubeClient.qps` | QPS for Kubernetes client rate limiter | `100` |
+| `controller.kubeClient.burst` | Burst for Kubernetes client rate limiter | `200` |
 | `controller.leaderElection.enabled` | Enable leader election | `true` |
 | `controller.nodeSelector` | Node labels for pod assignment | `{}` |
 | `controller.tolerations` | Tolerations for pod assignment | `[]` |
@@ -121,6 +123,19 @@ controller:
       cpu: 100m
       memory: 128Mi
 ```
+
+### Custom Kubernetes Client Rate Limiter
+
+Configure the QPS and Burst for the Kubernetes client to handle high-throughput scenarios:
+
+```yaml
+controller:
+  kubeClient:
+    qps: 100
+    burst: 250
+```
+
+> Note: Default values are QPS=100, Burst=200.
 
 ### Use Private Registry
 

--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
         {{- end }}
         - --health-probe-bind-address=:8081
         - --zap-log-level={{ .Values.controller.logLevel }}
+        {{- if and .Values.controller.kubeClient (gt .Values.controller.kubeClient.qps 0) }}
+        - --kube-client-qps={{ .Values.controller.kubeClient.qps }}
+        {{- end }}
+        {{- if and .Values.controller.kubeClient (gt .Values.controller.kubeClient.burst 0) }}
+        - --kube-client-burst={{ .Values.controller.kubeClient.burst }}
+        {{- end }}
         ports:
         - name: health
           containerPort: 8081

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -36,7 +36,14 @@ controller:
   
   # -- Log level for zap logger (debug, info, error)
   logLevel: info
-  
+
+  # -- Kubernetes client rate limiter configuration
+  kubeClient:
+    # -- QPS for Kubernetes client rate limiter.
+    qps: 100
+    # -- Burst for Kubernetes client rate limiter.
+    burst: 200
+
   # -- Enable leader election for controller manager
   leaderElection:
     enabled: true

--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -73,6 +73,10 @@ func main() {
 	var logMaxAge int
 	var logCompress bool
 
+	// Kubernetes client rate limiter options
+	var kubeClientQPS float64
+	var kubeClientBurst int
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -98,6 +102,8 @@ func main() {
 	flag.IntVar(&logMaxBackups, "log-max-backups", 10, "Maximum number of old log files to retain")
 	flag.IntVar(&logMaxAge, "log-max-age", 30, "Maximum number of days to retain old log files")
 	flag.BoolVar(&logCompress, "log-compress", true, "Compress determines if the rotated log files should be compressed using gzip")
+	flag.Float64Var(&kubeClientQPS, "kube-client-qps", 100, "QPS for Kubernetes client rate limiter.")
+	flag.IntVar(&kubeClientBurst, "kube-client-burst", 200, "Burst for Kubernetes client rate limiter.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -208,7 +214,16 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	config := ctrl.GetConfigOrDie()
+	// Set client rate limiter if specified
+	if kubeClientQPS > 0 {
+		config.QPS = float32(kubeClientQPS)
+	}
+	if kubeClientBurst > 0 {
+		config.Burst = kubeClientBurst
+	}
+
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,


### PR DESCRIPTION
 (#490)

# Summary
- What is changing and why?
  -  The controller uses client-go default rate limiter (QPS=5, Burst=10), which is too small for production.
  -  Add configurable Kubernetes client rate limiter (QPS/Burst)

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
