### PR TITLE
FEATURE: configurable DNS upstream chain with failover

### DIFF
--- a/components/egress/README.md
+++ b/components/egress/README.md
@@ -51,7 +51,7 @@ The egress control is implemented as a **Sidecar** that shares the network names
   In `dns+nft` mode, the sidecar automatically allows:
   - **127.0.0.1** — so packets redirected by iptables to the proxy (127.0.0.1:15353) are accepted by nft.
   - **Nameserver IPs** from `/etc/resolv.conf` — so client DNS and proxy upstream work (e.g. private DNS).  
-  Nameserver IPs are validated (unspecified and loopback are skipped) and capped. Use `OPENSANDBOX_EGRESS_MAX_NS` (default `3`; `0` = no cap, `1`–`10` = cap). See [SECURITY-RISKS.md](SECURITY-RISKS.md) for trust and scope of this whitelist.
+  Nameserver IPs are validated (unspecified and loopback are skipped) and capped at the first **10** lines from `/etc/resolv.conf` (not configurable). See [SECURITY-RISKS.md](SECURITY-RISKS.md) for trust and scope of this whitelist.
 - **Blocked hostname webhook**  
   - `OPENSANDBOX_EGRESS_DENY_WEBHOOK`: HTTP endpoint URL. When set, egress asynchronously POSTs JSON **only when a hostname is denied**: `{"hostname": "<original query>", "timestamp": "<RFC3339>", "source": "opensandbox-egress", "sandboxId": "<id-or-empty>"}`. Default timeout 5s, up to 3 retries with exponential backoff starting at 1s; 4xx is not retried, 5xx/network errors are retried.
   - `OPENSANDBOX_EGRESS_SANDBOX_ID`: optional sandbox identifier injected into the webhook payload as `sandboxId`. The value is read once at startup (unset → empty string).

--- a/components/egress/main.go
+++ b/components/egress/main.go
@@ -67,14 +67,7 @@ func main() {
 		log.Fatalf("failed to load always allow/deny rule files: %v", err)
 	}
 
-	allowIPs := AllowIPsForNft("/etc/resolv.conf")
-	// Merge nameserver exempt IPs into nft allow set so proxy traffic to them (no SO_MARK) is allowed in dns+nft mode.
-	for _, addr := range dnsproxy.ParseNameserverExemptList() {
-		if !containsAddr(allowIPs, addr) {
-			allowIPs = append(allowIPs, addr)
-		}
-	}
-
+	allowIPs := allowIps()
 	mode := parseMode()
 	log.Infof("enforcement mode: %s", mode)
 	nftMgr := createNftManager(mode)

--- a/components/egress/nameserver.go
+++ b/components/egress/nameserver.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"net/netip"
-	"os"
-	"strconv"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/dnsproxy"
@@ -27,14 +25,14 @@ import (
 // AllowIPsForNft returns the list of IPs to merge into the nft allow set for DNS in dns+nft mode:
 // 127.0.0.1 (proxy listen / iptables redirect target) plus validated, capped nameserver IPs from resolvPath.
 // Validation: skips unspecified (0.0.0.0, ::) and loopback (127.x, ::1).
-// Cap: at most max nameservers (default 3; set EGRESS_MAX_NAMESERVERS=0 for no cap, or 1–10).
+// Cap: at most constants.ResolvNameserverCap nameservers from resolv.conf.
 func AllowIPsForNft(resolvPath string) []netip.Addr {
 	raw, _ := dnsproxy.ResolvNameserverIPs(resolvPath)
-	maxNsCount := maxNameserversFromEnv()
+	maxNsCount := constants.ResolvNameserverCap
 
 	var validated []netip.Addr
 	for _, ip := range raw {
-		if maxNsCount > 0 && len(validated) >= maxNsCount {
+		if len(validated) >= maxNsCount {
 			break
 		}
 		if !isValidNameserverIP(ip) {
@@ -56,22 +54,6 @@ func AllowIPsForNft(resolvPath string) []netip.Addr {
 	return out
 }
 
-func maxNameserversFromEnv() int {
-	s := os.Getenv(constants.EnvMaxNameservers)
-	if s == "" {
-		return constants.DefaultMaxNameservers
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 {
-		return constants.DefaultMaxNameservers
-	}
-	if n > 10 {
-		return 10
-	}
-	// 0 = no cap
-	return n
-}
-
 func isValidNameserverIP(ip netip.Addr) bool {
 	if ip.IsUnspecified() {
 		return false
@@ -88,4 +70,25 @@ func formatIPs(ips []netip.Addr) []string {
 		out[i] = ip.String()
 	}
 	return out
+}
+
+func allowIps() []netip.Addr {
+	upstreams, err := dnsproxy.DiscoverUpstreams()
+	if err != nil {
+		log.Fatalf("failed to resolve DNS upstreams: %v", err)
+	}
+	allowIPs := AllowIPsForNft("/etc/resolv.conf")
+	for _, addr := range dnsproxy.AllowIPsFromUpstreamAddrs(upstreams) {
+		if !containsAddr(allowIPs, addr) {
+			allowIPs = append(allowIPs, addr)
+		}
+	}
+
+	// Merge nameserver exempt IPs into nft allow set so proxy traffic to them (no SO_MARK) is allowed in dns+nft mode.
+	for _, addr := range dnsproxy.ParseNameserverExemptList() {
+		if !containsAddr(allowIPs, addr) {
+			allowIPs = append(allowIPs, addr)
+		}
+	}
+	return allowIPs
 }

--- a/components/egress/nameserver_test.go
+++ b/components/egress/nameserver_test.go
@@ -15,12 +15,13 @@
 package main
 
 import (
+	"fmt"
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,17 +62,18 @@ func TestAllowIPsForNft_FiltersInvalid(t *testing.T) {
 func TestAllowIPsForNft_Cap(t *testing.T) {
 	dir := t.TempDir()
 	resolv := filepath.Join(dir, "resolv.conf")
-	content := "nameserver 10.0.0.1\nnameserver 10.0.0.2\nnameserver 10.0.0.3\nnameserver 10.0.0.4\n"
+	var lines []string
+	for i := 1; i <= 11; i++ {
+		lines = append(lines, fmt.Sprintf("nameserver 10.0.0.%d", i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
 	require.NoError(t, os.WriteFile(resolv, []byte(content), 0644))
-	old := os.Getenv(constants.EnvMaxNameservers)
-	defer os.Setenv(constants.EnvMaxNameservers, old)
-	os.Setenv(constants.EnvMaxNameservers, "2")
 
 	ips := AllowIPsForNft(resolv)
-	// 127.0.0.1 + 2 nameservers (cap)
-	require.Len(t, ips, 3, "expected 3 IPs (127.0.0.1 + 2 capped)")
+	// 127.0.0.1 + first 10 nameservers (fixed cap)
+	require.Len(t, ips, 11, "expected 11 IPs (127.0.0.1 + 10 from resolv)")
 	require.Equal(t, netip.MustParseAddr("10.0.0.1"), ips[1], "expected first nameserver to be 10.0.0.1")
-	require.Equal(t, netip.MustParseAddr("10.0.0.2"), ips[2], "expected second nameserver to be 10.0.0.2")
+	require.Equal(t, netip.MustParseAddr("10.0.0.10"), ips[10], "expected tenth nameserver to be 10.0.0.10")
 }
 
 func TestIsValidNameserverIP(t *testing.T) {
@@ -94,29 +96,5 @@ func TestIsValidNameserverIP(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isValidNameserverIP(%s) = %v, want %v", tt.ip, got, tt.want)
 		}
-	}
-}
-
-func TestMaxNameserversFromEnv(t *testing.T) {
-	old := os.Getenv(constants.EnvMaxNameservers)
-	defer os.Setenv(constants.EnvMaxNameservers, old)
-
-	for _, s := range []string{"", "x", "-1"} {
-		os.Setenv(constants.EnvMaxNameservers, s)
-		if got := maxNameserversFromEnv(); got != constants.DefaultMaxNameservers {
-			t.Errorf("maxNameserversFromEnv(%q) = %d, want default %d", s, got, constants.DefaultMaxNameservers)
-		}
-	}
-	os.Setenv(constants.EnvMaxNameservers, "0")
-	if got := maxNameserversFromEnv(); got != 0 {
-		t.Errorf("maxNameserversFromEnv(0) = %d, want 0", got)
-	}
-	os.Setenv(constants.EnvMaxNameservers, "5")
-	if got := maxNameserversFromEnv(); got != 5 {
-		t.Errorf("maxNameserversFromEnv(5) = %d, want 5", got)
-	}
-	os.Setenv(constants.EnvMaxNameservers, "99")
-	if got := maxNameserversFromEnv(); got != 10 {
-		t.Errorf("maxNameserversFromEnv(99) = %d, want 10 (capped)", got)
 	}
 }

--- a/components/egress/pkg/constants/configuration.go
+++ b/components/egress/pkg/constants/configuration.go
@@ -24,7 +24,6 @@ const (
 	EnvEgressPolicyFile = "OPENSANDBOX_EGRESS_POLICY_FILE" // optional JSON snapshot; if present and valid, overrides EnvEgressRules at startup
 	EnvEgressLogLevel   = "OPENSANDBOX_EGRESS_LOG_LEVEL"
 	EnvMaxEgressRules   = "OPENSANDBOX_EGRESS_MAX_RULES" // max egress rules for POST/PATCH; 0 = unlimited; empty = default
-	EnvMaxNameservers   = "OPENSANDBOX_EGRESS_MAX_NS"
 	EnvBlockedWebhook   = "OPENSANDBOX_EGRESS_DENY_WEBHOOK"
 	ENVSandboxID        = "OPENSANDBOX_EGRESS_SANDBOX_ID"
 	// EnvEgressMetricsExtraAttrs optional comma-separated key=value pairs appended to every egress OTLP metric datapoint (first '=' splits key/value per segment).
@@ -32,6 +31,12 @@ const (
 
 	// EnvNameserverExempt comma-separated IPs; proxy upstream to these is not marked and is allowed in nft allow set
 	EnvNameserverExempt = "OPENSANDBOX_EGRESS_NAMESERVER_EXEMPT"
+
+	// EnvDNSUpstream comma-separated upstream resolvers; each address must be a literal IPv4/IPv6 (optional :port). Hostnames are rejected (DNS recursion via REDIRECT).
+	EnvDNSUpstream = "OPENSANDBOX_EGRESS_DNS_UPSTREAM"
+
+	// EnvDNSUpstreamTimeout is the per-upstream DNS forward timeout in whole seconds (default 5). Invalid/empty uses default.
+	EnvDNSUpstreamTimeout = "OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT"
 )
 
 const (
@@ -41,6 +46,8 @@ const (
 
 const (
 	DefaultEgressServerAddr = ":18080"
-	DefaultMaxNameservers   = 3
-	DefaultMaxEgressRules   = 4096
+	// ResolvNameserverCap is the max number of nameserver lines read from /etc/resolv.conf for nft allow-list merge and auto upstream chain (not configurable).
+	ResolvNameserverCap          = 10
+	DefaultMaxEgressRules        = 4096
+	DefaultDNSUpstreamTimeoutSec = 5
 )

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/miekg/dns"
 
+	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/events"
 	"github.com/alibaba/opensandbox/egress/pkg/log"
 	"github.com/alibaba/opensandbox/egress/pkg/nftables"
@@ -36,14 +39,15 @@ import (
 const defaultListenAddr = "127.0.0.1:15353"
 
 type Proxy struct {
-	policyMu        sync.RWMutex
-	userPolicy      *policy.NetworkPolicy
-	effectivePolicy *policy.NetworkPolicy
-	alwaysDeny      []policy.EgressRule
-	alwaysAllow     []policy.EgressRule
-	listenAddr      string
-	upstream        string // single upstream for MVP
-	servers         []*dns.Server
+	policyMu                sync.RWMutex
+	userPolicy              *policy.NetworkPolicy
+	effectivePolicy         *policy.NetworkPolicy
+	alwaysDeny              []policy.EgressRule
+	alwaysAllow             []policy.EgressRule
+	listenAddr              string
+	upstreams               []string // ordered resolver chain; try next on forward failure
+	upstreamExchangeTimeout time.Duration
+	servers                 []*dns.Server
 
 	// optional; called in goroutine when A/AAAA are present
 	onResolved func(domain string, ips []nftables.ResolvedIP)
@@ -62,16 +66,17 @@ func New(p *policy.NetworkPolicy, listenAddr string, alwaysDeny, alwaysAllow []p
 	if p == nil {
 		p = policy.DefaultDenyPolicy()
 	}
-	_, err := discoverUpstream()
+	upstreams, err := DiscoverUpstreams()
 	if err != nil {
 		return nil, err
 	}
 	proxy := &Proxy{
-		listenAddr:  listenAddr,
-		upstream:    "29.29.29.29",
-		userPolicy:  ensurePolicyDefaults(p),
-		alwaysDeny:  append([]policy.EgressRule(nil), alwaysDeny...),
-		alwaysAllow: append([]policy.EgressRule(nil), alwaysAllow...),
+		listenAddr:              listenAddr,
+		upstreams:               upstreams,
+		upstreamExchangeTimeout: upstreamExchangeTimeoutFromEnv(),
+		userPolicy:              ensurePolicyDefaults(p),
+		alwaysDeny:              append([]policy.EgressRule(nil), alwaysDeny...),
+		alwaysAllow:             append([]policy.EgressRule(nil), alwaysAllow...),
 	}
 	proxy.refreshEffectivePolicy()
 	return proxy, nil
@@ -79,6 +84,21 @@ func New(p *policy.NetworkPolicy, listenAddr string, alwaysDeny, alwaysAllow []p
 
 func (p *Proxy) refreshEffectivePolicy() {
 	p.effectivePolicy = policy.MergeAlwaysOverlay(p.userPolicy, p.alwaysDeny, p.alwaysAllow)
+}
+
+func upstreamExchangeTimeoutFromEnv() time.Duration {
+	s := strings.TrimSpace(os.Getenv(constants.EnvDNSUpstreamTimeout))
+	if s == "" {
+		return time.Duration(constants.DefaultDNSUpstreamTimeoutSec) * time.Second
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return time.Duration(constants.DefaultDNSUpstreamTimeoutSec) * time.Second
+	}
+	if n > 120 {
+		n = 120
+	}
+	return time.Duration(n) * time.Second
 }
 
 func (p *Proxy) Start(ctx context.Context) error {
@@ -168,17 +188,65 @@ func (p *Proxy) maybeNotifyResolved(domain string, resp *dns.Msg) {
 }
 
 func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
-	c := &dns.Client{
-		Timeout: 5 * time.Second,
-		Dialer:  p.dialerWithMark(),
+	var lastErr error
+	for i, upstream := range p.upstreams {
+		c := &dns.Client{
+			Timeout: p.upstreamExchangeTimeout,
+			Dialer:  p.dialerForUpstream(upstream),
+		}
+		resp, _, err := c.Exchange(r, upstream)
+		if err != nil {
+			lastErr = err
+			log.Warnf("[dns] upstream %s exchange error: %v", upstream, err)
+			continue
+		}
+		if resp == nil {
+			lastErr = fmt.Errorf("nil response from %s", upstream)
+			continue
+		}
+		if tryNext, reason := p.shouldFailoverAfterResponse(resp, i); tryNext {
+			lastErr = fmt.Errorf("%s from %s", reason, upstream)
+			log.Warnf("[dns] upstream %s: %s; trying next", upstream, reason)
+			continue
+		}
+		return resp, nil
 	}
-	resp, _, err := c.Exchange(r, p.upstream)
-	return resp, err
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("no upstream resolvers configured")
 }
 
-// UpstreamHost returns the host part of the upstream resolver, empty on parse error.
+// shouldFailoverAfterResponse returns whether to try the next upstream.
+// NXDOMAIN is not retried. NOERROR with an empty Answer (NODATA) is retried when another upstream exists:
+// a broken or non-recursive first hop may return empty NOERROR while a public resolver succeeds.
+func (p *Proxy) shouldFailoverAfterResponse(resp *dns.Msg, upstreamIdx int) (tryNext bool, reason string) {
+	if resp == nil {
+		return true, "nil response"
+	}
+	switch resp.Rcode {
+	case dns.RcodeNameError:
+		return false, ""
+	case dns.RcodeSuccess:
+		if len(resp.Answer) == 0 && upstreamIdx < len(p.upstreams)-1 {
+			return true, "empty NOERROR"
+		}
+		return false, ""
+	default:
+		rcStr := dns.RcodeToString[resp.Rcode]
+		if rcStr == "" {
+			rcStr = fmt.Sprintf("rcode %d", resp.Rcode)
+		}
+		return true, rcStr
+	}
+}
+
+// UpstreamHost returns the host part of the first upstream resolver, empty on parse error.
 func (p *Proxy) UpstreamHost() string {
-	host, _, err := net.SplitHostPort(p.upstream)
+	if len(p.upstreams) == 0 {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(p.upstreams[0])
 	if err != nil {
 		return ""
 	}
@@ -264,32 +332,133 @@ func extractResolvedIPs(resp *dns.Msg) []nftables.ResolvedIP {
 
 const fallbackUpstream = "8.8.8.8:53"
 
-func discoverUpstream() (string, error) {
+// DiscoverUpstreams returns the same ordered resolver chain used by the DNS proxy (env or /etc/resolv.conf).
+func DiscoverUpstreams() ([]string, error) {
+	raw := strings.TrimSpace(os.Getenv(constants.EnvDNSUpstream))
+	if raw != "" {
+		return parseEnvDNSUpstreams(raw)
+	}
+	return discoverUpstreamsFromResolv()
+}
+
+// parseEnvDNSUpstreams parses OPENSANDBOX_EGRESS_DNS_UPSTREAM (comma-separated).
+func parseEnvDNSUpstreams(raw string) ([]string, error) {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		addr, err := normalizeEnvUpstreamAddr(part)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", constants.EnvDNSUpstream, err)
+		}
+		out = append(out, addr)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s must list at least one upstream resolver", constants.EnvDNSUpstream)
+	}
+	return dedupeUpstreamAddrs(out), nil
+}
+
+// normalizeEnvUpstreamAddr parses a single OPENSANDBOX_EGRESS_DNS_UPSTREAM entry into host:port (default 53).
+// Only literal IPv4/IPv6 addresses are allowed. Hostnames are rejected: resolving them would use port 53,
+// which iptables redirects back into this proxy and causes recursive lookup failure.
+func normalizeEnvUpstreamAddr(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("empty upstream address")
+	}
+	if host, port, err := net.SplitHostPort(s); err == nil {
+		if port == "" {
+			return "", fmt.Errorf("invalid port in %q", s)
+		}
+		if _, err := netip.ParseAddr(host); err != nil {
+			return "", fmt.Errorf("host %q must be a literal IP address, not a hostname (avoids DNS self-recursion with REDIRECT)", host)
+		}
+		return net.JoinHostPort(host, port), nil
+	}
+	if strings.HasPrefix(s, "[") {
+		if !strings.HasSuffix(s, "]") {
+			return "", fmt.Errorf("invalid bracketed IPv6 %q", s)
+		}
+		inner := strings.TrimPrefix(strings.TrimSuffix(s, "]"), "[")
+		if _, err := netip.ParseAddr(inner); err != nil {
+			return "", fmt.Errorf("invalid IP inside brackets %q", s)
+		}
+		return net.JoinHostPort(inner, "53"), nil
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return "", fmt.Errorf("upstream %q must be a literal IP address, not a hostname: %w", s, err)
+	}
+	return net.JoinHostPort(addr.String(), "53"), nil
+}
+
+func discoverUpstreamsFromResolv() ([]string, error) {
 	cfg, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil || len(cfg.Servers) == 0 {
 		if err != nil {
 			log.Warnf("[dns] fallback upstream resolver due to error: %v", err)
 		}
-		return fallbackUpstream, nil
+		return []string{fallbackUpstream}, nil
 	}
-	// Prefer first non-loopback nameserver (e.g. K8s cluster DNS after 127.0.0.11).
-	// If only loopback exists (e.g. Docker 127.0.0.11), use it: proxy upstream traffic
-	// is marked and bypasses the redirect, so loopback is reachable from the sidecar.
-	var chosen string
+	port := cfg.Port
+	if port == "" {
+		port = "53"
+	}
+	var nonLoop, loop []string
 	for _, s := range cfg.Servers {
+		addr := net.JoinHostPort(s, port)
 		if ip := net.ParseIP(s); ip != nil && ip.IsLoopback() {
-			if chosen == "" {
-				chosen = s
-			}
+			loop = append(loop, addr)
 			continue
 		}
-		chosen = s
-		break
+		nonLoop = append(nonLoop, addr)
 	}
-	if chosen == "" {
-		chosen = cfg.Servers[0]
+	out := append(nonLoop, loop...)
+	if len(out) == 0 {
+		out = []string{net.JoinHostPort(cfg.Servers[0], port)}
 	}
-	return net.JoinHostPort(chosen, cfg.Port), nil
+	if len(out) > constants.ResolvNameserverCap {
+		out = out[:constants.ResolvNameserverCap]
+	}
+	return dedupeUpstreamAddrs(out), nil
+}
+
+func dedupeUpstreamAddrs(addrs []string) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	var out []string
+	for _, a := range addrs {
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		out = append(out, a)
+	}
+	return out
+}
+
+// AllowIPsFromUpstreamAddrs extracts literal resolver IPs from normalized upstream addresses (host:port).
+func AllowIPsFromUpstreamAddrs(upstreams []string) []netip.Addr {
+	var out []netip.Addr
+	seen := make(map[netip.Addr]struct{})
+	for _, a := range upstreams {
+		host, _, err := net.SplitHostPort(a)
+		if err != nil {
+			continue
+		}
+		ip, err := netip.ParseAddr(host)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[ip]; ok {
+			continue
+		}
+		seen[ip] = struct{}{}
+		out = append(out, ip)
+	}
+	return out
 }
 
 // ResolvNameserverIPs reads nameserver lines from resolvPath and returns parsed IPv4/IPv6 addresses.

--- a/components/egress/pkg/dnsproxy/proxy_linux.go
+++ b/components/egress/pkg/dnsproxy/proxy_linux.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"sync"
 	"syscall"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -30,20 +29,24 @@ import (
 
 var exemptDialerLogOnce sync.Once
 
-// dialerWithMark sets SO_MARK so iptables can RETURN marked packets (bypass
+// dialerForUpstream sets SO_MARK so iptables can RETURN marked packets (bypass
 // redirect for proxy's own upstream DNS queries). When upstream is in the nameserver
 // exempt list, returns a plain dialer (no mark) so upstream traffic follows normal
 // routing (e.g. via tun); iptables still does not redirect by destination exempt.
-func (p *Proxy) dialerWithMark() *net.Dialer {
-	if UpstreamInExemptList(p.UpstreamHost()) {
+func (p *Proxy) dialerForUpstream(upstreamAddr string) *net.Dialer {
+	host, _, err := net.SplitHostPort(upstreamAddr)
+	if err != nil {
+		host = upstreamAddr
+	}
+	if UpstreamInExemptList(host) {
 		exemptDialerLogOnce.Do(func() {
-			log.Infof("[dns] upstream %s in nameserver exempt list, not setting SO_MARK", p.UpstreamHost())
+			log.Infof("[dns] upstream %s in nameserver exempt list, not setting SO_MARK", host)
 		})
-		return &net.Dialer{Timeout: 5 * time.Second}
+		return &net.Dialer{Timeout: p.upstreamExchangeTimeout}
 	}
 
 	return &net.Dialer{
-		Timeout: 5 * time.Second,
+		Timeout: p.upstreamExchangeTimeout,
 		Control: func(network, address string, c syscall.RawConn) error {
 			var opErr error
 			if err := c.Control(func(fd uintptr) {

--- a/components/egress/pkg/dnsproxy/proxy_other.go
+++ b/components/egress/pkg/dnsproxy/proxy_other.go
@@ -18,10 +18,10 @@ package dnsproxy
 
 import (
 	"net"
-	"time"
 )
 
 // Non-linux: no SO_MARK; return basic dialer.
-func (p *Proxy) dialerWithMark() *net.Dialer {
-	return &net.Dialer{Timeout: 5 * time.Second}
+func (p *Proxy) dialerForUpstream(upstreamAddr string) *net.Dialer {
+	_ = upstreamAddr
+	return &net.Dialer{Timeout: p.upstreamExchangeTimeout}
 }

--- a/components/egress/pkg/dnsproxy/upstream_test.go
+++ b/components/egress/pkg/dnsproxy/upstream_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dnsproxy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeEnvUpstreamAddr(t *testing.T) {
+	got, err := normalizeEnvUpstreamAddr("8.8.8.8")
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8:53", got)
+
+	got, err = normalizeEnvUpstreamAddr("1.1.1.1:5353")
+	require.NoError(t, err)
+	require.Equal(t, "1.1.1.1:5353", got)
+
+	got, err = normalizeEnvUpstreamAddr("2001:db8::1")
+	require.NoError(t, err)
+	require.Equal(t, "[2001:db8::1]:53", got)
+
+	got, err = normalizeEnvUpstreamAddr("[2001:db8::2]:853")
+	require.NoError(t, err)
+	require.Equal(t, "[2001:db8::2]:853", got)
+
+	got, err = normalizeEnvUpstreamAddr("[2001:db8::3]")
+	require.NoError(t, err)
+	require.Equal(t, "[2001:db8::3]:53", got)
+
+	_, err = normalizeEnvUpstreamAddr("")
+	require.Error(t, err)
+
+	_, err = normalizeEnvUpstreamAddr("dns.google")
+	require.Error(t, err)
+
+	_, err = normalizeEnvUpstreamAddr("dns.google:53")
+	require.Error(t, err)
+}
+
+func TestParseEnvDNSUpstreams(t *testing.T) {
+	got, err := parseEnvDNSUpstreams("8.8.8.8,1.1.1.1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"8.8.8.8:53", "1.1.1.1:53"}, got)
+
+	got, err = parseEnvDNSUpstreams("8.8.8.8")
+	require.NoError(t, err)
+	require.Equal(t, []string{"8.8.8.8:53"}, got)
+
+	got, err = parseEnvDNSUpstreams("8.8.8.8, 8.8.8.8, 1.1.1.1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"8.8.8.8:53", "1.1.1.1:53"}, got)
+
+	_, err = parseEnvDNSUpstreams("dns.google,8.8.8.8")
+	require.Error(t, err)
+}
+
+func TestAllowIPsFromUpstreamAddrs(t *testing.T) {
+	ips := AllowIPsFromUpstreamAddrs([]string{"8.8.8.8:53", "1.1.1.1:53", "resolver.example.com:53"})
+	require.Len(t, ips, 2)
+	require.Equal(t, "8.8.8.8", ips[0].String())
+	require.Equal(t, "1.1.1.1", ips[1].String())
+}
+
+func TestShouldFailoverAfterResponse(t *testing.T) {
+	p2 := &Proxy{upstreams: []string{"198.51.100.254:53", "8.8.8.8:53"}}
+
+	emptyOK := new(dns.Msg)
+	emptyOK.Rcode = dns.RcodeSuccess
+	try, _ := p2.shouldFailoverAfterResponse(emptyOK, 0)
+	require.True(t, try, "empty NOERROR on first upstream should failover")
+
+	try, _ = p2.shouldFailoverAfterResponse(emptyOK, 1)
+	require.False(t, try, "empty NOERROR on last upstream should not failover")
+
+	withA := new(dns.Msg)
+	withA.Rcode = dns.RcodeSuccess
+	withA.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "x."}, A: net.ParseIP("1.1.1.1")}}
+	try, _ = p2.shouldFailoverAfterResponse(withA, 0)
+	require.False(t, try)
+
+	nx := new(dns.Msg)
+	nx.Rcode = dns.RcodeNameError
+	try, _ = p2.shouldFailoverAfterResponse(nx, 0)
+	require.False(t, try)
+
+	sf := new(dns.Msg)
+	sf.Rcode = dns.RcodeServerFailure
+	try, _ = p2.shouldFailoverAfterResponse(sf, 0)
+	require.True(t, try)
+}

--- a/components/egress/tests/smoke-dynamic-ip.sh
+++ b/components/egress/tests/smoke-dynamic-ip.sh
@@ -44,6 +44,7 @@ docker run -d --name "${containerName}" \
   --sysctl net.ipv6.conf.all.disable_ipv6=1 \
   --sysctl net.ipv6.conf.default.disable_ipv6=1 \
   -e OPENSANDBOX_EGRESS_MODE=dns+nft \
+  -e OPENSANDBOX_EGRESS_DNS_UPSTREAM=8.8.8.8,8.8.4.4 \
   -p ${POLICY_PORT}:18080 \
   "${IMG}"
 
@@ -67,7 +68,7 @@ pass() { info "PASS: $*"; }
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 info "Test: allowed domain (google.com) should succeed via dynamic IP"
-run_in_app -I https://google.com --max-time 15 >/dev/null 2>&1 || fail "google.com should succeed (DNS allow + dynamic IP in nft)"
+run_in_app -I https://google.com --max-time 20 >/dev/null 2>&1 || fail "google.com should succeed (DNS allow + dynamic IP in nft)"
 pass "google.com allowed"
 
 info "Test: denied domain (api.github.com) should fail"

--- a/components/egress/tests/smoke-nft.sh
+++ b/components/egress/tests/smoke-nft.sh
@@ -16,6 +16,7 @@
 
 # Simple smoke test using local image.
 # Requires Docker with --cap-add=NET_ADMIN available.
+# Optional upstream failover check: tests/smoke-dns-upstream-failover.sh
 
 set -euo pipefail
 
@@ -43,6 +44,7 @@ docker run -d --name "${containerName}" \
   --sysctl net.ipv6.conf.all.disable_ipv6=1 \
   --sysctl net.ipv6.conf.default.disable_ipv6=1 \
   -e OPENSANDBOX_EGRESS_MODE=dns+nft \
+  -e OPENSANDBOX_EGRESS_DNS_UPSTREAM=8.8.8.8,8.8.4.4 \
   -p ${POLICY_PORT}:18080 \
   "${IMG}"
 
@@ -66,7 +68,7 @@ pass() { info "PASS: $*"; }
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 info "Test: allowed domain should succeed (google.com)"
-run_in_app -I https://google.com --max-time 10 >/dev/null 2>&1 || fail "google.com should succeed"
+run_in_app -I https://google.com --max-time 20 >/dev/null 2>&1 || fail "google.com should succeed"
 pass "google.com allowed"
 
 info "Test: denied domain should fail (api.github.com)"
@@ -110,7 +112,7 @@ curl -sSf -XPATCH "http://127.0.0.1:${POLICY_PORT}/policy" \
   -d '[{"action":"allow","target":"www.cloudflare.com"}]'
 
 info "Test: www.cloudflare.com should be allowed after patch"
-run_in_app -I https://www.cloudflare.com --max-time 10 >/dev/null 2>&1 || fail "www.cloudflare.com should succeed after patch"
+run_in_app -I https://www.cloudflare.com --max-time 20 >/dev/null 2>&1 || fail "www.cloudflare.com should succeed after patch"
 pass "www.cloudflare.com allowed after patch"
 
 info "Rules update: wildcard allow -> patch deny specific (dns+nft)"
@@ -118,7 +120,7 @@ curl -sSf -XPOST "http://127.0.0.1:${POLICY_PORT}/policy" \
   -d '{"defaultAction":"deny","egress":[{"action":"allow","target":"*.mozilla.org"}]}'
 
 info "Test: www.mozilla.org should be allowed initially (allow via wildcard)"
-run_in_app -I https://www.mozilla.org --max-time 10 >/dev/null 2>&1 || fail "www.mozilla.org should succeed before patch"
+run_in_app -I https://www.mozilla.org --max-time 20 >/dev/null 2>&1 || fail "www.mozilla.org should succeed before patch"
 pass "www.mozilla.org allowed before patch"
 
 info "Patching deny for www.mozilla.org (specific should override earlier allow)"


### PR DESCRIPTION
# Summary
- Add `OPENSANDBOX_EGRESS_DNS_UPSTREAM` so resolvers are not taken only from `/etc/resolv.conf`.
- Try upstreams in order: retry on exchange errors and on DNS rcodes other than NOERROR/NXDOMAIN. When the env var is unset, build a chain from `resolv.conf` (non-loopback first, then loopback), capped by `OPENSANDBOX_EGRESS_MAX_NS`.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered