### PR TITLE
Stabilize cross-language E2E streaming tests

### DIFF
--- a/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
@@ -96,18 +96,27 @@ public class CodeInterpreterE2ETests : IClassFixture<CodeInterpreterE2ETestFixtu
     {
         var interpreter = _fixture.Interpreter;
 
-        var py = await interpreter.Codes.RunAsync("print(1+2)", new RunCodeOptions { Language = SupportedLanguage.Python });
-        Assert.Contains(py.Logs.Stdout, s => s.Text.Contains("3", StringComparison.Ordinal));
+        var py = await RunWithRetryAsync(
+            interpreter,
+            "result = 1 + 2\nresult",
+            new RunCodeOptions { Language = SupportedLanguage.Python });
+        Assert.True(HasText(py, "3"));
         Assert.Null(py.ExitCode);
         Assert.NotNull(py.Complete);
 
-        var js = await interpreter.Codes.RunAsync("console.log(3+4)", new RunCodeOptions { Language = SupportedLanguage.JavaScript });
-        Assert.Contains(js.Logs.Stdout, s => s.Text.Contains("7", StringComparison.Ordinal));
+        var js = await RunWithRetryAsync(
+            interpreter,
+            "console.log(3+4)",
+            new RunCodeOptions { Language = SupportedLanguage.JavaScript });
+        Assert.True(HasText(js, "7"));
         Assert.Null(js.ExitCode);
         Assert.NotNull(js.Complete);
 
-        var bash = await interpreter.Codes.RunAsync("echo $((8+9))", new RunCodeOptions { Language = SupportedLanguage.Bash });
-        Assert.Contains(bash.Logs.Stdout, s => s.Text.Contains("17", StringComparison.Ordinal));
+        var bash = await RunWithRetryAsync(
+            interpreter,
+            "echo $((8+9))",
+            new RunCodeOptions { Language = SupportedLanguage.Bash });
+        Assert.True(HasText(bash, "17"));
         Assert.Null(bash.ExitCode);
         Assert.NotNull(bash.Complete);
     }

--- a/tests/python/tests/test_code_interpreter_e2e_sync.py
+++ b/tests/python/tests/test_code_interpreter_e2e_sync.py
@@ -25,6 +25,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, contextmanager
 from datetime import timedelta
+from threading import Event
 
 import pytest
 from code_interpreter import CodeInterpreterSync
@@ -409,14 +410,16 @@ class TestCodeInterpreterE2ESync:
                 on_init=on_init,
             )
 
-            simple_result = code_interpreter.codes.run(
+            # Use retry for first execution in context because Java kernel init can be slow.
+            simple_result = run_with_retry_sync(
+                code_interpreter,
                 "System.out.println(\"Hello from Java!\");\n"
                 + "int result = 2 + 2;\n"
                 + "System.out.println(\"2 + 2 = \" + result);\n"
                 + "result",
                 context=java_context,
                 handlers=handlers,
-                )
+            )
             assert simple_result is not None
             assert simple_result.id is not None and simple_result.id.strip()
             assert simple_result.error is None
@@ -977,9 +980,11 @@ class TestCodeInterpreterE2ESync:
             init_events_int: list[ExecutionInit] = []
             completed_events: list[ExecutionComplete] = []
             errors: list[ExecutionError] = []
+            init_received = Event()
 
             def on_init(init: ExecutionInit):
                 init_events_int.append(init)
+                init_received.set()
 
             def on_complete(complete: ExecutionComplete):
                 completed_events.append(complete)
@@ -1006,10 +1011,7 @@ class TestCodeInterpreterE2ESync:
                     handlers=handlers_int,
                     )
 
-                deadline = time.time() + 15
-                while len(init_events_int) == 0 and time.time() < deadline:
-                    time.sleep(0.1)
-
+                assert init_received.wait(timeout=15), "Execution init event was not received within 15s"
                 assert len(init_events_int) == 1, "Execution should have been initialized exactly once"
                 execution_id = init_events_int[-1].id
                 assert execution_id is not None and execution_id.strip()

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -24,6 +24,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from io import BytesIO
+from threading import Event
 
 import httpx
 import pytest
@@ -1200,9 +1201,11 @@ class TestSandboxE2ESync:
         init_events: list[ExecutionInit] = []
         completed_events: list[ExecutionComplete] = []
         errors: list[ExecutionError] = []
+        init_received = Event()
 
         def on_init(init: ExecutionInit):
             init_events.append(init)
+            init_received.set()
 
         def on_complete(complete: ExecutionComplete):
             completed_events.append(complete)
@@ -1223,9 +1226,7 @@ class TestSandboxE2ESync:
                 "sleep 30",
                 handlers=handlers,
             )
-            deadline = time.time() + 15
-            while len(init_events) == 0 and time.time() < deadline:
-                time.sleep(0.1)
+            assert init_received.wait(timeout=15), "Execution init event was not received within 15s"
             assert len(init_events) == 1
             assert init_events[0].id is not None and init_events[0].id.strip()
             _assert_recent_timestamp_ms(init_events[0].timestamp)


### PR DESCRIPTION
# Summary
- Stabilize cross-language E2E tests around transient streaming and initialization jitter.
- Keep the original Java sync fix in `tests/python/tests/test_code_interpreter_e2e_sync.py` by routing the first Java execution in a fresh context through `run_with_retry_sync(...)`, matching the async path.
- Extend async Python test retries to recognize transient transport failures such as `ReadError`, `RemoteProtocolError`, `incomplete chunked read`, and `server disconnected without sending a response`.
- Stabilize sync interrupt E2E tests by replacing cross-thread polling of `init_events` with `threading.Event` coordination in `tests/python/tests/test_sandbox_e2e_sync.py` and `tests/python/tests/test_code_interpreter_e2e_sync.py`.
- Align the C# multi-language basic execution test with existing code-interpreter behavior by using retry for first-run executions and asserting through the shared `HasText(...)` helper so both `stdout` and `result` output shapes are accepted.
- These changes are test-only stabilization; they do not change context persistence semantics or SDK API contracts.

# Motivation
- Java/Python code-interpreter E2E coverage is stricter than some other suites and frequently exercises first-run kernel startup, streamed execution, interrupt timing, and context reuse.
- Recent failures were caused by transient first-run instability, incomplete streamed responses, and brittle test synchronization/expectations rather than intended behavior changes.
- The updated tests now match the more robust patterns already used elsewhere in the repository.

# Testing
- [x] Not run (explain why)
- Static analysis and log-driven debugging only. The changes are targeted test-only stabilizations based on CI failures and existing passing patterns in adjacent suites.
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
