### PR TITLE
Avoid nft "conflicting intervals" when static allow/deny lists overlap

### DIFF
--- a/components/egress/nft.go
+++ b/components/egress/nft.go
@@ -44,7 +44,7 @@ func setupNft(ctx context.Context, nftMgr nftApplier, initialPolicy *policy.Netw
 	}
 	log.Infof("applying nftables static policy (dns+nft mode) with %d nameserver IP(s) merged into allow set", len(nameserverIPs))
 	policyWithNS := initialPolicy.WithExtraAllowIPs(nameserverIPs)
-	if err := nftMgr.ApplyStatic(ctx, policyWithNS, true); err != nil {
+	if err := nftMgr.ApplyStatic(ctx, policyWithNS); err != nil {
 		log.Fatalf("nftables static apply failed: %v", err)
 	}
 	log.Infof("nftables static policy applied (table inet opensandbox); DNS-resolved IPs will be added to dynamic allow sets")

--- a/components/egress/pkg/nftables/interval.go
+++ b/components/egress/pkg/nftables/interval.go
@@ -22,7 +22,7 @@ import (
 // normalizeNFTIntervalSet drops entries that are redundant for nftables sets with
 // `flags interval`: a host or smaller CIDR that falls strictly inside another
 // listed CIDR would make `nft add element` fail with "conflicting intervals specified".
-// Used only when ApplyStatic is called with normalizeIntervalSets=true (startup).
+// Used on every ApplyStatic (startup and /policy updates).
 func normalizeNFTIntervalSet(elems []string) ([]string, error) {
 	if len(elems) == 0 {
 		return nil, nil

--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -83,10 +83,9 @@ func NewManagerWithOptions(opts Options) *Manager {
 // callback: without this, add-element could run while the table is being deleted/recreated
 // and fail, causing a transient deny for a client that already got an allowed DNS answer.
 //
-// normalizeIntervalSets should be true only on the first apply at process startup: it
-// removes redundant IPv4/IPv6 entries that would make nft "interval" sets fail
-// (e.g. a host inside a listed CIDR). Runtime policy updates pass false.
-func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy, normalizeIntervalSets bool) error {
+// On every call (startup and /policy updates), static allow/deny and DoH blocklist
+// interval sets are normalized so overlapping CIDR/host pairs do not make nft fail.
+func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy) error {
 	if p == nil {
 		p = policy.DefaultDenyPolicy()
 	}
@@ -95,7 +94,7 @@ func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy, norm
 		p.DefaultAction, len(allowV4), len(allowV6), len(denyV4), len(denyV6))
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	script, err := buildRuleset(p, m.opts, normalizeIntervalSets)
+	script, err := buildRuleset(p, m.opts)
 	if err != nil {
 		return err
 	}
@@ -134,31 +133,29 @@ func (m *Manager) AddResolvedIPs(ctx context.Context, ips []ResolvedIP) error {
 	return err
 }
 
-func buildRuleset(p *policy.NetworkPolicy, opts Options, normalizeIntervalSets bool) (string, error) {
+func buildRuleset(p *policy.NetworkPolicy, opts Options) (string, error) {
 	allowV4, allowV6, denyV4, denyV6 := p.StaticIPSets()
 	var err error
-	if normalizeIntervalSets {
-		if allowV4, err = normalizeNFTIntervalSet(allowV4); err != nil {
-			return "", err
-		}
-		if allowV6, err = normalizeNFTIntervalSet(allowV6); err != nil {
-			return "", err
-		}
-		if denyV4, err = normalizeNFTIntervalSet(denyV4); err != nil {
-			return "", err
-		}
-		if denyV6, err = normalizeNFTIntervalSet(denyV6); err != nil {
-			return "", err
-		}
+	if allowV4, err = normalizeNFTIntervalSet(allowV4); err != nil {
+		return "", err
+	}
+	if allowV6, err = normalizeNFTIntervalSet(allowV6); err != nil {
+		return "", err
+	}
+	if denyV4, err = normalizeNFTIntervalSet(denyV4); err != nil {
+		return "", err
+	}
+	if denyV6, err = normalizeNFTIntervalSet(denyV6); err != nil {
+		return "", err
 	}
 	dohBlockV4 := opts.DoHBlocklistV4
 	dohBlockV6 := opts.DoHBlocklistV6
-	if normalizeIntervalSets && len(dohBlockV4) > 0 {
+	if len(dohBlockV4) > 0 {
 		if dohBlockV4, err = normalizeNFTIntervalSet(dohBlockV4); err != nil {
 			return "", err
 		}
 	}
-	if normalizeIntervalSets && len(dohBlockV6) > 0 {
+	if len(dohBlockV6) > 0 {
 		if dohBlockV6, err = normalizeNFTIntervalSet(dohBlockV6); err != nil {
 			return "", err
 		}

--- a/components/egress/pkg/nftables/manager_test.go
+++ b/components/egress/pkg/nftables/manager_test.go
@@ -42,7 +42,7 @@ func TestApplyStatic_BuildsRuleset_DefaultDeny(t *testing.T) {
 	}`)
 	require.NoError(t, err, "unexpected parse error")
 
-	require.NoError(t, m.ApplyStatic(context.Background(), p, false), "ApplyStatic returned error")
+	require.NoError(t, m.ApplyStatic(context.Background(), p), "ApplyStatic returned error")
 
 	expectContains(t, rendered, "add chain inet opensandbox egress { type filter hook output priority 0; policy drop; }")
 	expectContains(t, rendered, "add rule inet opensandbox egress ct state established,related accept")
@@ -72,7 +72,7 @@ func TestApplyStatic_DefaultAllowUsesAcceptPolicy(t *testing.T) {
 	}`)
 	require.NoError(t, err, "unexpected parse error")
 
-	require.NoError(t, m.ApplyStatic(context.Background(), p, false), "ApplyStatic returned error")
+	require.NoError(t, m.ApplyStatic(context.Background(), p), "ApplyStatic returned error")
 
 	expectContains(t, rendered, "policy accept;")
 	expectContains(t, rendered, "add rule inet opensandbox egress tcp dport 853 drop")
@@ -98,7 +98,7 @@ func TestApplyStatic_RetryWhenTableMissing(t *testing.T) {
 	})
 
 	p, _ := policy.ParsePolicy(`{"egress":[]}`)
-	require.NoError(t, m.ApplyStatic(context.Background(), p, false), "expected retry to succeed")
+	require.NoError(t, m.ApplyStatic(context.Background(), p), "expected retry to succeed")
 	require.Equal(t, 2, calls, "expected 2 calls (fail then retry)")
 	require.GreaterOrEqual(t, len(scripts), 2, "expected second attempt script to be recorded")
 	require.NotContains(t, scripts[1], "delete table inet opensandbox", "expected second attempt to drop delete-table line")
@@ -118,7 +118,7 @@ func TestApplyStatic_DoHBlocklist(t *testing.T) {
 	}, opts)
 
 	p, _ := policy.ParsePolicy(`{"defaultAction":"allow","egress":[]}`)
-	require.NoError(t, m.ApplyStatic(context.Background(), p, false), "ApplyStatic returned error")
+	require.NoError(t, m.ApplyStatic(context.Background(), p), "ApplyStatic returned error")
 
 	expectContains(t, rendered, "add set inet opensandbox doh_block_v4 { type ipv4_addr; flags interval; }")
 	expectContains(t, rendered, "add element inet opensandbox doh_block_v4 { 9.9.9.9 }")
@@ -165,30 +165,20 @@ func TestAddResolvedIPs_EmptyNoOp(t *testing.T) {
 	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{}), "AddResolvedIPs returned error")
 }
 
-func TestApplyStatic_NormalizeIntervalSetsOnlyWhenTrue(t *testing.T) {
-	overlap := `{
+func TestApplyStatic_NormalizesOverlappingAllow(t *testing.T) {
+	var rendered string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		rendered = script
+		return nil, nil
+	})
+	p, err := policy.ParsePolicy(`{
 		"defaultAction":"deny",
 		"egress":[
 			{"action":"allow","target":"100.64.0.0/10"},
 			{"action":"allow","target":"100.100.2.136"}
 		]
-	}`
-	p, err := policy.ParsePolicy(overlap)
+	}`)
 	require.NoError(t, err)
-
-	var withNorm, withoutNorm string
-	m1 := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
-		withNorm = script
-		return nil, nil
-	})
-	require.NoError(t, m1.ApplyStatic(context.Background(), p, true))
-	expectContains(t, withNorm, "add element inet opensandbox allow_v4 { 100.64.0.0/10 }")
-
-	m2 := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
-		withoutNorm = script
-		return nil, nil
-	})
-	require.NoError(t, m2.ApplyStatic(context.Background(), p, false))
-	require.Contains(t, withoutNorm, "100.100.2.136", "without normalization both entries should appear in script")
-	require.Contains(t, withoutNorm, "100.64.0.0/10", withoutNorm)
+	require.NoError(t, m.ApplyStatic(context.Background(), p))
+	expectContains(t, rendered, "add element inet opensandbox allow_v4 { 100.64.0.0/10 }")
 }

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -44,7 +44,7 @@ type enforcementReporter interface {
 
 // nftApplier applies static policy and optional dynamic DNS-learned IPs to nftables.
 type nftApplier interface {
-	ApplyStatic(ctx context.Context, p *policy.NetworkPolicy, normalizeIntervalSets bool) error
+	ApplyStatic(context.Context, *policy.NetworkPolicy) error
 	AddResolvedIPs(context.Context, []nftables.ResolvedIP) error
 }
 
@@ -253,7 +253,7 @@ func (s *policyServer) commitPolicy(ctx context.Context, w http.ResponseWriter, 
 		return false
 	}
 	if s.nft != nil {
-		if err := s.nft.ApplyStatic(ctx, pol.WithExtraAllowIPs(s.nameserverIPs), false); err != nil {
+		if err := s.nft.ApplyStatic(ctx, pol.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
 			log.Errorf("policy API: nftables apply failed (%s): %v", op, err)
 			http.Error(w, fmt.Sprintf("failed to apply nftables policy: %v", err), http.StatusInternalServerError)
 			return false

--- a/components/egress/policy_server_test.go
+++ b/components/egress/policy_server_test.go
@@ -48,7 +48,7 @@ type stubNft struct {
 	applied *policy.NetworkPolicy
 }
 
-func (s *stubNft) ApplyStatic(_ context.Context, p *policy.NetworkPolicy, _ bool) error {
+func (s *stubNft) ApplyStatic(_ context.Context, p *policy.NetworkPolicy) error {
 	s.calls++
 	s.applied = p
 	return s.err


### PR DESCRIPTION
# Summary
- Clamp nft element timeouts to 60–360s (was 60–300s) so the upper bound still matches a 300s DNS TTL cap plus slack; raise dyn_allow_* set timeout to 360s.
- Avoid nft "conflicting intervals" when static allow/deny lists overlap (e.g. CGNAT + host inside). Add normalizeNFTIntervalSet to drop strictly contained prefixes before add element.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered