### PR TITLE
feat(server): add file logger

### DIFF
--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -245,15 +245,15 @@ class LogConfig(BaseModel):
         default=None,
         description=(
             "Path to the main log file. When file_enabled=true and this is unset, "
-            "defaults to /var/log/opensandbox/server.log."
+            "defaults to ~/logs/opensandbox/server.log."
         ),
     )
     access_file_path: Optional[str] = Field(
         default=None,
         description=(
-            "Path to the HTTP access log file. When set, uvicorn.access logs are written to this "
-            "file separately. When file_enabled=true and this is unset, access logs go to the main log. "
-            "Example: '/var/log/opensandbox/access.log'."
+            "Path to the HTTP access log file. When file_enabled=true, access logs are written "
+            "to a separate file by default (~/logs/opensandbox/access.log). Set this to override "
+            "the path. Example: '~/logs/opensandbox/access.log'."
         ),
     )
     file_max_bytes: int = Field(
@@ -268,8 +268,9 @@ class LogConfig(BaseModel):
     )
 
     # Default paths when file_enabled=true and user paths are not set.
-    DEFAULT_FILE_PATH: ClassVar[str] = "/var/log/opensandbox/server.log"
-    DEFAULT_ACCESS_FILE_PATH: ClassVar[str] = "/var/log/opensandbox/access.log"
+    # Uses ~/logs/opensandbox/ which is writable for non-root users.
+    DEFAULT_FILE_PATH: ClassVar[str] = str(Path.home() / "logs" / "opensandbox" / "server.log")
+    DEFAULT_ACCESS_FILE_PATH: ClassVar[str] = str(Path.home() / "logs" / "opensandbox" / "access.log")
 
     def resolved_file_path(self) -> Optional[str]:
         """Return the effective file path, using default if file_enabled and not overridden."""
@@ -278,10 +279,10 @@ class LogConfig(BaseModel):
         return self.file_path or self.DEFAULT_FILE_PATH
 
     def resolved_access_file_path(self) -> Optional[str]:
-        """Return the effective access file path, or None if access logs should merge into main."""
+        """Return the effective access file path (defaults to separate file when file_enabled)."""
         if not self.file_enabled:
             return None
-        return self.access_file_path  # None means merge into main log
+        return self.access_file_path or self.DEFAULT_ACCESS_FILE_PATH
 
 
 class ServerConfig(BaseModel):
@@ -305,10 +306,6 @@ class ServerConfig(BaseModel):
             "Idle keep-alive timeout in seconds passed to uvicorn. "
             "Connections idle longer than this may be closed by the server."
         ),
-    )
-    log: LogConfig = Field(
-        default_factory=LogConfig,
-        description="Logging configuration (level, file output, rotation).",
     )
     api_key: Optional[str] = Field(
         default=None,
@@ -624,6 +621,10 @@ class AppConfig(BaseModel):
     """Root application configuration model."""
 
     server: ServerConfig = Field(default_factory=ServerConfig)
+    log: LogConfig = Field(
+        default_factory=LogConfig,
+        description="Logging configuration (level, file output, rotation).",
+    )
     renew_intent: RenewIntentConfig = Field(
         default_factory=RenewIntentConfig,
         description="Auto-renew sandbox expiration when reverse-proxy access is observed.",

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -26,7 +26,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, ClassVar, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
@@ -226,6 +226,64 @@ class IngressConfig(BaseModel):
         return self
 
 
+class LogConfig(BaseModel):
+    """Logging configuration."""
+
+    level: str = Field(
+        default="INFO",
+        description="Python logging level for the server process.",
+        min_length=3,
+    )
+    file_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, logs are written to rotating files instead of stdout. "
+            "Uses default paths (/var/log/opensandbox/) unless file_path/access_file_path are set."
+        ),
+    )
+    file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to the main log file. When file_enabled=true and this is unset, "
+            "defaults to /var/log/opensandbox/server.log."
+        ),
+    )
+    access_file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to the HTTP access log file. When set, uvicorn.access logs are written to this "
+            "file separately. When file_enabled=true and this is unset, access logs go to the main log. "
+            "Example: '/var/log/opensandbox/access.log'."
+        ),
+    )
+    file_max_bytes: int = Field(
+        default=100 * 1024 * 1024,  # 100MB
+        ge=1,
+        description="Maximum size of each log file in bytes before rotation (default: 100MB).",
+    )
+    file_backup_count: int = Field(
+        default=5,
+        ge=0,
+        description="Number of backup log files to keep after rotation (default: 5).",
+    )
+
+    # Default paths when file_enabled=true and user paths are not set.
+    DEFAULT_FILE_PATH: ClassVar[str] = "/var/log/opensandbox/server.log"
+    DEFAULT_ACCESS_FILE_PATH: ClassVar[str] = "/var/log/opensandbox/access.log"
+
+    def resolved_file_path(self) -> Optional[str]:
+        """Return the effective file path, using default if file_enabled and not overridden."""
+        if not self.file_enabled:
+            return None
+        return self.file_path or self.DEFAULT_FILE_PATH
+
+    def resolved_access_file_path(self) -> Optional[str]:
+        """Return the effective access file path, or None if access logs should merge into main."""
+        if not self.file_enabled:
+            return None
+        return self.access_file_path  # None means merge into main log
+
+
 class ServerConfig(BaseModel):
     """FastAPI server configuration."""
 
@@ -248,10 +306,9 @@ class ServerConfig(BaseModel):
             "Connections idle longer than this may be closed by the server."
         ),
     )
-    log_level: str = Field(
-        default="INFO",
-        description="Python logging level for the server process.",
-        min_length=3,
+    log: LogConfig = Field(
+        default_factory=LogConfig,
+        description="Logging configuration (level, file output, rotation).",
     )
     api_key: Optional[str] = Field(
         default=None,
@@ -696,6 +753,7 @@ __all__ = [
     "RenewIntentConfig",
     "RenewIntentRedisConfig",
     "ServerConfig",
+    "LogConfig",
     "RuntimeConfig",
     "IngressConfig",
     "GatewayConfig",

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -25,8 +25,15 @@
 [server]
 host = "0.0.0.0"
 port = 8080
-log_level = "INFO"
 # api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
+
+[server.log]
+level = "INFO"
+file_enabled = true  # When true, logs go to rotating files instead of stdout
+# file_path = "/var/log/opensandbox/server.log"  # Optional: override default server log path
+# access_file_path = "/var/log/opensandbox/access.log"  # Optional: separate access log file
+# file_max_bytes = 104857600  # 100MB - max file size before rotation
+# file_backup_count = 5       # Number of rotated files to keep
 
 # 🧪 [EXPERIMENTAL] Renew-on-access. Off by default — see server/README.md.
 [renew_intent]

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -27,11 +27,11 @@ host = "0.0.0.0"
 port = 8080
 # api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
 
-[server.log]
+[log]
 level = "INFO"
 file_enabled = true  # When true, logs go to rotating files instead of stdout
-# file_path = "/var/log/opensandbox/server.log"  # Optional: override default server log path
-# access_file_path = "/var/log/opensandbox/access.log"  # Optional: separate access log file
+# file_path = "~/logs/opensandbox/server.log"  # Optional: override default server log path
+# access_file_path = "~/logs/opensandbox/access.log"  # Optional: override default access log path
 # file_max_bytes = 104857600  # 100MB - max file size before rotation
 # file_backup_count = 5       # Number of rotated files to keep
 

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -27,11 +27,11 @@ host = "0.0.0.0"
 port = 8080
 # api_key = "your-secret-api-key"  # 可选：取消注释以启用 API Key 认证
 
-[server.log]
+[log]
 level = "INFO"
-file_enabled = true  # 开启后日志写入文件（默认路径 /var/log/opensandbox/）
-# file_path = "/var/log/opensandbox/server.log"  # 可选：自定义 server.log 路径
-# access_file_path = "/var/log/opensandbox/access.log"  # 可选：分离 access log
+file_enabled = true  # 开启后日志写入文件（默认路径 ~/logs/opensandbox/）
+# file_path = "~/logs/opensandbox/server.log"  # 可选：自定义 server.log 路径
+# access_file_path = "~/logs/opensandbox/access.log"  # 可选：自定义 access.log 路径
 # file_max_bytes = 104857600  # 100MB - 轮转前最大文件大小
 # file_backup_count = 5       # 保留的轮转文件数量
 

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -25,8 +25,15 @@
 [server]
 host = "0.0.0.0"
 port = 8080
-log_level = "INFO"
-# api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
+# api_key = "your-secret-api-key"  # 可选：取消注释以启用 API Key 认证
+
+[server.log]
+level = "INFO"
+file_enabled = true  # 开启后日志写入文件（默认路径 /var/log/opensandbox/）
+# file_path = "/var/log/opensandbox/server.log"  # 可选：自定义 server.log 路径
+# access_file_path = "/var/log/opensandbox/access.log"  # 可选：分离 access log
+# file_max_bytes = 104857600  # 100MB - 轮转前最大文件大小
+# file_backup_count = 5       # 保留的轮转文件数量
 
 # 🧪 [EXPERIMENTAL] 按访问续期。默认关闭 — 见 server/README_zh.md。
 [renew_intent]

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -17,15 +17,24 @@
 # Each top-level block mirrors the sections supported by opensandbox_server/config.py.
 
 [server]
-# Lifecycle API host/port and logging settings
+# Lifecycle API host/port settings
 # -----------------------------------------------------------------
 host = "127.0.0.1"
 port = 8080
-log_level = "INFO"
 # api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
 # eip = "1.2.3.4"  # Optional: External IP/hostname for endpoint URLs when returning sandbox endpoints
 # Maximum TTL for sandboxes that specify timeout. Comment out this line to disable the upper bound.
 max_sandbox_timeout_seconds = 86400
+
+[server.log]
+# Logging configuration
+# -----------------------------------------------------------------
+level = "INFO"
+file_enabled = true  # When true, logs go to rotating files instead of stdout
+# file_path = "/var/log/opensandbox/server.log"  # Optional: override default server log path
+# access_file_path = "/var/log/opensandbox/access.log"  # Optional: separate access log file
+# file_max_bytes = 104857600  # 100MB - max file size before rotation
+# file_backup_count = 5       # Number of rotated files to keep
 
 # 🧪 [EXPERIMENTAL] Renew-on-access (OSEP-0009). Off by default — see server/README.md.
 [renew_intent]

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -26,13 +26,13 @@ port = 8080
 # Maximum TTL for sandboxes that specify timeout. Comment out this line to disable the upper bound.
 max_sandbox_timeout_seconds = 86400
 
-[server.log]
+[log]
 # Logging configuration
 # -----------------------------------------------------------------
 level = "INFO"
 file_enabled = true  # When true, logs go to rotating files instead of stdout
-# file_path = "/var/log/opensandbox/server.log"  # Optional: override default server log path
-# access_file_path = "/var/log/opensandbox/access.log"  # Optional: separate access log file
+# file_path = "~/logs/opensandbox/server.log"  # Optional: override default server log path
+# access_file_path = "~/logs/opensandbox/access.log"  # Optional: override default access log path
 # file_max_bytes = 104857600  # 100MB - max file size before rotation
 # file_backup_count = 5       # Number of rotated files to keep
 

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -23,13 +23,13 @@ host = "127.0.0.1"
 port = 8080
 # api_key = "your-secret-api-key"  # 可选：取消注释以启用 API Key 认证
 
-[server.log]
+[log]
 # 日志配置
 # -----------------------------------------------------------------
 level = "INFO"
-file_enabled = true  # 开启后日志写入文件（默认路径 /var/log/opensandbox/）
-# file_path = "/var/log/opensandbox/server.log"  # 可选：自定义 server.log 路径
-# access_file_path = "/var/log/opensandbox/access.log"  # 可选：分离 access log
+file_enabled = true  # 开启后日志写入文件（默认路径 ~/logs/opensandbox/）
+# file_path = "~/logs/opensandbox/server.log"  # 可选：自定义 server.log 路径
+# access_file_path = "~/logs/opensandbox/access.log"  # 可选：自定义 access.log 路径
 # file_max_bytes = 104857600  # 100MB - 轮转前最大文件大小
 # file_backup_count = 5       # 保留的轮转文件数量
 

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -17,12 +17,21 @@
 # Each top-level block mirrors the sections supported by opensandbox_server/config.py.
 
 [server]
-# Lifecycle API host/port and logging settings
+# Lifecycle API 主机/端口设置
 # -----------------------------------------------------------------
 host = "127.0.0.1"
 port = 8080
-log_level = "INFO"
-# api_key = "your-secret-api-key"  # Optional: Uncomment to enable API key authentication
+# api_key = "your-secret-api-key"  # 可选：取消注释以启用 API Key 认证
+
+[server.log]
+# 日志配置
+# -----------------------------------------------------------------
+level = "INFO"
+file_enabled = true  # 开启后日志写入文件（默认路径 /var/log/opensandbox/）
+# file_path = "/var/log/opensandbox/server.log"  # 可选：自定义 server.log 路径
+# access_file_path = "/var/log/opensandbox/access.log"  # 可选：分离 access log
+# file_max_bytes = 104857600  # 100MB - 轮转前最大文件大小
+# file_backup_count = 5       # 保留的轮转文件数量
 
 # 🧪 [EXPERIMENTAL] 按访问续期（OSEP-0009）。默认关闭 — 说明见 server/README_zh.md。
 [renew_intent]

--- a/server/opensandbox_server/logging_config.py
+++ b/server/opensandbox_server/logging_config.py
@@ -1,0 +1,148 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Logging configuration for the OpenSandbox server.
+
+Two output modes:
+
+  stdout (default)
+    All loggers write to stdout via uvicorn's ColorizingFormatter,
+    which supports %(levelprefix)s (colored, padded level name).
+
+  file  (when log_cfg.file_enabled is true)
+    All loggers write to a rotating file.  %(levelprefix)s is replaced
+    with %(levelname)-8s because the standard logging.Formatter does not
+    inject that uvicorn-only field.
+
+    Optionally, uvicorn.access can be separated into its own rotating file
+    (log_cfg.access_file_path) following the Nginx/Gunicorn convention.
+
+urllib3 InsecureRequestWarning is silenced at startup because it comes from
+expected unverified HTTPS calls (e.g. in-cluster k8s API) and produces
+high-frequency noise without actionable content.
+"""
+
+import copy
+import logging
+import logging.config
+from pathlib import Path
+
+import urllib3
+from uvicorn.config import LOGGING_CONFIG as UVICORN_LOGGING_CONFIG
+
+from opensandbox_server.config import LogConfig
+
+# %(levelprefix)s: colored, padded label injected by uvicorn's ColorizingFormatter.
+_STDOUT_FMT = "%(levelprefix)s %(asctime)s [%(request_id)s] %(name)s: %(message)s"
+# %(levelname)-8s: plain, left-aligned label (width=8) for the standard Formatter.
+_FILE_FMT = "%(levelname)-8s %(asctime)s [%(request_id)s] %(name)s: %(message)s"
+_DATEFMT = "%Y-%m-%d %H:%M:%S%z"
+
+# dictConfig factory string for RequestIdFilter.
+_REQUEST_ID_FILTER = {"()": "opensandbox_server.middleware.request_id.RequestIdFilter"}
+
+
+def _rotating_file_handler(filename: str, log_cfg: LogConfig) -> dict:
+    """Return a dictConfig handler entry for a RotatingFileHandler."""
+    return {
+        "class": "logging.handlers.RotatingFileHandler",
+        "formatter": "file",
+        "filters": ["request_id"],
+        "filename": filename,
+        "maxBytes": log_cfg.file_max_bytes,
+        "backupCount": log_cfg.file_backup_count,
+        "encoding": "utf-8",
+    }
+
+
+def _apply_stdout_config(log_config: dict, level: str) -> None:
+    """Patch uvicorn's stdout handlers/formatters with unified format and request_id filter."""
+    for name in ("default", "access"):
+        log_config["formatters"][name]["fmt"] = _STDOUT_FMT
+        log_config["formatters"][name]["datefmt"] = _DATEFMT
+        log_config["formatters"][name]["use_colors"] = True
+
+    log_config["handlers"]["default"]["filters"] = ["request_id"]
+    log_config["handlers"]["access"]["filters"] = ["request_id"]
+
+    log_config["loggers"]["opensandbox_server"] = {
+        "handlers": ["default"],
+        "level": level,
+        "propagate": False,
+    }
+
+
+def _apply_file_config(log_config: dict, log_cfg: LogConfig, level: str) -> None:
+    """
+    Register file handlers and route all loggers to them.
+
+    uvicorn.access is routed to access_file when resolved_access_file_path() returns
+    a path, otherwise it shares the main file handler with the rest.
+    """
+    # Use resolved paths (defaults applied when file_enabled=true and paths not set).
+    file_path = log_cfg.resolved_file_path()
+    access_file_path = log_cfg.resolved_access_file_path()
+
+    # Ensure parent directories exist.
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+
+    log_config["formatters"]["file"] = {"format": _FILE_FMT, "datefmt": _DATEFMT}
+    log_config["handlers"]["file"] = _rotating_file_handler(file_path, log_cfg)
+
+    if access_file_path:
+        Path(access_file_path).parent.mkdir(parents=True, exist_ok=True)
+        log_config["handlers"]["access_file"] = _rotating_file_handler(
+            access_file_path, log_cfg
+        )
+        access_handler = "access_file"
+    else:
+        access_handler = "file"
+
+    for logger_name in ("uvicorn", "uvicorn.error", "opensandbox_server"):
+        log_config["loggers"].setdefault(logger_name, {})
+        log_config["loggers"][logger_name]["handlers"] = ["file"]
+        log_config["loggers"][logger_name]["propagate"] = False
+
+    log_config["loggers"].setdefault("uvicorn.access", {})
+    log_config["loggers"]["uvicorn.access"]["handlers"] = [access_handler]
+    log_config["loggers"]["uvicorn.access"]["propagate"] = False
+
+    log_config["loggers"]["opensandbox_server"]["level"] = level
+
+
+def configure_logging(log_cfg: LogConfig) -> dict:
+    """
+    Build and apply the server logging configuration.
+
+    Returns the final dictConfig dict for reuse by callers (e.g. uvicorn.run).
+    """
+    # Silence high-frequency noise from expected unverified HTTPS calls.
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    level = log_cfg.level.upper()
+    log_config = copy.deepcopy(UVICORN_LOGGING_CONFIG)
+
+    # Register the request_id filter so any handler can reference it by name.
+    log_config["filters"] = {"request_id": _REQUEST_ID_FILTER}
+
+    if log_cfg.resolved_file_path():
+        _apply_file_config(log_config, log_cfg, level)
+    else:
+        _apply_stdout_config(log_config, level)
+
+    logging.config.dictConfig(log_config)
+    logging.getLogger().setLevel(getattr(logging, level, logging.INFO))
+
+    return log_config

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -19,8 +19,7 @@ This module initializes the FastAPI application with middleware, routes,
 and configuration for the sandbox lifecycle management service.
 """
 
-import copy
-import logging.config
+import logging
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -32,43 +31,11 @@ from fastapi.responses import JSONResponse
 
 from opensandbox_server.config import load_config
 from opensandbox_server.integrations.renew_intent import start_renew_intent_consumer
-from uvicorn.config import LOGGING_CONFIG as UVICORN_LOGGING_CONFIG
+from opensandbox_server.logging_config import configure_logging
 
 # Load configuration before initializing routers/middleware
 app_config = load_config()
-
-# Unify logging format (including uvicorn access/error logs) with timestamp prefix.
-_log_config = copy.deepcopy(UVICORN_LOGGING_CONFIG)
-_fmt = "%(levelprefix)s %(asctime)s [%(request_id)s] %(name)s: %(message)s"
-_datefmt = "%Y-%m-%d %H:%M:%S%z"
-
-# Inject request_id into log records so one request's logs can be correlated.
-_log_config["filters"] = {
-    "request_id": {"()": "opensandbox_server.middleware.request_id.RequestIdFilter"},
-}
-_log_config["handlers"]["default"]["filters"] = ["request_id"]
-_log_config["handlers"]["access"]["filters"] = ["request_id"]
-
-# Enable colors and set format for both default and access loggers
-_log_config["formatters"]["default"]["fmt"] = _fmt
-_log_config["formatters"]["default"]["datefmt"] = _datefmt
-_log_config["formatters"]["default"]["use_colors"] = True
-
-_log_config["formatters"]["access"]["fmt"] = _fmt
-_log_config["formatters"]["access"]["datefmt"] = _datefmt
-_log_config["formatters"]["access"]["use_colors"] = True
-
-# Ensure project loggers emit at configured level using the default handler.
-_log_config["loggers"]["opensandbox_server"] = {
-    "handlers": ["default"],
-    "level": app_config.server.log_level.upper(),
-    "propagate": False,
-}
-
-logging.config.dictConfig(_log_config)
-logging.getLogger().setLevel(
-    getattr(logging, app_config.server.log_level.upper(), logging.INFO)
-)
+_log_config = configure_logging(app_config.server.log)
 
 from opensandbox_server.api.devops import router as devops_router  # noqa: E402
 from opensandbox_server.api.pool import router as pool_router  # noqa: E402

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -35,7 +35,7 @@ from opensandbox_server.logging_config import configure_logging
 
 # Load configuration before initializing routers/middleware
 app_config = load_config()
-_log_config = configure_logging(app_config.server.log)
+_log_config = configure_logging(app_config.log)
 
 from opensandbox_server.api.devops import router as devops_router  # noqa: E402
 from opensandbox_server.api.pool import router as pool_router  # noqa: E402

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 from opensandbox_server import config as config_module
 from opensandbox_server.config import (
     AppConfig,
+    LogConfig,
     RenewIntentRedisConfig,
     EGRESS_MODE_DNS,
     EGRESS_MODE_DNS_NFT,
@@ -45,9 +46,11 @@ def test_load_config_from_file(tmp_path, monkeypatch):
         [server]
         host = "127.0.0.1"
         port = 9000
-        log_level = "DEBUG"
         api_key = "secret"
         max_sandbox_timeout_seconds = 172800
+
+        [server.log]
+        level = "DEBUG"
 
         [runtime]
         type = "kubernetes"
@@ -65,7 +68,7 @@ def test_load_config_from_file(tmp_path, monkeypatch):
     loaded = config_module.load_config(config_path)
     assert loaded.server.host == "127.0.0.1"
     assert loaded.server.port == 9000
-    assert loaded.server.log_level == "DEBUG"
+    assert loaded.server.log.level == "DEBUG"
     assert loaded.server.api_key == "secret"
     assert loaded.server.max_sandbox_timeout_seconds == 172800
     assert loaded.runtime.type == "kubernetes"
@@ -695,3 +698,247 @@ def test_egress_config_mode_literal():
     assert EgressConfig(image="opensandbox/egress:v1").mode == EGRESS_MODE_DNS
     cfg = EgressConfig(image="opensandbox/egress:v1", mode=EGRESS_MODE_DNS_NFT)
     assert cfg.mode == EGRESS_MODE_DNS_NFT
+
+
+# ============================================================================
+# LogConfig Tests
+# ============================================================================
+
+
+def test_log_config_defaults():
+    """LogConfig should have sensible defaults."""
+    cfg = LogConfig()
+    assert cfg.level == "INFO"
+    assert cfg.file_enabled is False
+    assert cfg.file_path is None
+    assert cfg.access_file_path is None
+    assert cfg.file_max_bytes == 100 * 1024 * 1024  # 100MB
+    assert cfg.file_backup_count == 5
+
+
+def test_log_config_resolved_file_path():
+    """resolved_file_path() should return None when file_enabled=False."""
+    cfg = LogConfig(file_enabled=False)
+    assert cfg.resolved_file_path() is None
+
+    # file_enabled=True without file_path uses default
+    cfg = LogConfig(file_enabled=True)
+    assert cfg.resolved_file_path() == LogConfig.DEFAULT_FILE_PATH
+
+    # file_enabled=True with file_path uses custom path
+    cfg = LogConfig(file_enabled=True, file_path="/custom/path.log")
+    assert cfg.resolved_file_path() == "/custom/path.log"
+
+
+def test_log_config_resolved_access_file_path():
+    """resolved_access_file_path() should return None when not configured."""
+    # file_enabled=False always returns None
+    cfg = LogConfig(file_enabled=False, access_file_path="/path/access.log")
+    assert cfg.resolved_access_file_path() is None
+
+    # file_enabled=True without access_file_path returns None (merge into main)
+    cfg = LogConfig(file_enabled=True)
+    assert cfg.resolved_access_file_path() is None
+
+    # file_enabled=True with access_file_path returns the path
+    cfg = LogConfig(file_enabled=True, access_file_path="/custom/access.log")
+    assert cfg.resolved_access_file_path() == "/custom/access.log"
+
+
+def test_log_config_level_min_length():
+    """LogConfig level must be at least 3 characters."""
+    with pytest.raises(ValidationError):
+        LogConfig(level="AB")
+    cfg = LogConfig(level="DEBUG")
+    assert cfg.level == "DEBUG"
+
+
+def test_log_config_file_max_bytes_validation():
+    """LogConfig file_max_bytes must be at least 1."""
+    with pytest.raises(ValidationError):
+        LogConfig(file_max_bytes=0)
+    cfg = LogConfig(file_max_bytes=50 * 1024 * 1024)  # 50MB
+    assert cfg.file_max_bytes == 50 * 1024 * 1024
+
+
+def test_log_config_file_backup_count_validation():
+    """LogConfig file_backup_count must be >= 0."""
+    with pytest.raises(ValidationError):
+        LogConfig(file_backup_count=-1)
+    cfg = LogConfig(file_backup_count=10)
+    assert cfg.file_backup_count == 10
+    cfg_zero = LogConfig(file_backup_count=0)
+    assert cfg_zero.file_backup_count == 0
+
+
+def test_server_config_log_defaults():
+    """ServerConfig should include default LogConfig."""
+    cfg = ServerConfig()
+    assert cfg.log is not None
+    assert cfg.log.level == "INFO"
+    assert cfg.log.file_path is None
+
+
+def test_load_config_with_log_subsection(tmp_path, monkeypatch):
+    """LogConfig should be loaded from [server.log] TOML subsection."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [server.log]
+        level = "DEBUG"
+        file_path = "/var/log/opensandbox/server.log"
+        file_max_bytes = 52428800
+        file_backup_count = 3
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.level == "DEBUG"
+    assert loaded.server.log.file_path == "/var/log/opensandbox/server.log"
+    assert loaded.server.log.file_max_bytes == 52428800
+    assert loaded.server.log.file_backup_count == 3
+
+
+def test_load_config_without_log_subsection_uses_defaults(tmp_path, monkeypatch):
+    """AppConfig should use default LogConfig when [server.log] is not in TOML."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.level == "INFO"
+    assert loaded.server.log.file_path is None
+    assert loaded.server.log.file_max_bytes == 100 * 1024 * 1024
+    assert loaded.server.log.file_backup_count == 5
+
+
+def test_load_config_log_file_path_only(tmp_path, monkeypatch):
+    """LogConfig should accept only file_path with other defaults."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [server.log]
+        file_path = "/var/log/test.log"
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.level == "INFO"  # default
+    assert loaded.server.log.file_path == "/var/log/test.log"
+    assert loaded.server.log.access_file_path is None  # default
+    assert loaded.server.log.file_max_bytes == 100 * 1024 * 1024  # default
+    assert loaded.server.log.file_backup_count == 5  # default
+
+
+def test_load_config_log_access_file_path(tmp_path, monkeypatch):
+    """LogConfig should accept access_file_path for separate access log file."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [server.log]
+        file_path = "/var/log/opensandbox/server.log"
+        access_file_path = "/var/log/opensandbox/access.log"
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.file_path == "/var/log/opensandbox/server.log"
+    assert loaded.server.log.access_file_path == "/var/log/opensandbox/access.log"
+
+
+def test_load_config_log_file_enabled(tmp_path, monkeypatch):
+    """LogConfig file_enabled should enable file logging with default paths."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [server.log]
+        file_enabled = true
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.file_enabled is True
+    assert loaded.server.log.file_path is None  # not set, uses default
+    assert loaded.server.log.access_file_path is None
+    # resolved_* methods should return default paths
+    assert loaded.server.log.resolved_file_path() == LogConfig.DEFAULT_FILE_PATH
+    assert loaded.server.log.resolved_access_file_path() is None
+
+
+def test_load_config_log_file_enabled_with_custom_paths(tmp_path, monkeypatch):
+    """LogConfig file_enabled with custom paths should use those paths."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [server.log]
+        file_enabled = true
+        file_path = "/custom/server.log"
+        access_file_path = "/custom/access.log"
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.log.file_enabled is True
+    assert loaded.server.log.resolved_file_path() == "/custom/server.log"
+    assert loaded.server.log.resolved_access_file_path() == "/custom/access.log"

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -49,7 +49,7 @@ def test_load_config_from_file(tmp_path, monkeypatch):
         api_key = "secret"
         max_sandbox_timeout_seconds = 172800
 
-        [server.log]
+        [log]
         level = "DEBUG"
 
         [runtime]
@@ -68,7 +68,7 @@ def test_load_config_from_file(tmp_path, monkeypatch):
     loaded = config_module.load_config(config_path)
     assert loaded.server.host == "127.0.0.1"
     assert loaded.server.port == 9000
-    assert loaded.server.log.level == "DEBUG"
+    assert loaded.log.level == "DEBUG"
     assert loaded.server.api_key == "secret"
     assert loaded.server.max_sandbox_timeout_seconds == 172800
     assert loaded.runtime.type == "kubernetes"
@@ -731,16 +731,16 @@ def test_log_config_resolved_file_path():
 
 
 def test_log_config_resolved_access_file_path():
-    """resolved_access_file_path() should return None when not configured."""
+    """resolved_access_file_path() should return default path when file_enabled."""
     # file_enabled=False always returns None
     cfg = LogConfig(file_enabled=False, access_file_path="/path/access.log")
     assert cfg.resolved_access_file_path() is None
 
-    # file_enabled=True without access_file_path returns None (merge into main)
+    # file_enabled=True without access_file_path returns default path
     cfg = LogConfig(file_enabled=True)
-    assert cfg.resolved_access_file_path() is None
+    assert cfg.resolved_access_file_path() == LogConfig.DEFAULT_ACCESS_FILE_PATH
 
-    # file_enabled=True with access_file_path returns the path
+    # file_enabled=True with access_file_path returns the custom path
     cfg = LogConfig(file_enabled=True, access_file_path="/custom/access.log")
     assert cfg.resolved_access_file_path() == "/custom/access.log"
 
@@ -771,16 +771,18 @@ def test_log_config_file_backup_count_validation():
     assert cfg_zero.file_backup_count == 0
 
 
-def test_server_config_log_defaults():
-    """ServerConfig should include default LogConfig."""
-    cfg = ServerConfig()
+def test_app_config_log_defaults():
+    """AppConfig should include default LogConfig."""
+    cfg = AppConfig(
+        runtime=RuntimeConfig(type="docker", execd_image="test:latest")
+    )
     assert cfg.log is not None
     assert cfg.log.level == "INFO"
     assert cfg.log.file_path is None
 
 
 def test_load_config_with_log_subsection(tmp_path, monkeypatch):
-    """LogConfig should be loaded from [server.log] TOML subsection."""
+    """LogConfig should be loaded from [log] TOML section."""
     _reset_config(monkeypatch)
     toml = textwrap.dedent(
         """
@@ -788,7 +790,7 @@ def test_load_config_with_log_subsection(tmp_path, monkeypatch):
         host = "127.0.0.1"
         port = 9000
 
-        [server.log]
+        [log]
         level = "DEBUG"
         file_path = "/var/log/opensandbox/server.log"
         file_max_bytes = 52428800
@@ -803,14 +805,14 @@ def test_load_config_with_log_subsection(tmp_path, monkeypatch):
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.level == "DEBUG"
-    assert loaded.server.log.file_path == "/var/log/opensandbox/server.log"
-    assert loaded.server.log.file_max_bytes == 52428800
-    assert loaded.server.log.file_backup_count == 3
+    assert loaded.log.level == "DEBUG"
+    assert loaded.log.file_path == "/var/log/opensandbox/server.log"
+    assert loaded.log.file_max_bytes == 52428800
+    assert loaded.log.file_backup_count == 3
 
 
 def test_load_config_without_log_subsection_uses_defaults(tmp_path, monkeypatch):
-    """AppConfig should use default LogConfig when [server.log] is not in TOML."""
+    """AppConfig should use default LogConfig when [log] is not in TOML."""
     _reset_config(monkeypatch)
     toml = textwrap.dedent(
         """
@@ -827,10 +829,10 @@ def test_load_config_without_log_subsection_uses_defaults(tmp_path, monkeypatch)
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.level == "INFO"
-    assert loaded.server.log.file_path is None
-    assert loaded.server.log.file_max_bytes == 100 * 1024 * 1024
-    assert loaded.server.log.file_backup_count == 5
+    assert loaded.log.level == "INFO"
+    assert loaded.log.file_path is None
+    assert loaded.log.file_max_bytes == 100 * 1024 * 1024
+    assert loaded.log.file_backup_count == 5
 
 
 def test_load_config_log_file_path_only(tmp_path, monkeypatch):
@@ -842,7 +844,7 @@ def test_load_config_log_file_path_only(tmp_path, monkeypatch):
         host = "127.0.0.1"
         port = 9000
 
-        [server.log]
+        [log]
         file_path = "/var/log/test.log"
 
         [runtime]
@@ -854,11 +856,11 @@ def test_load_config_log_file_path_only(tmp_path, monkeypatch):
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.level == "INFO"  # default
-    assert loaded.server.log.file_path == "/var/log/test.log"
-    assert loaded.server.log.access_file_path is None  # default
-    assert loaded.server.log.file_max_bytes == 100 * 1024 * 1024  # default
-    assert loaded.server.log.file_backup_count == 5  # default
+    assert loaded.log.level == "INFO"  # default
+    assert loaded.log.file_path == "/var/log/test.log"
+    assert loaded.log.access_file_path is None  # default
+    assert loaded.log.file_max_bytes == 100 * 1024 * 1024  # default
+    assert loaded.log.file_backup_count == 5  # default
 
 
 def test_load_config_log_access_file_path(tmp_path, monkeypatch):
@@ -870,7 +872,7 @@ def test_load_config_log_access_file_path(tmp_path, monkeypatch):
         host = "127.0.0.1"
         port = 9000
 
-        [server.log]
+        [log]
         file_path = "/var/log/opensandbox/server.log"
         access_file_path = "/var/log/opensandbox/access.log"
 
@@ -883,8 +885,8 @@ def test_load_config_log_access_file_path(tmp_path, monkeypatch):
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.file_path == "/var/log/opensandbox/server.log"
-    assert loaded.server.log.access_file_path == "/var/log/opensandbox/access.log"
+    assert loaded.log.file_path == "/var/log/opensandbox/server.log"
+    assert loaded.log.access_file_path == "/var/log/opensandbox/access.log"
 
 
 def test_load_config_log_file_enabled(tmp_path, monkeypatch):
@@ -896,7 +898,7 @@ def test_load_config_log_file_enabled(tmp_path, monkeypatch):
         host = "127.0.0.1"
         port = 9000
 
-        [server.log]
+        [log]
         file_enabled = true
 
         [runtime]
@@ -908,12 +910,12 @@ def test_load_config_log_file_enabled(tmp_path, monkeypatch):
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.file_enabled is True
-    assert loaded.server.log.file_path is None  # not set, uses default
-    assert loaded.server.log.access_file_path is None
+    assert loaded.log.file_enabled is True
+    assert loaded.log.file_path is None  # not set, uses default
+    assert loaded.log.access_file_path is None
     # resolved_* methods should return default paths
-    assert loaded.server.log.resolved_file_path() == LogConfig.DEFAULT_FILE_PATH
-    assert loaded.server.log.resolved_access_file_path() is None
+    assert loaded.log.resolved_file_path() == LogConfig.DEFAULT_FILE_PATH
+    assert loaded.log.resolved_access_file_path() == LogConfig.DEFAULT_ACCESS_FILE_PATH
 
 
 def test_load_config_log_file_enabled_with_custom_paths(tmp_path, monkeypatch):
@@ -925,7 +927,7 @@ def test_load_config_log_file_enabled_with_custom_paths(tmp_path, monkeypatch):
         host = "127.0.0.1"
         port = 9000
 
-        [server.log]
+        [log]
         file_enabled = true
         file_path = "/custom/server.log"
         access_file_path = "/custom/access.log"
@@ -939,6 +941,6 @@ def test_load_config_log_file_enabled_with_custom_paths(tmp_path, monkeypatch):
     config_path.write_text(toml)
 
     loaded = config_module.load_config(config_path)
-    assert loaded.server.log.file_enabled is True
-    assert loaded.server.log.resolved_file_path() == "/custom/server.log"
-    assert loaded.server.log.resolved_access_file_path() == "/custom/access.log"
+    assert loaded.log.file_enabled is True
+    assert loaded.log.resolved_file_path() == "/custom/server.log"
+    assert loaded.log.resolved_access_file_path() == "/custom/access.log"


### PR DESCRIPTION
# Summary
Currently, the server logs are output to stdout, which is not conducive to log collection.
Add a file logger configuration to write both server logs and access logs to files.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
