### PR TITLE
fix(sdks,server): align Host.path validation with spec across runtimes

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -120,6 +120,8 @@ public class Host
 {
     /// <summary>
     /// Gets or sets the absolute host path.
+    /// Must start with '/' (Unix) or a drive letter such as 'C:\' or 'D:/'
+    /// (Windows), and be under an allowed prefix.
     /// </summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }

--- a/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
@@ -19,6 +19,7 @@ using OpenSandbox.Models;
 using OpenSandbox.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.RegularExpressions;
 
 namespace OpenSandbox;
 
@@ -31,6 +32,8 @@ namespace OpenSandbox;
 /// </remarks>
 public sealed class Sandbox : IAsyncDisposable
 {
+    private static readonly Regex HostPathPattern = new("^(/|[A-Za-z]:[\\\\/])", RegexOptions.Compiled);
+
     /// <summary>
     /// Gets the sandbox ID.
     /// </summary>
@@ -125,6 +128,7 @@ public sealed class Sandbox : IAsyncDisposable
         var logger = loggerFactory.CreateLogger("OpenSandbox.Sandbox");
         var lifecycleBaseUrl = connectionConfig.GetBaseUrl();
         var adapterFactory = options.AdapterFactory ?? DefaultAdapterFactory.Create();
+        ValidateHostPaths(options.Volumes);
         var httpClientProvider = new HttpClientProvider(connectionConfig, loggerFactory);
 
         ISandboxes sandboxes;
@@ -647,6 +651,24 @@ public sealed class Sandbox : IAsyncDisposable
         _logger.LogDebug("Disposing sandbox resources: {SandboxId}", Id);
         _httpClientProvider.Dispose();
         return default;
+    }
+
+    private static void ValidateHostPaths(IEnumerable<Volume>? volumes)
+    {
+        if (volumes == null)
+        {
+            return;
+        }
+
+        foreach (var volume in volumes)
+        {
+            var hostPath = volume.Host?.Path;
+            if (hostPath != null && !HostPathPattern.IsMatch(hostPath))
+            {
+                throw new InvalidArgumentException(
+                    "Host path must be an absolute path starting with '/' or a Windows drive letter (e.g. 'C:\\' or 'D:/')");
+            }
+        }
     }
 
     internal static IReadOnlyDictionary<string, string> MergeHeaders(

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -63,6 +63,82 @@ public class SandboxEgressLifecycleTests
         egress.PatchRulesCallCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task CreateAsync_ShouldAcceptWindowsHostPath()
+    {
+        var sandboxes = new StubSandboxes();
+        var adapterFactory = new StubAdapterFactory(sandboxes, new StubEgress());
+
+        await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+        {
+            Image = "python:3.12",
+            ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+            {
+                Domain = "127.0.0.1:8080",
+                Protocol = ConnectionProtocol.Http
+            }),
+            AdapterFactory = adapterFactory,
+            SkipHealthCheck = true,
+            Volumes =
+            [
+                new Volume
+                {
+                    Name = "host-vol",
+                    Host = new Host { Path = "D:/sandbox-mnt/ReMe" },
+                    MountPath = "/mnt/data"
+                }
+            ],
+            Diagnostics = new SdkDiagnosticsOptions
+            {
+                LoggerFactory = NullLoggerFactory.Instance
+            }
+        });
+
+        sandboxes.LastCreateRequest.Should().NotBeNull();
+        sandboxes.LastCreateRequest!.Volumes.Should().NotBeNull();
+        sandboxes.LastCreateRequest.Volumes!.Should().ContainSingle();
+        sandboxes.LastCreateRequest.Volumes![0].Host!.Path.Should().Be("D:/sandbox-mnt/ReMe");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectRelativeHostPath()
+    {
+        var sandboxes = new StubSandboxes();
+        var adapterFactory = new StubAdapterFactory(sandboxes, new StubEgress());
+
+        Func<Task> act = async () =>
+        {
+            await Sandbox.CreateAsync(new SandboxCreateOptions
+            {
+                Image = "python:3.12",
+                ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+                {
+                    Domain = "127.0.0.1:8080",
+                    Protocol = ConnectionProtocol.Http
+                }),
+                AdapterFactory = adapterFactory,
+                SkipHealthCheck = true,
+                Volumes =
+                [
+                    new Volume
+                    {
+                        Name = "host-vol",
+                        Host = new Host { Path = "relative/path" },
+                        MountPath = "/mnt/data"
+                    }
+                ],
+                Diagnostics = new SdkDiagnosticsOptions
+                {
+                    LoggerFactory = NullLoggerFactory.Instance
+                }
+            });
+        };
+
+        await act.Should().ThrowAsync<InvalidArgumentException>()
+            .WithMessage("Host path must be an absolute path starting with '/' or a Windows drive letter*");
+        adapterFactory.LifecycleStackCallCount.Should().Be(0);
+    }
+
     private sealed class StubAdapterFactory : IAdapterFactory
     {
         private readonly ISandboxes _sandboxes;
@@ -75,11 +151,13 @@ public class SandboxEgressLifecycleTests
         }
 
         public int EgressStackCallCount { get; private set; }
+        public int LifecycleStackCallCount { get; private set; }
 
         public string? LastEgressBaseUrl { get; private set; }
 
         public LifecycleStack CreateLifecycleStack(CreateLifecycleStackOptions options)
         {
+            LifecycleStackCallCount++;
             return new LifecycleStack
             {
                 Sandboxes = _sandboxes
@@ -111,9 +189,11 @@ public class SandboxEgressLifecycleTests
     private sealed class StubSandboxes : ISandboxes
     {
         public List<int> EndpointCalls { get; } = new();
+        public CreateSandboxRequest? LastCreateRequest { get; private set; }
 
         public Task<CreateSandboxResponse> CreateSandboxAsync(CreateSandboxRequest request, CancellationToken cancellationToken = default)
         {
+            LastCreateRequest = request;
             return Task.FromResult(new CreateSandboxResponse
             {
                 Id = "sandbox-test-id",

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -803,7 +803,8 @@ export interface components {
         Host: {
             /**
              * @description Absolute path on the host filesystem to mount.
-             *     Must start with '/' and be under an allowed prefix.
+             *     Must start with '/' (Unix) or a drive letter such as 'C:\' or 'D:/'
+             *     (Windows), and be under an allowed prefix.
              */
             path: string;
         };

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -75,6 +75,8 @@ export interface NetworkPolicy extends Record<string, unknown> {
 export interface Host extends Record<string, unknown> {
   /**
    * Absolute path on the host filesystem to mount.
+   * Must start with '/' (Unix) or a drive letter such as 'C:\' or 'D:/'
+   * (Windows), and be under an allowed prefix.
    */
   path: string;
 }

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -43,6 +43,8 @@ import type {
 } from "./models/sandboxes.js";
 import { SandboxReadyTimeoutException } from "./core/exceptions.js";
 
+const HOST_PATH_PATTERN = /^([/]|[A-Za-z]:[\\/])/;
+
 export interface SandboxCreateOptions {
   /**
    * Connection configuration for calling the OpenSandbox Lifecycle API and the sandbox's execd API.
@@ -224,6 +226,28 @@ export class Sandbox {
   }
 
   static async create(opts: SandboxCreateOptions): Promise<Sandbox> {
+    // Validate volumes before allocating transport resources.
+    if (opts.volumes) {
+      for (const vol of opts.volumes) {
+        const backendsSpecified = [vol.host, vol.pvc, vol.ossfs].filter((b) => b != null).length;
+        if (backendsSpecified === 0) {
+          throw new Error(
+            `Volume '${vol.name}' must specify exactly one backend (host, pvc, ossfs), but none was provided.`
+          );
+        }
+        if (backendsSpecified > 1) {
+          throw new Error(
+            `Volume '${vol.name}' must specify exactly one backend (host, pvc, ossfs), but multiple were provided.`
+          );
+        }
+        if (vol.host && !HOST_PATH_PATTERN.test(vol.host.path)) {
+          throw new Error(
+            "Host path must be an absolute path starting with '/' or a Windows drive letter (e.g. 'C:\\' or 'D:/')"
+          );
+        }
+      }
+    }
+
     const baseConnectionConfig =
       opts.connectionConfig instanceof ConnectionConfig
         ? opts.connectionConfig
@@ -241,23 +265,6 @@ export class Sandbox {
     } catch (err) {
       await connectionConfig.closeTransport();
       throw err;
-    }
-
-    // Validate volumes: exactly one backend must be specified per volume
-    if (opts.volumes) {
-      for (const vol of opts.volumes) {
-        const backendsSpecified = [vol.host, vol.pvc, vol.ossfs].filter((b) => b != null).length;
-        if (backendsSpecified === 0) {
-          throw new Error(
-            `Volume '${vol.name}' must specify exactly one backend (host, pvc, ossfs), but none was provided.`
-          );
-        }
-        if (backendsSpecified > 1) {
-          throw new Error(
-            `Volume '${vol.name}' must specify exactly one backend (host, pvc, ossfs), but multiple were provided.`
-          );
-        }
-      }
     }
 
     const rawTimeout = opts.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;

--- a/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ConnectionConfig,
   DEFAULT_EGRESS_PORT,
   DEFAULT_EXECD_PORT,
   DEFAULT_TIMEOUT_SECONDS,
@@ -215,6 +216,58 @@ test("Sandbox.create rejects volume with multiple backends", async () => {
     }),
     /must specify exactly one backend \(host, pvc, ossfs\)/
   );
+});
+
+test("Sandbox.create accepts host volume with windows drive path", async () => {
+  const { adapterFactory, recordedRequests } = createAdapterFactory();
+
+  await Sandbox.create({
+    adapterFactory,
+    connectionConfig: { domain: "http://127.0.0.1:8080" },
+    image: "python:3.12",
+    skipHealthCheck: true,
+    volumes: [{ name: "host-vol", host: { path: "D:/sandbox-mnt/ReMe" }, mountPath: "/mnt" }],
+  });
+
+  assert.equal(recordedRequests.length, 1);
+  assert.equal(recordedRequests[0].volumes[0].host.path, "D:/sandbox-mnt/ReMe");
+});
+
+test("Sandbox.create rejects host volume with relative path", async () => {
+  const { adapterFactory } = createAdapterFactory();
+
+  await assert.rejects(
+    Sandbox.create({
+      adapterFactory,
+      connectionConfig: { domain: "http://127.0.0.1:8080" },
+      image: "python:3.12",
+      skipHealthCheck: true,
+      volumes: [{ name: "host-vol", host: { path: "relative/path" }, mountPath: "/mnt" }],
+    }),
+    /Host path must be an absolute path starting with '\/' or a Windows drive letter/
+  );
+});
+
+test("Sandbox.create validates host path before transport initialization", async () => {
+  const { adapterFactory } = createAdapterFactory();
+  const connectionConfig = new ConnectionConfig({ domain: "http://127.0.0.1:8080" });
+  let transportInitialized = false;
+  connectionConfig.withTransportIfMissing = () => {
+    transportInitialized = true;
+    throw new Error("transport initialized");
+  };
+
+  await assert.rejects(
+    Sandbox.create({
+      adapterFactory,
+      connectionConfig,
+      image: "python:3.12",
+      skipHealthCheck: true,
+      volumes: [{ name: "host-vol", host: { path: "relative/path" }, mountPath: "/mnt" }],
+    }),
+    /Host path must be an absolute path starting with '\/' or a Windows drive letter/
+  );
+  assert.equal(transportInitialized, false);
 });
 
 test("Sandbox.create treats null backends as absent", async () => {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -328,6 +328,8 @@ class Host private constructor(
     val path: String,
 ) {
     companion object {
+        private val HOST_PATH_PATTERN = Regex("""^(/|[A-Za-z]:[\\/])""")
+
         @JvmStatic
         fun builder(): Builder = Builder()
 
@@ -339,7 +341,9 @@ class Host private constructor(
         private var path: String? = null
 
         fun path(path: String): Builder {
-            require(path.startsWith("/")) { "Host path must be an absolute path starting with '/'" }
+            require(HOST_PATH_PATTERN.containsMatchIn(path)) {
+                "Host path must be an absolute path starting with '/' or a Windows drive letter (e.g. 'C:\\' or 'D:/')"
+            }
             this.path = path
             return this
         }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
@@ -36,6 +36,24 @@ class VolumeModelsTest {
     }
 
     @Test
+    fun `Host should accept windows path with backslashes`() {
+        val backend = Host.of("D:\\sandbox-mnt\\ReMe")
+        assertEquals("D:\\sandbox-mnt\\ReMe", backend.path)
+    }
+
+    @Test
+    fun `Host should accept windows path with forward slashes`() {
+        val backend = Host.of("D:/sandbox-mnt/ReMe")
+        assertEquals("D:/sandbox-mnt/ReMe", backend.path)
+    }
+
+    @Test
+    fun `Host should accept windows drive root`() {
+        val backend = Host.of("Z:\\")
+        assertEquals("Z:\\", backend.path)
+    }
+
+    @Test
     fun `Host should reject relative path`() {
         assertThrows(IllegalArgumentException::class.java) {
             Host.of("relative/path")

--- a/server/opensandbox_server/services/validators.py
+++ b/server/opensandbox_server/services/validators.py
@@ -21,7 +21,6 @@ enforce the same preconditions before performing runtime-specific work.
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 

--- a/server/opensandbox_server/services/validators.py
+++ b/server/opensandbox_server/services/validators.py
@@ -56,6 +56,17 @@ DNS_LABEL_PATTERN = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?"
 DNS_SUBDOMAIN_RE = re.compile(rf"^(?:{DNS_LABEL_PATTERN}\.)*{DNS_LABEL_PATTERN}$")
 LABEL_NAME_RE = re.compile(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$")
 LABEL_VALUE_RE = re.compile(r"^([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?$")
+HOST_PATH_RE = re.compile(r"^(/|[A-Za-z]:[\\/])")
+
+
+def _normalize_prefix_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    # Windows drive letters are case-insensitive; canonicalize for comparisons.
+    if re.match(r"^[A-Za-z]:", normalized):
+        normalized = normalized[0].lower() + normalized[1:]
+    if len(normalized) > 1 and normalized.endswith("/"):
+        return normalized[:-1]
+    return normalized
 
 
 def _is_valid_label_key(key: str) -> bool:
@@ -365,20 +376,24 @@ def ensure_valid_host_path(
             },
         )
 
-    if not os.path.isabs(path):
+    if not HOST_PATH_RE.match(path):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "code": SandboxErrorCodes.INVALID_HOST_PATH,
-                "message": f"Host path '{path}' must be an absolute path.",
+                "message": (
+                    f"Host path '{path}' must be an absolute path starting with '/' "
+                    "or a Windows drive letter (e.g. 'C:\\' or 'D:/')."
+                ),
             },
         )
 
     # Normalize separators to forward slashes for consistent security checks.
-    # Strip the drive prefix (e.g. "C:") so that "C:/" is not mis-detected as
-    # containing "//".
-    _drive, _tail = os.path.splitdrive(path)
-    _tail_fwd = _tail.replace("\\", "/")
+    # Keep checks cross-platform by parsing drive prefixes without relying on
+    # os.path.splitdrive behavior of the host OS.
+    _path_fwd = path.replace("\\", "/")
+    _windows_drive_match = re.match(r"^[A-Za-z]:/", _path_fwd)
+    _tail_fwd = _path_fwd[2:] if _windows_drive_match else _path_fwd
 
     # Reject path traversal components
     if "/.." in _tail_fwd or _tail_fwd == "/..":
@@ -402,10 +417,12 @@ def ensure_valid_host_path(
 
     # Check against allowed prefixes if provided
     if allowed_prefixes is not None:
-        norm_path = os.path.normpath(path)
+        # Normalize separators for cross-platform prefix checks so Windows-style
+        # paths can be validated consistently even when server runs on Unix.
+        norm_path = _normalize_prefix_path(path)
         is_allowed = any(
-            norm_path == os.path.normpath(prefix)
-            or norm_path.startswith(os.path.normpath(prefix) + os.sep)
+            norm_path == _normalize_prefix_path(prefix)
+            or norm_path.startswith(_normalize_prefix_path(prefix) + "/")
             for prefix in allowed_prefixes
         )
         if not is_allowed:

--- a/server/tests/test_schema.py
+++ b/server/tests/test_schema.py
@@ -41,6 +41,11 @@ class TestHost:
         backend = Host(path="/data/opensandbox")
         assert backend.path == "/data/opensandbox"
 
+    def test_valid_windows_path(self):
+        """Windows absolute drive path should be accepted."""
+        backend = Host(path=r"D:\sandbox-mnt\ReMe")
+        assert backend.path == r"D:\sandbox-mnt\ReMe"
+
     def test_path_required(self):
         """Path field should be required."""
         with pytest.raises(ValidationError) as exc_info:

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -327,6 +327,16 @@ class TestEnsureValidHostPath:
         ensure_valid_host_path("/data/opensandbox")
         ensure_valid_host_path("/tmp")
 
+    def test_valid_windows_absolute_path(self):
+        """Windows absolute paths should be valid."""
+        ensure_valid_host_path(r"D:\sandbox-mnt\ReMe")
+        ensure_valid_host_path("D:/sandbox-mnt/ReMe")
+
+    def test_valid_windows_drive_root(self):
+        """Windows drive roots should be valid absolute paths."""
+        ensure_valid_host_path("D:\\")
+        ensure_valid_host_path("D:/")
+
     def test_empty_path_raises(self):
         """Empty path should raise HTTPException."""
         with pytest.raises(HTTPException) as exc_info:
@@ -365,6 +375,17 @@ class TestEnsureValidHostPath:
         """Exact prefix match should be valid."""
         allowed = ["/data/opensandbox"]
         ensure_valid_host_path("/data/opensandbox", allowed)
+
+    def test_allowed_prefix_match_windows_paths(self):
+        """Windows paths under an allowed Windows prefix should be valid."""
+        allowed = [r"D:\sandbox-mnt"]
+        ensure_valid_host_path(r"D:\sandbox-mnt\ReMe", allowed)
+        ensure_valid_host_path("D:/sandbox-mnt/ReMe", allowed)
+
+    def test_allowed_prefix_match_windows_paths_is_case_insensitive_for_drive(self):
+        """Drive-letter casing differences should not break allowlist checks."""
+        allowed = ["D:/sandbox-mnt"]
+        ensure_valid_host_path("d:/sandbox-mnt/ReMe", allowed)
 
     def test_path_not_in_allowed_prefix_raises(self):
         """Paths not under allowed prefixes should raise HTTPException."""


### PR DESCRIPTION
# Summary
- Align `Host.path` behavior with the lifecycle spec pattern `^(/|[A-Za-z]:[\\/])` across sandbox SDKs and server validators.
- Keep client/server validation consistent for Unix + Windows absolute host paths, and close validation-order resource-leak paths found during review.
- Add targeted regression tests for Windows paths, drive-root handling, allowlist behavior, and early validation flow.

# Testing
- [x] Not run (explain why)
  - C# local tests could not be run in this environment because `dotnet` is unavailable.
- [x] Unit tests
  - `cd sdks/sandbox/javascript && pnpm run test`
  - `cd sdks/sandbox/kotlin && ./gradlew :sandbox:test`
  - `cd server && uv run pytest tests/test_validators.py tests/test_schema.py`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation #632 
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
