### PR TITLE
refactor(sdks): refactor run in session

### DIFF
--- a/sdks/AGENTS.md
+++ b/sdks/AGENTS.md
@@ -88,6 +88,7 @@ Always:
 - Prefer tests for request mapping, response conversion, error mapping, streaming behavior, and resource cleanup.
 - Keep package-local validation fast before widening to multi-language verification.
 - Match public behavior across languages unless a documented platform constraint prevents it.
+- Keep wire-format units and public SDK units separate. Public SDK interfaces should expose time durations as language-native duration types where available (`timedelta`, `Duration`) or otherwise as explicitly second-based fields such as `timeoutSeconds`.
 
 Ask first:
 

--- a/sdks/sandbox/csharp/README.md
+++ b/sdks/sandbox/csharp/README.md
@@ -365,6 +365,7 @@ await sandbox.PatchEgressRulesAsync(new[]
 
 - `ConnectionConfig.RequestTimeoutSeconds` controls timeout for SDK HTTP calls.
 - `RunCommandOptions.TimeoutSeconds` controls command execution timeout for command runs.
+- `RunInSessionOptions.TimeoutSeconds` controls command execution timeout for session runs.
 - `SandboxCreateOptions.TimeoutSeconds` controls sandbox server-side TTL.
 - `ReadyTimeoutSeconds` controls how long `CreateAsync` / `ConnectAsync` waits for readiness.
 - The SDK does not automatically retry failed API requests; implement retries in caller code where appropriate.

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/CommandsAdapter.cs
@@ -287,7 +287,9 @@ internal sealed class CommandsAdapter : IExecdCommands
         {
             Command = command,
             Cwd = options?.WorkingDirectory,
-            Timeout = options?.Timeout
+            Timeout = options?.TimeoutSeconds is not null
+                ? options.TimeoutSeconds.Value * 1000L
+                : null
         };
     }
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Execd.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Execd.cs
@@ -403,9 +403,10 @@ public class RunInSessionOptions
     public string? WorkingDirectory { get; set; }
 
     /// <summary>
-    /// Gets or sets the maximum execution time in milliseconds.
+    /// Gets or sets the maximum execution time in seconds.
     /// </summary>
-    public long? Timeout { get; set; }
+    public int? TimeoutSeconds { get; set; }
+
 }
 
 /// <summary>

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandsAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/CommandsAdapterTests.cs
@@ -356,7 +356,7 @@ data: {"type":"error","error":{"ename":"CommandExecError","evalue":"","traceback
         var run = await adapter.RunInSessionAsync(
             "sess-1",
             "pwd",
-            new RunInSessionOptions { WorkingDirectory = "/var", Timeout = 5000 });
+            new RunInSessionOptions { WorkingDirectory = "/var", TimeoutSeconds = 5 });
 
         run.Should().NotBeNull();
         run.Logs.Stdout.Should().ContainSingle(m => m.Text == "/var");

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
@@ -381,11 +381,11 @@ public class ModelsTests
         var options = new RunInSessionOptions
         {
             WorkingDirectory = "/workspace",
-            Timeout = 5000
+            TimeoutSeconds = 5
         };
 
         options.WorkingDirectory.Should().Be("/workspace");
-        options.Timeout.Should().Be(5000);
+        options.TimeoutSeconds.Should().Be(5);
     }
 
     [Fact]

--- a/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
@@ -80,7 +80,7 @@ function toRunCommandRequest(command: string, opts?: RunCommandOpts): ApiRunComm
 
 function toRunInSessionRequest(
   command: string,
-  opts?: { workingDirectory?: string; timeout?: number },
+  opts?: { workingDirectory?: string; timeoutSeconds?: number },
 ): ApiRunInSessionRequest {
   const body: ApiRunInSessionRequest = {
     command,
@@ -88,8 +88,8 @@ function toRunInSessionRequest(
   if (opts?.workingDirectory != null) {
     body.cwd = opts.workingDirectory;
   }
-  if (opts?.timeout != null) {
-    body.timeout = opts.timeout;
+  if (opts?.timeoutSeconds != null) {
+    body.timeout = Math.round(opts.timeoutSeconds * 1000);
   }
   return body;
 }
@@ -158,7 +158,7 @@ export class CommandsAdapter implements ExecdCommands {
   private buildRunInSessionStreamSpec(
     sessionId: string,
     command: string,
-    opts?: { workingDirectory?: string; timeout?: number },
+    opts?: { workingDirectory?: string; timeoutSeconds?: number },
   ): StreamingExecutionSpec<ApiRunInSessionRequest> {
     assertNonBlank(sessionId, "sessionId");
     assertNonBlank(command, "command");
@@ -304,7 +304,7 @@ export class CommandsAdapter implements ExecdCommands {
   async *runInSessionStream(
     sessionId: string,
     command: string,
-    opts?: { workingDirectory?: string; timeout?: number },
+    opts?: { workingDirectory?: string; timeoutSeconds?: number },
     signal?: AbortSignal,
   ): AsyncIterable<ServerStreamEvent> {
     for await (const ev of this.streamExecution(
@@ -318,7 +318,7 @@ export class CommandsAdapter implements ExecdCommands {
   async runInSession(
     sessionId: string,
     command: string,
-    options?: { workingDirectory?: string; timeout?: number },
+    options?: { workingDirectory?: string; timeoutSeconds?: number },
     handlers?: ExecutionHandlers,
     signal?: AbortSignal,
   ): Promise<CommandExecution> {

--- a/sdks/sandbox/javascript/src/services/execdCommands.ts
+++ b/sdks/sandbox/javascript/src/services/execdCommands.ts
@@ -62,7 +62,10 @@ export interface ExecdCommands {
   runInSession(
     sessionId: string,
     command: string,
-    options?: { workingDirectory?: string; timeout?: number },
+    options?: {
+      workingDirectory?: string;
+      timeoutSeconds?: number;
+    },
     handlers?: ExecutionHandlers,
     signal?: AbortSignal,
   ): Promise<CommandExecution>;

--- a/sdks/sandbox/javascript/tests/commands.run.test.mjs
+++ b/sdks/sandbox/javascript/tests/commands.run.test.mjs
@@ -101,7 +101,7 @@ test("CommandsAdapter.runInSession sends command and timeout fields", async () =
 
   const execution = await adapter.runInSession("sess-1", "pwd", {
     workingDirectory: "/var",
-    timeout: 5000,
+    timeoutSeconds: 5,
   });
 
   assert.deepEqual(requestBody, {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunInSessionRequest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunInSessionRequest.kt
@@ -16,18 +16,20 @@
 
 package com.alibaba.opensandbox.sandbox.domain.models.execd.executions
 
+import kotlin.time.Duration
+
 /**
  * Request to run a command in an existing bash session.
  *
  * @property command Shell command to execute
  * @property workingDirectory Optional working directory override for this run
- * @property timeout Optional max execution time in milliseconds
+ * @property timeout Optional max execution time
  * @property handlers Optional execution handlers for streaming events
  */
 class RunInSessionRequest private constructor(
     val command: String,
     val workingDirectory: String?,
-    val timeout: Long?,
+    val timeout: Duration?,
     val handlers: ExecutionHandlers?,
 ) {
     companion object {
@@ -38,7 +40,7 @@ class RunInSessionRequest private constructor(
     class Builder {
         private var command: String? = null
         private var workingDirectory: String? = null
-        private var timeout: Long? = null
+        private var timeout: Duration? = null
         private var handlers: ExecutionHandlers? = null
 
         fun command(command: String): Builder {
@@ -52,7 +54,7 @@ class RunInSessionRequest private constructor(
             return this
         }
 
-        fun timeout(timeout: Long?): Builder {
+        fun timeout(timeout: Duration?): Builder {
             this.timeout = timeout
             return this
         }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Commands.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Commands.kt
@@ -21,6 +21,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandSta
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunInSessionRequest
+import kotlin.time.Duration
 
 /**
  * Command execution operations for sandbox environments.
@@ -112,7 +113,7 @@ interface Commands {
         sessionId: String,
         command: String,
         workingDirectory: String? = null,
-        timeout: Long? = null,
+        timeout: Duration? = null,
     ): Execution {
         return runInSession(
             sessionId,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
@@ -196,7 +196,7 @@ internal class CommandsAdapter(
                 RunInSessionRequestApi(
                     command = request.command,
                     cwd = request.workingDirectory,
-                    timeout = request.timeout,
+                    timeout = request.timeout?.inWholeMilliseconds,
                 )
             val runUrl =
                 execdBaseUrl

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 class CommandsAdapterTest {
     // CommandsAdapter unit tests
@@ -285,7 +286,7 @@ data: {"type":"execution_complete","execution_time":100,"timestamp":167253120100
                 RunInSessionRequest.builder()
                     .command("echo Hello")
                     .workingDirectory("/workspace")
-                    .timeout(5000)
+                    .timeout(5.seconds)
                     .handlers(handlers)
                     .build(),
             )

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -23,6 +23,7 @@ synchronous and streaming execution modes with proper session management.
 
 import json
 import logging
+from datetime import timedelta
 
 import httpx
 
@@ -54,6 +55,19 @@ from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.services.command import Commands
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
+    if timeout is None:
+        return None
+    if isinstance(timeout, timedelta):
+        timeout_ms = int(timeout.total_seconds() * 1000)
+        if timeout_ms < 0:
+            raise InvalidArgumentException("timeout must be positive")
+        return timeout_ms
+    raise InvalidArgumentException(
+        "timeout must be a datetime.timedelta or None"
+    )
 
 
 def _infer_foreground_exit_code(execution: Execution) -> int | None:
@@ -385,7 +399,7 @@ class CommandsAdapter(Commands):
         command: str,
         *,
         working_directory: str | None = None,
-        timeout: int | None = None,
+        timeout: timedelta | None = None,
         handlers: ExecutionHandlers | None = None,
     ) -> Execution:
         if not (session_id and session_id.strip()):
@@ -393,8 +407,9 @@ class CommandsAdapter(Commands):
         if not (command and command.strip()):
             raise InvalidArgumentException("command cannot be empty")
 
+        timeout_ms = _resolve_run_in_session_timeout(timeout)
         body = _build_run_in_session_request_body(
-            command, working_directory, timeout
+            command, working_directory, timeout_ms
         )
         url = self._get_execd_url(
             self.RUN_IN_SESSION_PATH.format(session_id=session_id)

--- a/sdks/sandbox/python/src/opensandbox/services/command.py
+++ b/sdks/sandbox/python/src/opensandbox/services/command.py
@@ -19,6 +19,7 @@ Command service interface.
 Protocol for sandbox command execution operations.
 """
 
+from datetime import timedelta
 from typing import Protocol
 
 from opensandbox.models.execd import (
@@ -134,7 +135,7 @@ class Commands(Protocol):
         command: str,
         *,
         working_directory: str | None = None,
-        timeout: int | None = None,
+        timeout: timedelta | None = None,
         handlers: ExecutionHandlers | None = None,
     ) -> Execution:
         """
@@ -144,7 +145,7 @@ class Commands(Protocol):
             session_id: Session ID from create_session.
             command: Shell command to execute.
             working_directory: Optional working directory override for this run.
-            timeout: Optional max execution time in milliseconds for this session run.
+            timeout: Optional max execution time for this session run.
             handlers: Optional async handlers for streaming events.
 
         Returns:

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -19,6 +19,7 @@ Synchronous command adapter implementation (including SSE streaming).
 
 import json
 import logging
+from datetime import timedelta
 
 import httpx
 
@@ -49,6 +50,19 @@ from opensandbox.sync.adapters.converter.execution_event_dispatcher import (
 from opensandbox.sync.services.command import CommandsSync
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
+    if timeout is None:
+        return None
+    if isinstance(timeout, timedelta):
+        timeout_ms = int(timeout.total_seconds() * 1000)
+        if timeout_ms < 0:
+            raise InvalidArgumentException("timeout must be positive")
+        return timeout_ms
+    raise InvalidArgumentException(
+        "timeout must be a datetime.timedelta or None"
+    )
 
 
 def _infer_foreground_exit_code(execution: Execution) -> int | None:
@@ -331,7 +345,7 @@ class CommandsAdapterSync(CommandsSync):
         command: str,
         *,
         working_directory: str | None = None,
-        timeout: int | None = None,
+        timeout: timedelta | None = None,
         handlers: ExecutionHandlersSync | None = None,
     ) -> Execution:
         if not (session_id and session_id.strip()):
@@ -339,8 +353,9 @@ class CommandsAdapterSync(CommandsSync):
         if not (command and command.strip()):
             raise InvalidArgumentException("command cannot be empty")
 
+        timeout_ms = _resolve_run_in_session_timeout(timeout)
         body = _build_run_in_session_request_body(
-            command, working_directory, timeout
+            command, working_directory, timeout_ms
         )
         url = self._get_execd_url(
             self.RUN_IN_SESSION_PATH.format(session_id=session_id)

--- a/sdks/sandbox/python/src/opensandbox/sync/services/command.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/command.py
@@ -20,6 +20,7 @@ Defines the contract for **blocking** command execution operations inside a sand
 This is the sync counterpart of :mod:`opensandbox.services.command`.
 """
 
+from datetime import timedelta
 from typing import Protocol
 
 from opensandbox.models.execd import (
@@ -127,7 +128,7 @@ class CommandsSync(Protocol):
         command: str,
         *,
         working_directory: str | None = None,
-        timeout: int | None = None,
+        timeout: timedelta | None = None,
         handlers: ExecutionHandlersSync | None = None,
     ) -> Execution:
         """Run a shell command in an existing bash session (streams output via SSE).
@@ -136,7 +137,7 @@ class CommandsSync(Protocol):
             session_id: Session ID from ``create_session``.
             command: Shell command to execute.
             working_directory: Optional working directory override for this run.
-            timeout: Optional max execution time in milliseconds for this session run.
+            timeout: Optional max execution time for this session run.
             handlers: Optional sync handlers for streaming events.
         """
         ...

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 
 import httpx
 import pytest
@@ -158,7 +159,7 @@ async def test_run_in_session_streaming_uses_generated_fields_and_exit_code() ->
         "sess-1",
         "pwd",
         working_directory="/var",
-        timeout=5000,
+        timeout=timedelta(seconds=5),
     )
 
     assert execution.logs.stdout[0].text == "/var"

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 
 import httpx
 
@@ -116,7 +117,7 @@ def test_sync_run_in_session_streaming_uses_generated_fields_and_exit_code() -> 
         "sess-1",
         "pwd",
         working_directory="/var",
-        timeout=5000,
+        timeout=timedelta(seconds=5),
     )
 
     assert execution.logs.stdout[0].text == "/var"


### PR DESCRIPTION
# Summary
Refactor sandbox SDK `runInSession` / `run_in_session` timeout parameters to match each language's existing public SDK timeout style instead of leaking execd wire-format milliseconds.

The main reason for this change is consistency and ambiguity reduction:
- Other timeout-related SDK APIs already use language-native duration types or explicit second-based fields.
- `runInSession` was an outlier that exposed raw millisecond semantics directly.
- Keeping that shape would continue to create unit confusion and semantic drift across SDKs.

This change keeps the server wire format unchanged (`timeout` is still sent in milliseconds), but updates the handwritten SDK public interfaces to use clearer SDK-facing timeout shapes:
- JavaScript: `timeoutSeconds`
- Python: `timedelta`
- Kotlin: `Duration`
- C#: `TimeoutSeconds`

Also add an SDK guideline in `sdks/AGENTS.md`: public SDK duration parameters should use language-native duration types where available, or explicit second-based fields such as `timeoutSeconds`.

# Testing
- [x] Unit tests
  - Kotlin: `./gradlew test`
  - JavaScript: `/Users/ninan/.nvm/versions/node/v22.21.1/bin/node --test tests/commands.run.test.mjs`
  - Python: `./.venv/bin/python -m pytest tests/test_command_service_adapter_streaming.py tests/test_sync_command_service_adapter_streaming.py -q`
- [ ] Integration tests
- [ ] e2e / manual verification

Notes:
- C# targeted unit tests were blocked in this environment by `vstest` socket permission errors.
- Python tests were run via the local virtualenv instead of `uv` because `uv` was unstable in this environment.

# Breaking Changes
- [ ] None
- [x] Yes

This PR intentionally introduces SDK breaking changes so old timeout call sites fail fast instead of silently keeping ambiguous millisecond semantics.

Migration examples:
- JavaScript
  - Old: `runInSession(id, cmd, { timeout: 5000 })`
  - New: `runInSession(id, cmd, { timeoutSeconds: 5 })`

- Python
  - Old: `run_in_session(id, cmd, timeout=5000)`
  - New: `run_in_session(id, cmd, timeout=timedelta(seconds=5))`

- Kotlin
  - Old: `runInSession(id, cmd, timeout = 5000)`
  - New: `runInSession(id, cmd, timeout = 5.seconds)` / `Duration.ofSeconds(5)`

- C#
  - Old: `new RunInSessionOptions { Timeout = 5000 }`
  - New: `new RunInSessionOptions { TimeoutSeconds = 5 }`

# Checklist
- [x] Motivation clearly described
- [x] Docs updated
- [x] Tests updated
- [x] Security impact considered
- [x] Backward compatibility considered
