### PR TITLE
fix(server): honor server.eip for proxied endpoint URLs

### DIFF
--- a/server/opensandbox_server/api/lifecycle.py
+++ b/server/opensandbox_server/api/lifecycle.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Header, Query, Request, status
 from fastapi.responses import Response
 
 from opensandbox_server.extensions import validate_extensions
+from opensandbox_server.config import get_config
 from opensandbox_server.api.schema import (
     CreateSandboxRequest,
     CreateSandboxResponse,
@@ -391,8 +392,11 @@ async def get_sandbox_endpoint(
     endpoint = sandbox_service.get_endpoint(sandbox_id, port)
 
     if use_server_proxy:
-        # Construct proxy URL
+        # Prefer configured external address when available.
         base_url = str(request.base_url).rstrip("/")
+        eip = (get_config().server.eip or "").strip().rstrip("/")
+        if eip:
+            base_url = eip
         base_url = base_url.replace("https://", "").replace("http://", "")
         endpoint.endpoint = f"{base_url}/sandboxes/{sandbox_id}/proxy/{port}"
 

--- a/server/tests/test_routes_endpoint_behavior.py
+++ b/server/tests/test_routes_endpoint_behavior.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
 
 from opensandbox_server.api import lifecycle
@@ -63,6 +65,33 @@ def test_get_endpoint_use_server_proxy_rewrites_url(
 
     assert response.status_code == 200
     assert response.json()["endpoint"] == "testserver/sandboxes/sbx-001/proxy/44772"
+
+
+def test_get_endpoint_use_server_proxy_prefers_server_eip(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109/proxy/44772")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(
+        lifecycle,
+        "get_config",
+        lambda: SimpleNamespace(server=SimpleNamespace(eip="sandbox.example.com/opensandbox/")),
+    )
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/endpoints/44772",
+        params={"use_server_proxy": "true"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["endpoint"] == "sandbox.example.com/opensandbox/sandboxes/sbx-001/proxy/44772"
 
 
 def test_get_endpoint_rejects_non_numeric_port(


### PR DESCRIPTION
# Summary
- Use configured server.eip when use_server_proxy=true so external clients receive reachable proxy endpoints instead of internal base_url addresses; keep existing fallback behavior when eip is unset.
- closes #727

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered