### PR TITLE
oss fs for c#/kotlin

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -138,8 +138,50 @@ public class PVC
 }
 
 /// <summary>
+/// Alibaba Cloud OSS mount backend via ossfs.
+/// </summary>
+public class OSSFS
+{
+    /// <summary>
+    /// Gets or sets the OSS bucket name.
+    /// </summary>
+    [JsonPropertyName("bucket")]
+    public required string Bucket { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OSS endpoint.
+    /// </summary>
+    [JsonPropertyName("endpoint")]
+    public required string Endpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OSS access key ID for inline credentials mode.
+    /// </summary>
+    [JsonPropertyName("accessKeyId")]
+    public required string AccessKeyId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OSS access key secret for inline credentials mode.
+    /// </summary>
+    [JsonPropertyName("accessKeySecret")]
+    public required string AccessKeySecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ossfs major version used by runtime mount integration. Defaults to "2.0".
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "2.0";
+
+    /// <summary>
+    /// Gets or sets additional ossfs mount options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyList<string>? Options { get; set; }
+}
+
+/// <summary>
 /// Storage mount definition for sandbox creation.
-/// Exactly one backend (Host or PVC) should be provided per volume.
+/// Exactly one backend (Host, PVC, or OSSFS) should be provided per volume.
 /// </summary>
 public class Volume
 {
@@ -160,6 +202,12 @@ public class Volume
     /// </summary>
     [JsonPropertyName("pvc")]
     public PVC? Pvc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OSSFS backend configuration.
+    /// </summary>
+    [JsonPropertyName("ossfs")]
+    public OSSFS? Ossfs { get; set; }
 
     /// <summary>
     /// Gets or sets the absolute mount path inside the container.

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json;
 using FluentAssertions;
 using OpenSandbox.Models;
 using Xunit;
@@ -206,6 +207,43 @@ public class ModelsTests
         policy.Egress.Should().HaveCount(2);
         policy.Egress![0].Action.Should().Be(NetworkRuleAction.Allow);
         policy.Egress[0].Target.Should().Be("example.com");
+    }
+
+    [Fact]
+    public void Volume_WithOssfs_ShouldSerializeExpectedPayload()
+    {
+        var request = new CreateSandboxRequest
+        {
+            Image = new ImageSpec { Uri = "python:3.11" },
+            ResourceLimits = new Dictionary<string, string>(),
+            Entrypoint = new List<string> { "python" },
+            Volumes = new List<Volume>
+            {
+                new()
+                {
+                    Name = "oss-data",
+                    MountPath = "/mnt/oss",
+                    SubPath = "prefix",
+                    Ossfs = new OSSFS
+                    {
+                        Bucket = "bucket-a",
+                        Endpoint = "oss-cn-hangzhou.aliyuncs.com",
+                        AccessKeyId = "ak",
+                        AccessKeySecret = "sk",
+                        Options = new List<string> { "allow_other" }
+                    }
+                }
+            }
+        };
+
+        string json = JsonSerializer.Serialize(request);
+
+        json.Should().Contain("\"ossfs\":");
+        json.Should().Contain("\"bucket\":\"bucket-a\"");
+        json.Should().Contain("\"endpoint\":\"oss-cn-hangzhou.aliyuncs.com\"");
+        json.Should().Contain("\"accessKeyId\":\"ak\"");
+        json.Should().Contain("\"accessKeySecret\":\"sk\"");
+        json.Should().Contain("\"version\":\"2.0\"");
     }
 
     [Fact]

--- a/sdks/sandbox/javascript/README.md
+++ b/sdks/sandbox/javascript/README.md
@@ -165,7 +165,32 @@ const { endpoint } = await sandbox.getEndpoint(44772);
 const url = await sandbox.getEndpointUrl(44772);
 ```
 
-### 6. Sandbox Management (Admin)
+### 6. Volume Mounts
+
+`volumes` supports `host`, `pvc`, and `ossfs` backends. Each volume must specify exactly one backend.
+
+```ts
+const sandbox = await Sandbox.create({
+  connectionConfig: config,
+  image: "ubuntu",
+  volumes: [
+    {
+      name: "oss-data",
+      ossfs: {
+        bucket: "bucket-a",
+        endpoint: "oss-cn-hangzhou.aliyuncs.com",
+        accessKeyId: process.env.OSS_ACCESS_KEY_ID!,
+        accessKeySecret: process.env.OSS_ACCESS_KEY_SECRET!,
+        version: "2.0",
+      },
+      mountPath: "/mnt/oss",
+      subPath: "prefix",
+    },
+  ],
+});
+```
+
+### 7. Sandbox Management (Admin)
 
 Use `SandboxManager` for administrative tasks and finding existing sandboxes.
 

--- a/sdks/sandbox/javascript/README_zh.md
+++ b/sdks/sandbox/javascript/README_zh.md
@@ -166,7 +166,32 @@ const { endpoint } = await sandbox.getEndpoint(44772);
 const url = await sandbox.getEndpointUrl(44772);
 ```
 
-### 6. 沙箱管理（Admin）
+### 6. Volume 挂载
+
+`volumes` 现在支持 `host`、`pvc` 和 `ossfs` 三种 backend。每个 volume 必须且只能指定其中一种。
+
+```ts
+const sandbox = await Sandbox.create({
+  connectionConfig: config,
+  image: "ubuntu",
+  volumes: [
+    {
+      name: "oss-data",
+      ossfs: {
+        bucket: "bucket-a",
+        endpoint: "oss-cn-hangzhou.aliyuncs.com",
+        accessKeyId: process.env.OSS_ACCESS_KEY_ID!,
+        accessKeySecret: process.env.OSS_ACCESS_KEY_SECRET!,
+        version: "2.0",
+      },
+      mountPath: "/mnt/oss",
+      subPath: "prefix",
+    },
+  ],
+});
+```
+
+### 7. 沙箱管理（Admin）
 
 使用 `SandboxManager` 进行管理操作，如查询现有沙箱列表。
 

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -79,7 +79,7 @@ export interface SandboxCreateOptions {
   networkPolicy?: NetworkPolicy;
   /**
    * Optional list of volume mounts for persistent storage.
-   * Each volume specifies a backend (host path or PVC) and mount configuration.
+   * Each volume specifies a backend (host path, PVC, or OSSFS) and mount configuration.
    */
   volumes?: Volume[];
   /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -387,11 +387,105 @@ class PVC private constructor(
 }
 
 /**
+ * Alibaba Cloud OSS mount backend via ossfs.
+ *
+ * @property bucket OSS bucket name
+ * @property endpoint OSS endpoint (for example, `oss-cn-hangzhou.aliyuncs.com`)
+ * @property accessKeyId OSS access key ID for inline credentials mode
+ * @property accessKeySecret OSS access key secret for inline credentials mode
+ * @property version ossfs major version used by runtime mount integration
+ * @property options Additional ossfs mount options
+ */
+class OSSFS private constructor(
+    val bucket: String,
+    val endpoint: String,
+    val accessKeyId: String,
+    val accessKeySecret: String,
+    val version: String,
+    val options: List<String>?,
+) {
+    companion object {
+        const val VERSION_1_0 = "1.0"
+        const val VERSION_2_0 = "2.0"
+
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var bucket: String? = null
+        private var endpoint: String? = null
+        private var accessKeyId: String? = null
+        private var accessKeySecret: String? = null
+        private var version: String = VERSION_2_0
+        private var options: List<String>? = null
+
+        fun bucket(bucket: String): Builder {
+            require(bucket.isNotBlank()) { "Bucket cannot be blank" }
+            this.bucket = bucket
+            return this
+        }
+
+        fun endpoint(endpoint: String): Builder {
+            require(endpoint.isNotBlank()) { "Endpoint cannot be blank" }
+            this.endpoint = endpoint
+            return this
+        }
+
+        fun accessKeyId(accessKeyId: String): Builder {
+            require(accessKeyId.isNotBlank()) { "Access key ID cannot be blank" }
+            this.accessKeyId = accessKeyId
+            return this
+        }
+
+        fun accessKeySecret(accessKeySecret: String): Builder {
+            require(accessKeySecret.isNotBlank()) { "Access key secret cannot be blank" }
+            this.accessKeySecret = accessKeySecret
+            return this
+        }
+
+        fun version(version: String): Builder {
+            require(version == VERSION_1_0 || version == VERSION_2_0) {
+                "OSSFS version must be one of: 1.0, 2.0"
+            }
+            this.version = version
+            return this
+        }
+
+        fun options(options: List<String>?): Builder {
+            this.options = options
+            return this
+        }
+
+        fun options(vararg options: String): Builder {
+            this.options = options.toList()
+            return this
+        }
+
+        fun build(): OSSFS {
+            val bucketValue = bucket ?: throw IllegalArgumentException("Bucket must be specified")
+            val endpointValue = endpoint ?: throw IllegalArgumentException("Endpoint must be specified")
+            val accessKeyIdValue = accessKeyId ?: throw IllegalArgumentException("Access key ID must be specified")
+            val accessKeySecretValue =
+                accessKeySecret ?: throw IllegalArgumentException("Access key secret must be specified")
+            return OSSFS(
+                bucket = bucketValue,
+                endpoint = endpointValue,
+                accessKeyId = accessKeyIdValue,
+                accessKeySecret = accessKeySecretValue,
+                version = version,
+                options = options,
+            )
+        }
+    }
+}
+
+/**
  * Storage mount definition for a sandbox.
  *
  * Each volume entry contains:
  * - A unique name identifier
- * - Exactly one backend (host, pvc) with backend-specific fields
+ * - Exactly one backend (host, pvc, ossfs) with backend-specific fields
  * - Common mount settings (mountPath, readOnly, subPath)
  *
  * Example usage:
@@ -413,8 +507,9 @@ class PVC private constructor(
  * ```
  *
  * @property name Unique identifier for the volume within the sandbox
- * @property host Host path bind mount backend (mutually exclusive with pvc)
- * @property pvc Kubernetes PVC mount backend (mutually exclusive with host)
+ * @property host Host path bind mount backend (mutually exclusive with pvc/ossfs)
+ * @property pvc Kubernetes PVC mount backend (mutually exclusive with host/ossfs)
+ * @property ossfs OSSFS mount backend (mutually exclusive with host/pvc)
  * @property mountPath Absolute path inside the container where the volume is mounted
  * @property readOnly If true, the volume is mounted as read-only. Defaults to false (read-write).
  * @property subPath Optional subdirectory under the backend path to mount
@@ -423,6 +518,7 @@ class Volume private constructor(
     val name: String,
     val host: Host?,
     val pvc: PVC?,
+    val ossfs: OSSFS?,
     val mountPath: String,
     val readOnly: Boolean,
     val subPath: String?,
@@ -436,6 +532,7 @@ class Volume private constructor(
         private var name: String? = null
         private var host: Host? = null
         private var pvc: PVC? = null
+        private var ossfs: OSSFS? = null
         private var mountPath: String? = null
         private var readOnly: Boolean = false
         private var subPath: String? = null
@@ -453,6 +550,11 @@ class Volume private constructor(
 
         fun pvc(pvc: PVC): Builder {
             this.pvc = pvc
+            return this
+        }
+
+        fun ossfs(ossfs: OSSFS): Builder {
+            this.ossfs = ossfs
             return this
         }
 
@@ -477,18 +579,23 @@ class Volume private constructor(
             val mountPathValue = mountPath ?: throw IllegalArgumentException("Mount path must be specified")
 
             // Validate exactly one backend is specified
-            val backendsSpecified = listOfNotNull(host, pvc).size
+            val backendsSpecified = listOfNotNull(host, pvc, ossfs).size
             if (backendsSpecified == 0) {
-                throw IllegalArgumentException("Exactly one backend (host, pvc) must be specified, but none was provided")
+                throw IllegalArgumentException(
+                    "Exactly one backend (host, pvc, ossfs) must be specified, but none was provided",
+                )
             }
             if (backendsSpecified > 1) {
-                throw IllegalArgumentException("Exactly one backend (host, pvc) must be specified, but multiple were provided")
+                throw IllegalArgumentException(
+                    "Exactly one backend (host, pvc, ossfs) must be specified, but multiple were provided",
+                )
             }
 
             return Volume(
                 name = nameValue,
                 host = host,
                 pvc = pvc,
+                ossfs = ossfs,
                 mountPath = mountPathValue,
                 readOnly = readOnly,
                 subPath = subPath,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -29,6 +29,7 @@ import com.alibaba.opensandbox.sandbox.api.models.execd.Metrics
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Host
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkRule
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.OSSFS
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PVC
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PaginationInfo
@@ -45,6 +46,7 @@ import java.time.OffsetDateTime
 import com.alibaba.opensandbox.sandbox.api.models.Host as ApiHost
 import com.alibaba.opensandbox.sandbox.api.models.NetworkPolicy as ApiNetworkPolicy
 import com.alibaba.opensandbox.sandbox.api.models.NetworkRule as ApiNetworkRule
+import com.alibaba.opensandbox.sandbox.api.models.OSSFS as ApiOSSFS
 import com.alibaba.opensandbox.sandbox.api.models.PVC as ApiPVC
 import com.alibaba.opensandbox.sandbox.api.models.PaginationInfo as ApiPaginationInfo
 import com.alibaba.opensandbox.sandbox.api.models.Sandbox as ApiSandbox
@@ -193,6 +195,25 @@ internal object SandboxModelConverter {
     }
 
     /**
+     * Converts Domain OSSFS -> API OSSFS
+     */
+    fun OSSFS.toApiOSSFS(): ApiOSSFS {
+        return ApiOSSFS(
+            bucket = this.bucket,
+            endpoint = this.endpoint,
+            accessKeyId = this.accessKeyId,
+            accessKeySecret = this.accessKeySecret,
+            version =
+                when (this.version) {
+                    OSSFS.VERSION_1_0 -> ApiOSSFS.Version._1Period0
+                    OSSFS.VERSION_2_0 -> ApiOSSFS.Version._2Period0
+                    else -> throw IllegalArgumentException("Unsupported OSSFS version: ${this.version}")
+                },
+            options = this.options,
+        )
+    }
+
+    /**
      * Converts Domain Volume -> API Volume
      */
     fun Volume.toApiVolume(): ApiVolume {
@@ -202,6 +223,7 @@ internal object SandboxModelConverter {
             readOnly = this.readOnly,
             host = this.host?.toApiHost(),
             pvc = this.pvc?.toApiPVC(),
+            ossfs = this.ossfs?.toApiOSSFS(),
             subPath = this.subPath,
         )
     }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
@@ -17,6 +17,7 @@
 package com.alibaba.opensandbox.sandbox.domain.models
 
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Host
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.OSSFS
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PVC
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -93,6 +94,55 @@ class VolumeModelsTest {
     }
 
     @Test
+    fun `OSSFS should require inline credentials and default to version 2_0`() {
+        val backend =
+            OSSFS.builder()
+                .bucket("bucket-a")
+                .endpoint("oss-cn-hangzhou.aliyuncs.com")
+                .accessKeyId("ak")
+                .accessKeySecret("sk")
+                .build()
+
+        assertEquals("bucket-a", backend.bucket)
+        assertEquals("oss-cn-hangzhou.aliyuncs.com", backend.endpoint)
+        assertEquals("ak", backend.accessKeyId)
+        assertEquals("sk", backend.accessKeySecret)
+        assertEquals(OSSFS.VERSION_2_0, backend.version)
+        assertNull(backend.options)
+    }
+
+    @Test
+    fun `Volume with OSSFS backend should be created correctly`() {
+        val volume =
+            Volume.builder()
+                .name("oss")
+                .ossfs(
+                    OSSFS.builder()
+                        .bucket("bucket-a")
+                        .endpoint("oss-cn-hangzhou.aliyuncs.com")
+                        .accessKeyId("ak")
+                        .accessKeySecret("sk")
+                        .version(OSSFS.VERSION_1_0)
+                        .options("allow_other", "max_stat_cache_size=0")
+                        .build(),
+                )
+                .mountPath("/mnt/oss")
+                .subPath("prefix")
+                .build()
+
+        assertEquals("oss", volume.name)
+        assertNull(volume.host)
+        assertNull(volume.pvc)
+        assertNotNull(volume.ossfs)
+        assertEquals("bucket-a", volume.ossfs?.bucket)
+        assertEquals(OSSFS.VERSION_1_0, volume.ossfs?.version)
+        assertEquals(listOf("allow_other", "max_stat_cache_size=0"), volume.ossfs?.options)
+        assertEquals("/mnt/oss", volume.mountPath)
+        assertFalse(volume.readOnly)
+        assertEquals("prefix", volume.subPath)
+    }
+
+    @Test
     fun `Volume should reject blank name`() {
         assertThrows(IllegalArgumentException::class.java) {
             Volume.builder()
@@ -131,6 +181,14 @@ class VolumeModelsTest {
                 .name("test")
                 .host(Host.of("/data"))
                 .pvc(PVC.of("my-pvc"))
+                .ossfs(
+                    OSSFS.builder()
+                        .bucket("bucket-a")
+                        .endpoint("oss-cn-hangzhou.aliyuncs.com")
+                        .accessKeyId("ak")
+                        .accessKeySecret("sk")
+                        .build(),
+                )
                 .mountPath("/mnt")
                 .build()
         }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -20,9 +20,11 @@ import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkRule
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.OSSFS
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxImageSpec
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxState
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -162,6 +164,64 @@ class SandboxesAdapterTest {
             )
 
         assertEquals("manual-sbx", result.id)
+    }
+
+    @Test
+    fun `createSandbox should serialize OSSFS volume`() {
+        val responseBody =
+            """
+            {
+                "id": "ossfs-sbx",
+                "status": { "state": "Running" },
+                "expiresAt": null,
+                "createdAt": "2023-01-01T10:00:00Z",
+                "entrypoint": ["bash"]
+            }
+            """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(201))
+
+        val spec = SandboxImageSpec.builder().image("ubuntu:latest").build()
+        val volumes =
+            listOf(
+                Volume.builder()
+                    .name("oss-data")
+                    .ossfs(
+                        OSSFS.builder()
+                            .bucket("bucket-a")
+                            .endpoint("oss-cn-hangzhou.aliyuncs.com")
+                            .accessKeyId("ak")
+                            .accessKeySecret("sk")
+                            .options("allow_other", "max_stat_cache_size=0")
+                            .build(),
+                    )
+                    .mountPath("/mnt/oss")
+                    .subPath("prefix")
+                    .build(),
+            )
+
+        sandboxesAdapter.createSandbox(
+            spec = spec,
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = null,
+            resource = mapOf("cpu" to "1"),
+            networkPolicy = null,
+            extensions = emptyMap(),
+            volumes = volumes,
+        )
+
+        val request = mockWebServer.takeRequest()
+        val payload = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+        val serializedVolume = payload["volumes"]!!.jsonArray[0].jsonObject
+        val ossfs = serializedVolume["ossfs"]!!.jsonObject
+
+        assertEquals("bucket-a", ossfs["bucket"]!!.jsonPrimitive.content)
+        assertEquals("oss-cn-hangzhou.aliyuncs.com", ossfs["endpoint"]!!.jsonPrimitive.content)
+        assertEquals("ak", ossfs["accessKeyId"]!!.jsonPrimitive.content)
+        assertEquals("sk", ossfs["accessKeySecret"]!!.jsonPrimitive.content)
+        assertEquals("2.0", ossfs["version"]!!.jsonPrimitive.content)
+        assertEquals("prefix", serializedVolume["subPath"]!!.jsonPrimitive.content)
     }
 
     @Test


### PR DESCRIPTION
# Summary
Add OSSFS volume backend support to the C# and Kotlin sandbox SDKs, and align the JavaScript SDK docs/comments now that OSSFS support has landed there.

Closes #476.

**Changes:**
- `sdks/sandbox/csharp`: add `OSSFS` model, expose `Volume.ossfs`, and add serialization coverage for sandbox create payloads
- `sdks/sandbox/kotlin`: add domain `OSSFS` model/builder, extend `Volume` validation to `host/pvc/ossfs`, wire OSSFS into API conversion, and add model + adapter tests
- `sdks/sandbox/javascript`: update README/README_zh and public option comments so docs match the current `ossfs` support

# Testing
- [x] Unit tests
  - Added/updated C# model serialization tests
  - Added/updated Kotlin model and adapter serialization tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
