### PR TITLE
chore(egress): relax dns upstream failover

### DIFF
--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -212,7 +212,7 @@ func (p *Proxy) maybeNotifyResolved(domain string, resp *dns.Msg) {
 func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
 	list := p.forwardUpstreams()
 	var lastErr error
-	for i, upstream := range list {
+	for _, upstream := range list {
 		c := &dns.Client{
 			Timeout: p.upstreamExchangeTimeout,
 			Dialer:  p.dialerForUpstream(upstream),
@@ -227,7 +227,7 @@ func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
 			lastErr = fmt.Errorf("nil response from %s", upstream)
 			continue
 		}
-		if tryNext, reason := p.shouldFailoverAfterResponse(resp, i, len(list)); tryNext {
+		if tryNext, reason := p.shouldFailoverAfterResponse(resp); tryNext {
 			lastErr = fmt.Errorf("%s from %s", reason, upstream)
 			log.Warnf("[dns] upstream %s: %s; trying next", upstream, reason)
 			continue
@@ -241,9 +241,9 @@ func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
 }
 
 // shouldFailoverAfterResponse returns whether to try the next upstream.
-// NXDOMAIN is not retried. NOERROR with an empty Answer (NODATA) is retried when another upstream exists:
-// a broken or non-recursive first hop may return empty NOERROR while a public resolver succeeds.
-func (p *Proxy) shouldFailoverAfterResponse(resp *dns.Msg, upstreamIdx, upstreamCount int) (tryNext bool, reason string) {
+//
+// NXDOMAIN and NOERROR are both accepted as final DNS responses (no retry).
+func (p *Proxy) shouldFailoverAfterResponse(resp *dns.Msg) (tryNext bool, reason string) {
 	if resp == nil {
 		return true, "nil response"
 	}
@@ -251,9 +251,6 @@ func (p *Proxy) shouldFailoverAfterResponse(resp *dns.Msg, upstreamIdx, upstream
 	case dns.RcodeNameError:
 		return false, ""
 	case dns.RcodeSuccess:
-		if len(resp.Answer) == 0 && upstreamIdx < upstreamCount-1 {
-			return true, "empty NOERROR"
-		}
 		return false, ""
 	default:
 		rcStr := dns.RcodeToString[resp.Rcode]

--- a/components/egress/pkg/dnsproxy/upstream_test.go
+++ b/components/egress/pkg/dnsproxy/upstream_test.go
@@ -40,17 +40,17 @@ func TestUpstreamProbeFromEnv(t *testing.T) {
 	t.Setenv(constants.EnvDNSUpstreamProbe, "")
 	n, qt := upstreamProbeFromEnv()
 	require.Equal(t, ".", n)
-	require.Equal(t, uint16(dns.TypeNS), qt)
+	require.Equal(t, dns.TypeNS, qt)
 
 	t.Setenv(constants.EnvDNSUpstreamProbe, ".")
 	n, qt = upstreamProbeFromEnv()
 	require.Equal(t, ".", n)
-	require.Equal(t, uint16(dns.TypeNS), qt)
+	require.Equal(t, dns.TypeNS, qt)
 
 	t.Setenv(constants.EnvDNSUpstreamProbe, "intranet.corp")
 	n, qt = upstreamProbeFromEnv()
 	require.Equal(t, "intranet.corp.", n)
-	require.Equal(t, uint16(dns.TypeA), qt)
+	require.Equal(t, dns.TypeA, qt)
 }
 
 func TestNormalizeEnvUpstreamAddr(t *testing.T) {
@@ -110,29 +110,45 @@ func TestAllowIPsFromUpstreamAddrs(t *testing.T) {
 
 func TestShouldFailoverAfterResponse(t *testing.T) {
 	p2 := &Proxy{upstreams: []string{"198.51.100.254:53", "8.8.8.8:53"}}
-	const n = 2
 
 	emptyOK := new(dns.Msg)
 	emptyOK.Rcode = dns.RcodeSuccess
-	try, _ := p2.shouldFailoverAfterResponse(emptyOK, 0, n)
-	require.True(t, try, "empty NOERROR on first upstream should failover")
+	try, _ := p2.shouldFailoverAfterResponse(emptyOK)
+	require.False(t, try, "empty NOERROR should not failover")
 
-	try, _ = p2.shouldFailoverAfterResponse(emptyOK, 1, n)
+	try, _ = p2.shouldFailoverAfterResponse(emptyOK)
 	require.False(t, try, "empty NOERROR on last upstream should not failover")
+
+	emptyNODATA := new(dns.Msg)
+	emptyNODATA.Rcode = dns.RcodeSuccess
+	emptyNODATA.Ns = []dns.RR{
+		&dns.SOA{
+			Hdr:     dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 60},
+			Ns:      "ns1.example.com.",
+			Mbox:    "hostmaster.example.com.",
+			Serial:  1,
+			Refresh: 60,
+			Retry:   60,
+			Expire:  60,
+			Minttl:  60,
+		},
+	}
+	try, _ = p2.shouldFailoverAfterResponse(emptyNODATA)
+	require.False(t, try, "A/AAAA NODATA with authority should not failover")
 
 	withA := new(dns.Msg)
 	withA.Rcode = dns.RcodeSuccess
 	withA.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "x."}, A: net.ParseIP("1.1.1.1")}}
-	try, _ = p2.shouldFailoverAfterResponse(withA, 0, n)
+	try, _ = p2.shouldFailoverAfterResponse(withA)
 	require.False(t, try)
 
 	nx := new(dns.Msg)
 	nx.Rcode = dns.RcodeNameError
-	try, _ = p2.shouldFailoverAfterResponse(nx, 0, n)
+	try, _ = p2.shouldFailoverAfterResponse(nx)
 	require.False(t, try)
 
 	sf := new(dns.Msg)
 	sf.Rcode = dns.RcodeServerFailure
-	try, _ = p2.shouldFailoverAfterResponse(sf, 0, n)
+	try, _ = p2.shouldFailoverAfterResponse(sf)
 	require.True(t, try)
 }

--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -112,7 +112,7 @@ func (m *Manager) AddResolvedIPs(ctx context.Context, ips []ResolvedIP) error {
 	if script == "" {
 		return nil
 	}
-	log.Infof("nftables: adding %d resolved IP(s) to dynamic allow sets with script statement %s", len(ips), script)
+	log.Debugf("nftables: adding %d resolved IP(s) to dynamic allow sets with script statement %s", len(ips), script)
 	_, err := m.run(ctx, script)
 	if err == nil {
 		telemetry.RecordNftablesUpdate()


### PR DESCRIPTION
# Summary
- relax dns upstream failover
- change dynamic nftables log to debug

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered