### PR TITLE
fix(server): increase default pids_limit to 4096 for production use

### DIFF
--- a/server/docker-compose.example.yaml
+++ b/server/docker-compose.example.yaml
@@ -22,7 +22,10 @@ configs:
       host_ip = "host.docker.internal"
       drop_capabilities = ["AUDIT_WRITE", "MKNOD", "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_MODULE", "SYS_PTRACE", "SYS_TIME", "SYS_TTY_CONFIG"]
       no_new_privileges = true
-      pids_limit = 512
+      # TODO: For production environments, it is recommended to set this to '4096' or higher to avoid
+      # "can't start new thread" errors when multiple sandboxes are running concurrently.
+      # See: https://github.com/alibaba/OpenSandbox/issues/447
+      pids_limit = 4096
 
       [ingress]
       mode = "direct"

--- a/server/example.config.toml
+++ b/server/example.config.toml
@@ -61,7 +61,10 @@ no_new_privileges = true
 # Optional: set an AppArmor profile name (e.g., "docker-default") when AppArmor is enabled
 apparmor_profile = ""
 # Limit process count to reduce host impact from fork bombs; set to null to disable
-pids_limit = 512
+# TODO: For production environments, it is recommended to set this to '4096' or higher to avoid
+# "can't start new thread" errors when multiple sandboxes are running concurrently.
+# See: https://github.com/alibaba/OpenSandbox/issues/447
+pids_limit = 4096
 # Seccomp profile: empty string uses Docker default; set to an absolute path for a custom profile
 seccomp_profile = ""
 

--- a/server/example.config.zh.toml
+++ b/server/example.config.zh.toml
@@ -55,7 +55,7 @@ no_new_privileges = true
 # Optional: set an AppArmor profile name (e.g., "docker-default") when AppArmor is enabled
 apparmor_profile = ""
 # Limit process count to reduce host impact from fork bombs; set to null to disable
-# 生产环境建议设置为 4096 或更高，避免多沙箱并发时出现 "can't start new thread" 错误
+# TODO: 生产环境建议设置为 4096 或更高，避免多沙箱并发时出现 "can't start new thread" 错误
 # See: https://github.com/alibaba/OpenSandbox/issues/447
 pids_limit = 4096
 # Seccomp profile: empty string uses Docker default; set to an absolute path for a custom profile

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -474,7 +474,7 @@ class DockerConfig(BaseModel):
         ),
     )
     pids_limit: Optional[int] = Field(
-        default=512,
+        default=4096,
         ge=1,
         description="Maximum number of processes allowed per sandbox container. Set to null to disable the limit.",
     )


### PR DESCRIPTION
# Summary
- increase default pids_limit to 4096 for production use.
- adjust the `pid_limit` configuration in the source code to `4096`.
- change default config from source code. complete #495 

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered