### PR TITLE
fix: normalize traceback for command start errors

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -141,7 +141,11 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		close(done)
 		wg.Wait()
 		request.Hooks.OnExecuteInit(session)
-		request.Hooks.OnExecuteError(&execute.ErrorOutput{EName: "CommandExecError", EValue: err.Error()})
+		request.Hooks.OnExecuteError(&execute.ErrorOutput{
+			EName:     "CommandExecError",
+			EValue:    err.Error(),
+			Traceback: []string{err.Error()},
+		})
 		log.Error("CommandExecError: error starting commands: %v", err)
 		return nil
 	}

--- a/components/execd/pkg/runtime/command_test.go
+++ b/components/execd/pkg/runtime/command_test.go
@@ -216,6 +216,50 @@ func TestRunCommand_Error(t *testing.T) {
 	require.Equal(t, "3", gotErr.EValue)
 }
 
+func TestRunCommand_StartErrorIncludesTraceback(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("bash not available on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+
+	c := NewController("", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		sessionID      string
+		gotErr         *execute.ErrorOutput
+		completeCalled bool
+	)
+
+	req := &ExecuteCodeRequest{
+		Code:    `echo "hello"`,
+		Cwd:     filepath.Join(t.TempDir(), "missing"),
+		Timeout: 5 * time.Second,
+		Hooks: ExecuteResultHook{
+			OnExecuteInit: func(s string) { sessionID = s },
+			OnExecuteError: func(err *execute.ErrorOutput) {
+				gotErr = err
+			},
+			OnExecuteComplete: func(_ time.Duration) {
+				completeCalled = true
+			},
+		},
+	}
+
+	require.NoError(t, c.runCommand(ctx, req))
+
+	require.NotEmpty(t, sessionID, "expected session id to be set")
+	require.NotNil(t, gotErr, "expected error hook to be called")
+	require.Equal(t, "CommandExecError", gotErr.EName)
+	require.NotEmpty(t, gotErr.Traceback, "expected traceback to be populated")
+	require.Equal(t, gotErr.EValue, gotErr.Traceback[0])
+	require.False(t, completeCalled, "did not expect completion hook on start failure")
+}
+
 // TestStdLogDescriptor_AutoCreatesTempDir verifies that stdLogDescriptor
 // recreates the temp directory when it has been deleted, rather than failing.
 // Regression test for https://github.com/alibaba/OpenSandbox/issues/400.

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/event_node.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/event_node.py
@@ -17,7 +17,9 @@
 EventNode model for parsing Server-Sent Events from execd.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class EventNodeError(BaseModel):
@@ -26,6 +28,18 @@ class EventNodeError(BaseModel):
     name: str | None = Field(default=None, alias="ename")
     value: str | None = Field(default=None, alias="evalue")
     traceback: list[str] = Field(default_factory=list)
+
+    @field_validator("traceback", mode="before")
+    @classmethod
+    def normalize_traceback(cls, value: Any) -> list[str]:
+        """Normalize older or malformed SSE payloads into a stable list form."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item) for item in value]
+        if isinstance(value, tuple):
+            return [str(item) for item in value]
+        return [str(value)]
 
 
 class EventNodeResults(BaseModel):

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -78,6 +78,18 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 request=request,
             )
 
+        if request.url.path == "/command" and payload.get("command") == "exit null":
+            sse = (
+                b'data: {"type":"init","text":"exec-null","timestamp":1}\n\n'
+                b'data: {"type":"error","error":{"ename":"CommandExecError","evalue":"fork/exec /usr/bin/bash: resource temporarily unavailable","traceback":null},"timestamp":2}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
+
         return httpx.Response(500, content=b"boom", request=request)
 
 
@@ -125,6 +137,21 @@ async def test_run_command_streaming_non_zero_exit_updates_exit_code() -> None:
     assert execution.error.value == "7"
     assert execution.complete is None
     assert execution.exit_code == 7
+
+
+@pytest.mark.asyncio
+async def test_run_command_streaming_tolerates_null_traceback() -> None:
+    cfg = ConnectionConfig(protocol="http", transport=_SseTransport())
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapter(cfg, endpoint)
+
+    execution = await adapter.run("exit null")
+
+    assert execution.id == "exec-null"
+    assert execution.error is not None
+    assert execution.error.value == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    assert execution.error.traceback == []
+    assert execution.complete is None
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -69,6 +69,18 @@ class _SseTransport(httpx.BaseTransport):
                 request=request,
             )
 
+        if request.url.path == "/command" and payload.get("command") == "exit null":
+            sse = (
+                b'data: {"type":"init","text":"exec-null","timestamp":1}\n\n'
+                b'data: {"type":"error","error":{"ename":"CommandExecError","evalue":"fork/exec /usr/bin/bash: resource temporarily unavailable","traceback":null},"timestamp":2}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
+
         sse = (
             b'data: {"type":"init","text":"exec-2","timestamp":1}\n\n'
             b'data: {"type":"error","error":{"ename":"CommandExecError","evalue":"7","traceback":["exit status 7"]},"timestamp":2}\n\n'
@@ -105,6 +117,20 @@ def test_sync_run_command_streaming_non_zero_exit_updates_exit_code() -> None:
     assert execution.error.value == "7"
     assert execution.complete is None
     assert execution.exit_code == 7
+
+
+def test_sync_run_command_streaming_tolerates_null_traceback() -> None:
+    cfg = ConnectionConfigSync(protocol="http", transport=_SseTransport())
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapterSync(cfg, endpoint)
+
+    execution = adapter.run("exit null")
+
+    assert execution.id == "exec-null"
+    assert execution.error is not None
+    assert execution.error.value == "fork/exec /usr/bin/bash: resource temporarily unavailable"
+    assert execution.error.traceback == []
+    assert execution.complete is None
 
 
 def test_sync_run_in_session_streaming_uses_generated_fields_and_exit_code() -> None:


### PR DESCRIPTION
# Summary
- Normalize `traceback` for foreground command start failures in `execd` so SSE error payloads stay aligned with the API contract.
- Harden the Python sandbox SDK SSE parser to tolerate `traceback: null` from older or mixed deployments.
- Add regression coverage for both async and sync command streaming paths.

Closes #700

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Executed:
- `go test ./pkg/runtime` in `components/execd`
- `uv run pytest tests/test_command_service_adapter_streaming.py tests/test_sync_command_service_adapter_streaming.py -q` in `sdks/sandbox/python`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
