### PR TITLE
fix(execd): deduplicate context entries in listAllContexts and listLa…

### DIFF
--- a/components/execd/pkg/runtime/context.go
+++ b/components/execd/pkg/runtime/context.go
@@ -254,10 +254,13 @@ func (c *Controller) deleteDefaultSessionByID(sessionID string) {
 
 func (c *Controller) listAllContexts() ([]CodeContext, error) {
 	contexts := make([]CodeContext, 0)
+	seen := make(map[string]struct{})
+
 	c.jupyterClientMap.Range(func(key, value any) bool {
 		session, _ := key.(string)
 		if kernel, ok := value.(*jupyterKernel); ok && kernel != nil {
 			contexts = append(contexts, CodeContext{ID: session, Language: kernel.language})
+			seen[session] = struct{}{}
 		}
 		return true
 	})
@@ -266,6 +269,10 @@ func (c *Controller) listAllContexts() ([]CodeContext, error) {
 		lang, _ := key.(Language)
 		session, _ := value.(string)
 		if session == "" {
+			return true
+		}
+		// Skip if already collected from jupyterClientMap to avoid duplicates.
+		if _, exists := seen[session]; exists {
 			return true
 		}
 		contexts = append(contexts, CodeContext{ID: session, Language: lang})
@@ -277,16 +284,22 @@ func (c *Controller) listAllContexts() ([]CodeContext, error) {
 
 func (c *Controller) listLanguageContexts(language Language) ([]CodeContext, error) {
 	contexts := make([]CodeContext, 0)
+	seen := make(map[string]struct{})
+
 	c.jupyterClientMap.Range(func(key, value any) bool {
 		session, _ := key.(string)
 		if kernel, ok := value.(*jupyterKernel); ok && kernel != nil && kernel.language == language {
 			contexts = append(contexts, CodeContext{ID: session, Language: language})
+			seen[session] = struct{}{}
 		}
 		return true
 	})
 
 	if defaultContext := c.getDefaultLanguageSession(language); defaultContext != "" {
-		contexts = append(contexts, CodeContext{ID: defaultContext, Language: language})
+		// Skip if already collected from jupyterClientMap to avoid duplicates.
+		if _, exists := seen[defaultContext]; !exists {
+			contexts = append(contexts, CodeContext{ID: defaultContext, Language: language})
+		}
 	}
 
 	return contexts, nil


### PR DESCRIPTION
# Summary
- What is changing and why?
createDefaultLanguageJupyterContext() stores session ID in both jupyterClientMap and defaultLanguageSessions. When listing contexts, both maps are iterated, causing default contexts to appear twice.

Add a 'seen' map to skip already-collected session IDs during the second iteration over defaultLanguageSessions.

Fixes duplicate entries in GET /code/contexts responses.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
