### PR TITLE
feat(egress): load fixed always allow/deny lists at startup

### DIFF
--- a/components/egress/main.go
+++ b/components/egress/main.go
@@ -62,6 +62,11 @@ func main() {
 	}
 	logEgressLoaded(initialRules)
 
+	alwaysDeny, alwaysAllow, err := policy.LoadAlwaysRuleFiles()
+	if err != nil {
+		log.Fatalf("failed to load always allow/deny rule files: %v", err)
+	}
+
 	allowIPs := AllowIPsForNft("/etc/resolv.conf")
 	// Merge nameserver exempt IPs into nft allow set so proxy traffic to them (no SO_MARK) is allowed in dns+nft mode.
 	for _, addr := range dnsproxy.ParseNameserverExemptList() {
@@ -73,7 +78,7 @@ func main() {
 	mode := parseMode()
 	log.Infof("enforcement mode: %s", mode)
 	nftMgr := createNftManager(mode)
-	proxy, err := dnsproxy.New(initialRules, "")
+	proxy, err := dnsproxy.New(initialRules, "", alwaysDeny, alwaysAllow)
 	if err != nil {
 		log.Fatalf("failed to init dns proxy: %v", err)
 	}
@@ -99,11 +104,11 @@ func main() {
 	}
 	log.Infof("iptables redirect configured (OUTPUT 53 -> 15353) with SO_MARK bypass for proxy upstream traffic")
 
-	setupNft(ctx, nftMgr, initialRules, proxy, allowIPs)
+	setupNft(ctx, nftMgr, initialRules, proxy, allowIPs, alwaysDeny, alwaysAllow)
 
 	// start policy server
 	httpAddr := envOrDefault(constants.EnvEgressHTTPAddr, constants.DefaultEgressServerAddr)
-	if err = startPolicyServer(ctx, proxy, nftMgr, mode, httpAddr, os.Getenv(constants.EnvEgressToken), allowIPs, os.Getenv(constants.EnvEgressPolicyFile)); err != nil {
+	if err = startPolicyServer(ctx, proxy, nftMgr, mode, httpAddr, os.Getenv(constants.EnvEgressToken), allowIPs, os.Getenv(constants.EnvEgressPolicyFile), alwaysDeny, alwaysAllow); err != nil {
 		log.Fatalf("failed to start policy server: %v", err)
 	}
 	log.Infof("policy server listening on %s (POST /policy)", httpAddr)

--- a/components/egress/nft.go
+++ b/components/egress/nft.go
@@ -37,13 +37,15 @@ func createNftManager(mode string) nftApplier {
 
 // setupNft applies static policy to nft and wires DNS-resolved IPs into the proxy when nft is enabled.
 // nameserverIPs are merged into the allow set at startup so system DNS works (client + proxy upstream, e.g. private DNS).
-func setupNft(ctx context.Context, nftMgr nftApplier, initialPolicy *policy.NetworkPolicy, proxy *dnsproxy.Proxy, nameserverIPs []netip.Addr) {
+// alwaysDeny/alwaysAllow are optional file-based rules merged ahead of initialPolicy (not persisted).
+func setupNft(ctx context.Context, nftMgr nftApplier, initialPolicy *policy.NetworkPolicy, proxy *dnsproxy.Proxy, nameserverIPs []netip.Addr, alwaysDeny, alwaysAllow []policy.EgressRule) {
 	if nftMgr == nil {
 		log.Warnf("nftables disabled (dns-only mode)")
 		return
 	}
 	log.Infof("applying nftables static policy (dns+nft mode) with %d nameserver IP(s) merged into allow set", len(nameserverIPs))
-	policyWithNS := initialPolicy.WithExtraAllowIPs(nameserverIPs)
+	merged := policy.MergeAlwaysOverlay(initialPolicy, alwaysDeny, alwaysAllow)
+	policyWithNS := merged.WithExtraAllowIPs(nameserverIPs)
 	if err := nftMgr.ApplyStatic(ctx, policyWithNS); err != nil {
 		log.Fatalf("nftables static apply failed: %v", err)
 	}

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -36,11 +36,14 @@ import (
 const defaultListenAddr = "127.0.0.1:15353"
 
 type Proxy struct {
-	policyMu   sync.RWMutex
-	policy     *policy.NetworkPolicy
-	listenAddr string
-	upstream   string // single upstream for MVP
-	servers    []*dns.Server
+	policyMu        sync.RWMutex
+	userPolicy      *policy.NetworkPolicy
+	effectivePolicy *policy.NetworkPolicy
+	alwaysDeny      []policy.EgressRule
+	alwaysAllow     []policy.EgressRule
+	listenAddr      string
+	upstream        string // single upstream for MVP
+	servers         []*dns.Server
 
 	// optional; called in goroutine when A/AAAA are present
 	onResolved func(domain string, ips []nftables.ResolvedIP)
@@ -50,7 +53,9 @@ type Proxy struct {
 }
 
 // New builds a proxy with resolved upstream; listenAddr can be empty for default.
-func New(p *policy.NetworkPolicy, listenAddr string) (*Proxy, error) {
+// alwaysDeny and alwaysAllow are optional operator rules merged ahead of user egress
+// (see policy.MergeAlwaysOverlay); they are not persisted via the policy API.
+func New(p *policy.NetworkPolicy, listenAddr string, alwaysDeny, alwaysAllow []policy.EgressRule) (*Proxy, error) {
 	if listenAddr == "" {
 		listenAddr = defaultListenAddr
 	}
@@ -62,11 +67,18 @@ func New(p *policy.NetworkPolicy, listenAddr string) (*Proxy, error) {
 		return nil, err
 	}
 	proxy := &Proxy{
-		listenAddr: listenAddr,
-		upstream:   upstream,
-		policy:     ensurePolicyDefaults(p),
+		listenAddr:  listenAddr,
+		upstream:    upstream,
+		userPolicy:  ensurePolicyDefaults(p),
+		alwaysDeny:  append([]policy.EgressRule(nil), alwaysDeny...),
+		alwaysAllow: append([]policy.EgressRule(nil), alwaysAllow...),
 	}
+	proxy.refreshEffectivePolicy()
 	return proxy, nil
+}
+
+func (p *Proxy) refreshEffectivePolicy() {
+	p.effectivePolicy = policy.MergeAlwaysOverlay(p.userPolicy, p.alwaysDeny, p.alwaysAllow)
 }
 
 func (p *Proxy) Start(ctx context.Context) error {
@@ -113,7 +125,7 @@ func (p *Proxy) serveDNS(w dns.ResponseWriter, r *dns.Msg) {
 	host := normalizeDNSHost(domain)
 
 	p.policyMu.RLock()
-	currentPolicy := p.policy
+	currentPolicy := p.effectivePolicy
 	p.policyMu.RUnlock()
 	if currentPolicy != nil && currentPolicy.Evaluate(domain) == policy.ActionDeny {
 		telemetry.RecordDNSDenied()
@@ -173,19 +185,20 @@ func (p *Proxy) UpstreamHost() string {
 	return host
 }
 
-// UpdatePolicy swaps the in-memory policy used by the proxy.
+// UpdatePolicy swaps the user-facing policy (without always-deny/allow file overlay).
 // Passing nil reverts to the default deny-all policy.
 func (p *Proxy) UpdatePolicy(newPolicy *policy.NetworkPolicy) {
 	p.policyMu.Lock()
-	p.policy = ensurePolicyDefaults(newPolicy)
+	p.userPolicy = ensurePolicyDefaults(newPolicy)
+	p.refreshEffectivePolicy()
 	p.policyMu.Unlock()
 }
 
-// CurrentPolicy returns the policy currently enforced by the proxy.
+// CurrentPolicy returns the user policy (POST/PATCH/GET), not the always-deny/allow overlay.
 func (p *Proxy) CurrentPolicy() *policy.NetworkPolicy {
 	p.policyMu.RLock()
 	defer p.policyMu.RUnlock()
-	return p.policy
+	return p.userPolicy
 }
 
 // SetOnResolved sets the callback invoked when an allowed domain resolves to A/AAAA.

--- a/components/egress/pkg/dnsproxy/proxy_test.go
+++ b/components/egress/pkg/dnsproxy/proxy_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestProxyUpdatePolicy(t *testing.T) {
-	proxy, err := New(nil, "127.0.0.1:15353")
+	proxy, err := New(nil, "127.0.0.1:15353", nil, nil)
 	require.NoError(t, err, "init proxy")
 
 	require.NotNil(t, proxy.CurrentPolicy(), "expected default deny policy (non-nil)")
@@ -43,6 +43,17 @@ func TestProxyUpdatePolicy(t *testing.T) {
 	proxy.UpdatePolicy(nil)
 	require.NotNil(t, proxy.CurrentPolicy(), "expected default deny policy after clearing")
 	require.Equal(t, policy.ActionDeny, proxy.CurrentPolicy().Evaluate("example.com."), "expected default deny after clearing")
+}
+
+func TestProxyAlwaysOverlayPrecedence(t *testing.T) {
+	deny, err := policy.ParseValidatedEgressRule(policy.ActionDeny, "nope.test")
+	require.NoError(t, err)
+	pol, err := policy.ParsePolicy(`{"defaultAction":"deny","egress":[{"action":"allow","target":"nope.test"}]}`)
+	require.NoError(t, err)
+	proxy, err := New(pol, "127.0.0.1:15353", []policy.EgressRule{deny}, nil)
+	require.NoError(t, err)
+	require.Equal(t, policy.ActionAllow, proxy.CurrentPolicy().Evaluate("nope.test."), "user policy without overlay")
+	require.Equal(t, policy.ActionDeny, proxy.effectivePolicy.Evaluate("nope.test."), "effective policy includes always deny")
 }
 
 func TestExtractResolvedIPs(t *testing.T) {
@@ -72,7 +83,7 @@ func TestExtractResolvedIPs_EmptyOrNil(t *testing.T) {
 }
 
 func TestSetOnResolved(t *testing.T) {
-	proxy, err := New(policy.DefaultDenyPolicy(), "")
+	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)
 	var called bool
 	var capturedDomain string
@@ -91,7 +102,7 @@ func TestSetOnResolved(t *testing.T) {
 }
 
 func TestMaybeNotifyResolved_CallsCallbackWhenAOrAAAA(t *testing.T) {
-	proxy, err := New(policy.DefaultDenyPolicy(), "")
+	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)
 	ch := make(chan struct {
 		domain string
@@ -121,7 +132,7 @@ func TestMaybeNotifyResolved_CallsCallbackWhenAOrAAAA(t *testing.T) {
 }
 
 func TestMaybeNotifyResolved_NoCallWhenOnResolvedNil(t *testing.T) {
-	proxy, err := New(policy.DefaultDenyPolicy(), "")
+	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)
 	msg := new(dns.Msg)
 	msg.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "x.", Ttl: 60}, A: net.ParseIP("10.0.0.1")}}
@@ -130,7 +141,7 @@ func TestMaybeNotifyResolved_NoCallWhenOnResolvedNil(t *testing.T) {
 }
 
 func TestMaybeNotifyResolved_NoCallWhenNoAOrAAAA(t *testing.T) {
-	proxy, err := New(policy.DefaultDenyPolicy(), "")
+	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)
 	ch := make(chan struct {
 		domain string

--- a/components/egress/pkg/policy/always_rules.go
+++ b/components/egress/pkg/policy/always_rules.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alibaba/opensandbox/egress/pkg/log"
+)
+
+// Fixed paths for operator-managed lists. Missing files are ignored (no effect).
+const (
+	alwaysDenyFilePath  = "/var/egress/rules/deny.always"
+	alwaysAllowFilePath = "/var/egress/rules/allow.always"
+)
+
+// LoadAlwaysRuleFiles reads optional deny/allow lists from the standard paths.
+func LoadAlwaysRuleFiles() (deny, allow []EgressRule, err error) {
+	deny, err = loadAlwaysRuleFile(alwaysDenyFilePath, ActionDeny)
+	if err != nil {
+		return nil, nil, err
+	}
+	allow, err = loadAlwaysRuleFile(alwaysAllowFilePath, ActionAllow)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Infof("loaded %d always-deny rule(s) from %s", len(deny), alwaysDenyFilePath)
+	log.Infof("loaded %d always-allow rule(s) from %s", len(allow), alwaysAllowFilePath)
+	return deny, allow, nil
+}
+
+func loadAlwaysRuleFile(path, action string) ([]EgressRule, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseAlwaysRuleLines(data, action, path)
+}
+
+func parseAlwaysRuleLines(data []byte, action, pathForErr string) ([]EgressRule, error) {
+	var out []EgressRule
+	sc := bufio.NewScanner(strings.NewReader(string(data)))
+	lineNum := 0
+	for sc.Scan() {
+		lineNum++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		rule, err := ParseValidatedEgressRule(action, line)
+		if err != nil {
+			return nil, fmt.Errorf("%s line %d: %w", pathForErr, lineNum, err)
+		}
+		out = append(out, rule)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("%s: %w", pathForErr, err)
+	}
+	return out, nil
+}
+
+// ParseValidatedEgressRule builds one normalized egress rule (domain/IP/CIDR).
+func ParseValidatedEgressRule(action, target string) (EgressRule, error) {
+	p := NetworkPolicy{
+		DefaultAction: ActionDeny,
+		Egress:        []EgressRule{{Action: action, Target: target}},
+	}
+	if err := normalizePolicy(&p); err != nil {
+		return EgressRule{}, err
+	}
+	return p.Egress[0], nil
+}
+
+// MergeAlwaysOverlay prepends always-deny, then always-allow, then user egress.
+// First matching domain rule in Evaluate wins; deny.always therefore overrides
+// user rules and allow.always for the same target. Between two always files,
+// deny entries are ordered before allow entries so deny wins on duplicate targets.
+func MergeAlwaysOverlay(user *NetworkPolicy, alwaysDeny, alwaysAllow []EgressRule) *NetworkPolicy {
+	if user == nil {
+		user = DefaultDenyPolicy()
+	}
+	out := *user
+	out.Egress = append([]EgressRule(nil), user.Egress...)
+	n := len(alwaysDeny) + len(alwaysAllow) + len(out.Egress)
+	merged := make([]EgressRule, 0, n)
+	merged = append(merged, alwaysDeny...)
+	merged = append(merged, alwaysAllow...)
+	merged = append(merged, out.Egress...)
+	out.Egress = merged
+	return ensureDefaults(&out)
+}

--- a/components/egress/pkg/policy/always_rules_test.go
+++ b/components/egress/pkg/policy/always_rules_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeAlwaysOverlay_OrderAndPrecedence(t *testing.T) {
+	user, err := ParsePolicy(`{"defaultAction":"deny","egress":[{"action":"allow","target":"evil.com"}]}`)
+	require.NoError(t, err)
+
+	deny, err := ParseValidatedEgressRule(ActionDeny, "evil.com")
+	require.NoError(t, err)
+	merged := MergeAlwaysOverlay(user, []EgressRule{deny}, nil)
+	require.Equal(t, ActionDeny, merged.Evaluate("evil.com."), "always deny must override user allow")
+
+	user2, err := ParsePolicy(`{"defaultAction":"deny","egress":[{"action":"deny","target":"good.com"}]}`)
+	require.NoError(t, err)
+	allow, err := ParseValidatedEgressRule(ActionAllow, "good.com")
+	require.NoError(t, err)
+	merged2 := MergeAlwaysOverlay(user2, nil, []EgressRule{allow})
+	require.Equal(t, ActionAllow, merged2.Evaluate("good.com."), "always allow must override user deny")
+}
+
+func TestMergeAlwaysOverlay_DenyAlwaysBeatsAllowAlways(t *testing.T) {
+	user := DefaultDenyPolicy()
+	deny, err := ParseValidatedEgressRule(ActionDeny, "x.com")
+	require.NoError(t, err)
+	allow, err := ParseValidatedEgressRule(ActionAllow, "x.com")
+	require.NoError(t, err)
+	merged := MergeAlwaysOverlay(user, []EgressRule{deny}, []EgressRule{allow})
+	require.Equal(t, ActionDeny, merged.Evaluate("x.com."))
+}
+
+func TestParseAlwaysRuleLines(t *testing.T) {
+	raw := "# c\n\n192.0.2.1\n2001:db8::/32\n*.foo.test\n"
+	got, err := parseAlwaysRuleLines([]byte(raw), ActionDeny, "test")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+}
+
+func TestLoadAlwaysRuleFile_Missing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nope")
+	got, err := loadAlwaysRuleFile(path, ActionDeny)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestParseValidatedEgressRule_EmptyTarget(t *testing.T) {
+	_, err := ParseValidatedEgressRule(ActionDeny, "")
+	require.Error(t, err)
+}

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -51,7 +51,7 @@ type nftApplier interface {
 // startPolicyServer launches a lightweight HTTP API for updating the egress policy at runtime.
 //
 // nameserverIPs are merged into every applied policy so system DNS stays allowed (e.g. private DNS).
-func startPolicyServer(ctx context.Context, proxy policyUpdater, nft nftApplier, enforcementMode string, addr string, token string, nameserverIPs []netip.Addr, policyFile string) error {
+func startPolicyServer(ctx context.Context, proxy policyUpdater, nft nftApplier, enforcementMode string, addr string, token string, nameserverIPs []netip.Addr, policyFile string, alwaysDeny, alwaysAllow []policy.EgressRule) error {
 	maxEgressRules := maxEgressRulesFromEnv()
 	if maxEgressRules > 0 {
 		log.Infof("policy API: max egress rules per policy (POST/PATCH) = %d (set %s=0 to disable)", maxEgressRules, constants.EnvMaxEgressRules)
@@ -66,6 +66,8 @@ func startPolicyServer(ctx context.Context, proxy policyUpdater, nft nftApplier,
 		nameserverIPs:   nameserverIPs,
 		policyFile:      strings.TrimSpace(policyFile),
 		maxEgressRules:  maxEgressRules,
+		alwaysDeny:      append([]policy.EgressRule(nil), alwaysDeny...),
+		alwaysAllow:     append([]policy.EgressRule(nil), alwaysAllow...),
 	}
 
 	mux.HandleFunc("/policy", handler.handlePolicy)
@@ -115,9 +117,11 @@ type policyServer struct {
 	token           string
 	enforcementMode string
 	nameserverIPs   []netip.Addr
-	policyFile      string     // if set, successful policy changes are persisted here
-	maxEgressRules  int        // 0 = unlimited; >0 = max len(Egress) for POST/PATCH
-	mu              sync.Mutex // serializes read-merge-apply to avoid lost updates across POST/PATCH
+	policyFile      string              // if set, successful policy changes are persisted here
+	maxEgressRules  int                 // 0 = unlimited; >0 = max len(Egress) for POST/PATCH
+	alwaysDeny      []policy.EgressRule // from deny.always at startup; merged for enforcement, not persisted
+	alwaysAllow     []policy.EgressRule // from allow.always at startup; merged for enforcement, not persisted
+	mu              sync.Mutex          // serializes read-merge-apply to avoid lost updates across POST/PATCH
 }
 
 type policyStatusResponse struct {
@@ -269,8 +273,9 @@ func (s *policyServer) commitPolicy(ctx context.Context, w http.ResponseWriter, 
 		http.Error(w, fmt.Sprintf("failed to persist policy: %v", err), http.StatusInternalServerError)
 		return false
 	}
+	merged := policy.MergeAlwaysOverlay(pol, s.alwaysDeny, s.alwaysAllow)
 	if s.nft != nil {
-		if err := s.nft.ApplyStatic(ctx, pol.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
+		if err := s.nft.ApplyStatic(ctx, merged.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
 			logEgressUpdateFailedError(fmt.Sprintf("nftables apply (%s): %v", op, err))
 			log.Errorf("policy API: nftables apply failed (%s): %v", op, err)
 			http.Error(w, fmt.Sprintf("failed to apply nftables policy: %v", err), http.StatusInternalServerError)

--- a/components/egress/policy_server_test.go
+++ b/components/egress/policy_server_test.go
@@ -58,6 +58,28 @@ func (s *stubNft) AddResolvedIPs(_ context.Context, _ []nftables.ResolvedIP) err
 	return nil
 }
 
+func TestHandlePolicy_AlwaysDenyMergedIntoNft(t *testing.T) {
+	deny, err := policy.ParseValidatedEgressRule(policy.ActionDeny, "9.9.9.9")
+	require.NoError(t, err)
+	proxy := &stubProxy{}
+	nft := &stubNft{}
+	srv := &policyServer{proxy: proxy, nft: nft, enforcementMode: "dns+nft", alwaysDeny: []policy.EgressRule{deny}}
+
+	body := `{"defaultAction":"deny","egress":[{"action":"allow","target":"9.9.9.9"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/policy", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handlePolicy(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 OK")
+	require.NotNil(t, nft.applied, "expected nft applied")
+	_, _, denyV4, _ := nft.applied.StaticIPSets()
+	require.Contains(t, denyV4, "9.9.9.9", "always deny must appear in nft static deny set")
+	require.Len(t, proxy.updated.Egress, 1, "persisted/user policy must not include always rules")
+	require.Equal(t, "9.9.9.9", proxy.updated.Egress[0].Target)
+}
+
 func TestHandlePolicy_AppliesNftAndUpdatesProxy(t *testing.T) {
 	proxy := &stubProxy{}
 	nft := &stubNft{}


### PR DESCRIPTION
# Summary
- load fixed always allow/deny lists at startup from `/var/egress/rules/allow.always` and `/var/egress/rules/deny.always`

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered