### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/components/execd/pkg/jupyter/transport.go
+++ b/components/execd/pkg/jupyter/transport.go
@@ -14,15 +14,36 @@
 
 package jupyter
 
-import "net/http"
+import (
+	"net/http"
+	"sync"
+)
 
 type AuthTransport struct {
 	Token string
 	Base  http.RoundTripper
+
+	host   string
+	scheme string
+	mu     sync.Mutex
 }
 
 func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqClone := req.Clone(req.Context())
-	reqClone.Header.Set("Authorization", "Token "+t.Token)
+	allowAuth := true
+	if reqClone.URL != nil {
+		t.mu.Lock()
+		if t.host == "" {
+			t.host = reqClone.URL.Host
+		}
+		if t.scheme == "" {
+			t.scheme = reqClone.URL.Scheme
+		}
+		allowAuth = reqClone.URL.Host == t.host && reqClone.URL.Scheme == t.scheme
+		t.mu.Unlock()
+	}
+	if allowAuth {
+		reqClone.Header.Set("Authorization", "Token "+t.Token)
+	}
 	return t.Base.RoundTrip(reqClone)
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `components/execd/pkg/jupyter/transport.go:L24`

The custom `AuthTransport` unconditionally injects the Jupyter token into every outgoing request in `RoundTrip`. If the HTTP client follows redirects, and a redirect points to a different host, this transport can re-attach the token to redirected requests, potentially exposing credentials to unintended domains.

## Solution

Bind token injection to an allowlisted host/scheme (e.g., compare `req.URL.Host` to the expected Jupyter endpoint before setting `Authorization`), and/or disable redirects for this client (`CheckRedirect`) unless explicitly safe.

## Changes

- `components/execd/pkg/jupyter/transport.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
