### PR TITLE
test(runtime): improve timing waits in process test cases

### DIFF
--- a/kubernetes/internal/task-executor/runtime/process_test.go
+++ b/kubernetes/internal/task-executor/runtime/process_test.go
@@ -73,6 +73,9 @@ func TestProcessExecutor_Lifecycle(t *testing.T) {
 		t.Fatalf("Start failed: %v", err)
 	}
 
+	// Wait for process to fully start and PID file to be written
+	time.Sleep(100 * time.Millisecond)
+
 	// 3. Inspect (Running)
 	status, err := executor.Inspect(ctx, task)
 	if err != nil {
@@ -88,8 +91,8 @@ func TestProcessExecutor_Lifecycle(t *testing.T) {
 	}
 
 	// 5. Inspect (Terminated)
-	// Wait a bit for file to be written
-	time.Sleep(100 * time.Millisecond)
+	// Wait for exit file to be written
+	time.Sleep(200 * time.Millisecond)
 	status, err = executor.Inspect(ctx, task)
 	if err != nil {
 		t.Fatalf("Inspect failed: %v", err)


### PR DESCRIPTION
- Added wait after process start to ensure PID file is created
- Increased wait time before inspecting terminated process to 200ms
- Replaced comments to clarify purpose of wait statements

# Summary
- What is changing and why?

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
