### PR TITLE
feat(specs): diagnostics spec

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,21 @@ Defines the complete lifecycle interfaces for creating, managing, and destroying
 - HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`
 - Environment Variable: `OPEN_SANDBOX_API_KEY` (for SDK clients)
 
-### 2. execd-api.yaml
+### 2. diagnostic-api.yml
+
+**Sandbox Diagnostics API**
+
+Defines best-effort plain-text troubleshooting snapshots for sandbox diagnostic logs and events. This spec does not define a structured audit or observability model.
+
+**Main Endpoints (base path `/v1`):**
+- `GET /sandboxes/{sandboxId}/diagnostics/logs` - Retrieve diagnostic log text for an optional scope
+- `GET /sandboxes/{sandboxId}/diagnostics/events` - Retrieve diagnostic event text for an optional scope
+
+**Authentication:**
+- HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`
+- Environment Variable: `OPEN_SANDBOX_API_KEY` (for SDK clients)
+
+### 3. execd-api.yaml
 
 **Code Execution API Inside Sandbox**
 
@@ -86,7 +100,7 @@ Defines interfaces for executing code, commands, and file operations within sand
 - `GET /metrics` - Get system resource metrics
 - `GET /metrics/watch` - Watch system metrics in real-time (SSE stream)
 
-### 3. egress-api.yaml
+### 4. egress-api.yaml
 
 **Sandbox Egress Runtime API**
 

--- a/specs/README_zh.md
+++ b/specs/README_zh.md
@@ -35,7 +35,21 @@
 - HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`
 - 环境变量: `OPEN_SANDBOX_API_KEY`（SDK 客户端）
 
-### 2. execd-api.yaml
+### 2. diagnostic-api.yml
+
+**沙箱诊断 API**
+
+定义用于排障的 best-effort 纯文本快照接口，用于获取沙箱诊断日志和事件。该规范不定义结构化审计或可观测性模型。
+
+**主要端点（基础路径 `/v1`）：**
+- `GET /sandboxes/{sandboxId}/diagnostics/logs` - 获取可选 scope 下的诊断日志文本
+- `GET /sandboxes/{sandboxId}/diagnostics/events` - 获取可选 scope 下的诊断事件文本
+
+**认证方式：**
+- HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`
+- 环境变量: `OPEN_SANDBOX_API_KEY`（SDK 客户端）
+
+### 3. execd-api.yaml
 
 **沙箱内代码执行 API**
 
@@ -86,7 +100,7 @@
 - `GET /metrics` - 获取系统资源指标
 - `GET /metrics/watch` - 实时监控系统指标（SSE 流）
 
-### 3. egress-api.yaml
+### 4. egress-api.yaml
 
 **沙箱 Egress 运行时 API**
 

--- a/specs/diagnostic-api.yml
+++ b/specs/diagnostic-api.yml
@@ -1,0 +1,264 @@
+openapi: 3.1.0
+info:
+  title: OpenSandbox Diagnostics API
+  version: 0.1.0
+  description: |
+    The OpenSandbox Diagnostics API exposes best-effort plain-text diagnostic
+    snapshots for a sandbox. It is intended for humans and troubleshooting agents
+    that need to collect runtime troubleshooting material without depending on a
+    stable structured observability model.
+
+    This API is not an audit log API and does not define the canonical
+    observability schema for OpenSandbox. Structured telemetry, long-term
+    retention, filtering, pagination, and streaming may be provided separately.
+
+    Successful responses are display-oriented `text/plain` output. Clients should
+    not parse individual lines as a stable schema. Servers may impose
+    implementation-defined retention and response size limits.
+
+    ## Authentication
+
+    API Key authentication is required for all operations:
+
+    1. **HTTP Header**
+       ```
+       OPEN-SANDBOX-API-KEY: your-api-key
+       ```
+
+    2. **Environment Variable** (for SDK clients)
+       ```
+       OPEN_SANDBOX_API_KEY=your-api-key
+       ```
+
+       SDK clients will automatically pick up this environment variable.
+servers:
+  - url: http://localhost:8080/v1
+    description: Local development
+security:
+  - apiKeyAuth: []
+tags:
+  - name: Diagnostics
+    description: Plain-text sandbox troubleshooting snapshots
+paths:
+  /sandboxes/{sandboxId}/diagnostics/logs:
+    get:
+      tags: [Diagnostics]
+      summary: Get diagnostic logs
+      description: |
+        Retrieve a best-effort plain-text snapshot of sandbox diagnostic logs.
+
+        Logs are not limited to a structured observability model. Depending on the
+        selected `scope` and server configuration, log text may include sandbox
+        container stdout/stderr, lifecycle diagnostic text, network diagnostic text,
+        or other implementation-defined diagnostic material.
+
+        This endpoint does not provide streaming, pagination, or a stable line-level
+        schema in this version. The server returns currently available diagnostic
+        text for the requested scope, subject to implementation-defined retention
+        and response size limits.
+
+        This version only supports `text/plain` successful responses. Clients should
+        send `Accept: text/plain`. If `Accept` is omitted or includes `*/*`, the
+        server returns `text/plain`. Requests whose `Accept` header does not allow
+        `text/plain` return `406 Not Acceptable`.
+      parameters:
+        - $ref: '#/components/parameters/SandboxId'
+        - $ref: '#/components/parameters/DiagnosticScope'
+      responses:
+        '200':
+          description: Diagnostic log text snapshot
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                container:
+                  summary: Container log text
+                  value: |
+                    2026-03-25T10:01:13Z execd started
+                    2026-03-25T10:01:14Z sandbox process ready
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /sandboxes/{sandboxId}/diagnostics/events:
+    get:
+      tags: [Diagnostics]
+      summary: Get diagnostic events
+      description: |
+        Retrieve a best-effort plain-text snapshot of sandbox diagnostic events.
+
+        Events are rendered as diagnostic text rather than exposed as a stable
+        structured event model. Depending on the selected `scope` and runtime, event
+        text may include lifecycle transitions, runtime or platform events such as
+        Kubernetes Events, network diagnostic events, process activity events, or
+        other implementation-defined event material.
+
+        This endpoint does not provide streaming, pagination, or a stable line-level
+        schema in this version. The server returns currently available diagnostic
+        event text for the requested scope, subject to implementation-defined
+        retention and response size limits.
+
+        This version only supports `text/plain` successful responses. Clients should
+        send `Accept: text/plain`. If `Accept` is omitted or includes `*/*`, the
+        server returns `text/plain`. Requests whose `Accept` header does not allow
+        `text/plain` return `406 Not Acceptable`.
+      parameters:
+        - $ref: '#/components/parameters/SandboxId'
+        - $ref: '#/components/parameters/DiagnosticScope'
+      responses:
+        '200':
+          description: Diagnostic event text snapshot
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                runtime:
+                  summary: Runtime event text
+                  value: |
+                    2026-03-25T10:01:13Z runtime Normal Scheduled Successfully assigned sandbox pod
+                    2026-03-25T10:01:14Z runtime Normal Pulled Container image pulled
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: OPEN-SANDBOX-API-KEY
+      description: |
+        API Key for authentication. Can be provided via:
+        1. HTTP Header: OPEN-SANDBOX-API-KEY: your-api-key
+        2. Environment variable: OPEN_SANDBOX_API_KEY (for SDK clients)
+  parameters:
+    SandboxId:
+      name: sandboxId
+      in: path
+      required: true
+      description: Unique sandbox identifier
+      schema:
+        type: string
+    DiagnosticScope:
+      name: scope
+      in: query
+      required: false
+      description: |
+        Optional diagnostic scope selector. Known scopes may include `container`,
+        `lifecycle`, `runtime`, `network`, `process`, and `all`. Supported scopes
+        and defaults are implementation-defined; servers may add new scopes over
+        time.
+      schema:
+        type: string
+      examples:
+        container:
+          summary: Sandbox container diagnostics
+          value: container
+        runtime:
+          summary: Runtime or platform diagnostics
+          value: runtime
+        all:
+          summary: Best-effort aggregate across supported scopes
+          value: all
+  headers:
+    XRequestId:
+      description: Unique request identifier for tracing
+      schema:
+        type: string
+        format: uuid
+  responses:
+    BadRequest:
+      description: The request was invalid or malformed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    Unauthorized:
+      description: Authentication credentials are missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    Forbidden:
+      description: The authenticated user lacks permission for this operation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    NotFound:
+      description: The requested sandbox does not exist
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    NotAcceptable:
+      description: |
+        Requested media type is not supported by this operation. This version only
+        supports `text/plain` successful responses.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    InternalServerError:
+      description: An unexpected server error occurred
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+  schemas:
+    ErrorResponse:
+      type: object
+      description: |
+        Standard error response for all non-2xx HTTP responses.
+        HTTP status code indicates the error category; code and message provide details.
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+        message:
+          type: string
+          description: Human-readable error message describing what went wrong.
+      required: [code, message]
+      additionalProperties: false


### PR DESCRIPTION
# Summary
- Add a standalone `specs/diagnostic-api.yml` for sandbox diagnostics instead of folding diagnostics into `sandbox-lifecycle.yml`.
- Keep the first public contract intentionally narrow:
  - `GET /sandboxes/{sandboxId}/diagnostics/logs`
  - `GET /sandboxes/{sandboxId}/diagnostics/events`
- Define both endpoints as best-effort `text/plain` snapshots with only an optional `scope` selector.
- Update `specs/README.md` and `specs/README_zh.md` to list the new diagnostics spec as a separate API surface.

# Design Notes
- Diagnostics are separated from the lifecycle API because this surface is conceptually different from sandbox lifecycle management and should not expand the lifecycle contract prematurely.
- The response format is intentionally plain text. The goal is to provide troubleshooting material for humans and agents without freezing a structured audit or observability model before the event/log model is mature.
- `logs` and `events` are defined as diagnostic text views, not as canonical observability records:
  - `logs` can include container stdout/stderr and other implementation-defined diagnostic log text.
  - `events` can include lifecycle, runtime/platform, network, process, or other implementation-defined diagnostic event text.
- `scope` is an open string rather than a closed enum. Known scopes may include:
  - `container`: sandbox container stdout/stderr, including execd output when execd writes to the same container stream.
  - `lifecycle`: OpenSandbox server-side lifecycle diagnostic text, such as create/provision/running/delete/expire transitions. This is not intended to expose raw server process logs.
  - `runtime`: runtime/platform diagnostic text, such as Kubernetes Events or Docker-derived container state/OOM/exit information.
  - `network`: egress or network diagnostic text, including future egress audit output.
  - `process`: future process activity diagnostic text.
  - `all`: best-effort aggregate across supported scopes.
- The intended default interpretation is `scope=container` for `/diagnostics/logs` and `scope=runtime` for `/diagnostics/events`, while still leaving defaults implementation-defined in the spec.
- The spec explicitly avoids promising streaming, pagination, stable line-level structure, long-term retention, or a structured audit schema. Those concerns can evolve separately, for example through future OTel-backed telemetry.

# Implementation Status
- This PR defines the target public diagnostics contract only.
- The existing server DevOps routes are not yet aligned with this spec. They still use the older `tail` / `since` / `limit` query shape and do not yet enforce the `Accept: text/plain` / `406 Not Acceptable` behavior.
- Server implementation and SDK wiring should be aligned in follow-up changes before this API is treated as implemented or exposed.

# Testing
- [x] Spec YAML parsing with Ruby `YAML.load_file` for:
  - `specs/sandbox-lifecycle.yml`
  - `specs/diagnostic-api.yml`
  - `specs/egress-api.yaml`
  - `specs/execd-api.yaml`
- [x] `git diff --check` for the edited spec and README files
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Motivation described in this PR
- [x] Added/updated docs
- [ ] Added/updated tests (not needed for spec-only design change)
- [x] Security impact considered: this spec only defines display-oriented diagnostic text and avoids committing to raw server logs or structured audit data.
- [x] Backward compatibility considered: new standalone spec is additive and does not modify the lifecycle API contract.
