### PR TITLE
feat(specs): sandbox snapshot specs

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -291,7 +291,10 @@ internal object SandboxModelConverter {
             entrypoint = this.entrypoint,
             expiresAt = this.expiresAt,
             createdAt = this.createdAt,
-            image = this.image.toImageSpec(),
+            image =
+                requireNotNull(this.image) {
+                    "Sandbox image is missing from API response. Snapshot-based sandbox responses are not supported by this SDK yet."
+                }.toImageSpec(),
             platform = this.platform?.toDomainPlatformSpec(),
             status = this.status.toSandboxStatus(),
             metadata = metadata,

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,22 +10,27 @@ This directory contains OpenAPI specification documents for the OpenSandbox proj
 
 **Sandbox Lifecycle Management API**
 
-Defines the complete lifecycle interfaces for creating, managing, and destroying sandbox environments directly from container images.
+Defines the complete lifecycle interfaces for creating, managing, and destroying sandbox environments from container images or snapshots.
 
 **Core Features:**
 - **Sandbox Management**: Create, list, query, and delete sandbox instances with metadata filters and pagination
 - **State Control**: Pause and resume sandbox execution
 - **Lifecycle States**: Supports transitions across Pending → Running → Pausing → Paused → Stopping → Terminated, and error handling with `Failed`
-- **Resource & Runtime Configuration**: Specify CPU/memory/GPU resource limits, required `entrypoint`, environment variables, and opaque `extensions`
+- **Resource & Runtime Configuration**: Specify CPU/memory/GPU resource limits, image startup `entrypoint`, environment variables, and opaque `extensions`
 - **Image Support**: Create sandboxes from public or private registries, including registry auth
 - **Timeout Management**: Mandatory `timeout` on creation with explicit renewal via API
 - **Endpoint Access**: Retrieve public access endpoints for services running inside sandboxes
+- **Snapshot Management**: Create snapshots from sandboxes, list snapshots, and delete snapshots
 
 **Main Endpoints (base path `/v1`):**
-- `POST /sandboxes` - Create a sandbox from an image with timeout and resource limits
+- `POST /sandboxes` - Create a sandbox from an image or snapshot with timeout and resource limits
 - `GET /sandboxes` - List sandboxes with state/metadata filters and pagination
-- `GET /sandboxes/{sandboxId}` - Get full sandbox details (including image and entrypoint)
+- `GET /sandboxes/{sandboxId}` - Get full sandbox details (including startup source and entrypoint)
 - `DELETE /sandboxes/{sandboxId}` - Delete a sandbox
+- `POST /sandboxes/{sandboxId}/snapshots` - Create a snapshot from a sandbox
+- `GET /snapshots` - List snapshots with optional sandbox filtering and pagination
+- `GET /snapshots/{snapshotId}` - Get snapshot state and metadata
+- `DELETE /snapshots/{snapshotId}` - Delete a snapshot
 - `POST /sandboxes/{sandboxId}/pause` - Pause a sandbox (asynchronous)
 - `POST /sandboxes/{sandboxId}/resume` - Resume a paused sandbox
 - `POST /sandboxes/{sandboxId}/renew-expiration` - Renew sandbox expiration (TTL)

--- a/specs/README_zh.md
+++ b/specs/README_zh.md
@@ -10,22 +10,27 @@
 
 **沙箱生命周期管理 API**
 
-定义了沙箱环境的创建、管理和销毁的完整生命周期接口，并可直接从容器镜像启动。
+定义了沙箱环境的创建、管理和销毁的完整生命周期接口，可从容器镜像创建或从快照恢复。
 
 **核心功能：**
 - **沙箱管理**：创建、列表、查询、删除沙箱实例，支持元数据过滤与分页
 - **状态控制**：暂停 (Pause)、恢复 (Resume) 沙箱执行
 - **生命周期**：支持 Pending → Running → Pausing → Paused → Stopping → Terminated，并包含错误态 `Failed`
-- **资源与运行时配置**：指定 CPU/内存/GPU 资源限制、必填 `entrypoint`、环境变量，以及自定义 `extensions`
+- **资源与运行时配置**：指定 CPU/内存/GPU 资源限制、镜像启动 `entrypoint`、环境变量，以及自定义 `extensions`
 - **镜像支持**：从公共或私有镜像仓库创建沙箱，支持私有仓库认证
 - **超时管理**：创建时必填 `timeout`，并可通过 API 续期
 - **端点访问**：获取沙箱内服务的公共访问端点
+- **快照管理**：从沙箱创建快照、列出快照、删除快照
 
 **主要端点（基础路径 `/v1`）：**
-- `POST /sandboxes` - 从镜像创建沙箱，设置超时与资源限制
+- `POST /sandboxes` - 从镜像或快照创建沙箱，设置超时与资源限制
 - `GET /sandboxes` - 列出沙箱，支持状态/元数据过滤与分页
-- `GET /sandboxes/{sandboxId}` - 获取完整沙箱详情（包含镜像与 entrypoint）
+- `GET /sandboxes/{sandboxId}` - 获取完整沙箱详情（包含启动来源与 entrypoint）
 - `DELETE /sandboxes/{sandboxId}` - 删除沙箱
+- `POST /sandboxes/{sandboxId}/snapshots` - 从沙箱创建快照
+- `GET /snapshots` - 列出快照，支持按沙箱过滤与分页
+- `GET /snapshots/{snapshotId}` - 获取快照状态与元数据
+- `DELETE /snapshots/{snapshotId}` - 删除快照
 - `POST /sandboxes/{sandboxId}/pause` - 异步暂停沙箱
 - `POST /sandboxes/{sandboxId}/resume` - 恢复已暂停的沙箱
 - `POST /sandboxes/{sandboxId}/renew-expiration` - 续期沙箱 TTL

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -5,8 +5,8 @@ info:
   description: |
     The Sandbox Lifecycle API coordinates how untrusted workloads are created,
     executed, paused, resumed, and finally disposed. This specification focuses on
-    the primary lifecycle flows for the `sandbox` domain concept. Sandboxes are
-    provisioned directly from container images without requiring pre-created templates.
+    the primary lifecycle flows for the `sandbox` domain concept. Sandboxes can
+    be provisioned directly from container images or restored from snapshots.
 
     ## Sandbox Lifecycle
 
@@ -44,6 +44,8 @@ security:
 tags:
   - name: Sandboxes
     description: Provision and transition sandboxes through their lifecycle
+  - name: Snapshots
+    description: Create, list, and delete persistent sandbox snapshots
 paths:
   /sandboxes:
     get:
@@ -104,11 +106,19 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Sandboxes]
-      summary: Create a sandbox from a container image
+      summary: Create a sandbox
       description: |
-        Creates a new sandbox from a container image with optional resource limits,
-        environment variables, and metadata. Sandboxes are provisioned directly from
-        the specified image without requiring a pre-created template.
+        Creates a new sandbox from a container image or restores one from a
+        persistent sandbox snapshot with optional resource limits, environment
+        variables, and metadata.
+
+        Exactly one startup source must be provided:
+        - `image` to provision directly from a container image.
+        - `snapshotId` to restore from a previously created snapshot.
+
+        When `image` is provided, `entrypoint` is required. When `snapshotId` is
+        provided, `entrypoint` must be omitted because the restored snapshot carries
+        its startup process.
 
         ## Authentication
 
@@ -163,6 +173,14 @@ paths:
                     cpu: "500m"
                     memory: "512Mi"
                   entrypoint: ["python", "/app/main.py"]
+              restore-snapshot:
+                summary: Restore from a snapshot
+                value:
+                  snapshotId: snap_123
+                  timeout: 3600
+                  resourceLimits:
+                    cpu: "500m"
+                    memory: "512Mi"
       responses:
         '202':
           description: |
@@ -170,15 +188,15 @@ paths:
 
             The returned sandbox includes:
             - `id`: Unique sandbox identifier
-            - `status.state: "Pending"` (auto-starting provisioning)
+            - `status.state: "Pending"` (auto-starting provisioning or restore)
             - `status.reason` and `status.message` indicating initialization stage
             - `metadata`, `expiresAt`, `createdAt`: Core sandbox information
 
-            Note: `image` and `updatedAt` are not included in the create response.
-            Use GET /sandboxes/{sandboxId} to retrieve the complete sandbox information including image spec.
+            Note: startup source details and `updatedAt` are not included in the create response.
+            Use GET /sandboxes/{sandboxId} to retrieve the complete sandbox information.
 
             To track provisioning progress, poll GET /sandboxes/{sandboxId}.
-            The sandbox will automatically transition to `Running` state once provisioning completes.
+            The sandbox will automatically transition to `Running` state once provisioning or restore completes.
           content:
             application/json:
               schema:
@@ -196,6 +214,103 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /snapshots:
+    get:
+      tags: [Snapshots]
+      summary: List snapshots
+      description: |
+        List all snapshots with optional filtering and pagination using query parameters.
+        Snapshots are persistent captures of sandbox state and may outlive the source sandbox.
+      parameters:
+        - name: sandboxId
+          in: query
+          description: Filter snapshots by source sandbox identifier
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: |
+            Filter by snapshot lifecycle state. Pass multiple times for OR logic.
+            Example: `?state=Ready&state=Failed`
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SnapshotState'
+          style: form
+          explode: true
+        - name: page
+          in: query
+          description: Page number for pagination
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          description: Number of items per page
+          schema:
+            type: integer
+            minimum: 1
+            default: 20
+      responses:
+        '200':
+          description: Paginated collection of snapshots
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSnapshotsResponse'
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /snapshots/{snapshotId}:
+    parameters:
+      - $ref: '#/components/parameters/SnapshotId'
+    get:
+      tags: [Snapshots]
+      summary: Fetch a snapshot by id
+      description: Returns snapshot state and metadata.
+      responses:
+        '200':
+          description: Snapshot current state and metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags: [Snapshots]
+      summary: Delete a snapshot
+      description: Delete a persistent sandbox snapshot by id.
+      responses:
+        '204':
+          description: Snapshot successfully deleted
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /sandboxes/{sandboxId}:
     parameters:
       - $ref: '#/components/parameters/SandboxId'
@@ -205,7 +320,7 @@ paths:
       description: |
         Returns the complete sandbox information including:
         - `id`, `status`, `metadata`, `expiresAt`, `createdAt`: Core information
-        - `image`: Container image specification (not included in create response)
+        - `image` or `snapshotId`: Startup source information (not included in create response)
         - `entrypoint`: Entry process specification
 
         This is the complete representation of the sandbox resource.
@@ -240,6 +355,59 @@ paths:
           headers:
             X-Request-ID:
               $ref: '#/components/headers/XRequestId'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /sandboxes/{sandboxId}/snapshots:
+    post:
+      tags: [Snapshots]
+      summary: Create a snapshot from a sandbox
+      description: |
+        Create a persistent point-in-time snapshot from the sandbox's current state.
+        The returned snapshot id identifies the created artifact. Snapshot creation may
+        temporarily pause the sandbox while the runtime captures provider-supported state.
+      parameters:
+        - $ref: '#/components/parameters/SandboxId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSnapshotRequest'
+            examples:
+              default:
+                summary: Create an unnamed snapshot
+                value: {}
+              named:
+                summary: Create a named snapshot
+                value:
+                  name: checkpoint-before-import
+      responses:
+        '202':
+          description: |
+            Snapshot creation accepted.
+
+            The returned snapshot includes `status.state: "Creating"`.
+            Poll GET /snapshots/{snapshotId} to track progress until the snapshot
+            transitions to `Ready` or `Failed`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestId'
+            Location:
+              $ref: '#/components/headers/Location'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -405,6 +573,13 @@ components:
       description: Unique sandbox identifier
       schema:
         type: string
+    SnapshotId:
+      name: snapshotId
+      in: path
+      required: true
+      description: Unique snapshot identifier
+      schema:
+        type: string
   headers:
     XRequestId:
       description: Unique request identifier for tracing
@@ -493,6 +668,16 @@ components:
         pagination:
           $ref: '#/components/schemas/PaginationInfo'
       required: [items, pagination]
+    ListSnapshotsResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Snapshot'
+        pagination:
+          $ref: '#/components/schemas/PaginationInfo'
+      required: [items, pagination]
     PaginationInfo:
       type: object
       description: Pagination metadata for list responses
@@ -519,7 +704,7 @@ components:
       required: [page, pageSize, totalItems, totalPages, hasNextPage]
     CreateSandboxResponse:
       type: object
-      description: Response from creating a new sandbox. Contains essential information without image and updatedAt.
+      description: Response from creating a new sandbox. Contains essential information without startup source details and updatedAt.
       properties:
         id:
           type: string
@@ -555,7 +740,10 @@ components:
           type: array
           items:
             type: string
-          description: Entry process specification from creation request
+          description: |
+            Entry process specification for the sandbox. For image-created sandboxes,
+            this is copied from the creation request. For snapshot-created sandboxes,
+            this is restored from the snapshot.
 
       required:
         - id
@@ -563,9 +751,90 @@ components:
         - createdAt
         - entrypoint
 
+    CreateSnapshotRequest:
+      type: object
+      description: Optional settings for creating a sandbox snapshot.
+      properties:
+        name:
+          type: string
+          description: Optional human-readable snapshot name.
+          minLength: 1
+      additionalProperties: false
+
+    Snapshot:
+      type: object
+      description: Persistent point-in-time capture of a sandbox.
+      properties:
+        id:
+          type: string
+          description: Unique snapshot identifier
+
+        sandboxId:
+          type: string
+          description: Source sandbox identifier used to create this snapshot
+
+        name:
+          type: string
+          description: Optional human-readable snapshot name
+
+        status:
+          $ref: '#/components/schemas/SnapshotStatus'
+          description: Current snapshot lifecycle status and detailed state information
+
+        createdAt:
+          type: string
+          format: date-time
+          description: Snapshot creation timestamp
+
+      required:
+        - id
+        - sandboxId
+        - status
+        - createdAt
+      additionalProperties: false
+
+    SnapshotState:
+      type: string
+      description: |
+        Snapshot lifecycle state.
+
+        Common state values:
+        - Creating: Snapshot creation has been accepted and runtime capture is in progress.
+        - Ready: Snapshot is available for restoring sandboxes.
+        - Failed: Snapshot creation failed.
+
+        Note: New state values may be added in future versions.
+        Clients should handle unknown state values gracefully.
+
+    SnapshotStatus:
+      type: object
+      description: Detailed snapshot status information with lifecycle state and transition details.
+      properties:
+        state:
+          $ref: '#/components/schemas/SnapshotState'
+          description: Current lifecycle state of the snapshot
+
+        reason:
+          type: string
+          description: |
+            Short machine-readable reason code for the current state.
+            Examples: "snapshot_accepted", "snapshot_ready", "snapshot_capture_failed"
+
+        message:
+          type: string
+          description: Human-readable message describing the current state or failure reason
+
+        lastTransitionAt:
+          type: string
+          format: date-time
+          description: Timestamp of the last state transition
+
+      required: [state]
+      additionalProperties: false
+
     Sandbox:
       type: object
-      description: Runtime execution environment provisioned from a container image
+      description: Runtime execution environment provisioned from a container image or restored from a snapshot
       properties:
         id:
           type: string
@@ -575,7 +844,15 @@ components:
           $ref: '#/components/schemas/ImageSpec'
           description: |
             Container image specification used to provision this sandbox.
-            Only present in responses for GET/LIST operations. Not returned in createSandbox response.
+            Present when the sandbox was created directly from a container image.
+            Not returned in createSandbox response.
+
+        snapshotId:
+          type: string
+          description: |
+            Snapshot identifier used to restore this sandbox.
+            Present when the sandbox was restored from a snapshot.
+            Not returned in createSandbox response.
 
         platform:
           $ref: '#/components/schemas/PlatformSpec'
@@ -599,7 +876,9 @@ components:
             type: string
           description: |
             The command to execute as the sandbox's entry process.
-            Always present in responses since entrypoint is required in creation requests.
+            Always present in responses. For image-created sandboxes, this is copied
+            from the creation request. For snapshot-created sandboxes, this is restored
+            from the snapshot.
 
         expiresAt:
           type: string
@@ -616,7 +895,6 @@ components:
         - status
         - createdAt
         - entrypoint
-        - image
     SandboxState:
       type: string
       description: |
@@ -728,15 +1006,28 @@ components:
       additionalProperties: false
     CreateSandboxRequest:
       type: object
-      required: [image, resourceLimits, entrypoint]
+      required: [resourceLimits]
       description: |
-        Request to create a new sandbox from a container image.
+        Request to create a new sandbox from either a container image or a snapshot.
+        Exactly one of `image` or `snapshotId` must be provided.
+
+        When `image` is provided, `entrypoint` is required. When `snapshotId` is
+        provided, `entrypoint` must be omitted because the restored snapshot carries
+        its startup process.
 
         **Note**: API Key authentication is required via the `OPEN-SANDBOX-API-KEY` header.
       properties:
         image:
           $ref: '#/components/schemas/ImageSpec'
-          description: Container image specification for the sandbox
+          description: |
+            Container image specification for the sandbox.
+            Mutually exclusive with `snapshotId`.
+
+        snapshotId:
+          type: string
+          description: |
+            Snapshot identifier to restore from.
+            Mutually exclusive with `image`.
 
         platform:
           $ref: '#/components/schemas/PlatformSpec'
@@ -795,7 +1086,10 @@ components:
             type: string
           minItems: 1
           description: |
-            The command to execute as the sandbox's entry process (required).
+            The command to execute as the sandbox's entry process.
+
+            Required when `image` is provided. Must be omitted when `snapshotId`
+            is provided because the restored snapshot carries its startup process.
 
             Explicitly specifies the user's expected main process, allowing the sandbox management
             service to reliably inject control processes before executing this command.


### PR DESCRIPTION
# Summary
- Add sandbox snapshot APIs to the lifecycle spec:
  - `POST /sandboxes/{sandboxId}/snapshots` creates a snapshot and returns its snapshot id.
  - `GET /snapshots` lists snapshots with optional `sandboxId` filtering and pagination.
  - `DELETE /snapshots/{snapshotId}` deletes a snapshot.
- Extend `POST /sandboxes` so a sandbox can be created either from `image` or restored from `snapshotId`.
  - Exactly one of `image` or `snapshotId` must be provided.
  - `entrypoint` is required for image-based creation.
  - `entrypoint` must be omitted for snapshot-based creation because the snapshot carries the startup process.
- Update `Sandbox` response shape so the startup source can be represented by either `image` or `snapshotId`.
- Update English and Chinese specs README endpoint summaries.

# Testing
- [x] Not run (spec/docs contract update only; server and SDK implementations are not included in this PR)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

Notes:
- This is intended as an additive wire-contract change. Existing image-based sandbox creation remains supported.
- Server-side validation should enforce the conditional request rules (`image` xor `snapshotId`, and `entrypoint` only for image-based creation).
- SDK regeneration/handwritten adapter updates are follow-up work; object-level `oneOf` is intentionally avoided to keep generated SDK models simple, especially for Kotlin.
- Expected SDK follow-up: expose snapshot management through `SandboxManager`, including creating a snapshot from a sandbox, listing snapshots, deleting snapshots, and creating/restoring a sandbox from `snapshotId`.
- Expected server follow-up: add persistent snapshot storage, persist snapshot objects, and maintain a `snapshotId` to snapshot runtime configuration mapping so restore requests can resolve the correct runtime artifact/configuration.
