### PR TITLE
docs: add CNCF Landscape links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
   <a href="https://badge.fury.io/js/@alibaba-group%2Fopensandbox">
     <img src="https://badge.fury.io/js/@alibaba-group%2Fopensandbox.svg" alt="npm version" />
   </a>
+  <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox">
+    <img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4" alt="CNCF Landscape" />
+  </a>
   <a href="https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11">
     <img src="https://img.shields.io/badge/DingTalk-Join-0089FF?logo=dingtalk&logoColor=white" alt="DingTalk" />
   </a>
@@ -39,6 +42,8 @@
 [Documentation](https://open-sandbox.ai/) | [中文文档](https://open-sandbox.ai/zh/)
 
 OpenSandbox is a **general-purpose sandbox platform** for AI applications, offering multi-language SDKs, unified sandbox APIs, and Docker/Kubernetes runtimes for scenarios like Coding Agents, GUI Agents, Agent Evaluation, AI Code Execution, and RL Training.
+
+OpenSandbox is now listed in the [CNCF Landscape](https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox).
 
 ## Features
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -19,6 +19,9 @@
   <a href="https://badge.fury.io/js/@alibaba-group%2Fopensandbox">
     <img src="https://badge.fury.io/js/@alibaba-group%2Fopensandbox.svg" alt="npm version" />
   </a>
+  <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox">
+    <img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4" alt="CNCF Landscape" />
+  </a>
   <a href="https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11">
     <img src="https://img.shields.io/badge/DingTalk-Join-0089FF?logo=dingtalk&logoColor=white" alt="DingTalk" />
   </a>
@@ -33,6 +36,8 @@
 中文 | [English](../README.md)
 
 OpenSandbox 是一个面向 AI 应用场景设计的「通用沙箱平台」，为LLM相关的能力（命令执行、文件操作、代码执行、浏览器操作、Agent 运行等）提供 **多语言 SDK、沙箱接口协议和沙箱运行时**。
+
+OpenSandbox 已进入 [CNCF Landscape](https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox)。
 
 ## 核心特性
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ features:
 
 ## Typical Scenarios
 
+OpenSandbox is now listed in the [CNCF Landscape](https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox).
+
 <div class="scenario-grid">
   <a class="scenario-card" href="./examples/claude-code/readme">
     <h3>Coding Agents</h3>

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -26,6 +26,8 @@ features:
 
 ## 典型落地场景
 
+OpenSandbox 已进入 [CNCF Landscape](https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox)。
+
 <div class="scenario-grid">
   <a class="scenario-card" href="./examples/claude-code/readme">
     <h3>Coding Agent</h3>


### PR DESCRIPTION
## Summary
- add a CNCF Landscape badge to the English and Chinese README badge sections
- add direct CNCF Landscape links to the README and docs home pages
- update links to point to the OpenSandbox CNCF Landscape entry

## Testing
- not run (documentation-only changes)