### PR TITLE
fix(execd): enlarge jupyter polling interval to 100ms

### DIFF
--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -38,7 +38,7 @@ func InitFlags() {
 	ServerLogLevel = 6
 	ServerAccessToken = ""
 	ApiGracefulShutdownTimeout = time.Second * 1
-	JupyterIdlePollInterval = 10 * time.Millisecond
+	JupyterIdlePollInterval = 100 * time.Millisecond
 
 	// First, set default values from environment variables
 	if jupyterFromEnv := os.Getenv(jupyterHostEnv); jupyterFromEnv != "" {
@@ -80,13 +80,13 @@ func InitFlags() {
 	}
 
 	flag.DurationVar(&ApiGracefulShutdownTimeout, "graceful-shutdown-timeout", ApiGracefulShutdownTimeout, "API graceful shutdown timeout duration (default: 1s)")
-	flag.DurationVar(&JupyterIdlePollInterval, "jupyter-idle-poll-interval", JupyterIdlePollInterval, "Polling interval after Jupyter idle status before closing stream (default: 10ms)")
+	flag.DurationVar(&JupyterIdlePollInterval, "jupyter-idle-poll-interval", JupyterIdlePollInterval, "Polling interval after Jupyter idle status before closing stream (default: 100ms)")
 
 	// Parse flags - these will override environment variables if provided
 	flag.Parse()
 	if JupyterIdlePollInterval <= 0 {
-		stdlog.Printf("Invalid --jupyter-idle-poll-interval=%s; fallback to default %s", JupyterIdlePollInterval, 10*time.Millisecond)
-		JupyterIdlePollInterval = 10 * time.Millisecond
+		stdlog.Printf("Invalid --jupyter-idle-poll-interval=%s; fallback to default %s", JupyterIdlePollInterval, 100*time.Millisecond)
+		JupyterIdlePollInterval = 100 * time.Millisecond
 	}
 
 	// Log final values

--- a/components/execd/pkg/flag/parser_test.go
+++ b/components/execd/pkg/flag/parser_test.go
@@ -26,7 +26,7 @@ import (
 func TestInitFlagsSanitizesNonPositiveJupyterIdlePollIntervalFromCLI(t *testing.T) {
 	previousArgs := os.Args
 	previousCommandLine := flag.CommandLine
-	defaultPollInterval := 10 * time.Millisecond
+	defaultPollInterval := 100 * time.Millisecond
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	os.Args = []string{previousArgs[0], "--jupyter-idle-poll-interval=0"}

--- a/components/execd/pkg/jupyter/execute/execute.go
+++ b/components/execd/pkg/jupyter/execute/execute.go
@@ -300,7 +300,7 @@ func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan 
 
 	pollInterval := execdflag.JupyterIdlePollInterval
 	if pollInterval <= 0 {
-		pollInterval = 10 * time.Millisecond
+		pollInterval = 100 * time.Millisecond
 	}
 
 	for {

--- a/components/execd/pkg/jupyter/execute/execute_test.go
+++ b/components/execd/pkg/jupyter/execute/execute_test.go
@@ -295,6 +295,6 @@ func TestExecuteCodeStreamFallsBackWhenPollIntervalIsNonPositive(t *testing.T) {
 	elapsed := time.Since(start)
 
 	require.True(t, gotLateResult, "expected late execute_result to be delivered before stream close")
-	require.GreaterOrEqual(t, elapsed, 10*time.Millisecond, "expected non-positive poll interval to fall back to runtime default")
-	require.Less(t, elapsed, 120*time.Millisecond, "expected fallback poll interval to still close stream promptly")
+	require.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "expected non-positive poll interval to fall back to runtime default (100ms)")
+	require.Less(t, elapsed, 300*time.Millisecond, "expected fallback poll interval to still close stream promptly")
 }


### PR DESCRIPTION
# Summary
- enlarge jupyter polling interval to 100ms

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered