### PR TITLE
fix: increase default pids_limit to 4096 for production use

### DIFF
--- a/server/example.config.zh.toml
+++ b/server/example.config.zh.toml
@@ -1,0 +1,66 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example OpenSandbox configuration.
+# Copy this file to ~/.sandbox.toml or set SANDBOX_CONFIG_PATH to point at it.
+# Each top-level block mirrors the sections supported by src/config.py.
+
+[server]
+# Lifecycle API host/port and logging settings
+# -----------------------------------------------------------------
+host = "127.0.0.1"
+port = 8080
+log_level = "INFO"
+# api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
+
+[runtime]
+# Runtime selection (docker | kubernetes)
+# -----------------------------------------------------------------
+type = "docker"
+execd_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.7"
+
+[egress]
+# Egress configuration
+# -----------------------------------------------------------------
+image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.0.3"
+
+[storage]
+# 卷存储配置
+# -----------------------------------------------------------------
+# 允许进行 bind mount 的宿主机路径前缀白名单。
+# 仅匹配这些前缀的路径才能被挂载到沙箱中。
+# 如果为空，则允许所有路径（不建议在生产环境使用）。
+# 示例：allowed_host_paths = ["/data/opensandbox", "/tmp/sandbox"]
+allowed_host_paths = []
+
+[docker]
+# Docker-specific knobs
+# -----------------------------------------------------------------
+# Supported values for network_mode: "host", "bridge"
+network_mode = "bridge"
+# Drop dangerous capabilities and block privilege escalation
+drop_capabilities = ["AUDIT_WRITE", "MKNOD", "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_MODULE", "SYS_PTRACE", "SYS_TIME", "SYS_TTY_CONFIG"]
+no_new_privileges = true
+# Optional: set an AppArmor profile name (e.g., "docker-default") when AppArmor is enabled
+apparmor_profile = ""
+# Limit process count to reduce host impact from fork bombs; set to null to disable
+# 生产环境建议设置为 4096 或更高，避免多沙箱并发时出现 "can't start new thread" 错误
+# See: https://github.com/alibaba/OpenSandbox/issues/447
+pids_limit = 4096
+# Seccomp profile: empty string uses Docker default; set to an absolute path for a custom profile
+seccomp_profile = ""
+
+[ingress]
+# Ingress exposure mode: direct (default) or gateway
+mode = "direct"


### PR DESCRIPTION
## 修复 Issue #447, #493: RuntimeError: can't start new thread

### 问题
生产环境下多个沙箱并发运行时，默认的  过于严格，导致容器内进程无法创建新线程。

### 解决方案
将默认的  从 512 提高到 4096，更好地支持生产环境多沙箱并发场景。

### 参考
- Issue #447: RuntimeError: can't start new thread
- Issue #493: 容器内的进程无法创建新的线程