### PR TITLE
fix(sdk): correct Kotlin code context bulk delete

### DIFF
--- a/sdks/code-interpreter/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapter.kt
+++ b/sdks/code-interpreter/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapter.kt
@@ -106,7 +106,7 @@ class CodesAdapter(
 
     override fun deleteContexts(language: String) {
         try {
-            deleteContexts(language)
+            api.deleteContextsByLanguage(language)
         } catch (e: Exception) {
             logger.error("Failed to delete contexts", e)
             throw e.toSandboxException()

--- a/sdks/code-interpreter/kotlin/code-interpreter/src/test/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapterTest.kt
+++ b/sdks/code-interpreter/kotlin/code-interpreter/src/test/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapterTest.kt
@@ -200,6 +200,18 @@ class CodesAdapterTest {
     }
 
     @Test
+    fun `deleteContexts should send language query`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(204))
+
+        codesAdapter.deleteContexts("python")
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/code/contexts", request.requestUrl?.encodedPath)
+        assertEquals("python", request.requestUrl?.queryParameter("language"))
+    }
+
+    @Test
     fun `run should expose request id on api exception`() {
         mockWebServer.enqueue(
             MockResponse()


### PR DESCRIPTION
## Summary
- route Kotlin code-interpreter bulk context deletion through the generated API client instead of recursively calling the adapter method
- preserve the existing adapter error handling while fixing the language-scoped delete path
- add a regression test that asserts the Kotlin adapter sends `DELETE /code/contexts?language=...`

## Testing
- `cd sdks/code-interpreter/kotlin && JAVA_HOME=/home/cc/tmp/jdk/jdk-17.0.18+8 PATH=/home/cc/tmp/jdk/jdk-17.0.18+8/bin:$PATH ./gradlew test --tests com.alibaba.opensandbox.codeinterpreter.infrastructure.adapters.service.CodesAdapterTest`