### PR TITLE
ci: add publish workflow for CLI package

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,53 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - 'cli/v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pypi:
+    if: startsWith(github.ref, 'refs/tags/cli/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Build package
+        working-directory: cli
+        run: |
+          uv build
+
+      - name: Publish to PyPI
+        working-directory: cli
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv publish

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -64,8 +64,8 @@ source = "vcs"
 
 [tool.hatch.version.raw-options]
 root = ".."
-tag_regex = "^python/cli/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
-git_describe_command = 'git describe --dirty --tags --long --match "python/cli/v*"'
+tag_regex = "^cli/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
+git_describe_command = 'git describe --dirty --tags --long --match "cli/v*"'
 fallback_version = "0.1.0"
 
 [tool.hatch.build]


### PR DESCRIPTION
# Summary
- Add GitHub Actions workflow (`publish-cli.yml`) to automate publishing the `opensandbox-cli` package to PyPI, triggered by `cli/v*` tags. Follows the same pattern as existing `publish-server.yml` and `publish-python-sdks.yml` workflows using `uv build` + `uv publish`.
- Update `pyproject.toml` tag regex from `python/cli/v*` to `cli/v*` to match the workflow trigger.

# Testing
- [x] Not run — CI-only change (workflow YAML) + tag regex update, no application code modified. Will be validated on first tag push (`cli/v0.1.0`).

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered — uses existing `PYPI_API_TOKEN` secret, no new credentials required
- [x] Backward compatibility considered — new workflow only, no impact on existing pipelines