### PR TITLE
Security: Global mutable logger can cause cross-request context leakage and audit integrity issues

### DIFF
--- a/components/ingress/pkg/proxy/logger.go
+++ b/components/ingress/pkg/proxy/logger.go
@@ -22,7 +22,24 @@ import (
 
 var Logger slogger.Logger
 
+type loggerContextKey struct{}
+
+var loggerKey = loggerContextKey{}
+
 func WithLogger(ctx context.Context, logger slogger.Logger) context.Context {
-	Logger = logger
-	return ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+func LoggerFromContext(ctx context.Context) slogger.Logger {
+	if ctx == nil {
+		return Logger
+	}
+	logger, ok := ctx.Value(loggerKey).(slogger.Logger)
+	if ok {
+		return logger
+	}
+	return Logger
 }


### PR DESCRIPTION
## Summary

Security: Global mutable logger can cause cross-request context leakage and audit integrity issues

## Problem

**Severity**: `Medium` | **File**: `components/ingress/pkg/proxy/logger.go:L23`

`WithLogger` stores a logger in a package-level global (`Logger = logger`) rather than request-scoped context. In concurrent workloads, one request can overwrite another request's logger, causing mixed or incorrect attribution in logs. This weakens audit trail integrity and may leak request metadata across tenants.

## Solution

Avoid global mutable logger state. Store/retrieve logger via `context.Context` or make logger an immutable dependency on a handler/proxy struct. If global state is unavoidable, protect with synchronization and avoid request-scoped fields in global logger instances.

## Changes

- `components/ingress/pkg/proxy/logger.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced