### PR TITLE
fix(ingress): relax WebSocket CheckOrigin for trusted reverse proxy

### DIFF
--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -35,6 +35,10 @@ var (
 	defaultUpgrader = &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		// Allow any Origin: ingress sits behind trusted gateways where Host/Origin
+		// often diverge (e.g. browser UI vs internal target). gorilla's default
+		// same-origin check rejects those upgrades.
+		CheckOrigin: func(_ *http.Request) bool { return true },
 	}
 )
 


### PR DESCRIPTION
# Summary
- relax WebSocket CheckOrigin for trusted reverse proxy

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [x] Backward compatibility considered