### PR TITLE
fix: fix interrupt

### DIFF
--- a/sdks/code-interpreter/csharp/README.md
+++ b/sdks/code-interpreter/csharp/README.md
@@ -238,13 +238,24 @@ Stop a running code execution:
 var context = await interpreter.Codes.CreateContextAsync(SupportedLanguage.Python);
 
 // Start a long-running task
+var executionId = new TaskCompletionSource<string>();
 var task = interpreter.Codes.RunAsync(
     "import time\nwhile True: time.sleep(1)",
-    new RunCodeOptions { Context = context });
+    new RunCodeOptions
+    {
+        Context = context,
+        Handlers = new ExecutionHandlers
+        {
+            OnInit = init =>
+            {
+                executionId.TrySetResult(init.Id);
+                return Task.CompletedTask;
+            }
+        }
+    });
 
 // Interrupt after some time
-await Task.Delay(2000);
-await interpreter.Codes.InterruptAsync(context.Id!);
+await interpreter.Codes.InterruptAsync(await executionId.Task);
 ```
 
 ### Access Sandbox Services
@@ -299,7 +310,7 @@ Console.WriteLine($"CPU: {metrics.CpuUsedPercentage}%, Memory: {metrics.MemoryUs
 | `DeleteContextsAsync(language)` | Deletes all contexts for a language |
 | `RunAsync(code, options?)` | Executes code and returns the result |
 | `RunStreamAsync(request)` | Executes code with streaming output |
-| `InterruptAsync(contextId)` | Interrupts a running execution |
+| `InterruptAsync(executionId)` | Interrupts a running execution by execution ID |
 
 > All async methods support `CancellationToken`.
 

--- a/sdks/code-interpreter/csharp/README_zh.md
+++ b/sdks/code-interpreter/csharp/README_zh.md
@@ -244,13 +244,24 @@ await foreach (var ev in ci.Codes.RunStreamAsync(request))
 var ctx = await ci.Codes.CreateContextAsync(SupportedLanguage.Python);
 
 // 启动长时间运行的任务
+var executionId = new TaskCompletionSource<string>();
 var task = ci.Codes.RunAsync(
     "import time\nwhile True: time.sleep(1)",
-    new RunCodeOptions { Context = ctx });
+    new RunCodeOptions
+    {
+        Context = ctx,
+        Handlers = new ExecutionHandlers
+        {
+            OnInit = init =>
+            {
+                executionId.TrySetResult(init.Id);
+                return Task.CompletedTask;
+            }
+        }
+    });
 
-// 一段时间后中断
-await Task.Delay(2000);
-await ci.Codes.InterruptAsync(ctx.Id!);
+// 拿到执行 ID 后中断
+await ci.Codes.InterruptAsync(await executionId.Task);
 ```
 
 ## API 参考
@@ -281,7 +292,7 @@ await ci.Codes.InterruptAsync(ctx.Id!);
 | `DeleteContextsAsync(language)` | 删除某语言的所有上下文 |
 | `RunAsync(code, options?)` | 执行代码并返回结果 |
 | `RunStreamAsync(request)` | 执行代码并流式输出 |
-| `InterruptAsync(contextId)` | 中断正在运行的执行 |
+| `InterruptAsync(executionId)` | 按执行 ID 中断正在运行的执行 |
 
 ## 注意事项
 

--- a/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/Adapters/CodesAdapter.cs
+++ b/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/Adapters/CodesAdapter.cs
@@ -143,15 +143,15 @@ internal sealed class CodesAdapter : ICodes
         await _client.DeleteAsync("/code/contexts", queryParams, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task InterruptAsync(string contextId, CancellationToken cancellationToken = default)
+    public async Task InterruptAsync(string executionId, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(contextId))
+        if (string.IsNullOrWhiteSpace(executionId))
         {
-            throw new InvalidArgumentException("contextId cannot be empty");
+            throw new InvalidArgumentException("executionId cannot be empty");
         }
 
-        _logger.LogInformation("Interrupting code execution for context: {ContextId}", contextId);
-        var queryParams = new Dictionary<string, string?> { ["id"] = contextId };
+        _logger.LogInformation("Interrupting code execution: {ExecutionId}", executionId);
+        var queryParams = new Dictionary<string, string?> { ["id"] = executionId };
         await _client.DeleteAsync("/code", queryParams, cancellationToken).ConfigureAwait(false);
     }
 

--- a/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/Services/ICodes.cs
+++ b/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/Services/ICodes.cs
@@ -95,9 +95,11 @@ public interface ICodes
     /// <summary>
     /// Interrupts a running code execution.
     /// </summary>
-    /// <param name="contextId">The context ID to interrupt.</param>
+    /// <param name="executionId">
+    /// The execution ID to interrupt, typically obtained from the run result or the <c>init</c> event.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <exception cref="InvalidArgumentException">Thrown when <paramref name="contextId"/> is null or empty.</exception>
+    /// <exception cref="InvalidArgumentException">Thrown when <paramref name="executionId"/> is null or empty.</exception>
     /// <exception cref="SandboxException">Thrown when the sandbox service request fails.</exception>
-    Task InterruptAsync(string contextId, CancellationToken cancellationToken = default);
+    Task InterruptAsync(string executionId, CancellationToken cancellationToken = default);
 }

--- a/sdks/code-interpreter/csharp/tests/OpenSandbox.CodeInterpreter.Tests/CodesAdapterTests.cs
+++ b/sdks/code-interpreter/csharp/tests/OpenSandbox.CodeInterpreter.Tests/CodesAdapterTests.cs
@@ -115,6 +115,21 @@ public class CodesAdapterTests
         Assert.Contains(sseHandler.AcceptHeaders, value => value.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task InterruptAsync_SendsExecutionIdAsQueryParameter()
+    {
+        var httpHandler = new StubHttpMessageHandler((request, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        var adapter = CreateAdapter(
+            httpHandler,
+            new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))));
+
+        await adapter.InterruptAsync("exec-123");
+
+        Assert.Contains(httpHandler.RequestUris, uri => uri.Contains("/code?id=exec-123", StringComparison.Ordinal));
+    }
+
     private static async Task DrainAsync<T>(IAsyncEnumerable<T> source)
     {
         await foreach (var _ in source)

--- a/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
@@ -204,15 +204,52 @@ public class CodeInterpreterE2ETests : IClassFixture<CodeInterpreterE2ETestFixtu
         var interpreter = _fixture.Interpreter;
 
         var ctx = await interpreter.Codes.CreateContextAsync(SupportedLanguage.Python);
+        var initLatch = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var runTask = interpreter.Codes.RunAsync(
             "import time\nwhile True: time.sleep(1)",
+            new RunCodeOptions
+            {
+                Context = ctx,
+                Handlers = new ExecutionHandlers
+                {
+                    OnInit = init =>
+                    {
+                        initLatch.TrySetResult(init.Id);
+                        return Task.CompletedTask;
+                    }
+                }
+            });
+
+        var executionId = await initLatch.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        Assert.False(string.IsNullOrWhiteSpace(executionId));
+        await interpreter.Codes.InterruptAsync(executionId);
+
+        Execution? execution = null;
+        try
+        {
+            execution = await runTask.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException)
+        {
+            // Some environments interrupt the backend execution but do not close
+            // the SSE stream promptly. Treat this as acceptable if a follow-up
+            // run proves the interpreter remains usable.
+        }
+        catch
+        {
+            // The stream may terminate abruptly after interrupt.
+        }
+
+        if (execution != null)
+        {
+            Assert.Equal(executionId, execution.Id);
+        }
+
+        var quickResult = await interpreter.Codes.RunAsync(
+            "print('Quick Python execution')\nresult = 2 + 2\nprint(f'Result: {result}')",
             new RunCodeOptions { Context = ctx });
-
-        await Task.Delay(2000);
-        await interpreter.Codes.InterruptAsync(ctx.Id!);
-
-        var execution = await runTask.WaitAsync(TimeSpan.FromSeconds(30));
-        Assert.True(execution.Error != null || execution.Logs.Stderr.Count > 0 || execution.Complete != null);
+        Assert.NotNull(quickResult);
+        Assert.False(string.IsNullOrWhiteSpace(quickResult.Id));
 
         await interpreter.Codes.DeleteContextAsync(ctx.Id!);
     }


### PR DESCRIPTION
# Summary
- fix C# Code Interpreter interrupt semantics and examples to use the execution ID returned by the run result or `init` event instead of the context ID
- make the C# Code Interpreter interrupt E2E resilient to abrupt or delayed SSE shutdown after interrupt, matching the existing Python/Java/JavaScript test expectations
- add regression coverage for the C# codes adapter interrupt request mapping (`DELETE /code?id=<executionId>`)

# Testing
- [x] Not run locally (sandbox environment cannot complete `dotnet test` because NuGet audit access is blocked)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] Yes (pre-release C# API cleanup: `ICodes.InterruptAsync` parameter name changed from `contextId` to `executionId` to match actual protocol semantics; request behavior is unchanged)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
