### PR TITLE
fix(server): normalize BatchSandbox create status

### DIFF
--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -185,7 +185,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     continue
                 
                 # Get status
-                status_info = self.workload_provider.get_status(workload)
+                status_info = self._normalize_create_status(
+                    self.workload_provider.get_status(workload)
+                )
                 current_state = status_info["state"]
                 current_message = status_info["message"]
                 
@@ -224,6 +226,17 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 ),
             },
         )
+
+    @staticmethod
+    def _normalize_create_status(status_info: Dict[str, Any]) -> Dict[str, Any]:
+        if status_info.get("state") != "Allocated":
+            return status_info
+
+        return {
+            **status_info,
+            "state": "Running",
+            "message": "Pod has IP assigned and sandbox is ready for requests",
+        }
     
     def _ensure_network_policy_support(self, request: CreateSandboxRequest) -> None:
         """
@@ -363,7 +376,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 )
                 
                 # Get final status
-                status_info = self.workload_provider.get_status(workload)
+                status_info = self._normalize_create_status(
+                    self.workload_provider.get_status(workload)
+                )
                 
                 # Build and return response with Running state
                 return CreateSandboxResponse(

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -130,6 +130,28 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.create_workload.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_create_sandbox_normalizes_allocated_status_to_running(
+        self, k8s_service, create_sandbox_request, mock_workload
+    ):
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-123",
+            "uid": "abc-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Allocated",
+            "reason": "IP_ASSIGNED",
+            "message": "Pod has IP assigned but not ready",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+
+        response = await k8s_service.create_sandbox(create_sandbox_request)
+
+        assert response.status.state == "Running"
+        assert response.status.reason == "IP_ASSIGNED"
+        assert response.status.message == "Pod has IP assigned and sandbox is ready for requests"
+
+    @pytest.mark.asyncio
     async def test_create_sandbox_uses_configured_timeout_and_poll_interval(
         self, k8s_service, create_sandbox_request, mock_workload
     ):


### PR DESCRIPTION
## Summary
- normalize `create_sandbox` responses to return `Running` once the create wait gate has already accepted a BatchSandbox workload as usable
- keep the internal wait behavior unchanged while hiding the intermediate `Allocated` state from the public create response
- add a focused regression test covering the `Allocated` to `Running` normalization path

## Testing
- `cd server && uv run pytest tests/k8s/test_kubernetes_service.py -k \"create_sandbox_with_valid_request_succeeds or create_sandbox_normalizes_allocated_status_to_running or wait_for_allocated_pod_returns_immediately\"`
- `cd server && uv run ruff check opensandbox_server/services/k8s/kubernetes_service.py tests/k8s/test_kubernetes_service.py`