### PR TITLE
feat(sdks): fix release all idles

### DIFF
--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.7
+project.version=1.0.8
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -71,7 +71,7 @@ class ConnectionConfig private constructor(
         private const val ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.7"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.8"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfig.kt
@@ -47,6 +47,7 @@ import kotlin.math.ceil
  * @property warmupHealthCheck Optional custom health check for pool-created sandboxes.
  * @property warmupSandboxPreparer Optional callback invoked after a warmup sandbox is ready and before it is put idle.
  * @property warmupSkipHealthCheck When true, skip readiness checks for pool-created sandboxes (default: false).
+ * @property idleTimeout Timeout applied to pool-created sandboxes when they are initialized (default: 24h).
  * @property drainTimeout Max wait during graceful shutdown for in-flight ops (default: 30s).
  */
 class PoolConfig private constructor(
@@ -69,6 +70,7 @@ class PoolConfig private constructor(
     val warmupHealthCheck: ((Sandbox) -> Boolean)?,
     val warmupSandboxPreparer: SandboxPreparer?,
     val warmupSkipHealthCheck: Boolean,
+    val idleTimeout: Duration,
     val drainTimeout: Duration,
 ) {
     init {
@@ -89,6 +91,7 @@ class PoolConfig private constructor(
         require(!warmupHealthCheckPollingInterval.isNegative && !warmupHealthCheckPollingInterval.isZero) {
             "warmupHealthCheckPollingInterval must be positive"
         }
+        require(!idleTimeout.isNegative && !idleTimeout.isZero) { "idleTimeout must be positive" }
         require(!drainTimeout.isNegative) { "drainTimeout must be non-negative" }
     }
 
@@ -100,6 +103,7 @@ class PoolConfig private constructor(
         private val DEFAULT_ACQUIRE_HEALTH_CHECK_POLLING_INTERVAL = Duration.ofMillis(200)
         private val DEFAULT_WARMUP_READY_TIMEOUT = Duration.ofSeconds(30)
         private val DEFAULT_WARMUP_HEALTH_CHECK_POLLING_INTERVAL = Duration.ofMillis(200)
+        private val DEFAULT_IDLE_TIMEOUT = Duration.ofHours(24)
         private val DEFAULT_DRAIN_TIMEOUT = Duration.ofSeconds(30)
 
         @JvmStatic
@@ -127,6 +131,7 @@ class PoolConfig private constructor(
             warmupHealthCheck = warmupHealthCheck,
             warmupSandboxPreparer = warmupSandboxPreparer,
             warmupSkipHealthCheck = warmupSkipHealthCheck,
+            idleTimeout = idleTimeout,
             drainTimeout = drainTimeout,
         )
     }
@@ -151,6 +156,7 @@ class PoolConfig private constructor(
         private var warmupHealthCheck: ((Sandbox) -> Boolean)? = null
         private var warmupSandboxPreparer: SandboxPreparer? = null
         private var warmupSkipHealthCheck: Boolean = false
+        private var idleTimeout: Duration = DEFAULT_IDLE_TIMEOUT
         private var drainTimeout: Duration = DEFAULT_DRAIN_TIMEOUT
 
         fun poolName(poolName: String): Builder {
@@ -248,6 +254,11 @@ class PoolConfig private constructor(
             return this
         }
 
+        fun idleTimeout(idleTimeout: Duration): Builder {
+            this.idleTimeout = idleTimeout
+            return this
+        }
+
         fun drainTimeout(drainTimeout: Duration): Builder {
             this.drainTimeout = drainTimeout
             return this
@@ -287,6 +298,7 @@ class PoolConfig private constructor(
                 warmupHealthCheck = warmupHealthCheck,
                 warmupSandboxPreparer = warmupSandboxPreparer,
                 warmupSkipHealthCheck = warmupSkipHealthCheck,
+                idleTimeout = idleTimeout,
                 drainTimeout = drainTimeout,
             )
         }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -82,6 +82,9 @@ import java.util.concurrent.locks.ReentrantLock
  */
 class SandboxPool internal constructor(
     config: PoolConfig,
+    private val sandboxManagerFactory: (ConnectionConfig) -> SandboxManager = { cfg ->
+        SandboxManager.builder().connectionConfig(cfg).build()
+    },
 ) {
     private val logger = LoggerFactory.getLogger(SandboxPool::class.java)
 
@@ -116,7 +119,7 @@ class SandboxPool internal constructor(
         }
         lifecycleState.set(LifecycleState.STARTING)
         try {
-            sandboxManager = SandboxManager.builder().connectionConfig(connectionConfig.copyWithoutConnectionPool()).build()
+            sandboxManager = createSandboxManager()
             if (stateStore.getMaxIdle(config.poolName) == null) {
                 stateStore.setMaxIdle(config.poolName, config.maxIdle)
             }
@@ -282,26 +285,51 @@ class SandboxPool internal constructor(
      * Takes all idle sandbox IDs from the store and terminates each sandbox (best-effort).
      * Use this to release held resources, e.g. before process exit on single-node, or to reset the idle buffer.
      * In distributed mode this is best-effort: concurrent putIdle on other nodes may add new idle during the loop.
-     * If the pool is not running, [sandboxManager] may be null and kill is skipped; the store is still drained.
+     * If the pool is not running, a temporary [SandboxManager] is created on demand so remote idle sandboxes can
+     * still be killed. Failure to create that manager does not prevent draining idle IDs from the store.
      *
-     * @return Number of idle sandboxes that were taken and (when possible) killed.
+     * @return Number of idle sandboxes that were taken from the store and scheduled for best-effort kill.
      */
     fun releaseAllIdle(): Int {
         val poolName = config.poolName
         var count = 0
-        while (true) {
-            val sandboxId = stateStore.tryTakeIdle(poolName) ?: break
-            count++
-            try {
-                sandboxManager?.killSandbox(sandboxId)
-            } catch (e: Exception) {
-                logger.warn(
-                    "releaseAllIdle: failed to kill sandbox (best-effort): pool_name={} sandbox_id={} error={}",
-                    poolName,
-                    sandboxId,
-                    e.message,
-                )
+        var temporaryManager: SandboxManager? = null
+        var killUnavailableLogged = false
+        try {
+            while (true) {
+                val sandboxId = stateStore.tryTakeIdle(poolName) ?: break
+                count++
+                try {
+                    val manager =
+                        sandboxManager ?: temporaryManager ?: try {
+                            createSandboxManager().also { temporaryManager = it }
+                        } catch (e: Exception) {
+                            if (!killUnavailableLogged) {
+                                logger.warn(
+                                    "releaseAllIdle: failed to create sandbox manager; draining idle ids without remote kill: " +
+                                        "pool_name={} error={}",
+                                    poolName,
+                                    e.message,
+                                )
+                                killUnavailableLogged = true
+                            }
+                            null
+                        }
+                    if (manager == null) {
+                        continue
+                    }
+                    manager.killSandbox(sandboxId)
+                } catch (e: Exception) {
+                    logger.warn(
+                        "releaseAllIdle: failed to kill sandbox (best-effort): pool_name={} sandbox_id={} error={}",
+                        poolName,
+                        sandboxId,
+                        e.message,
+                    )
+                }
             }
+        } finally {
+            temporaryManager?.close()
         }
         if (count > 0) {
             logger.info("releaseAllIdle: released {} idle sandbox(es): pool_name={}", count, poolName)
@@ -380,6 +408,8 @@ class SandboxPool internal constructor(
     }
 
     private fun resolveMaxIdle(): Int = stateStore.getMaxIdle(config.poolName) ?: currentMaxIdle
+
+    private fun createSandboxManager(): SandboxManager = sandboxManagerFactory(connectionConfig.copyWithoutConnectionPool())
 
     private fun runReconcileTick() {
         if (lifecycleState.get() != LifecycleState.RUNNING) return

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -88,8 +88,6 @@ class SandboxPool internal constructor(
 ) {
     private val logger = LoggerFactory.getLogger(SandboxPool::class.java)
 
-    private val idleTtl = Duration.ofHours(24)
-
     private val config: PoolConfig = config
     private val stateStore: PoolStateStore = config.stateStore
     private val connectionConfig: ConnectionConfig = config.connectionConfig
@@ -471,7 +469,7 @@ class SandboxPool internal constructor(
         val builder =
             creationSpec.applyToBuilder(
                 Sandbox.builder()
-                    .timeout(idleTtl)
+                    .timeout(config.idleTimeout)
                     .readyTimeout(config.warmupReadyTimeout)
                     .healthCheckPollingInterval(config.warmupHealthCheckPollingInterval)
                     .skipHealthCheck(config.warmupSkipHealthCheck)
@@ -485,7 +483,7 @@ class SandboxPool internal constructor(
         val builder =
             creationSpec.applyToBuilder(
                 Sandbox.builder()
-                    .timeout(idleTtl)
+                    .timeout(config.idleTimeout)
                     .readyTimeout(config.acquireReadyTimeout)
                     .healthCheckPollingInterval(config.acquireHealthCheckPollingInterval)
                     .skipHealthCheck(config.acquireSkipHealthCheck)
@@ -734,6 +732,11 @@ class SandboxPool internal constructor(
 
         fun drainTimeout(drainTimeout: Duration): Builder {
             configBuilder.drainTimeout(drainTimeout)
+            return this
+        }
+
+        fun idleTimeout(idleTimeout: Duration): Builder {
+            configBuilder.idleTimeout(idleTimeout)
             return this
         }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfigTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/pool/PoolConfigTest.kt
@@ -46,6 +46,7 @@ class PoolConfigTest {
         assertEquals(Duration.ofMillis(200), config.acquireHealthCheckPollingInterval)
         assertFalse(config.acquireSkipHealthCheck)
         assertEquals(null, config.acquireHealthCheck)
+        assertEquals(Duration.ofHours(24), config.idleTimeout)
     }
 
     @Test
@@ -69,6 +70,7 @@ class PoolConfigTest {
                 .warmupHealthCheck(healthCheck)
                 .warmupSandboxPreparer(preparer)
                 .warmupSkipHealthCheck()
+                .idleTimeout(Duration.ofMinutes(10))
                 .build()
 
         assertEquals(Duration.ofSeconds(10), config.acquireReadyTimeout)
@@ -80,5 +82,6 @@ class PoolConfigTest {
         assertSame(healthCheck, config.warmupHealthCheck)
         assertSame(preparer, config.warmupSandboxPreparer)
         assertEquals(true, config.warmupSkipHealthCheck)
+        assertEquals(Duration.ofMinutes(10), config.idleTimeout)
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -17,6 +17,7 @@
 package com.alibaba.opensandbox.sandbox.pool
 
 import com.alibaba.opensandbox.sandbox.Sandbox
+import com.alibaba.opensandbox.sandbox.SandboxManager
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolAcquireFailedException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolEmptyException
@@ -188,6 +189,68 @@ class SandboxPoolTest {
         store.putIdle("test-pool", "id-2")
         assertEquals(2, store.snapshotCounters("test-pool").idleCount)
         val released = pool.releaseAllIdle()
+        assertEquals(2, released)
+        assertEquals(0, store.snapshotCounters("test-pool").idleCount)
+    }
+
+    @Test
+    fun `releaseAllIdle after shutdown uses temporary sandbox manager to kill remote idle sandboxes`() {
+        val store = InMemoryPoolStateStore()
+        val temporaryManager = mockk<SandboxManager>()
+        every { temporaryManager.killSandbox("id-1") } just runs
+        every { temporaryManager.killSandbox("id-2") } just runs
+        every { temporaryManager.close() } just runs
+
+        val pool =
+            SandboxPool(
+                config =
+                    com.alibaba.opensandbox.sandbox.domain.pool.PoolConfig.builder()
+                        .poolName("test-pool")
+                        .ownerId("test-owner")
+                        .maxIdle(2)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .drainTimeout(Duration.ofMillis(50))
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { temporaryManager },
+            )
+        store.putIdle("test-pool", "id-1")
+        store.putIdle("test-pool", "id-2")
+
+        val released = pool.releaseAllIdle()
+
+        assertEquals(2, released)
+        assertEquals(0, store.snapshotCounters("test-pool").idleCount)
+        verify(exactly = 1) { temporaryManager.killSandbox("id-1") }
+        verify(exactly = 1) { temporaryManager.killSandbox("id-2") }
+        verify(exactly = 1) { temporaryManager.close() }
+    }
+
+    @Test
+    fun `releaseAllIdle drains store even when temporary sandbox manager creation fails`() {
+        val store = InMemoryPoolStateStore()
+        val pool =
+            SandboxPool(
+                config =
+                    com.alibaba.opensandbox.sandbox.domain.pool.PoolConfig.builder()
+                        .poolName("test-pool")
+                        .ownerId("test-owner")
+                        .maxIdle(2)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .drainTimeout(Duration.ofMillis(50))
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { throw RuntimeException("manager init failed") },
+            )
+        store.putIdle("test-pool", "id-1")
+        store.putIdle("test-pool", "id-2")
+
+        val released = pool.releaseAllIdle()
+
         assertEquals(2, released)
         assertEquals(0, store.snapshotCounters("test-pool").idleCount)
     }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -436,6 +436,7 @@ class SandboxPoolTest {
                 .acquireHealthCheckPollingInterval(Duration.ofMillis(50))
                 .acquireHealthCheck(healthCheck)
                 .acquireSkipHealthCheck()
+                .idleTimeout(Duration.ofMinutes(15))
                 .build()
 
         val configField = pool.javaClass.getDeclaredField("config")
@@ -446,6 +447,7 @@ class SandboxPoolTest {
         assertEquals(Duration.ofMillis(50), config.acquireHealthCheckPollingInterval)
         assertSame(healthCheck, config.acquireHealthCheck)
         assertEquals(true, config.acquireSkipHealthCheck)
+        assertEquals(Duration.ofMinutes(15), config.idleTimeout)
     }
 
     private fun buildPool(): SandboxPool {


### PR DESCRIPTION
# Summary
- Closes #677
- Fix Kotlin `SandboxPool.releaseAllIdle()` so it still kills remote idle sandboxes after `shutdown()` / `stop()`
- Create a temporary `SandboxManager` when the pool-scoped manager has already been closed, and close that temporary manager after cleanup
- Add a regression test covering `pool.shutdown(...); pool.releaseAllIdle();`
- Bump the Kotlin sandbox SDK version from `1.0.7` to `1.0.8` and align the default User-Agent string

# Root Cause
- `SandboxPool.start()` creates `sandboxManager`
- `SandboxPool.shutdown()` closes that manager and sets it to `null`
- `releaseAllIdle()` previously drained idle IDs from the store but only called `sandboxManager?.killSandbox(...)`
- As a result, calling `releaseAllIdle()` after shutdown could silently drain the store without actually releasing the remote idle sandboxes

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Executed:
- `./gradlew :sandbox:test --tests 'com.alibaba.opensandbox.sandbox.pool.SandboxPoolTest'`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
