### PR TITLE
perf(egress): precompile domain rule index for fast Evaluate while preserving first-match semantics

### DIFF
--- a/components/egress/pkg/policy/domain_index.go
+++ b/components/egress/pkg/policy/domain_index.go
@@ -71,6 +71,9 @@ func (idx *compiledDomainIndex) match(domain string) (string, bool) {
 	matched := false
 
 	if rule, ok := idx.exact[domain]; ok {
+		if rule.index == 0 {
+			return rule.action, true
+		}
 		best = rule
 		matched = true
 	}
@@ -82,6 +85,9 @@ func (idx *compiledDomainIndex) match(domain string) (string, bool) {
 		}
 		suffix := cursor[dot:]
 		if rule, ok := idx.wildcard[suffix]; ok {
+			if rule.index == 0 {
+				return rule.action, true
+			}
 			if !matched || rule.index < best.index {
 				best = rule
 				matched = true

--- a/components/egress/pkg/policy/domain_index.go
+++ b/components/egress/pkg/policy/domain_index.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import "strings"
+
+// compiledDomainRule stores the original egress order and effective action.
+// The smallest index wins to preserve "first match wins" semantics.
+type compiledDomainRule struct {
+	index  int
+	action string
+}
+
+// compiledDomainIndex accelerates domain evaluate while preserving rule order semantics.
+// - exact holds exact-domain patterns (e.g. "api.example.com")
+// - wildcard holds wildcard suffix patterns (e.g. ".example.com" for "*.example.com")
+type compiledDomainIndex struct {
+	exact    map[string]compiledDomainRule
+	wildcard map[string]compiledDomainRule
+}
+
+func compileDomainIndex(egress []EgressRule) *compiledDomainIndex {
+	idx := &compiledDomainIndex{
+		exact:    make(map[string]compiledDomainRule),
+		wildcard: make(map[string]compiledDomainRule),
+	}
+	for i, r := range egress {
+		if r.targetKind != targetDomain {
+			continue
+		}
+		pattern := strings.ToLower(strings.TrimSpace(r.Target))
+		if pattern == "" {
+			continue
+		}
+		cr := compiledDomainRule{
+			index:  i,
+			action: r.Action,
+		}
+		if strings.HasPrefix(pattern, "*.") {
+			suffix := strings.TrimPrefix(pattern, "*")
+			if _, exists := idx.wildcard[suffix]; !exists {
+				idx.wildcard[suffix] = cr
+			}
+			continue
+		}
+		if _, exists := idx.exact[pattern]; !exists {
+			idx.exact[pattern] = cr
+		}
+	}
+	return idx
+}
+
+func (idx *compiledDomainIndex) match(domain string) (string, bool) {
+	if idx == nil || domain == "" {
+		return "", false
+	}
+
+	var best compiledDomainRule
+	matched := false
+
+	if rule, ok := idx.exact[domain]; ok {
+		best = rule
+		matched = true
+	}
+
+	for cursor := domain; ; {
+		dot := strings.IndexByte(cursor, '.')
+		if dot < 0 {
+			break
+		}
+		suffix := cursor[dot:]
+		if rule, ok := idx.wildcard[suffix]; ok {
+			if !matched || rule.index < best.index {
+				best = rule
+				matched = true
+			}
+		}
+		cursor = cursor[dot+1:]
+	}
+
+	if !matched {
+		return "", false
+	}
+	return best.action, true
+}

--- a/components/egress/pkg/policy/evaluate_benchmark_test.go
+++ b/components/egress/pkg/policy/evaluate_benchmark_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// BenchmarkEvaluateLinearMiss benchmarks the linear evaluation of a domain that is not present in the policy.
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/alibaba/opensandbox/egress/pkg/policy
+// cpu: Apple M2 Pro
+// BenchmarkEvaluateLinearMiss
+// BenchmarkEvaluateLinearMiss/rules_500
+// BenchmarkEvaluateLinearMiss/rules_500-10         	   54367	     21454 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkEvaluateLinearMiss/rules_1000
+// BenchmarkEvaluateLinearMiss/rules_1000-10        	   27912	     42489 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkEvaluateLinearMiss/rules_10000
+// BenchmarkEvaluateLinearMiss/rules_10000-10       	    2684	    446589 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkEvaluateLinearMiss(b *testing.B) {
+	for _, ruleCount := range []int{500, 1000, 10000} {
+		b.Run(fmt.Sprintf("rules_%d", ruleCount), func(b *testing.B) {
+			p := buildDomainOnlyPolicy(ruleCount, false)
+			query := "not-found.example.com."
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = p.evaluateLinear(strings.TrimSuffix(strings.ToLower(query), "."))
+			}
+		})
+	}
+}
+
+// BenchmarkEvaluateCompiledIndexMiss benchmarks the compiled evaluation of a domain that is not present in the policy.
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/alibaba/opensandbox/egress/pkg/policy
+// cpu: Apple M2 Pro
+// BenchmarkEvaluateCompiledIndexMiss
+// BenchmarkEvaluateCompiledIndexMiss/rules_500
+// BenchmarkEvaluateCompiledIndexMiss/rules_500-10         	25609082	        45.57 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkEvaluateCompiledIndexMiss/rules_1000
+// BenchmarkEvaluateCompiledIndexMiss/rules_1000-10        	26226450	        46.85 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkEvaluateCompiledIndexMiss/rules_10000
+// BenchmarkEvaluateCompiledIndexMiss/rules_10000-10       	26390857	        45.27 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkEvaluateCompiledIndexMiss(b *testing.B) {
+	for _, ruleCount := range []int{500, 1000, 10000} {
+		b.Run(fmt.Sprintf("rules_%d", ruleCount), func(b *testing.B) {
+			p := buildDomainOnlyPolicy(ruleCount, true)
+			query := "not-found.example.com."
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = p.Evaluate(query)
+			}
+		})
+	}
+}
+
+func buildDomainOnlyPolicy(ruleCount int, compiled bool) *NetworkPolicy {
+	egress := make([]EgressRule, 0, ruleCount)
+	for i := 0; i < ruleCount; i++ {
+		egress = append(egress, EgressRule{
+			Action:     ActionAllow,
+			Target:     fmt.Sprintf("rule-%d.example.com", i),
+			targetKind: targetDomain,
+		})
+	}
+	p := &NetworkPolicy{
+		Egress:        egress,
+		DefaultAction: ActionDeny,
+	}
+	if compiled {
+		return ensureDefaults(p)
+	}
+	return p
+}

--- a/components/egress/pkg/policy/policy.go
+++ b/components/egress/pkg/policy/policy.go
@@ -38,14 +38,18 @@ const (
 
 // DefaultDenyPolicy returns a new policy that denies all traffic.
 func DefaultDenyPolicy() *NetworkPolicy {
-	return &NetworkPolicy{DefaultAction: ActionDeny}
+	return &NetworkPolicy{
+		DefaultAction: ActionDeny,
+		domainIndex:   compileDomainIndex(nil),
+	}
 }
 
 // NetworkPolicy is the minimal MVP shape for egress control.
-// Only domain/wildcard targets are honored in this MVP.
 type NetworkPolicy struct {
 	Egress        []EgressRule `json:"egress"`
 	DefaultAction string       `json:"defaultAction"`
+
+	domainIndex *compiledDomainIndex
 }
 
 type EgressRule struct {
@@ -81,21 +85,39 @@ func (p *NetworkPolicy) Evaluate(domain string) string {
 		return ActionDeny
 	}
 	domain = strings.ToLower(strings.TrimSuffix(domain, "."))
-	for _, r := range p.Egress {
-		if r.targetKind != targetDomain {
-			continue
-		}
-		if r.matchesDomain(domain) {
-			if r.Action == "" {
+
+	if p.domainIndex != nil {
+		if action, ok := p.domainIndex.match(domain); ok {
+			if action == "" {
 				return ActionDeny
 			}
-			return r.Action
+			return action
+		}
+	} else {
+		// Keep compatibility for policies built manually without ParsePolicy/ensureDefaults.
+		if action, ok := p.evaluateLinear(domain); ok {
+			return action
 		}
 	}
 	if p.DefaultAction == "" {
 		return ActionDeny
 	}
 	return p.DefaultAction
+}
+
+func (p *NetworkPolicy) evaluateLinear(domain string) (string, bool) {
+	for _, r := range p.Egress {
+		if r.targetKind != targetDomain {
+			continue
+		}
+		if r.matchesDomain(domain) {
+			if r.Action == "" {
+				return ActionDeny, true
+			}
+			return r.Action, true
+		}
+	}
+	return "", false
 }
 
 // ensureDefaults guarantees a policy always has a default action.
@@ -106,6 +128,7 @@ func ensureDefaults(p *NetworkPolicy) *NetworkPolicy {
 	if p.DefaultAction == "" {
 		p.DefaultAction = ActionDeny
 	}
+	p.domainIndex = compileDomainIndex(p.Egress)
 	return p
 }
 

--- a/components/egress/pkg/policy/policy_test.go
+++ b/components/egress/pkg/policy/policy_test.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -104,4 +105,66 @@ func TestWithExtraAllowIPs(t *testing.T) {
 	// nil/empty ips returns same policy
 	require.Same(t, p, p.WithExtraAllowIPs(nil), "WithExtraAllowIPs(nil) should return same policy")
 	require.Same(t, p, p.WithExtraAllowIPs([]netip.Addr{}), "WithExtraAllowIPs([]) should return same policy")
+}
+
+func TestEvaluate_CompiledIndexMatchesLinear(t *testing.T) {
+	p, err := ParsePolicy(`{
+		"defaultAction":"deny",
+		"egress":[
+			{"action":"allow","target":"*.example.com"},
+			{"action":"deny","target":"api.example.com"},
+			{"action":"allow","target":"*.internal.example.com"},
+			{"action":"deny","target":"10.0.0.1"},
+			{"action":"allow","target":"10.0.0.0/24"}
+		]
+	}`)
+	require.NoError(t, err)
+	require.NotNil(t, p.domainIndex, "parsed policy should build compiled domain index")
+
+	queries := []string{
+		"api.example.com.",
+		"www.example.com.",
+		"a.internal.example.com.",
+		"internal.example.com.",
+		"unknown.test.",
+	}
+	for _, q := range queries {
+		got := p.Evaluate(q)
+		want, matched := p.evaluateLinear(normalizeQueryForTest(q))
+		if !matched {
+			want = p.DefaultAction
+		}
+		require.Equalf(t, want, got, "compiled evaluate mismatch for query=%s", q)
+	}
+}
+
+func TestEvaluate_ManualPolicyFallsBackToLinear(t *testing.T) {
+	manual := &NetworkPolicy{
+		DefaultAction: ActionDeny,
+		Egress: []EgressRule{
+			{Action: ActionAllow, Target: "*.example.com", targetKind: targetDomain},
+			{Action: ActionDeny, Target: "api.example.com", targetKind: targetDomain},
+		},
+	}
+	require.Nil(t, manual.domainIndex, "manual policy intentionally skips compile")
+	require.Equal(t, ActionAllow, manual.Evaluate("api.example.com."))
+	require.Equal(t, ActionAllow, manual.Evaluate("www.example.com."))
+	require.Equal(t, ActionDeny, manual.Evaluate("unknown.example."))
+}
+
+func TestEvaluate_CompiledIndexKeepsFirstMatchPriority(t *testing.T) {
+	p := &NetworkPolicy{
+		DefaultAction: ActionDeny,
+		Egress: []EgressRule{
+			{Action: ActionAllow, Target: "*.example.com", targetKind: targetDomain},
+			{Action: ActionDeny, Target: "api.example.com", targetKind: targetDomain},
+		},
+	}
+	p = ensureDefaults(p)
+	require.NotNil(t, p.domainIndex)
+	require.Equal(t, ActionAllow, p.Evaluate("api.example.com."))
+}
+
+func normalizeQueryForTest(domain string) string {
+	return strings.ToLower(strings.TrimSuffix(domain, "."))
 }


### PR DESCRIPTION
# Summary
- Compile domain/wildcard egress rules into an internal index at policy build time and use it in Evaluate to avoid linear scans on hot DNS paths.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered