### PR TITLE
fix(server): exclude null fields in sandbox lifecycle API responses

### DIFF
--- a/server/src/api/lifecycle.py
+++ b/server/src/api/lifecycle.py
@@ -54,6 +54,7 @@ sandbox_service = create_sandbox_service()
 @router.post(
     "/sandboxes",
     response_model=CreateSandboxResponse,
+    response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
     responses={
         202: {"description": "Sandbox creation accepted for asynchronous provisioning"},
@@ -92,6 +93,7 @@ async def create_sandbox(
 @router.get(
     "/sandboxes",
     response_model=ListSandboxesResponse,
+    response_model_exclude_none=True,
     responses={
         200: {"description": "Paginated collection of sandboxes"},
         400: {"model": ErrorResponse, "description": "The request was invalid or malformed"},
@@ -155,6 +157,7 @@ async def list_sandboxes(
 @router.get(
     "/sandboxes/{sandbox_id}",
     response_model=Sandbox,
+    response_model_exclude_none=True,
     responses={
         200: {"description": "Sandbox current state and metadata"},
         401: {"model": ErrorResponse, "description": "Authentication credentials are missing or invalid"},

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -72,7 +72,7 @@ logging.getLogger().setLevel(
 
 from src.api.lifecycle import router  # noqa: E402
 from src.api.pool import router as pool_router  # noqa: E402
-from src.api.lifecycle import router, sandbox_service  # noqa: E402
+from src.api.lifecycle import sandbox_service  # noqa: E402
 from src.api.proxy import router as proxy_router  # noqa: E402
 from src.integrations.renew_intent.proxy_renew import ProxyRenewCoordinator  # noqa: E402
 from src.middleware.auth import AuthMiddleware  # noqa: E402

--- a/server/tests/k8s/test_pool_service.py
+++ b/server/tests/k8s/test_pool_service.py
@@ -19,7 +19,7 @@ All tests mock the Kubernetes CustomObjectsApi so no cluster connection is neede
 """
 
 import pytest
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 from kubernetes.client import ApiException
 
 from src.api.schema import (

--- a/server/tests/test_pool_api.py
+++ b/server/tests/test_pool_api.py
@@ -19,7 +19,6 @@ Routes are exercised via FastAPI TestClient.  The K8s PoolService is patched
 so no real cluster connection is needed.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from fastapi import HTTPException, status as http_status

--- a/server/tests/test_routes.py
+++ b/server/tests/test_routes.py
@@ -164,14 +164,14 @@ class TestGetSandbox:
         """
         pass
 
-    def test_get_sandbox_preserves_nullable_expires_at(
+    def test_get_sandbox_omits_null_optional_fields(
         self,
         client: TestClient,
         auth_headers: dict,
         monkeypatch,
     ):
         """
-        Ensure expiresAt is returned as null for manual-cleanup sandboxes.
+        Ensure optional null fields are omitted from JSON (manual-cleanup sandboxes).
         """
         now = datetime.now(timezone.utc)
         sandbox = Sandbox(
@@ -195,16 +195,15 @@ class TestGetSandbox:
         assert response.status_code == 200
 
         payload = response.json()
-        assert payload["metadata"] is None
+        assert "metadata" not in payload
         assert payload["id"] == "sandbox-123"
         assert payload["entrypoint"] == ["python"]
-        assert "expiresAt" in payload
-        assert payload["expiresAt"] is None
+        assert "expiresAt" not in payload
         assert "createdAt" in payload
         assert payload["status"]["state"] == "Running"
-        assert payload["status"]["reason"] is None
-        assert payload["status"]["message"] is None
-        assert payload["status"]["lastTransitionAt"] is None
+        assert "reason" not in payload["status"]
+        assert "message" not in payload["status"]
+        assert "lastTransitionAt" not in payload["status"]
 
     def test_get_sandbox_not_found(
         self,

--- a/server/tests/test_routes_create_delete.py
+++ b/server/tests/test_routes_create_delete.py
@@ -60,7 +60,7 @@ def test_create_sandbox_returns_202_and_service_payload(
     assert calls[0].image.uri == "python:3.11"
 
 
-def test_create_sandbox_manual_cleanup_returns_null_expiration(
+def test_create_sandbox_manual_cleanup_omits_null_optional_fields(
     client: TestClient,
     auth_headers: dict,
     sample_sandbox_request: dict,
@@ -91,11 +91,11 @@ def test_create_sandbox_manual_cleanup_returns_null_expiration(
 
     assert response.status_code == 202
     payload = response.json()
-    assert payload["expiresAt"] is None
-    assert payload["metadata"] is None
-    assert payload["status"]["reason"] is None
-    assert payload["status"]["message"] is None
-    assert payload["status"]["lastTransitionAt"] is None
+    assert "expiresAt" not in payload
+    assert "metadata" not in payload
+    assert "reason" not in payload["status"]
+    assert "message" not in payload["status"]
+    assert "lastTransitionAt" not in payload["status"]
 
 
 def test_create_sandbox_rejects_invalid_request(

--- a/server/tests/test_routes_list_sandboxes.py
+++ b/server/tests/test_routes_list_sandboxes.py
@@ -132,7 +132,7 @@ def test_list_sandboxes_keeps_blank_metadata_values(
     assert captured_requests[0].filter.metadata == {"team": "infra", "note": ""}
 
 
-def test_list_sandboxes_preserves_only_nullable_expires_at(
+def test_list_sandboxes_omits_null_optional_fields(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -169,11 +169,11 @@ def test_list_sandboxes_preserves_only_nullable_expires_at(
 
     assert response.status_code == 200
     item = response.json()["items"][0]
-    assert item["expiresAt"] is None
-    assert item["metadata"] is None
-    assert item["status"]["reason"] is None
-    assert item["status"]["message"] is None
-    assert item["status"]["lastTransitionAt"] is None
+    assert "expiresAt" not in item
+    assert "metadata" not in item
+    assert "reason" not in item["status"]
+    assert "message" not in item["status"]
+    assert "lastTransitionAt" not in item["status"]
 
 
 def test_list_sandboxes_validates_page_bounds(


### PR DESCRIPTION
# Summary
- exclude null fields in sandbox lifecycle API responses
- closes #550 

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation #550 
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered