### PR TITLE
fix(ingress): use LoadOrStore for renew-intent MinInterval throttle

### DIFF
--- a/components/ingress/pkg/renewintent/redis.go
+++ b/components/ingress/pkg/renewintent/redis.go
@@ -84,11 +84,14 @@ func (p *RedisPublisher) shouldSendIntent(sandboxID string) bool {
 	if p.cfg.MinInterval <= 0 {
 		return true
 	}
+
 	now := time.Now()
-	if v, ok := p.lastSent.Load(sandboxID); ok {
-		if now.Sub(v.(time.Time)) < p.cfg.MinInterval {
-			return false
-		}
+	prev, loaded := p.lastSent.LoadOrStore(sandboxID, now)
+	if !loaded {
+		return true
+	}
+	if now.Sub(prev.(time.Time)) < p.cfg.MinInterval {
+		return false
 	}
 	p.lastSent.Store(sandboxID, now)
 	return true


### PR DESCRIPTION
# Summary
- use LoadOrStore for renew-intent MinInterval throttle

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered