### PR TITLE
fix(execd): expand env before file read/stat

### DIFF
--- a/components/execd/pkg/runtime/bash_session.go
+++ b/components/execd/pkg/runtime/bash_session.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 const (
@@ -44,14 +45,18 @@ const (
 )
 
 func (c *Controller) createBashSession(req *CreateContextRequest) (string, error) {
-	if req.Cwd != "" {
-		err := os.MkdirAll(req.Cwd, os.ModePerm)
+	resolvedCwd, err := pathutil.ExpandPath(req.Cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve request cwd %s: %w", req.Cwd, err)
+	}
+	if resolvedCwd != "" {
+		err := os.MkdirAll(resolvedCwd, os.ModePerm)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	session := newBashSession(req.Cwd)
+	session := newBashSession(resolvedCwd)
 	if err := session.start(); err != nil {
 		return "", fmt.Errorf("failed to start bash session: %w", err)
 	}
@@ -163,7 +168,12 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 	cwd := s.cwd
 	// override original cwd if specified
 	if request.Cwd != "" {
-		cwd = request.Cwd
+		expandedCwd, err := pathutil.ExpandPath(request.Cwd)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("resolve cwd: %w", err)
+		}
+		cwd = expandedCwd
 	}
 	sessionID := s.config.Session
 	s.mu.Unlock()

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 // getShell returns the preferred shell, falling back to sh if bash is not available.
@@ -107,6 +108,10 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	log.Info("received command: %v", request.Code)
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
+	cwd, err := pathutil.ExpandPath(request.Cwd)
+	if err != nil {
+		return fmt.Errorf("resolve request cwd %s: %w", request.Cwd, err)
+	}
 
 	// Configure credentials and process group
 	cred, err := buildCredential(request.Uid, request.Gid)
@@ -122,7 +127,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	cmd.Stderr = stderr
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
-	cmd.Dir = request.Cwd
+	cmd.Dir = cwd
 
 	done := make(chan struct{}, 1)
 	var wg sync.WaitGroup
@@ -238,11 +243,17 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	log.Info("received command: %v", request.Code)
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
-	cmd.Dir = request.Cwd
+	cwd, err := pathutil.ExpandPath(request.Cwd)
+	if err != nil {
+		cancel()
+		return fmt.Errorf("resolve cwd: %w", err)
+	}
+	cmd.Dir = cwd
 	// Configure credentials and process group
 	cred, err := buildCredential(request.Uid, request.Gid)
 	if err != nil {
-		log.Error("failed to build credentials: %v", err)
+		cancel()
+		return fmt.Errorf("build credential: %w", err)
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid:    true,

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -108,7 +108,8 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	log.Info("received command: %v", request.Code)
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
-	cwd, err := pathutil.ExpandPath(request.Cwd)
+	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
+	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
 		return fmt.Errorf("resolve request cwd %s: %w", request.Cwd, err)
 	}
@@ -125,7 +126,6 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
 	cmd.Dir = cwd
 
@@ -243,7 +243,8 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	log.Info("received command: %v", request.Code)
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
-	cwd, err := pathutil.ExpandPath(request.Cwd)
+	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
+	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
 		cancel()
 		return fmt.Errorf("resolve cwd: %w", err)
@@ -262,7 +263,6 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 
 	cmd.Stdout = pipe
 	cmd.Stderr = pipe
-	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
 
 	// use DevNull as stdin so interactive programs exit immediately.

--- a/components/execd/pkg/runtime/command_test.go
+++ b/components/execd/pkg/runtime/command_test.go
@@ -274,6 +274,69 @@ func TestRunCommand_ExpandsHomeInCwd(t *testing.T) {
 	require.True(t, found, "pwd output does not match expected cwd; got=%v target=%s", stdoutLines, target)
 }
 
+func TestRunCommand_ExpandsCwdFromRequestEnvWithHigherPriority(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("bash not available on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+
+	processDir := t.TempDir()
+	requestDir := t.TempDir()
+	t.Setenv("WORKDIR", processDir)
+
+	c := NewController("", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		stdoutLines []string
+		gotErr      *execute.ErrorOutput
+	)
+	req := &ExecuteCodeRequest{
+		Code:    `pwd`,
+		Cwd:     `$WORKDIR`,
+		Timeout: 5 * time.Second,
+		Envs: map[string]string{
+			"WORKDIR": requestDir,
+		},
+		Hooks: ExecuteResultHook{
+			OnExecuteInit:   func(_ string) {},
+			OnExecuteStdout: func(s string) { stdoutLines = append(stdoutLines, s) },
+			OnExecuteStderr: func(_ string) {},
+			OnExecuteError: func(err *execute.ErrorOutput) {
+				gotErr = err
+			},
+			OnExecuteComplete: func(_ time.Duration) {},
+		},
+	}
+
+	require.NoError(t, c.runCommand(ctx, req))
+	require.Nil(t, gotErr, "expected cwd expansion to use request env")
+
+	requestRealPath, err := filepath.EvalSymlinks(requestDir)
+	require.NoError(t, err)
+	requestRealPath = filepath.Clean(requestRealPath)
+
+	found := false
+	for _, line := range stdoutLines {
+		p := strings.TrimSpace(line)
+		if p == "" {
+			continue
+		}
+		pRealPath, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			continue
+		}
+		if filepath.Clean(pRealPath) == requestRealPath {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "pwd output does not match request env cwd; got=%v requestDir=%s", stdoutLines, requestDir)
+}
+
 func TestRunCommand_StartErrorIncludesTraceback(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("bash not available on windows")

--- a/components/execd/pkg/runtime/command_test.go
+++ b/components/execd/pkg/runtime/command_test.go
@@ -216,6 +216,64 @@ func TestRunCommand_Error(t *testing.T) {
 	require.Equal(t, "3", gotErr.EValue)
 }
 
+func TestRunCommand_ExpandsHomeInCwd(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("bash not available on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+
+	home := t.TempDir()
+	target := filepath.Join(home, "workspace")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	c := NewController("", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var stdoutLines []string
+	req := &ExecuteCodeRequest{
+		Code:    `pwd`,
+		Cwd:     "~/workspace",
+		Timeout: 5 * time.Second,
+		Hooks: ExecuteResultHook{
+			OnExecuteInit:   func(_ string) {},
+			OnExecuteStdout: func(s string) { stdoutLines = append(stdoutLines, s) },
+			OnExecuteStderr: func(_ string) {},
+			OnExecuteError: func(err *execute.ErrorOutput) {
+				require.Failf(t, "unexpected error hook", "%+v", err)
+			},
+			OnExecuteComplete: func(_ time.Duration) {},
+		},
+	}
+
+	require.NoError(t, c.runCommand(ctx, req))
+
+	targetRealPath, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+	targetRealPath = filepath.Clean(targetRealPath)
+
+	found := false
+	for _, line := range stdoutLines {
+		p := strings.TrimSpace(line)
+		if p == "" {
+			continue
+		}
+		pRealPath, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			continue
+		}
+		if filepath.Clean(pRealPath) == targetRealPath {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "pwd output does not match expected cwd; got=%v target=%s", stdoutLines, target)
+}
+
 func TestRunCommand_StartErrorIncludesTraceback(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("bash not available on windows")

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/internal/safego"
 )
 
@@ -44,10 +45,14 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
+	cwd, err := pathutil.ExpandPath(request.Cwd)
+	if err != nil {
+		return fmt.Errorf("resolve cwd: %w", err)
+	}
 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	cmd.Dir = request.Cwd
+	cmd.Dir = cwd
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
 
@@ -118,8 +123,12 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
+	cwd, err := pathutil.ExpandPath(request.Cwd)
+	if err != nil {
+		return fmt.Errorf("resolve cwd: %w", err)
+	}
 
-	cmd.Dir = request.Cwd
+	cmd.Dir = cwd
 	cmd.Stdout = pipe
 	cmd.Stderr = pipe
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -45,7 +45,8 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
-	cwd, err := pathutil.ExpandPath(request.Cwd)
+	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
+	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
 		return fmt.Errorf("resolve cwd: %w", err)
 	}
@@ -53,7 +54,6 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Dir = cwd
-	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
 
 	done := make(chan struct{}, 1)
@@ -123,7 +123,8 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	startAt := time.Now()
 	log.Info("received command: %v", request.Code)
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
-	cwd, err := pathutil.ExpandPath(request.Cwd)
+	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
+	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
 		return fmt.Errorf("resolve cwd: %w", err)
 	}
@@ -131,7 +132,6 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	cmd.Dir = cwd
 	cmd.Stdout = pipe
 	cmd.Stderr = pipe
-	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
 
 	devNull, _ := os.OpenFile(os.DevNull, os.O_RDWR, 0) // best-effort, ignore error

--- a/components/execd/pkg/runtime/context.go
+++ b/components/execd/pkg/runtime/context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter"
 	jupytersession "github.com/alibaba/opensandbox/execd/pkg/jupyter/session"
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 // CreateContext provisions a kernel-backed session and returns its ID.
@@ -129,14 +130,18 @@ func (c *Controller) newContextID() string {
 }
 
 func (c *Controller) newIpynbPath(sessionID, cwd string) (string, error) {
+	resolvedCwd, err := pathutil.ExpandPath(cwd)
+	if err != nil {
+		return "", err
+	}
 	if cwd != "" {
-		err := os.MkdirAll(cwd, os.ModePerm)
+		err := os.MkdirAll(resolvedCwd, os.ModePerm)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	return filepath.Join(cwd, fmt.Sprintf("%s.ipynb", sessionID)), nil
+	return filepath.Join(resolvedCwd, fmt.Sprintf("%s.ipynb", sessionID)), nil
 }
 
 // createDefaultLanguageJupyterContext prewarms a session for stateless execution.

--- a/components/execd/pkg/runtime/context_test.go
+++ b/components/execd/pkg/runtime/context_test.go
@@ -70,6 +70,17 @@ func TestNewIpynbPath_ErrorWhenCwdIsFile(t *testing.T) {
 	require.Error(t, err, "expected error when cwd is a file")
 }
 
+func TestNewIpynbPath_ExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	c := NewController("", "")
+	path, err := c.newIpynbPath("abc", "~/workspace")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "workspace", "abc.ipynb"), path)
+}
+
 func TestListContextUnsupportedLanguage(t *testing.T) {
 	c := NewController("", "")
 	_, err := c.ListContext(Command.String())

--- a/components/execd/pkg/runtime/env.go
+++ b/components/execd/pkg/runtime/env.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 // loadExtraEnvFromFile reads key=value lines from EXECD_ENVS (if set).
@@ -29,10 +30,15 @@ func loadExtraEnvFromFile() map[string]string {
 	if path == "" {
 		return nil
 	}
-
-	data, err := os.ReadFile(path)
+	resolvedPath, err := pathutil.ExpandPath(path)
 	if err != nil {
-		log.Warn("EXECD_ENVS: failed to read file %s: %v", path, err)
+		log.Warn("EXECD_ENVS: failed to resolve file path %s: %v", path, err)
+		return nil
+	}
+
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		log.Warn("EXECD_ENVS: failed to read file %s: %v", resolvedPath, err)
 		return nil
 	}
 

--- a/components/execd/pkg/runtime/env_test.go
+++ b/components/execd/pkg/runtime/env_test.go
@@ -63,6 +63,19 @@ func TestLoadExtraEnvFromFileMissingFile(t *testing.T) {
 	require.Nil(t, loadExtraEnvFromFile(), "expected nil for missing file")
 }
 
+func TestLoadExtraEnvFromFileSupportsHomePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	envFile := filepath.Join(home, "extra.env")
+	require.NoError(t, os.WriteFile(envFile, []byte("FOO=bar\n"), 0o644))
+	t.Setenv("EXECD_ENVS", "~/extra.env")
+
+	got := loadExtraEnvFromFile()
+	require.Equal(t, "bar", got["FOO"])
+}
+
 func TestMergeEnvsOverlaysExtra(t *testing.T) {
 	base := []string{"A=1", "B=2"}
 	extra := map[string]string{"B": "override", "C": "3"}

--- a/components/execd/pkg/runtime/jupyter_hooks_test.go
+++ b/components/execd/pkg/runtime/jupyter_hooks_test.go
@@ -1,11 +1,11 @@
 // Copyright 2026 Alibaba Group Holding Ltd.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/components/execd/pkg/runtime/pty_session.go
+++ b/components/execd/pkg/runtime/pty_session.go
@@ -31,6 +31,7 @@ import (
 	"github.com/creack/pty"
 
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 // PTYSession is the public interface for an interactive PTY/pipe session.
@@ -544,13 +545,17 @@ func (s *ptySession) close() {
 
 // CreatePTYSession creates a new PTY session and stores it in the map.
 func (c *Controller) CreatePTYSession(id, cwd string) (PTYSession, error) {
-	if cwd != "" {
-		err := os.MkdirAll(cwd, os.ModePerm)
+	resolvedCwd, err := pathutil.ExpandPath(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving PTY session work directory: %w", err)
+	}
+	if resolvedCwd != "" {
+		err := os.MkdirAll(resolvedCwd, os.ModePerm)
 		if err != nil {
 			return nil, fmt.Errorf("error creating PTY session work directory: %w", err)
 		}
 	}
-	s := newPTYSession(id, cwd)
+	s := newPTYSession(id, resolvedCwd)
 	c.ptySessionMap.Store(id, s)
 	log.Info("created pty session %s", id)
 	return s, nil

--- a/components/execd/pkg/runtime/workingdir.go
+++ b/components/execd/pkg/runtime/workingdir.go
@@ -17,13 +17,19 @@ package runtime
 import (
 	"fmt"
 	"os"
+
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
 func ValidateWorkingDir(cwd string) error {
 	if cwd == "" {
 		return nil
 	}
-	fi, err := os.Stat(cwd)
+	resolvedCwd, err := pathutil.ExpandPath(cwd)
+	if err != nil {
+		return fmt.Errorf("cannot resolve working directory %q: %w", cwd, err)
+	}
+	fi, err := os.Stat(resolvedCwd)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("working directory does not exist: %s", cwd)

--- a/components/execd/pkg/runtime/workingdir_test.go
+++ b/components/execd/pkg/runtime/workingdir_test.go
@@ -47,3 +47,13 @@ func TestValidateWorkingDir_notDir(t *testing.T) {
 func TestValidateWorkingDir_ok(t *testing.T) {
 	require.NoError(t, ValidateWorkingDir(t.TempDir()))
 }
+
+func TestValidateWorkingDir_ExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, "workspace")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	require.NoError(t, ValidateWorkingDir("~/workspace"))
+}

--- a/components/execd/pkg/util/pathutil/path.go
+++ b/components/execd/pkg/util/pathutil/path.go
@@ -25,7 +25,22 @@ import (
 
 var envVarPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
 
-func validateEnvVars(path string) error {
+func envMapFromProcessAndOverrides(envOverrides map[string]string) map[string]string {
+	out := make(map[string]string, len(envOverrides)+16)
+	for _, kv := range os.Environ() {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out[parts[0]] = parts[1]
+	}
+	for k, v := range envOverrides {
+		out[k] = v
+	}
+	return out
+}
+
+func validateEnvVars(path string, env map[string]string) error {
 	matches := envVarPattern.FindAllStringSubmatch(path, -1)
 	if len(matches) == 0 {
 		return nil
@@ -37,7 +52,7 @@ func validateEnvVars(path string) error {
 		if name == "" {
 			name = m[2]
 		}
-		if _, ok := os.LookupEnv(name); !ok {
+		if _, ok := env[name]; !ok {
 			missingSet[name] = struct{}{}
 		}
 	}
@@ -53,17 +68,20 @@ func validateEnvVars(path string) error {
 	return fmt.Errorf("path references undefined environment variables: %s", strings.Join(missing, ","))
 }
 
-// ExpandPath expands environment variables and a leading "~" to user home.
-// It supports "~", "~/" and "~\" prefixes.
-func ExpandPath(path string) (string, error) {
+// ExpandPathWithEnv expands environment variables and a leading "~" to user home.
+// Environment resolution uses process env overlaid by envOverrides.
+func ExpandPathWithEnv(path string, envOverrides map[string]string) (string, error) {
 	if path == "" {
 		return "", nil
 	}
-	if err := validateEnvVars(path); err != nil {
+	env := envMapFromProcessAndOverrides(envOverrides)
+	if err := validateEnvVars(path, env); err != nil {
 		return "", err
 	}
 
-	expanded := os.ExpandEnv(path)
+	expanded := os.Expand(path, func(key string) string {
+		return env[key]
+	})
 	if expanded == "~" || strings.HasPrefix(expanded, "~/") || strings.HasPrefix(expanded, `~\`) {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -78,8 +96,14 @@ func ExpandPath(path string) (string, error) {
 	return expanded, nil
 }
 
+// ExpandPath expands environment variables and a leading "~" to user home.
+// It supports "~", "~/" and "~\" prefixes.
+func ExpandPath(path string) (string, error) {
+	return ExpandPathWithEnv(path, nil)
+}
+
 func ExpandAbsPath(path string) (string, error) {
-	expanded, err := ExpandPath(path)
+	expanded, err := ExpandPathWithEnv(path, nil)
 	if err != nil {
 		return "", err
 	}

--- a/components/execd/pkg/util/pathutil/path.go
+++ b/components/execd/pkg/util/pathutil/path.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var envVarPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+func validateEnvVars(path string) error {
+	matches := envVarPattern.FindAllStringSubmatch(path, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	missingSet := make(map[string]struct{})
+	for _, m := range matches {
+		name := m[1]
+		if name == "" {
+			name = m[2]
+		}
+		if _, ok := os.LookupEnv(name); !ok {
+			missingSet[name] = struct{}{}
+		}
+	}
+	if len(missingSet) == 0 {
+		return nil
+	}
+
+	missing := make([]string, 0, len(missingSet))
+	for name := range missingSet {
+		missing = append(missing, name)
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("path references undefined environment variables: %s", strings.Join(missing, ","))
+}
+
+// ExpandPath expands environment variables and a leading "~" to user home.
+// It supports "~", "~/" and "~\" prefixes.
+func ExpandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if err := validateEnvVars(path); err != nil {
+		return "", err
+	}
+
+	expanded := os.ExpandEnv(path)
+	if expanded == "~" || strings.HasPrefix(expanded, "~/") || strings.HasPrefix(expanded, `~\`) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if expanded == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, expanded[2:]), nil
+	}
+
+	return expanded, nil
+}
+
+func ExpandAbsPath(path string) (string, error) {
+	expanded, err := ExpandPath(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(expanded)
+}

--- a/components/execd/pkg/util/pathutil/path_test.go
+++ b/components/execd/pkg/util/pathutil/path_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandPath_HomeAndEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("BASE_DIR", "project")
+
+	got, err := ExpandPath("~/docs/$BASE_DIR")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "docs", "project"), got)
+}
+
+func TestExpandPath_Empty(t *testing.T) {
+	got, err := ExpandPath("")
+	require.NoError(t, err)
+	require.Equal(t, "", got)
+}
+
+func TestExpandPath_EnvVarInMiddle(t *testing.T) {
+	t.Setenv("MID", "segment")
+
+	got, err := ExpandPath("prefix/$MID/suffix")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("prefix", "segment", "suffix"), got)
+}
+
+func TestExpandPath_UndefinedEnvVarInMiddleReturnsError(t *testing.T) {
+	got, err := ExpandPath("prefix/$NOT_SET/suffix")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NOT_SET")
+	require.Equal(t, "", got)
+}
+
+func TestExpandPath_UndefinedEnvVarReturnsError(t *testing.T) {
+	got, err := ExpandPath("$NOT_SET/tmp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NOT_SET")
+	require.Equal(t, "", got)
+}
+
+func TestExpandPath_UndefinedEnvVarOnlyReturnsError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	got, err := ExpandPath("$NOT_SET")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NOT_SET")
+	require.Equal(t, "", got)
+}

--- a/components/execd/pkg/util/pathutil/path_test.go
+++ b/components/execd/pkg/util/pathutil/path_test.go
@@ -46,6 +46,24 @@ func TestExpandPath_EnvVarInMiddle(t *testing.T) {
 	require.Equal(t, filepath.Join("prefix", "segment", "suffix"), got)
 }
 
+func TestExpandPathWithEnv_RequestOverrideHasHigherPriority(t *testing.T) {
+	t.Setenv("WORKDIR", "from-process")
+
+	got, err := ExpandPathWithEnv("base/$WORKDIR", map[string]string{
+		"WORKDIR": "from-request",
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("base", "from-request"), got)
+}
+
+func TestExpandPathWithEnv_CanResolveVarOnlyInOverride(t *testing.T) {
+	got, err := ExpandPathWithEnv("$WORKDIR/tmp", map[string]string{
+		"WORKDIR": "/tmp/ws",
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("/tmp/ws", "tmp"), got)
+}
+
 func TestExpandPath_UndefinedEnvVarInMiddleReturnsError(t *testing.T) {
 	got, err := ExpandPath("prefix/$NOT_SET/suffix")
 	require.Error(t, err)

--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/alibaba/opensandbox/execd/pkg/util/glob"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
@@ -171,7 +172,16 @@ func (c *FilesystemController) MakeDirs() {
 func (c *FilesystemController) RemoveDirs() {
 	paths := c.ctx.QueryArray("path")
 	for _, dir := range paths {
-		if err := os.RemoveAll(dir); err != nil {
+		resolvedDir, err := pathutil.ExpandPath(dir)
+		if err != nil {
+			c.RespondError(
+				http.StatusInternalServerError,
+				model.ErrorCodeRuntimeError,
+				fmt.Sprintf("error resolving directory %s. %v", dir, err),
+			)
+			return
+		}
+		if err := os.RemoveAll(resolvedDir); err != nil {
 			c.RespondError(
 				http.StatusInternalServerError,
 				model.ErrorCodeRuntimeError,
@@ -196,7 +206,7 @@ func (c *FilesystemController) SearchFiles() {
 		return
 	}
 
-	path, err := filepath.Abs(path)
+	path, err := pathutil.ExpandAbsPath(path)
 	if err != nil {
 		c.RespondError(
 			http.StatusInternalServerError,
@@ -292,7 +302,7 @@ func (c *FilesystemController) ReplaceContent() {
 	}
 
 	for file, item := range request {
-		file, err := filepath.Abs(file)
+		file, err := pathutil.ExpandAbsPath(file)
 		if err != nil {
 			c.handleFileError(err)
 			return

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
@@ -37,8 +38,17 @@ func (c *FilesystemController) DownloadFile() {
 		)
 		return
 	}
+	resolvedFilePath, err := pathutil.ExpandPath(filePath)
+	if err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error resolving file path: %s. %v", filePath, err),
+		)
+		return
+	}
 
-	file, err := os.Open(filePath)
+	file, err := os.Open(resolvedFilePath)
 	if err != nil {
 		c.handleFileError(err)
 		return
@@ -50,13 +60,13 @@ func (c *FilesystemController) DownloadFile() {
 		c.RespondError(
 			http.StatusInternalServerError,
 			model.ErrorCodeRuntimeError,
-			fmt.Sprintf("error getting file stat info: %s. %v", filePath, err),
+			fmt.Sprintf("error getting file stat info: %s. %v", resolvedFilePath, err),
 		)
 		return
 	}
 
 	c.ctx.Header("Content-Type", "application/octet-stream")
-	c.ctx.Header("Content-Disposition", formatContentDisposition(filepath.Base(filePath)))
+	c.ctx.Header("Content-Disposition", formatContentDisposition(filepath.Base(resolvedFilePath)))
 	c.ctx.Header("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
 
 	if rangeHeader := c.ctx.GetHeader("Range"); rangeHeader != "" {
@@ -80,7 +90,7 @@ func (c *FilesystemController) DownloadFile() {
 		}
 	}
 
-	http.ServeContent(c.ctx.Writer, c.ctx.Request, filepath.Base(filePath), fileInfo.ModTime(), file)
+	http.ServeContent(c.ctx.Writer, c.ctx.Request, filepath.Base(resolvedFilePath), fileInfo.ModTime(), file)
 }
 
 // formatContentDisposition formats the Content-Disposition header value with proper

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -96,6 +96,31 @@ func TestFilesystemControllerReplaceContent(t *testing.T) {
 	require.Equal(t, "hello universe", string(data))
 }
 
+func TestFilesystemControllerReplaceContentSupportsHomePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	target := filepath.Join(home, "content.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hello world"), 0o644))
+
+	body, err := json.Marshal(map[string]model.ReplaceFileContentItem{
+		"~/content.txt": {
+			Old: "world",
+			New: "home",
+		},
+	})
+	require.NoError(t, err)
+
+	ctrl, rec := newFilesystemController(t, http.MethodPost, "/files/replace", body)
+	ctrl.ReplaceContent()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "hello home", string(data))
+}
+
 func TestFilesystemControllerSearchFilesHandlesAbsentDir(t *testing.T) {
 	rawURL := "/files/search?path=/not/exists"
 	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)

--- a/components/execd/pkg/web/controller/filesystem_upload.go
+++ b/components/execd/pkg/web/controller/filesystem_upload.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
@@ -110,8 +111,17 @@ func (c *FilesystemController) UploadFile() {
 			)
 			return
 		}
+		resolvedPath, err := pathutil.ExpandPath(targetPath)
+		if err != nil {
+			c.RespondError(
+				http.StatusInternalServerError,
+				model.ErrorCodeRuntimeError,
+				fmt.Sprintf("error resolving target path %s. %v", targetPath, err),
+			)
+			return
+		}
 
-		targetDir := filepath.Dir(targetPath)
+		targetDir := filepath.Dir(resolvedPath)
 		if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
 			c.RespondError(
 				http.StatusInternalServerError,
@@ -132,13 +142,13 @@ func (c *FilesystemController) UploadFile() {
 			return
 		}
 
-		dst, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+		dst, err := os.OpenFile(resolvedPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 		if err != nil {
 			file.Close()
 			c.RespondError(
 				http.StatusInternalServerError,
 				model.ErrorCodeRuntimeError,
-				fmt.Sprintf("error opening destination file %s. %v", targetPath, err),
+				fmt.Sprintf("error opening destination file %s. %v", resolvedPath, err),
 			)
 			return
 		}
@@ -149,7 +159,7 @@ func (c *FilesystemController) UploadFile() {
 			c.RespondError(
 				http.StatusInternalServerError,
 				model.ErrorCodeRuntimeError,
-				fmt.Sprintf("error copying file %s. %v", targetPath, err),
+				fmt.Sprintf("error copying file %s. %v", resolvedPath, err),
 			)
 			return
 		}
@@ -162,11 +172,11 @@ func (c *FilesystemController) UploadFile() {
 		}
 		file.Close()
 
-		if err := ChmodFile(targetPath, meta.Permission); err != nil {
+		if err := ChmodFile(resolvedPath, meta.Permission); err != nil {
 			c.RespondError(
 				http.StatusInternalServerError,
 				model.ErrorCodeRuntimeError,
-				fmt.Sprintf("error chmoding file %s. %v", targetPath, err),
+				fmt.Sprintf("error chmoding file %s. %v", resolvedPath, err),
 			)
 			return
 		}

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/alibaba/opensandbox/execd/pkg/util/glob"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
@@ -169,7 +170,16 @@ func (c *FilesystemController) MakeDirs() {
 func (c *FilesystemController) RemoveDirs() {
 	paths := c.ctx.QueryArray("path")
 	for _, dir := range paths {
-		if err := os.RemoveAll(dir); err != nil {
+		resolvedDir, err := pathutil.ExpandPath(dir)
+		if err != nil {
+			c.RespondError(
+				http.StatusInternalServerError,
+				model.ErrorCodeRuntimeError,
+				fmt.Sprintf("error resolving directory %s. %v", dir, err),
+			)
+			return
+		}
+		if err := os.RemoveAll(resolvedDir); err != nil {
 			c.RespondError(
 				http.StatusInternalServerError,
 				model.ErrorCodeRuntimeError,
@@ -194,7 +204,7 @@ func (c *FilesystemController) SearchFiles() {
 		return
 	}
 
-	path, err := filepath.Abs(path)
+	path, err := pathutil.ExpandAbsPath(path)
 	if err != nil {
 		c.RespondError(
 			http.StatusInternalServerError,
@@ -278,7 +288,7 @@ func (c *FilesystemController) ReplaceContent() {
 	}
 
 	for file, item := range request {
-		file, err := filepath.Abs(file)
+		file, err := pathutil.ExpandAbsPath(file)
 		if err != nil {
 			c.handleFileError(err)
 			return

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -28,11 +28,12 @@ import (
 	"syscall"
 
 	"github.com/alibaba/opensandbox/execd/pkg/log"
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
 func DeleteFile(filePath string) error {
-	absPath, err := filepath.Abs(filePath)
+	absPath, err := pathutil.ExpandAbsPath(filePath)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
@@ -57,7 +58,7 @@ func DeleteFile(filePath string) error {
 }
 
 func ChmodFile(file string, perms model.Permission) error {
-	abs, err := filepath.Abs(file)
+	abs, err := pathutil.ExpandAbsPath(file)
 	if err != nil {
 		return err
 	}
@@ -117,12 +118,12 @@ func SetFileOwnership(absPath string, owner string, group string) error {
 }
 
 func RenameFile(item model.RenameFileItem) error {
-	srcPath, err := filepath.Abs(item.Src)
+	srcPath, err := pathutil.ExpandAbsPath(item.Src)
 	if err != nil {
 		return fmt.Errorf("invalid source path: %w", err)
 	}
 
-	dstPath, err := filepath.Abs(item.Dest)
+	dstPath, err := pathutil.ExpandAbsPath(item.Dest)
 	if err != nil {
 		return fmt.Errorf("invalid destination path: %w", err)
 	}
@@ -149,7 +150,7 @@ func RenameFile(item model.RenameFileItem) error {
 }
 
 func MakeDir(dir string, perm model.Permission) error {
-	abs, err := filepath.Abs(dir)
+	abs, err := pathutil.ExpandAbsPath(dir)
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func MakeDir(dir string, perm model.Permission) error {
 }
 
 func GetFileInfo(filePath string) (model.FileInfo, error) {
-	absPath, err := filepath.Abs(filePath)
+	absPath, err := pathutil.ExpandAbsPath(filePath)
 	if err != nil {
 		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
 	}

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -27,11 +27,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
 func DeleteFile(filePath string) error {
-	absPath, err := filepath.Abs(filePath)
+	absPath, err := pathutil.ExpandAbsPath(filePath)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
@@ -56,7 +57,7 @@ func DeleteFile(filePath string) error {
 }
 
 func ChmodFile(file string, perms model.Permission) error {
-	abs, err := filepath.Abs(file)
+	abs, err := pathutil.ExpandAbsPath(file)
 	if err != nil {
 		return err
 	}
@@ -81,12 +82,12 @@ func SetFileOwnership(_ string, _ string, _ string) error {
 }
 
 func RenameFile(item model.RenameFileItem) error {
-	srcPath, err := filepath.Abs(item.Src)
+	srcPath, err := pathutil.ExpandAbsPath(item.Src)
 	if err != nil {
 		return fmt.Errorf("invalid source path: %w", err)
 	}
 
-	dstPath, err := filepath.Abs(item.Dest)
+	dstPath, err := pathutil.ExpandAbsPath(item.Dest)
 	if err != nil {
 		return fmt.Errorf("invalid destination path: %w", err)
 	}
@@ -113,7 +114,7 @@ func RenameFile(item model.RenameFileItem) error {
 }
 
 func MakeDir(dir string, perm model.Permission) error {
-	abs, err := filepath.Abs(dir)
+	abs, err := pathutil.ExpandAbsPath(dir)
 	if err != nil {
 		return err
 	}
@@ -126,7 +127,7 @@ func MakeDir(dir string, perm model.Permission) error {
 }
 
 func GetFileInfo(filePath string) (model.FileInfo, error) {
-	absPath, err := filepath.Abs(filePath)
+	absPath, err := pathutil.ExpandAbsPath(filePath)
 	if err != nil {
 		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
 	}

--- a/components/execd/tests/smoke_api.py
+++ b/components/execd/tests/smoke_api.py
@@ -148,6 +148,12 @@ def filesystem_smoke():
     sub_dir = os.path.join(base_dir, "sub")
     file_path = os.path.join(sub_dir, "hello.txt")
     renamed_path = os.path.join(sub_dir, "hello_renamed.txt")
+    home_dir = os.path.expanduser("~")
+    home_file_name = f"execd-smoke-home-{uuid.uuid4().hex}.txt"
+    home_file_abs = os.path.join(home_dir, home_file_name)
+    # Windows uses backslash path style by default; keep smoke path style aligned
+    # with platform so "~" expansion is exercised in a realistic way.
+    home_file_tilde = f"~\\{home_file_name}" if os.name == "nt" else f"~/{home_file_name}"
 
     # create dirs
     mk = session.post(f"{BASE_URL}/directories", json={sub_dir: {"mode": 0}}, timeout=10)
@@ -207,6 +213,26 @@ def filesystem_smoke():
     # remove file
     rm_file = session.delete(f"{BASE_URL}/files", params={"path": [renamed_path]}, timeout=10)
     expect(rm_file.status_code == 200, f"remove file failed: {rm_file.status_code} {rm_file.text}")
+
+    # read file using "~/<file>" style path
+    home_metadata = json.dumps({"path": home_file_abs})
+    home_files = {
+        "metadata": ("metadata", home_metadata, "application/json"),
+        "file": ("file", b"home path content\n", "application/octet-stream"),
+    }
+    home_up = session.post(f"{BASE_URL}/files/upload", files=home_files, timeout=10)
+    expect(home_up.status_code == 200, f"home upload failed: {home_up.status_code} {home_up.text}")
+
+    home_down = session.get(f"{BASE_URL}/files/download", params={"path": home_file_tilde}, timeout=10)
+    # On Windows, also accept "~/" form as a compatibility fallback.
+    if home_down.status_code != 200 and os.name == "nt":
+        alt_tilde = f"~/{home_file_name}"
+        home_down = session.get(f"{BASE_URL}/files/download", params={"path": alt_tilde}, timeout=10)
+    expect(home_down.status_code == 200, f"home download via tilde failed: {home_down.status_code} {home_down.text}")
+    expect(home_down.content == b"home path content\n", "home download content mismatch")
+
+    home_rm = session.delete(f"{BASE_URL}/files", params={"path": [home_file_tilde]}, timeout=10)
+    expect(home_rm.status_code == 200, f"home remove failed: {home_rm.status_code} {home_rm.text}")
 
     # remove dir
     rm_dir = session.delete(f"{BASE_URL}/directories", params={"path": [base_dir]}, timeout=10)


### PR DESCRIPTION
# Summary
- expand env before file read/stat
- resolved issue which execd cannot process file like `$HOME/abc`, `~/abc` or `$MY_WORKSPACE/abc`
- closes #711 

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered