### PR TITLE
test(code-interpreter/python): cover async endpoint headers

### DIFF
--- a/sdks/code-interpreter/python/tests/test_adapter_eager_init.py
+++ b/sdks/code-interpreter/python/tests/test_adapter_eager_init.py
@@ -28,3 +28,23 @@ async def test_code_service_eager_init_and_client_available() -> None:
 
     client = await adapter._get_client()
     assert client is not None
+
+
+@pytest.mark.asyncio
+async def test_code_service_eager_init_merges_endpoint_headers() -> None:
+    cfg = ConnectionConfig(
+        protocol="http", headers={"X-Base": "base", "X-Shared": "base"}
+    )
+    endpoint = SandboxEndpoint(
+        endpoint="localhost:44772",
+        port=44772,
+        headers={"X-Endpoint": "endpoint", "X-Shared": "endpoint"},
+    )
+    adapter = CodesAdapter(endpoint, cfg)
+
+    client = await adapter._get_client()
+    httpx_client = client.get_async_httpx_client()
+
+    assert httpx_client.headers["X-Base"] == "base"
+    assert httpx_client.headers["X-Endpoint"] == "endpoint"
+    assert httpx_client.headers["X-Shared"] == "endpoint"

--- a/sdks/code-interpreter/python/tests/test_code_service_adapter_streaming.py
+++ b/sdks/code-interpreter/python/tests/test_code_service_adapter_streaming.py
@@ -31,8 +31,16 @@ from code_interpreter.models.code import CodeContext, SupportedLanguage
 
 
 class _SseTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.last_request: httpx.Request | None = None
+
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        body = request.content.decode("utf-8") if isinstance(request.content, (bytes, bytearray)) else ""
+        self.last_request = request
+        body = (
+            request.content.decode("utf-8")
+            if isinstance(request.content, (bytes, bytearray))
+            else ""
+        )
         payload = json.loads(body) if body else {}
 
         if request.url.path == "/code" and payload.get("code") == "print(1)":
@@ -41,7 +49,12 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 b'data: {"type":"stdout","text":"1\\n","timestamp":2}\n\n'
                 b'data: {"type":"execution_complete","timestamp":3,"execution_time":7}\n\n'
             )
-            return httpx.Response(200, headers={"Content-Type": "text/event-stream"}, content=sse, request=request)
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
 
         if request.url.path == "/code" and payload.get("code") == "print(2)":
             assert payload["context"]["language"] == "go"
@@ -50,7 +63,12 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 b'data: {"type":"stdout","text":"2\\n","timestamp":2}\n\n'
                 b'data: {"type":"execution_complete","timestamp":3,"execution_time":7}\n\n'
             )
-            return httpx.Response(200, headers={"Content-Type": "text/event-stream"}, content=sse, request=request)
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
 
         return httpx.Response(
             400,
@@ -77,6 +95,30 @@ async def test_run_code_streaming_happy_path_updates_execution() -> None:
     execution = await adapter.run("print(1)")
     assert execution.id == "exec-1"
     assert execution.logs.stdout[0].text == "1\n"
+
+
+@pytest.mark.asyncio
+async def test_run_code_streaming_merges_endpoint_headers() -> None:
+    transport = _SseTransport()
+    cfg = ConnectionConfig(
+        protocol="http",
+        transport=transport,
+        headers={"X-Base": "base", "X-Shared": "base"},
+    )
+    endpoint = SandboxEndpoint(
+        endpoint="localhost:44772",
+        port=44772,
+        headers={"X-Endpoint": "endpoint", "X-Shared": "endpoint"},
+    )
+    adapter = CodesAdapter(endpoint, cfg)
+
+    execution = await adapter.run("print(1)")
+
+    assert execution.id == "exec-1"
+    assert transport.last_request is not None
+    assert transport.last_request.headers["X-Base"] == "base"
+    assert transport.last_request.headers["X-Endpoint"] == "endpoint"
+    assert transport.last_request.headers["X-Shared"] == "endpoint"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add async Python code-interpreter regression coverage proving `SandboxEndpoint.headers` reaches both the generated OpenAPI client and the SSE execution path
- lock endpoint-header precedence over connection-level headers so future parity changes do not regress the current async behavior
- keep this follow-up test-only and scoped to the Python async package while the sync parity fix is handled separately in #504

## Validation
- `cd sdks/code-interpreter/python && uv run pytest tests/test_adapter_eager_init.py tests/test_code_service_adapter_streaming.py -q`
- `cd sdks/code-interpreter/python && uv run ruff check tests/test_adapter_eager_init.py tests/test_code_service_adapter_streaming.py`