### PR TITLE
feat(egress): reload deny.always and allow.always every minute

### DIFF
--- a/components/egress/go.mod
+++ b/components/egress/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.41.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/sys v0.41.0
+	k8s.io/apimachinery v0.34.2
 )
 
 require (
@@ -39,8 +40,8 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.34.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 )
 
 replace github.com/alibaba/opensandbox/internal => ../internal

--- a/components/egress/go.sum
+++ b/components/egress/go.sum
@@ -86,3 +86,5 @@ k8s.io/apimachinery v0.34.2 h1:zQ12Uk3eMHPxrsbUJgNF8bTauTVR2WgqJsTmwTE/NW4=
 k8s.io/apimachinery v0.34.2/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -287,6 +287,16 @@ func (p *Proxy) UpdatePolicy(newPolicy *policy.NetworkPolicy) {
 	p.refreshEffectivePolicy()
 }
 
+// UpdateAlwaysRules swaps always-deny/always-allow overlays used by DNS evaluation.
+func (p *Proxy) UpdateAlwaysRules(alwaysDeny, alwaysAllow []policy.EgressRule) {
+	p.policyMu.Lock()
+	defer p.policyMu.Unlock()
+
+	p.alwaysDeny = append([]policy.EgressRule(nil), alwaysDeny...)
+	p.alwaysAllow = append([]policy.EgressRule(nil), alwaysAllow...)
+	p.refreshEffectivePolicy()
+}
+
 // CurrentPolicy returns the user policy (POST/PATCH/GET), not the always-deny/allow overlay.
 func (p *Proxy) CurrentPolicy() *policy.NetworkPolicy {
 	p.policyMu.RLock()

--- a/components/egress/pkg/policy/always_rules_test.go
+++ b/components/egress/pkg/policy/always_rules_test.go
@@ -15,8 +15,10 @@
 package policy
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -66,4 +68,56 @@ func TestLoadAlwaysRuleFile_Missing(t *testing.T) {
 func TestParseValidatedEgressRule_EmptyTarget(t *testing.T) {
 	_, err := ParseValidatedEgressRule(ActionDeny, "")
 	require.Error(t, err)
+}
+
+func TestAlwaysRuleLoader_RefreshIntervalAndReloadByMTime(t *testing.T) {
+	dir := t.TempDir()
+	denyPath := filepath.Join(dir, "deny.always")
+	allowPath := filepath.Join(dir, "allow.always")
+	require.NoError(t, os.WriteFile(denyPath, []byte("1.1.1.1\n"), 0o644))
+
+	loader := newAlwaysRuleLoader(time.Minute, denyPath, allowPath)
+	t0 := time.Unix(1000, 0)
+
+	deny, allow, changed, err := loader.RefreshIfDue(t0)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, deny, 1)
+	require.Nil(t, allow)
+	require.Equal(t, "1.1.1.1", deny[0].Target)
+
+	require.NoError(t, os.WriteFile(denyPath, []byte("2.2.2.2\n"), 0o644))
+	require.NoError(t, os.Chtimes(denyPath, t0.Add(10*time.Second), t0.Add(10*time.Second)))
+	deny, _, changed, err = loader.RefreshIfDue(t0.Add(30 * time.Second))
+	require.NoError(t, err)
+	require.False(t, changed, "should skip checks before refresh interval")
+	require.Len(t, deny, 1)
+	require.Equal(t, "1.1.1.1", deny[0].Target, "cached rules should remain before interval")
+
+	deny, _, changed, err = loader.RefreshIfDue(t0.Add(61 * time.Second))
+	require.NoError(t, err)
+	require.True(t, changed, "mtime changed after interval, should reload")
+	require.Len(t, deny, 1)
+	require.Equal(t, "2.2.2.2", deny[0].Target)
+}
+
+func TestAlwaysRuleLoader_DeleteFileRemovesRules(t *testing.T) {
+	dir := t.TempDir()
+	denyPath := filepath.Join(dir, "deny.always")
+	allowPath := filepath.Join(dir, "allow.always")
+	require.NoError(t, os.WriteFile(denyPath, []byte("3.3.3.3\n"), 0o644))
+
+	loader := newAlwaysRuleLoader(time.Minute, denyPath, allowPath)
+	t0 := time.Unix(2000, 0)
+
+	deny, _, changed, err := loader.RefreshIfDue(t0)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, deny, 1)
+
+	require.NoError(t, os.Remove(denyPath))
+	deny, _, changed, err = loader.RefreshIfDue(t0.Add(61 * time.Second))
+	require.NoError(t, err)
+	require.True(t, changed, "file deletion should be treated as rules removed")
+	require.Nil(t, deny)
 }

--- a/components/egress/pkg/policy/rules_loader.go
+++ b/components/egress/pkg/policy/rules_loader.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+type alwaysRuleFileState struct {
+	path    string
+	action  string
+	exists  bool
+	modTime time.Time
+	size    int64
+	rules   []EgressRule
+}
+
+// AlwaysRuleLoader refreshes deny/allow always-rules from files with a minimum check interval.
+type AlwaysRuleLoader struct {
+	mu              sync.RWMutex
+	refreshInterval time.Duration
+	lastCheck       time.Time
+	denyState       alwaysRuleFileState
+	allowState      alwaysRuleFileState
+}
+
+// NewAlwaysRuleLoader creates a loader for standard always-rule files.
+func NewAlwaysRuleLoader(refreshInterval time.Duration) *AlwaysRuleLoader {
+	return newAlwaysRuleLoader(refreshInterval, alwaysDenyFilePath, alwaysAllowFilePath)
+}
+
+func newAlwaysRuleLoader(refreshInterval time.Duration, denyPath, allowPath string) *AlwaysRuleLoader {
+	if refreshInterval <= 0 {
+		refreshInterval = time.Minute
+	}
+	return &AlwaysRuleLoader{
+		refreshInterval: refreshInterval,
+		denyState:       alwaysRuleFileState{path: denyPath, action: ActionDeny},
+		allowState:      alwaysRuleFileState{path: allowPath, action: ActionAllow},
+	}
+}
+
+// RefreshIfDue refreshes rules at most once per refreshInterval.
+// It returns changed=true only when deny/allow content state changed.
+func (l *AlwaysRuleLoader) RefreshIfDue(now time.Time) (deny, allow []EgressRule, changed bool, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.lastCheck.IsZero() && now.Sub(l.lastCheck) < l.refreshInterval {
+		return cloneRules(l.denyState.rules), cloneRules(l.allowState.rules), false, nil
+	}
+	l.lastCheck = now
+
+	denyChanged, err := l.refreshOne(&l.denyState)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	allowChanged, err := l.refreshOne(&l.allowState)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	changed = denyChanged || allowChanged
+	return cloneRules(l.denyState.rules), cloneRules(l.allowState.rules), changed, nil
+}
+
+// CurrentRules returns the latest cached deny/allow rules without refreshing.
+func (l *AlwaysRuleLoader) CurrentRules() (deny, allow []EgressRule) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	return cloneRules(l.denyState.rules), cloneRules(l.allowState.rules)
+}
+
+// SetCurrentRules seeds/overrides the in-memory cached rules.
+func (l *AlwaysRuleLoader) SetCurrentRules(deny, allow []EgressRule) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.denyState.rules = cloneRules(deny)
+	l.allowState.rules = cloneRules(allow)
+}
+
+func (l *AlwaysRuleLoader) refreshOne(state *alwaysRuleFileState) (bool, error) {
+	info, err := os.Stat(state.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if !state.exists {
+				return false, nil
+			}
+			state.exists = false
+			state.modTime = time.Time{}
+			state.size = 0
+			state.rules = nil
+			return true, nil
+		}
+		return false, err
+	}
+
+	if state.exists && info.ModTime().Equal(state.modTime) && info.Size() == state.size {
+		return false, nil
+	}
+
+	rules, err := loadAlwaysRuleFile(state.path, state.action)
+	if err != nil {
+		return false, err
+	}
+	state.exists = true
+	state.modTime = info.ModTime()
+	state.size = info.Size()
+	state.rules = rules
+	return true, nil
+}
+
+func cloneRules(in []EgressRule) []EgressRule {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]EgressRule, len(in))
+	copy(out, in)
+	return out
+}

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -31,11 +31,13 @@ import (
 	"github.com/alibaba/opensandbox/egress/pkg/nftables"
 	"github.com/alibaba/opensandbox/egress/pkg/policy"
 	"github.com/alibaba/opensandbox/internal/safego"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type policyUpdater interface {
 	CurrentPolicy() *policy.NetworkPolicy
 	UpdatePolicy(*policy.NetworkPolicy)
+	UpdateAlwaysRules(alwaysDeny, alwaysAllow []policy.EgressRule)
 }
 
 // enforcementReporter reports the current enforcement mode (dns | dns+nft).
@@ -61,16 +63,17 @@ func startPolicyServer(proxy policyUpdater, nft nftApplier, enforcementMode stri
 
 	mux := http.NewServeMux()
 	handler := &policyServer{
-		proxy:           proxy,
-		nft:             nft,
-		token:           token,
-		enforcementMode: enforcementMode,
-		nameserverIPs:   nameserverIPs,
-		policyFile:      strings.TrimSpace(policyFile),
-		maxEgressRules:  maxEgressRules,
-		alwaysDeny:      append([]policy.EgressRule(nil), alwaysDeny...),
-		alwaysAllow:     append([]policy.EgressRule(nil), alwaysAllow...),
+		proxy:            proxy,
+		nft:              nft,
+		token:            token,
+		enforcementMode:  enforcementMode,
+		nameserverIPs:    nameserverIPs,
+		policyFile:       strings.TrimSpace(policyFile),
+		maxEgressRules:   maxEgressRules,
+		alwaysLoader:     policy.NewAlwaysRuleLoader(time.Minute),
+		stopAlwaysReload: make(chan struct{}),
 	}
+	handler.setAlwaysRules(alwaysDeny, alwaysAllow)
 
 	mux.HandleFunc("/policy", handler.handlePolicy)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -80,6 +83,13 @@ func startPolicyServer(proxy policyUpdater, nft nftApplier, enforcementMode stri
 
 	srv := &http.Server{Addr: addr, Handler: mux}
 	handler.server = srv
+	srv.RegisterOnShutdown(func() {
+		select {
+		case <-handler.stopAlwaysReload:
+		default:
+			close(handler.stopAlwaysReload)
+		}
+	})
 
 	errCh := make(chan error, 1)
 	safego.Go(func() {
@@ -92,7 +102,7 @@ func startPolicyServer(proxy policyUpdater, nft nftApplier, enforcementMode stri
 	case err := <-errCh:
 		return nil, err
 	case <-time.After(200 * time.Millisecond):
-		// assume healthy start; keep logging future errors
+		handler.startAlwaysRuleReloadJob()
 		safego.Go(func() {
 			if err := <-errCh; err != nil {
 				log.Errorf("policy server error: %v", err)
@@ -109,11 +119,12 @@ type policyServer struct {
 	token           string
 	enforcementMode string
 	nameserverIPs   []netip.Addr
-	policyFile      string              // if set, successful policy changes are persisted here
-	maxEgressRules  int                 // 0 = unlimited; >0 = max len(Egress) for POST/PATCH
-	alwaysDeny      []policy.EgressRule // from deny.always at startup; merged for enforcement, not persisted
-	alwaysAllow     []policy.EgressRule // from allow.always at startup; merged for enforcement, not persisted
-	mu              sync.Mutex          // serializes read-merge-apply to avoid lost updates across POST/PATCH
+	policyFile      string     // if set, successful policy changes are persisted here
+	maxEgressRules  int        // 0 = unlimited; >0 = max len(Egress) for POST/PATCH
+	mu              sync.Mutex // serializes read-merge-apply to avoid lost updates across POST/PATCH
+
+	alwaysLoader     *policy.AlwaysRuleLoader
+	stopAlwaysReload chan struct{}
 }
 
 type policyStatusResponse struct {
@@ -265,7 +276,8 @@ func (s *policyServer) commitPolicy(ctx context.Context, w http.ResponseWriter, 
 		http.Error(w, fmt.Sprintf("failed to persist policy: %v", err), http.StatusInternalServerError)
 		return false
 	}
-	merged := policy.MergeAlwaysOverlay(pol, s.alwaysDeny, s.alwaysAllow)
+	alwaysDeny, alwaysAllow := s.currentAlwaysRules()
+	merged := policy.MergeAlwaysOverlay(pol, alwaysDeny, alwaysAllow)
 	if s.nft != nil {
 		if err := s.nft.ApplyStatic(ctx, merged.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
 			logEgressUpdateFailedError(fmt.Sprintf("nftables apply (%s): %v", op, err))
@@ -276,6 +288,62 @@ func (s *policyServer) commitPolicy(ctx context.Context, w http.ResponseWriter, 
 	}
 	s.proxy.UpdatePolicy(pol)
 	return true
+}
+
+func (s *policyServer) startAlwaysRuleReloadJob() {
+	safego.Go(func() {
+		wait.Until(s.reloadAlwaysRulesJob, time.Minute, s.stopAlwaysReload)
+	})
+}
+
+func (s *policyServer) reloadAlwaysRulesJob() {
+	changed, reloadErr := s.reloadAlwaysRules()
+	if reloadErr != nil {
+		log.Warnf("policy API: periodic reload of always rules failed: %v", reloadErr)
+		return
+	}
+	if !changed {
+		return
+	}
+	current := s.proxy.CurrentPolicy()
+	alwaysDeny, alwaysAllow := s.currentAlwaysRules()
+	merged := policy.MergeAlwaysOverlay(current, alwaysDeny, alwaysAllow)
+	if s.nft != nil {
+		if applyErr := s.nft.ApplyStatic(context.Background(), merged.WithExtraAllowIPs(s.nameserverIPs)); applyErr != nil {
+			log.Warnf("policy API: apply reloaded always rules to nftables failed: %v", applyErr)
+			return
+		}
+	}
+	log.Infof("policy API: reloaded always rules applied (deny=%d allow=%d)", len(alwaysDeny), len(alwaysAllow))
+}
+
+func (s *policyServer) reloadAlwaysRules() (bool, error) {
+	if s.alwaysLoader == nil {
+		return false, nil
+	}
+	deny, allow, changed, err := s.alwaysLoader.RefreshIfDue(time.Now())
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	s.proxy.UpdateAlwaysRules(deny, allow)
+	return true, nil
+}
+
+func (s *policyServer) setAlwaysRules(deny, allow []policy.EgressRule) {
+	if s.alwaysLoader == nil {
+		s.alwaysLoader = policy.NewAlwaysRuleLoader(time.Minute)
+	}
+	s.alwaysLoader.SetCurrentRules(deny, allow)
+}
+
+func (s *policyServer) currentAlwaysRules() (deny, allow []policy.EgressRule) {
+	if s.alwaysLoader == nil {
+		return nil, nil
+	}
+	return s.alwaysLoader.CurrentRules()
 }
 
 func (s *policyServer) authorize(r *http.Request) bool {

--- a/components/egress/policy_server_test.go
+++ b/components/egress/policy_server_test.go
@@ -32,6 +32,8 @@ import (
 
 type stubProxy struct {
 	updated *policy.NetworkPolicy
+	deny    []policy.EgressRule
+	allow   []policy.EgressRule
 }
 
 func (s *stubProxy) CurrentPolicy() *policy.NetworkPolicy {
@@ -40,6 +42,11 @@ func (s *stubProxy) CurrentPolicy() *policy.NetworkPolicy {
 
 func (s *stubProxy) UpdatePolicy(p *policy.NetworkPolicy) {
 	s.updated = p
+}
+
+func (s *stubProxy) UpdateAlwaysRules(alwaysDeny, alwaysAllow []policy.EgressRule) {
+	s.deny = append([]policy.EgressRule(nil), alwaysDeny...)
+	s.allow = append([]policy.EgressRule(nil), alwaysAllow...)
 }
 
 type stubNft struct {
@@ -67,7 +74,8 @@ func TestHandlePolicy_AlwaysDenyMergedIntoNft(t *testing.T) {
 	require.NoError(t, err)
 	proxy := &stubProxy{}
 	nft := &stubNft{}
-	srv := &policyServer{proxy: proxy, nft: nft, enforcementMode: "dns+nft", alwaysDeny: []policy.EgressRule{deny}}
+	srv := &policyServer{proxy: proxy, nft: nft, enforcementMode: "dns+nft"}
+	srv.setAlwaysRules([]policy.EgressRule{deny}, nil)
 
 	body := `{"defaultAction":"deny","egress":[{"action":"allow","target":"9.9.9.9"}]}`
 	req := httptest.NewRequest(http.MethodPost, "/policy", strings.NewReader(body))

--- a/components/egress/tests/smoke-nft.sh
+++ b/components/egress/tests/smoke-nft.sh
@@ -27,11 +27,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 IMG="opensandbox/egress:local"
 containerName="egress-smoke-nft"
 POLICY_PORT=18080
+ALWAYS_RULES_DIR_HOST="$(mktemp -d -t egress-always-rules.XXXXXX)"
 
 info() { echo "[$(date +%H:%M:%S)] $*"; }
 
 cleanup() {
   docker rm -f "${containerName}" >/dev/null 2>&1 || true
+  rm -rf "${ALWAYS_RULES_DIR_HOST}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -46,6 +48,7 @@ docker run -d --name "${containerName}" \
   -e OPENSANDBOX_EGRESS_MODE=dns+nft \
   -e OPENSANDBOX_EGRESS_DNS_UPSTREAM=8.8.8.8,8.8.4.4 \
   -p ${POLICY_PORT}:18080 \
+  -v "${ALWAYS_RULES_DIR_HOST}:/var/egress/rules" \
   "${IMG}"
 
 info "Waiting for policy server..."
@@ -66,6 +69,24 @@ run_in_app() {
 
 pass() { info "PASS: $*"; }
 fail() { echo "FAIL: $*" >&2; exit 1; }
+
+wait_until_always_flip() {
+  local timeout_sec="${1:-90}"
+  local elapsed=0
+  local step_sec=2
+  while [ "${elapsed}" -lt "${timeout_sec}" ]; do
+    # Expected after refresh:
+    # - deny.always blocks api.github.com
+    # - allow.always allows www.mozilla.org
+    if ! run_in_app -I https://api.github.com --max-time 8 >/dev/null 2>&1 \
+      && run_in_app -I https://www.mozilla.org --max-time 8 >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "${step_sec}"
+    elapsed=$((elapsed + step_sec))
+  done
+  return 1
+}
 
 info "Test: allowed domain should succeed (google.com)"
 run_in_app -I https://google.com --max-time 20 >/dev/null 2>&1 || fail "google.com should succeed"
@@ -132,6 +153,25 @@ if run_in_app -I https://www.mozilla.org --max-time 8 >/dev/null 2>&1; then
   fail "www.mozilla.org should be blocked after patch"
 else
   pass "www.mozilla.org blocked after patch"
+fi
+
+info "Always-rule dynamic check (single transition)"
+curl -sSf -XPOST "http://127.0.0.1:${POLICY_PORT}/policy" \
+  -d '{"defaultAction":"deny","egress":[{"action":"allow","target":"api.github.com"}]}'
+
+info "Baseline before file update: github allowed, mozilla blocked"
+run_in_app -I https://api.github.com --max-time 20 >/dev/null 2>&1 || fail "api.github.com should be allowed before always file update"
+if run_in_app -I https://www.mozilla.org --max-time 8 >/dev/null 2>&1; then
+  fail "www.mozilla.org should be blocked before always file update"
+fi
+pass "baseline verified"
+
+printf '%s\n' '*.github.com' > "${ALWAYS_RULES_DIR_HOST}/deny.always"
+printf '%s\n' 'www.mozilla.org' > "${ALWAYS_RULES_DIR_HOST}/allow.always"
+if wait_until_always_flip 90; then
+  pass "always files reloaded (github blocked, mozilla allowed)"
+else
+  fail "always file update did not take effect in time"
 fi
 
 info "All smoke tests passed."


### PR DESCRIPTION
# Summary
- Reload deny.always and allow.always every minute using mtime/size checks, treat file deletion as rule removal, and apply updates to both DNS evaluation and nft static policy.
- Decouple refresh from the policy API critical path by avoiding the main policy_server lock during refresh; commitPolicy now consumes the current always-rule snapshot only.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered