### PR TITLE
fix(config): use [log].level instead of [server].log_level

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -56,8 +56,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 8080
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
@@ -143,8 +144,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 8080
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
@@ -237,8 +239,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 8080
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
@@ -319,8 +322,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 8080
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"
@@ -403,8 +407,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 8080
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:local"

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -77,8 +77,9 @@ jobs:
           [server]
           host = "127.0.0.1"
           port = 32888
-          log_level = "INFO"
           api_key = ""
+          [log]
+          level = "INFO"
           [runtime]
           type = "docker"
           execd_image = "opensandbox/execd:latest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ uv sync
 cp server/opensandbox_server/examples/example.config.toml ~/.sandbox.toml
 
 # Edit configuration for development
-# Set log_level = "DEBUG" and api_key
+# Set [log] level = "DEBUG" and [server] api_key
 nano ~/.sandbox.toml
 
 # Run server

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,7 +4,9 @@ configs:
       [server]
       host = "0.0.0.0"
       port = 8090
-      log_level = "INFO"
+
+      [log]
+      level = "INFO"
 
       [runtime]
       type = "docker"

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -57,8 +57,10 @@ configToml: |
   [server]
   host = "0.0.0.0"
   port = 80
-  log_level = "INFO"
   api_key = ""
+
+  [log]
+  level = "INFO"
 
   [runtime]
   type = "kubernetes"

--- a/scripts/common/kubernetes-e2e.sh
+++ b/scripts/common/kubernetes-e2e.sh
@@ -172,8 +172,10 @@ configToml: |
   [server]
   host = "0.0.0.0"
   port = 80
-  log_level = "INFO"
   api_key = ""
+
+  [log]
+  level = "INFO"
 
   [runtime]
   type = "kubernetes"

--- a/server/DEVELOPMENT.md
+++ b/server/DEVELOPMENT.md
@@ -54,8 +54,10 @@ This guide provides comprehensive information for developers working on OpenSand
    [server]
    host = "0.0.0.0"
    port = 8080
-   log_level = "DEBUG"
    api_key = "your-secret-api-key-change-this"
+
+   [log]
+   level = "DEBUG"
 
    [runtime]
    type = "docker"
@@ -296,8 +298,8 @@ def get_sandbox(self, sandbox_id: str) -> Sandbox:
 ### Enable Debug Logging
 
 ```toml
-[server]
-log_level = "DEBUG"
+[log]
+level = "DEBUG"
 ```
 
 ### Interactive Debugging

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -21,17 +21,18 @@ Example files in this repository:
 
 1. [Top-level sections](#top-level-sections)
 2. [`[server]`](#server--lifecycle-api)
-3. [`[runtime]`](#runtime--required)
-4. [`[docker]`](#docker--only-when-runtime--docker)
-5. [`[kubernetes]`](#kubernetes--only-when-runtime--kubernetes)
-6. [`[agent_sandbox]`](#agent_sandbox--only-with-kubernetes--agent-sandbox)
-7. [`[ingress]`](#ingress)
-8. [`[egress]`](#egress)
-9. [`[storage]`](#storage)
-10. [`[secure_runtime]`](#secure_runtime)
-11. [`[renew_intent]`](#renew_intent--experimental)
-12. [Environment variables (outside TOML)](#environment-variables-outside-toml)
-13. [Cross-field validation rules](#cross-field-validation-rules)
+3. [`[log]`](#log)
+4. [`[runtime]`](#runtime--required)
+5. [`[docker]`](#docker--only-when-runtime--docker)
+6. [`[kubernetes]`](#kubernetes--only-when-runtime--kubernetes)
+7. [`[agent_sandbox]`](#agent_sandbox--only-with-kubernetes--agent-sandbox)
+8. [`[ingress]`](#ingress)
+9. [`[egress]`](#egress)
+10. [`[storage]`](#storage)
+11. [`[secure_runtime]`](#secure_runtime)
+12. [`[renew_intent]`](#renew_intent--experimental)
+13. [Environment variables (outside TOML)](#environment-variables-outside-toml)
+14. [Cross-field validation rules](#cross-field-validation-rules)
 
 ---
 
@@ -40,6 +41,7 @@ Example files in this repository:
 | Section | Required | When |
 |---------|----------|------|
 | `[server]` | No | Always (defaults apply if omitted) |
+| `[log]` | No | Always (defaults apply if omitted) |
 | `[runtime]` | **Yes** | Always |
 | `[docker]` | No | `runtime.type = "docker"` |
 | `[kubernetes]` | No | `runtime.type = "kubernetes"` (defaults are applied if missing) |
@@ -58,10 +60,23 @@ Example files in this repository:
 |-----|------|---------|-------------|
 | `host` | string | `"0.0.0.0"` | Bind address for the HTTP API. |
 | `port` | integer | `8080` | Listen port (1–65535). |
-| `log_level` | string | `"INFO"` | Python logging level for the server process. |
 | `api_key` | string \| omitted | `null` | If set to a non-empty string, requests must send header `OPEN-SANDBOX-API-KEY` with this value (except documented public routes such as `/health`, `/docs`, `/redoc`). If omitted or empty, API key checks are skipped (typical for local dev only). |
 | `eip` | string \| omitted | `null` | Public IP or hostname used as the **host part** when the server returns sandbox endpoint URLs (notably Docker runtime). |
 | `max_sandbox_timeout_seconds` | integer \| omitted | `null` | Upper bound on sandbox TTL in seconds for **create** requests that specify `timeout`. Must be ≥ **60** if set. Omit to disable the server-side cap. |
+| `timeout_keep_alive` | integer | `30` | Idle keep-alive timeout (seconds) passed to uvicorn. |
+
+---
+
+## `[log]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `level` | string | `"INFO"` | Python logging level for the server process (e.g. `"DEBUG"`, `"INFO"`, `"WARNING"`). |
+| `file_enabled` | boolean | `false` | When `true`, logs are written to rotating files instead of stdout. |
+| `file_path` | string \| omitted | `null` | Override path for the main log file. Defaults to `~/logs/opensandbox/server.log` when `file_enabled = true`. |
+| `access_file_path` | string \| omitted | `null` | Override path for the HTTP access log file. Defaults to `~/logs/opensandbox/access.log` when `file_enabled = true`. |
+| `file_max_bytes` | integer | `104857600` (100 MB) | Max bytes per log file before rotation. |
+| `file_backup_count` | integer | `5` | Number of rotated log files to retain. |
 
 ---
 

--- a/server/docker-compose.example.yaml
+++ b/server/docker-compose.example.yaml
@@ -4,7 +4,9 @@ configs:
       [server]
       host = "0.0.0.0"
       port = 8090
-      log_level = "INFO"
+
+      [log]
+      level = "INFO"
 
       [runtime]
       type = "docker"

--- a/server/tests/k8s/fixtures/k8s_fixtures.py
+++ b/server/tests/k8s/fixtures/k8s_fixtures.py
@@ -211,7 +211,6 @@ def k8s_app_config(k8s_runtime_config):
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(
@@ -231,7 +230,6 @@ def agent_sandbox_app_config(agent_sandbox_runtime_config):
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(
@@ -256,7 +254,6 @@ def app_config_no_k8s():
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(
@@ -276,7 +273,6 @@ def app_config_docker():
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(

--- a/server/tests/test_agent_sandbox_service.py
+++ b/server/tests/test_agent_sandbox_service.py
@@ -47,7 +47,6 @@ def agent_sandbox_app_config(agent_sandbox_runtime_config):
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(
@@ -69,7 +68,6 @@ def app_config_docker():
         server=ServerConfig(
             host="0.0.0.0",
             port=8080,
-            log_level="DEBUG",
             api_key="test-api-key",
         ),
         runtime=RuntimeConfig(
@@ -86,7 +84,6 @@ class TestAgentSandboxServiceInit:
             server=ServerConfig(
                 host="0.0.0.0",
                 port=8080,
-                log_level="DEBUG",
                 api_key="test-api-key",
             ),
             runtime=RuntimeConfig(
@@ -124,7 +121,6 @@ class TestAgentSandboxServiceInit:
                 server=ServerConfig(
                     host="0.0.0.0",
                     port=8080,
-                    log_level="DEBUG",
                     api_key="test-api-key",
                 ),
                 runtime=RuntimeConfig(

--- a/server/tests/testdata/config.toml
+++ b/server/tests/testdata/config.toml
@@ -15,8 +15,10 @@
 [server]
 host = "127.0.0.1"
 port = 9000
-log_level = "DEBUG"
 api_key = "test-api-key-12345"
+
+[log]
+level = "DEBUG"
 
 [runtime]
 type = "docker"

--- a/server/tests/testdata/k8s_config.toml
+++ b/server/tests/testdata/k8s_config.toml
@@ -17,8 +17,10 @@
 [server]
 host = "0.0.0.0"
 port = 8080
-log_level = "DEBUG"
 api_key = "test-k8s-api-key"
+
+[log]
+level = "DEBUG"
 
 [runtime]
 type = "kubernetes"


### PR DESCRIPTION
# Summary
- The server log level lives at `[log] level` (per `LogConfig` in `server/opensandbox_server/config.py`), but most docs, test fixtures, deployment templates, and CI workflows used `[server] log_level`. Pydantic silently ignores unknown fields on `ServerConfig`, so the key was a no-op — the server kept defaulting to `INFO` regardless of what was set, and any operator who copied a doc snippet to enable `DEBUG` got nothing.
- This PR moves every occurrence to the correct `[log] level = "..."` form and removes the equivalent dead `log_level=` kwarg passed to `ServerConfig(...)` in two test fixtures.
- Files touched: docs (`server/configuration.md` — added missing `[log]` reference table, removed bogus `[server].log_level` row; `server/DEVELOPMENT.md`; `CONTRIBUTING.md`), test data TOMLs (`server/tests/testdata/{config,k8s_config}.toml`), test fixtures (`server/tests/test_agent_sandbox_service.py`, `server/tests/k8s/fixtures/k8s_fixtures.py`), deployment configs (`docker-compose.test.yaml`, `server/docker-compose.example.yaml`, `kubernetes/charts/opensandbox-server/values.yaml`), CI/scripts (`.github/workflows/server-test.yml`, `.github/workflows/real-e2e.yml` — 5 occurrences, `scripts/common/kubernetes-e2e.sh`).

# Testing
- [x] Not run (explain why) — no runtime/code changes; only TOML keys and docs. Verified locally that `tests/testdata/*.toml` now parses through `AppConfig` with `cfg.log.level == "DEBUG"` (previously silently dropped).
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None — the old `[server] log_level` key was already silently ignored, so this only **starts honoring** the level operators thought they were setting. Anyone who explicitly relied on `INFO`-by-default behavior is unaffected because the example/deployment configs still set `INFO`.
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — added missing `[log]` section to `server/configuration.md`, fixed `DEVELOPMENT.md` and `CONTRIBUTING.md` snippets
- [x] Added/updated tests (if needed) — corrected test fixtures so `log.level` actually reaches the schema
- [x] Security impact considered — none (logging key only)
- [x] Backward compatibility considered — see Breaking Changes above
