### PR TITLE
fix(runtime): handle SIGTERM before child PID is set

### DIFF
--- a/kubernetes/internal/task-executor/runtime/process_test.go
+++ b/kubernetes/internal/task-executor/runtime/process_test.go
@@ -73,6 +73,9 @@ func TestProcessExecutor_Lifecycle(t *testing.T) {
 		t.Fatalf("Start failed: %v", err)
 	}
 
+	// Wait for process to fully start and PID file to be written
+	time.Sleep(100 * time.Millisecond)
+
 	// 3. Inspect (Running)
 	status, err := executor.Inspect(ctx, task)
 	if err != nil {
@@ -88,8 +91,8 @@ func TestProcessExecutor_Lifecycle(t *testing.T) {
 	}
 
 	// 5. Inspect (Terminated)
-	// Wait a bit for file to be written
-	time.Sleep(100 * time.Millisecond)
+	// Wait for exit file to be written
+	time.Sleep(200 * time.Millisecond)
 	status, err = executor.Inspect(ctx, task)
 	if err != nil {
 		t.Fatalf("Inspect failed: %v", err)


### PR DESCRIPTION
# Summary
- Exit immediately with code 143 if SIGTERM received prior to CHILD_PID assignment
- Add comment explaining early termination behavior
- Improve signal handling for graceful shutdown in sidecar/host modes

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
