### PR TITLE
fix(docs): use uvx for opensandbox-server quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Requirements:
 #### 1. Install and Configure the Sandbox Server
 
 ```bash
-uv pip install opensandbox-server
-opensandbox-server init-config ~/.sandbox.toml --example docker
+# No PATH setup required; uvx resolves and runs the CLI directly.
+uvx opensandbox-server init-config ~/.sandbox.toml --example docker
 ```
 
 > If you prefer working from source, you can still clone the repo for development, but you no longer need to clone this repository just to start the server.
@@ -84,10 +84,10 @@ opensandbox-server init-config ~/.sandbox.toml --example docker
 #### 2. Start the Sandbox Server
 
 ```bash
-opensandbox-server
+uvx opensandbox-server
 
 # Show help
-# opensandbox-server -h
+# uvx opensandbox-server -h
 ```
 
 #### 3. Create a Code Interpreter and Execute Commands/Codes

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -63,8 +63,8 @@ OpenSandbox 已进入 [CNCF Landscape](https://landscape.cncf.io/?item=orchestra
 #### 1. 安装并配置 Server
 
 ```bash
-uv pip install opensandbox-server
-opensandbox-server init-config ~/.sandbox.toml --example docker-zh
+# 无需额外配置 PATH，直接通过 uvx 调用 CLI
+uvx opensandbox-server init-config ~/.sandbox.toml --example docker-zh
 ```
 
 > 如果需要开发或使用源码编译，可通过clone仓库进行开发。
@@ -78,10 +78,10 @@ opensandbox-server init-config ~/.sandbox.toml --example docker-zh
 #### 2. 启动沙箱 Server
 
 ```bash
-opensandbox-server
+uvx opensandbox-server
 
 # Show help
-opensandbox-server -h
+uvx opensandbox-server -h
 ```
 
 #### 3. 创建代码解释器，并在沙箱中执行命令


### PR DESCRIPTION
# Summary
- Update quick-start server commands in `README.md` and `docs/README_zh.md` to use `uvx opensandbox-server`.
- This avoids `command not found` in environments where `uv pip install` does not place `opensandbox-server` on shell `PATH`.
- Keep English/Chinese docs aligned so users get consistent startup instructions.

# Testing
- [x] Not run (explain why)
  - Docs-only change; validated command behavior manually with `uvx opensandbox-server -h` and `uv run --with opensandbox-server opensandbox-server -h`.
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered