### PR TITLE
ci(real-e2e): prune dangling Docker images before E2E builds

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -42,6 +42,7 @@ jobs:
           docker ps -aq --filter "label=opensandbox" | xargs -r docker rm -f || true
           # Remove root-owned files from previous sandbox runs by mounting parent dir
           docker run --rm -v /tmp:/host_tmp alpine rm -rf /host_tmp/opensandbox-e2e || true
+          docker image prune -f || true
 
       - name: Build local egress image
         run: docker build -t opensandbox/egress:local -f components/egress/Dockerfile .
@@ -122,6 +123,7 @@ jobs:
         run: |
           docker ps -aq --filter "label=opensandbox" | xargs -r docker rm -f || true
           docker run --rm -v /tmp:/host_tmp alpine rm -rf /host_tmp/opensandbox-e2e || true
+          docker image prune -f || true
 
       - name: Build local egress image
         run: docker build -t opensandbox/egress:local -f components/egress/Dockerfile .
@@ -218,6 +220,7 @@ jobs:
         run: |
           docker ps -aq --filter "label=opensandbox" | xargs -r docker rm -f || true
           docker run --rm -v /tmp:/host_tmp alpine rm -rf /host_tmp/opensandbox-e2e || true
+          docker image prune -f || true
 
       - name: Build local egress image
         run: docker build -t opensandbox/egress:local -f components/egress/Dockerfile .
@@ -300,6 +303,7 @@ jobs:
         run: |
           docker ps -aq --filter "label=opensandbox" | xargs -r docker rm -f || true
           docker run --rm -v /tmp:/host_tmp alpine rm -rf /host_tmp/opensandbox-e2e || true
+          docker image prune -f || true
 
       - name: Build local egress image
         run: docker build -t opensandbox/egress:local -f components/egress/Dockerfile .


### PR DESCRIPTION
# Summary
- prune dangling Docker images before E2E builds

# Testing
- [x] Not run (just workflow changes)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered