### PR TITLE
fix(sdk): accept Windows drive-letter paths in Host.path validation

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/host.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/host.py
@@ -34,7 +34,8 @@ class Host:
 
         Attributes:
             path (str): Absolute path on the host filesystem to mount.
-                Must start with '/' and be under an allowed prefix.
+                Must start with '/' (Unix) or a drive letter such as 'C:\\'
+                or 'D:/' (Windows), and be under an allowed prefix.
     """
 
     path: str

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -19,6 +19,7 @@ Sandbox-related data models.
 Models for sandbox creation, configuration, status, and lifecycle management.
 """
 
+import re
 from datetime import datetime
 from typing import Literal
 
@@ -136,6 +137,9 @@ class NetworkPolicy(BaseModel):
 # Volume Models
 # ============================================================================
 
+# Matches Unix absolute paths (/…) and Windows drive-letter paths (C:\ or C:/).
+# Aligned with server-side pattern in server/opensandbox_server/api/schema.py.
+_HOST_PATH_RE = re.compile(r"^(/|[A-Za-z]:[\\/])")
 
 class Host(BaseModel):
     """
@@ -152,8 +156,11 @@ class Host(BaseModel):
     @field_validator("path")
     @classmethod
     def path_must_be_absolute(cls, v: str) -> str:
-        if not v.startswith("/"):
-            raise ValueError("Host path must be an absolute path starting with '/'")
+        if not _HOST_PATH_RE.match(v):
+            raise ValueError(
+                "Host path must be an absolute path starting with '/' "
+                "or a Windows drive letter (e.g. 'C:\\' or 'D:/')"
+            )
         return v
 
 

--- a/sdks/sandbox/python/tests/test_models_stability.py
+++ b/sdks/sandbox/python/tests/test_models_stability.py
@@ -161,6 +161,60 @@ def test_host_backend_requires_absolute_path() -> None:
     with pytest.raises(ValueError, match="absolute path"):
         Host(path="relative/path")
 
+def test_host_backend_accepts_unix_root_path() -> None:
+    """Unix root path '/' must be accepted."""
+    assert Host(path="/").path == "/"
+
+
+def test_host_backend_accepts_unix_nested_path() -> None:
+    """Unix nested absolute path must be accepted."""
+    assert Host(path="/mnt/host/project").path == "/mnt/host/project"
+
+
+def test_host_backend_accepts_windows_backslash_path() -> None:
+    """Windows drive path with backslashes must be accepted."""
+    backend = Host(path="D:\\sandbox-mnt\\ReMe")
+    assert backend.path == "D:\\sandbox-mnt\\ReMe"
+
+
+def test_host_backend_accepts_windows_forward_slash_path() -> None:
+    """Windows drive path with forward slashes must be accepted."""
+    backend = Host(path="D:/sandbox-mnt/ReMe")
+    assert backend.path == "D:/sandbox-mnt/ReMe"
+
+
+def test_host_backend_accepts_windows_drive_root() -> None:
+    """Windows drive root (e.g. 'Z:\\') must be accepted."""
+    assert Host(path="Z:\\").path == "Z:\\"
+
+
+def test_host_backend_accepts_windows_lowercase_drive() -> None:
+    """Lowercase drive letter must be accepted."""
+    assert Host(path="a:/lower").path == "a:/lower"
+
+
+def test_host_backend_rejects_relative_path() -> None:
+    """Relative path without leading separator must be rejected."""
+    with pytest.raises(ValueError, match="absolute path"):
+        Host(path="relative/path")
+
+
+def test_host_backend_rejects_dot_relative_path() -> None:
+    """Dot-relative paths must be rejected."""
+    with pytest.raises(ValueError, match="absolute path"):
+        Host(path="./local")
+
+
+def test_host_backend_rejects_parent_traversal_path() -> None:
+    """Parent-traversal paths must be rejected."""
+    with pytest.raises(ValueError, match="absolute path"):
+        Host(path="../parent")
+
+
+def test_host_backend_rejects_empty_path() -> None:
+    """Empty string must be rejected."""
+    with pytest.raises(ValueError, match="absolute path"):
+        Host(path="")
 
 def test_pvc_backend_rejects_blank_claim_name() -> None:
     backend = PVC(claimName="my-pvc")

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -956,8 +956,9 @@ components:
           type: string
           description: |
             Absolute path on the host filesystem to mount.
-            Must start with '/' and be under an allowed prefix.
-          pattern: "^/.*"
+            Must start with '/' (Unix) or a drive letter such as 'C:\' or 'D:/'
+            (Windows), and be under an allowed prefix.
+          pattern: "^(/|[A-Za-z]:[\\\\/])"
       additionalProperties: false
 
     PVC:


### PR DESCRIPTION
# Summary
The Python SDK Host.path validator only accepted paths starting with '/', rejecting valid Windows absolute paths like 'D:\data' or 'C:/data'. This was inconsistent with the server-side schema pattern which already supports both Unix and Windows paths.

- Update Host.path field_validator to use a regex aligned with the server-side pattern: ^(/|[A-Za-z]:[\\/])
- Update OpenAPI spec Host.path pattern accordingly
- Update API model docstring for Host.path
- Add tests for Windows and Unix path acceptance/rejection
- By rebuilding + installing to generate a wheel for installation and local testing.

# Question reproduction
When I was using the OpenSandbox SDK to mount files from Windows to Docker, I found that the Python version of the SDK does not support Windows drive-letter paths. This is inconsistent with the OpenSandbox‑server documentation. The specific test code and error are as follows (replacethe api_key ):
```python
import asyncio
import os
from datetime import timedelta

from opensandbox import Sandbox
from opensandbox.config import ConnectionConfig
from opensandbox.models.execd import ExecutionHandlers, OutputMessage
from opensandbox.models.sandboxes import Volume, Host


def _required_env(name: str) -> str:
    value = os.getenv(name)
    if not value:
        raise RuntimeError(f"{name} is required")
    return value


async def _print_execution_logs(execution) -> None:
    for msg in execution.logs.stdout:
        print(f"[stdout] {msg.text}")
    for msg in execution.logs.stderr:
        print(f"[stderr] {msg.text}")
    if execution.error:
        print(f"[error] {execution.error.name}: {execution.error.value}")


async def on_stdout(msg: OutputMessage):
    with open("analysis_output.txt", "a", encoding="utf-8") as f:
        f.write(msg.text + "\n")
    print(f"[实时] {msg.text}")  # 同时打印到控制台


async def on_stderr(msg: OutputMessage):
    with open("analysis_errors.txt", "a", encoding="utf-8") as f:
        f.write(msg.text + "\n")


async def on_error(err):
    with open("analysis_errors.txt", "a", encoding="utf-8") as f:
        f.write(f"{err.name}: {err.value}\n")
    print(f"[错误] {err.name}: {err.value}")


async def main() -> None:
    domain = os.getenv("SANDBOX_DOMAIN", "localhost:8080")
    api_key = os.getenv("SANDBOX_API_KEY")
    claude_auth_token = os.getenv("MOONSHOT_API_KEY")
    claude_base_url = "https://api.moonshot.cn/anthropic"
    claude_model_name = "kimi-k2.5"
    image = os.getenv(
        "SANDBOX_IMAGE",
        "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.2",
    )

    config = ConnectionConfig(
        domain=domain,
        api_key=api_key,
        request_timeout=timedelta(seconds=60),
    )

    # Inject Claude settings into container environment for CLI access
    env = {
        "ANTHROPIC_AUTH_TOKEN": claude_auth_token,
        "ANTHROPIC_BASE_URL": claude_base_url,
        "ANTHROPIC_MODEL": claude_model_name,
        "IS_SANDBOX": "1",
    }

    # Inject Claude settings into container environment for CLI access
    env = {
        "ANTHROPIC_AUTH_TOKEN": claude_auth_token,
        "ANTHROPIC_BASE_URL": claude_base_url,
        "ANTHROPIC_MODEL": claude_model_name,
        "IS_SANDBOX": "1",
    }
    # Drop None values to avoid overriding defaults inside CLI
    env = {k: v for k, v in env.items() if v is not None}


    sandbox = await Sandbox.create(
        image,
        connection_config=config,
        env=env,
        timeout=timedelta(hours=1),  # 沙箱存活 1 小时，防止运行途中被杀
        volumes=[Volume(
            name="projects",
            host=Host(path="D:\\sandbox-mnt\\files"),
            mountPath="/mnt/projects/files",
            readOnly=True,
        )]
    )

    async with sandbox:
        # Install Claude CLI (Node.js is already in the code-interpreter image)
        install_exec = await sandbox.commands.run(
            "npm i -g @anthropic-ai/claude-code@2.1.77"
        )

        import json
        env_config = {
            "env": {
                "API_TIMEOUT_MS": "3000000",
                "ANTHROPIC_MODEL": claude_model_name,
                "ANTHROPIC_SMALL_FAST_MODEL": claude_model_name,
                "CLAUDE_CODE_SUBAGENT_MODEL": claude_model_name,
                "ANTHROPIC_DEFAULT_SONNET_MODEL": claude_model_name,
                "ANTHROPIC_DEFAULT_OPUS_MODEL": claude_model_name,
                "ANTHROPIC_DEFAULT_HAIKU_MODEL": claude_model_name
            }
        }
        await sandbox.files.write_file(
            "~/.claude/settings.json",
            json.dumps(env_config, indent=2)
        )
        cc_config = {
        "hasCompletedOnboarding": True
        }

        await sandbox.files.write_file(
            "~/.claude.json",
            json.dumps(cc_config, indent=2)
        )

        await _print_execution_logs(install_exec)

        # Use Claude CLI to send a message
        while True:
            user_query = input("输入你的疑惑：")

            if user_query.lower() == "exit":
                break
            prompt = f'cd /mnt/projects/files && claude --permission-mode bypassPermissions "{user_query}"'
            
            run_exec = await sandbox.commands.run(
                prompt,
                handlers=ExecutionHandlers(
                    on_stdout=on_stdout,
                    on_stderr=on_stderr,
                    on_error=on_error,
                )
            )

            await _print_execution_logs(run_exec)

        await sandbox.kill()


if __name__ == "__main__":
    asyncio.run(main())
```

run the script
```shell
uv run main.py
```

error output log
```log
Traceback (most recent call last):
  File "D:\code\python\me\pre\sanbox_testing_by_claudecode\main.py", line 150, in <module>
    asyncio.run(main())
  File "C:...uv\python\cpython-3.11.14-windows-x86_64-none\Lib\asyncio\runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "C:...\uv\python\cpython-3.11.14-windows-x86_64-none\Lib\asyncio\runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:...\uv\python\cpython-3.11.14-windows-x86_64-none\Lib\asyncio\base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "D:\code\python\me\pre\sanbox_testing_by_claudecode\main.py", line 88, in main
    host=Host(path="D:\\sandbox-mnt\\files"),
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\code\python\me\pre\sanbox_testing_claudecode\.venv\Lib\site-packages\pydantic\main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Host
path
  Value error, Host path must be an absolute path starting with '/' [type=value_error, input_value='D:\\sandbox-mnt\\files', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```


# Testing
- [x] Unit tests
    - `cd sdks/sandbox/python && uv run pytest -v` (all passed)
- [x] e2e / manual verification
  - Verified `Host(path="D:\\sandbox-mnt\\...")` and
    `Host(path="D:/sandbox-mnt/...")` are accepted by the SDK
  - Verified `allowed_host_paths = ["D:\\sandbox-mnt"]` in `.sandbox.toml`
    correctly matches both path styles via `os.path.normpath` normalization

# Breaking Changes
- [ ] None
- [x] Yes (describe impact and migration path)
  The SDK `Host.path` error message changed from
  `"Host path must be an absolute path starting with '/'"` to
  `"Host path must be an absolute path starting with '/' or a Windows drive letter (e.g. 'C:\' or 'D:/')"`.
  Code that matches on the exact error string may need updating.
  All previously valid Unix paths remain valid — this change only
  **widens** the set of accepted paths.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
  - The regex `^(/|[A-Za-z]:[\\/])` is strictly scoped to single
    drive letters; server-side `ensure_valid_host_path` still enforces
    path traversal rejection, double-slash rejection, and
    `allowed_host_paths` prefix allowlist
- [x] Backward compatibility considered
  - Unix paths are unaffected; only Windows drive-letter paths are
    newly accepted; error message wording changed (see Breaking Changes)