### PR TITLE
feat(specs): optimize diagnostic api desgin

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -39,11 +39,11 @@ Defines the complete lifecycle interfaces for creating, managing, and destroying
 
 **Sandbox Diagnostics API**
 
-Defines best-effort plain-text troubleshooting snapshots for sandbox diagnostic logs and events. This spec does not define a structured audit or observability model.
+Defines best-effort troubleshooting descriptors for sandbox diagnostic logs and events. The descriptors either embed plain-text diagnostic content inline or return a download URL for the content. This spec does not define a structured audit or observability model.
 
 **Main Endpoints (base path `/v1`):**
-- `GET /sandboxes/{sandboxId}/diagnostics/logs` - Retrieve diagnostic log text for an optional scope
-- `GET /sandboxes/{sandboxId}/diagnostics/events` - Retrieve diagnostic event text for an optional scope
+- `GET /sandboxes/{sandboxId}/diagnostics/logs` - Retrieve a diagnostic log content descriptor for an optional scope
+- `GET /sandboxes/{sandboxId}/diagnostics/events` - Retrieve a diagnostic event content descriptor for an optional scope
 
 **Authentication:**
 - HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`

--- a/specs/README_zh.md
+++ b/specs/README_zh.md
@@ -39,11 +39,11 @@
 
 **沙箱诊断 API**
 
-定义用于排障的 best-effort 纯文本快照接口，用于获取沙箱诊断日志和事件。该规范不定义结构化审计或可观测性模型。
+定义用于排障的 best-effort 诊断描述符接口，用于获取沙箱诊断日志和事件。描述符可以内嵌纯文本诊断内容，也可以返回内容下载 URL。该规范不定义结构化审计或可观测性模型。
 
 **主要端点（基础路径 `/v1`）：**
-- `GET /sandboxes/{sandboxId}/diagnostics/logs` - 获取可选 scope 下的诊断日志文本
-- `GET /sandboxes/{sandboxId}/diagnostics/events` - 获取可选 scope 下的诊断事件文本
+- `GET /sandboxes/{sandboxId}/diagnostics/logs` - 获取可选 scope 下的诊断日志内容描述符
+- `GET /sandboxes/{sandboxId}/diagnostics/events` - 获取可选 scope 下的诊断事件内容描述符
 
 **认证方式：**
 - HTTP Header: `OPEN-SANDBOX-API-KEY: your-api-key`

--- a/specs/diagnostic-api.yml
+++ b/specs/diagnostic-api.yml
@@ -12,8 +12,10 @@ info:
     observability schema for OpenSandbox. Structured telemetry, long-term
     retention, filtering, pagination, and streaming may be provided separately.
 
-    Successful responses are display-oriented `text/plain` output. Clients should
-    not parse individual lines as a stable schema. Servers may impose
+    Successful responses return a JSON descriptor whose diagnostic payload is
+    either embedded inline or made available through a download URL. The diagnostic
+    payload itself is display-oriented `text/plain` content. Clients should not
+    parse individual payload lines as a stable schema. Servers may impose
     implementation-defined retention and response size limits.
 
     ## Authentication
@@ -38,14 +40,14 @@ security:
   - apiKeyAuth: []
 tags:
   - name: Diagnostics
-    description: Plain-text sandbox troubleshooting snapshots
+    description: Sandbox troubleshooting payload descriptors
 paths:
   /sandboxes/{sandboxId}/diagnostics/logs:
     get:
       tags: [Diagnostics]
       summary: Get diagnostic logs
       description: |
-        Retrieve a best-effort plain-text snapshot of sandbox diagnostic logs.
+        Retrieve a best-effort descriptor for sandbox diagnostic log text.
 
         Logs are not limited to a structured observability model. Depending on the
         selected `scope` and server configuration, log text may include sandbox
@@ -53,30 +55,46 @@ paths:
         or other implementation-defined diagnostic material.
 
         This endpoint does not provide streaming, pagination, or a stable line-level
-        schema in this version. The server returns currently available diagnostic
-        text for the requested scope, subject to implementation-defined retention
-        and response size limits.
-
-        This version only supports `text/plain` successful responses. Clients should
-        send `Accept: text/plain`. If `Accept` is omitted or includes `*/*`, the
-        server returns `text/plain`. Requests whose `Accept` header does not allow
-        `text/plain` return `406 Not Acceptable`.
+        schema in this version. The server returns a JSON descriptor for currently
+        available diagnostic text for the requested scope, subject to
+        implementation-defined retention and response size limits. The descriptor
+        either embeds the text as `content` or returns a `contentUrl` where the
+        text can be downloaded.
       parameters:
         - $ref: '#/components/parameters/SandboxId'
         - $ref: '#/components/parameters/DiagnosticScope'
       responses:
         '200':
-          description: Diagnostic log text snapshot
+          description: Diagnostic log content descriptor
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/DiagnosticContentResponse'
               examples:
-                container:
-                  summary: Container log text
-                  value: |
-                    2026-03-25T10:01:13Z execd started
-                    2026-03-25T10:01:14Z sandbox process ready
+                inline:
+                  summary: Inline container log text
+                  value:
+                    sandboxId: sbx_123
+                    kind: logs
+                    scope: container
+                    delivery: inline
+                    contentType: text/plain; charset=utf-8
+                    content: |
+                      2026-03-25T10:01:13Z execd started
+                      2026-03-25T10:01:14Z sandbox process ready
+                    truncated: false
+                url:
+                  summary: Downloadable container log text
+                  value:
+                    sandboxId: sbx_123
+                    kind: logs
+                    scope: container
+                    delivery: url
+                    contentType: text/plain; charset=utf-8
+                    contentUrl: https://example.com/diagnostics/sbx_123/logs.txt
+                    contentLength: 10485760
+                    expiresAt: "2026-04-14T10:30:00Z"
+                    truncated: false
           headers:
             X-Request-ID:
               $ref: '#/components/headers/XRequestId'
@@ -88,8 +106,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '406':
-          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /sandboxes/{sandboxId}/diagnostics/events:
@@ -97,7 +113,7 @@ paths:
       tags: [Diagnostics]
       summary: Get diagnostic events
       description: |
-        Retrieve a best-effort plain-text snapshot of sandbox diagnostic events.
+        Retrieve a best-effort descriptor for sandbox diagnostic event text.
 
         Events are rendered as diagnostic text rather than exposed as a stable
         structured event model. Depending on the selected `scope` and runtime, event
@@ -106,30 +122,46 @@ paths:
         other implementation-defined event material.
 
         This endpoint does not provide streaming, pagination, or a stable line-level
-        schema in this version. The server returns currently available diagnostic
-        event text for the requested scope, subject to implementation-defined
-        retention and response size limits.
-
-        This version only supports `text/plain` successful responses. Clients should
-        send `Accept: text/plain`. If `Accept` is omitted or includes `*/*`, the
-        server returns `text/plain`. Requests whose `Accept` header does not allow
-        `text/plain` return `406 Not Acceptable`.
+        schema in this version. The server returns a JSON descriptor for currently
+        available diagnostic event text for the requested scope, subject to
+        implementation-defined retention and response size limits. The descriptor
+        either embeds the text as `content` or returns a `contentUrl` where the
+        text can be downloaded.
       parameters:
         - $ref: '#/components/parameters/SandboxId'
         - $ref: '#/components/parameters/DiagnosticScope'
       responses:
         '200':
-          description: Diagnostic event text snapshot
+          description: Diagnostic event content descriptor
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/DiagnosticContentResponse'
               examples:
-                runtime:
-                  summary: Runtime event text
-                  value: |
-                    2026-03-25T10:01:13Z runtime Normal Scheduled Successfully assigned sandbox pod
-                    2026-03-25T10:01:14Z runtime Normal Pulled Container image pulled
+                inline:
+                  summary: Inline runtime event text
+                  value:
+                    sandboxId: sbx_123
+                    kind: events
+                    scope: runtime
+                    delivery: inline
+                    contentType: text/plain; charset=utf-8
+                    content: |
+                      2026-03-25T10:01:13Z runtime Normal Scheduled Successfully assigned sandbox pod
+                      2026-03-25T10:01:14Z runtime Normal Pulled Container image pulled
+                    truncated: false
+                url:
+                  summary: Downloadable runtime event text
+                  value:
+                    sandboxId: sbx_123
+                    kind: events
+                    scope: runtime
+                    delivery: url
+                    contentType: text/plain; charset=utf-8
+                    contentUrl: https://example.com/diagnostics/sbx_123/events.txt
+                    contentLength: 5242880
+                    expiresAt: "2026-04-14T10:30:00Z"
+                    truncated: false
           headers:
             X-Request-ID:
               $ref: '#/components/headers/XRequestId'
@@ -141,8 +173,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '406':
-          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
@@ -227,17 +257,6 @@ components:
       headers:
         X-Request-ID:
           $ref: '#/components/headers/XRequestId'
-    NotAcceptable:
-      description: |
-        Requested media type is not supported by this operation. This version only
-        supports `text/plain` successful responses.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-      headers:
-        X-Request-ID:
-          $ref: '#/components/headers/XRequestId'
     InternalServerError:
       description: An unexpected server error occurred
       content:
@@ -248,6 +267,65 @@ components:
         X-Request-ID:
           $ref: '#/components/headers/XRequestId'
   schemas:
+    DiagnosticContentResponse:
+      type: object
+      description: |
+        Descriptor for diagnostic text content.
+
+        When `delivery` is `inline`, servers MUST include `content` with the
+        diagnostic text and MUST omit `contentUrl` / `expiresAt`.
+
+        When `delivery` is `url`, servers MUST include `contentUrl` and `expiresAt`
+        to identify where the diagnostic text can be downloaded and MUST omit
+        `content`.
+      required: [sandboxId, kind, scope, delivery, contentType, truncated]
+      properties:
+        sandboxId:
+          type: string
+          description: Unique sandbox identifier.
+        kind:
+          type: string
+          description: Diagnostic payload kind.
+          enum: [logs, events]
+        scope:
+          type: string
+          description: Diagnostic scope used for this response.
+        delivery:
+          type: string
+          description: How the diagnostic text payload is delivered.
+          enum: [inline, url]
+        contentType:
+          type: string
+          description: Media type of the diagnostic payload.
+          examples: ["text/plain; charset=utf-8"]
+        content:
+          type: string
+          description: Inline diagnostic text payload. Present when `delivery` is `inline`.
+        contentUrl:
+          type: string
+          format: uri
+          description: URL where the diagnostic text payload can be downloaded. Present when `delivery` is `url`.
+        contentLength:
+          type: integer
+          minimum: 0
+          description: Payload size in bytes when known.
+        expiresAt:
+          type: string
+          format: date-time
+          description: Expiration time for the download URL. Present when `delivery` is `url`.
+        truncated:
+          type: boolean
+          description: |
+            Whether the diagnostic payload returned inline or by URL was
+            intentionally truncated by the server. This does not indicate backend
+            retention gaps such as expired Kubernetes Events; those should be
+            reported through `warnings` when available.
+        warnings:
+          type: array
+          description: Non-fatal warnings about payload completeness or availability.
+          items:
+            type: string
+      additionalProperties: false
     ErrorResponse:
       type: object
       description: |


### PR DESCRIPTION
# Summary
- Refine `specs/diagnostic-api.yml` response design for diagnostics logs and events.
- Change successful responses from raw `text/plain` snapshots to stable `application/json` content descriptors.
- Keep the diagnostic payload itself as display-oriented `text/plain`, delivered in one of two ways:
  - `delivery: inline` with embedded `content`
  - `delivery: url` with `contentUrl` and `expiresAt` for downloading larger payloads
- Keep the API narrow: `/diagnostics/logs` and `/diagnostics/events` still use only the optional `scope` selector.
- Update `specs/README.md` and `specs/README_zh.md` to describe diagnostics as content descriptors rather than direct plain-text snapshots.

# Design Notes
- Returning raw strings directly can be limiting for large diagnostics payloads, especially for SDK consumers.
- The new descriptor shape gives SDKs a stable JSON response while allowing the actual diagnostic text to remain unstructured and display-oriented.
- Large payloads can be delivered through `contentUrl` instead of forcing the server to embed a very large string in the JSON response.
- The response intentionally avoids `oneOf` / discriminator-based polymorphism. This should be easier for Java SDK generation and consumption:
  - one model: `DiagnosticContentResponse`
  - `delivery` indicates whether `content` or `contentUrl` is populated
- `truncated` means the inline or downloadable diagnostic payload was intentionally cut by the server. Backend retention gaps, such as expired Kubernetes Events, should be reported through `warnings` when available instead of using `truncated` alone.
- This still does not define a structured audit or observability model. The text payload is diagnostic material, not a canonical telemetry schema.

# Response Shape
Inline response:

```json
{
  "sandboxId": "sbx_123",
  "kind": "logs",
  "scope": "container",
  "delivery": "inline",
  "contentType": "text/plain; charset=utf-8",
  "content": "2026-03-25T10:01:13Z execd started\n",
  "truncated": false
}
```

URL response:

```json
{
  "sandboxId": "sbx_123",
  "kind": "logs",
  "scope": "container",
  "delivery": "url",
  "contentType": "text/plain; charset=utf-8",
  "contentUrl": "https://example.com/diagnostics/sbx_123/logs.txt",
  "contentLength": 10485760,
  "expiresAt": "2026-04-14T10:30:00Z",
  "truncated": false
}
```

# Testing
- [x] Parsed `specs/diagnostic-api.yml` with Ruby `YAML.load_file`
- [x] `git diff --check` for `specs/diagnostic-api.yml`, `specs/README.md`, and `specs/README_zh.md`
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None for implemented server behavior; the diagnostics spec is not implemented/exposed yet.
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Clearly described motivation
- [x] Added/updated docs
- [ ] Added/updated tests (not needed for spec-only design refinement)
- [x] Security impact considered: large diagnostic payloads can be delivered via expiring URLs instead of embedding everything inline.
- [x] Backward compatibility considered: this refines the newly added diagnostics spec before server/SDK implementation is treated as exposed.
