### PR TITLE
feat(sdks): sync PVC auto-provisioning fields across language models

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -155,6 +155,36 @@ public class PVC
     /// </summary>
     [JsonPropertyName("claimName")]
     public required string ClaimName { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to auto-create the volume if it does not exist. Defaults to true.
+    /// </summary>
+    [JsonPropertyName("createIfNotExists")]
+    public bool? CreateIfNotExists { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether auto-created Docker volumes should be removed on sandbox deletion.
+    /// </summary>
+    [JsonPropertyName("deleteOnSandboxTermination")]
+    public bool? DeleteOnSandboxTermination { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Kubernetes StorageClass for auto-created PVCs. Ignored for Docker.
+    /// </summary>
+    [JsonPropertyName("storageClass")]
+    public string? StorageClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the storage request for auto-created PVCs (e.g. "1Gi"). Ignored for Docker.
+    /// </summary>
+    [JsonPropertyName("storage")]
+    public string? Storage { get; set; }
+
+    /// <summary>
+    /// Gets or sets access modes for auto-created PVCs (e.g. "ReadWriteOnce"). Ignored for Docker.
+    /// </summary>
+    [JsonPropertyName("accessModes")]
+    public IReadOnlyList<string>? AccessModes { get; set; }
 }
 
 /// <summary>

--- a/sdks/sandbox/go/api/lifecycle/gen.go
+++ b/sdks/sandbox/go/api/lifecycle/gen.go
@@ -291,18 +291,43 @@ type OSSFS struct {
 type OSSFSVersion string
 
 // PVC Platform-managed named volume backend. A runtime-neutral abstraction
-// for referencing a pre-existing, platform-managed named volume.
+// for referencing a platform-managed named volume. If `createIfNotExists`
+// is true (the default) and the volume does not yet exist, it will be
+// created automatically using the provisioning hints below.
 //
 // - Kubernetes: maps to a PersistentVolumeClaim in the same namespace.
 // - Docker: maps to a Docker named volume (created via `docker volume create`).
-//
-// The volume must already exist on the target platform before sandbox
-// creation.
 type PVC struct {
 	// ClaimName Name of the volume on the target platform.
 	// In Kubernetes this is the PVC name; in Docker this is the named
 	// volume name. Must be a valid DNS label.
 	ClaimName string `json:"claimName"`
+
+	// CreateIfNotExists When true (the default), the volume is automatically created if
+	// it does not exist. When false, referencing a non-existent volume
+	// fails with an error.
+	CreateIfNotExists *bool `json:"createIfNotExists,omitempty"`
+
+	// DeleteOnSandboxTermination When true, the volume is automatically removed when the sandbox
+	// is deleted. Only applies to volumes that were auto-created by the
+	// server (Docker only). Pre-existing volumes are never removed.
+	// Has no effect on Kubernetes PVCs, whose lifecycle is managed by
+	// the StorageClass reclaim policy.
+	DeleteOnSandboxTermination *bool `json:"deleteOnSandboxTermination,omitempty"`
+
+	// StorageClass Kubernetes StorageClass name for auto-created PVCs. Null means
+	// use the cluster default. Ignored for Docker volumes.
+	StorageClass *string `json:"storageClass,omitempty"`
+
+	// Storage Storage capacity request for auto-created PVCs (e.g. "1Gi",
+	// "10Gi"). Defaults to the server-configured `volume_default_size`
+	// when omitted. Ignored for Docker volumes.
+	Storage *string `json:"storage,omitempty"`
+
+	// AccessModes Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]).
+	// Defaults to ["ReadWriteOnce"] when omitted. Ignored for Docker
+	// volumes.
+	AccessModes *[]string `json:"accessModes,omitempty"`
 }
 
 // PaginationInfo Pagination metadata for list responses

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -80,7 +80,12 @@ type Host struct {
 
 // PVC represents a platform-managed named volume backend.
 type PVC struct {
-	ClaimName string `json:"claimName"`
+	ClaimName                  string   `json:"claimName"`
+	CreateIfNotExists          *bool    `json:"createIfNotExists,omitempty"`
+	DeleteOnSandboxTermination *bool    `json:"deleteOnSandboxTermination,omitempty"`
+	StorageClass               *string  `json:"storageClass,omitempty"`
+	Storage                    *string  `json:"storage,omitempty"`
+	AccessModes                []string `json:"accessModes,omitempty"`
 }
 
 // OSSFS represents an Alibaba Cloud OSS mount backend via ossfs.

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -851,13 +851,12 @@ export interface components {
         };
         /**
          * @description Platform-managed named volume backend. A runtime-neutral abstraction
-         *     for referencing a pre-existing, platform-managed named volume.
+         *     for referencing a platform-managed named volume. If `createIfNotExists`
+         *     is true (the default) and the volume does not yet exist, it will be
+         *     created automatically using the provisioning hints below.
          *
          *     - Kubernetes: maps to a PersistentVolumeClaim in the same namespace.
          *     - Docker: maps to a Docker named volume (created via `docker volume create`).
-         *
-         *     The volume must already exist on the target platform before sandbox
-         *     creation.
          */
         PVC: {
             /**
@@ -866,6 +865,39 @@ export interface components {
              *     volume name. Must be a valid DNS label.
              */
             claimName: string;
+            /**
+             * @description When true (the default), the volume is automatically created if
+             *     it does not exist. When false, referencing a non-existent volume
+             *     fails with an error.
+             * @default true
+             */
+            createIfNotExists?: boolean;
+            /**
+             * @description When true, the volume is automatically removed when the sandbox
+             *     is deleted. Only applies to volumes that were auto-created by the
+             *     server (Docker only). Pre-existing volumes are never removed.
+             *     Has no effect on Kubernetes PVCs, whose lifecycle is managed by
+             *     the StorageClass reclaim policy.
+             * @default false
+             */
+            deleteOnSandboxTermination?: boolean;
+            /**
+             * @description Kubernetes StorageClass name for auto-created PVCs. Null means
+             *     use the cluster default. Ignored for Docker volumes.
+             */
+            storageClass?: string | null;
+            /**
+             * @description Storage capacity request for auto-created PVCs (e.g. "1Gi",
+             *     "10Gi"). Defaults to the server-configured `volume_default_size`
+             *     when omitted. Ignored for Docker volumes.
+             */
+            storage?: string | null;
+            /**
+             * @description Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]).
+             *     Defaults to ["ReadWriteOnce"] when omitted. Ignored for Docker
+             *     volumes.
+             */
+            accessModes?: string[] | null;
         };
         /**
          * @description Alibaba Cloud OSS mount backend via ossfs.

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -93,16 +93,41 @@ export interface Host extends Record<string, unknown> {
 }
 
 /**
- * Kubernetes PersistentVolumeClaim mount backend.
+ * Platform-managed named volume backend.
  *
- * References an existing PVC in the same namespace as the sandbox pod.
- * Only available in Kubernetes runtime.
+ * Runtime-neutral abstraction for referencing a pre-existing named volume:
+ * - Kubernetes: maps to a PersistentVolumeClaim in the same namespace.
+ * - Docker: maps to a Docker named volume.
  */
 export interface PVC extends Record<string, unknown> {
   /**
-   * Name of the PersistentVolumeClaim in the same namespace.
+   * Name of the platform volume.
+   * In Kubernetes this is the PVC name; in Docker this is the named volume name.
    */
   claimName: string;
+  /**
+   * When true (default), auto-create the volume if it does not exist.
+   */
+  createIfNotExists?: boolean;
+  /**
+   * When true, delete auto-created volume on sandbox deletion (Docker-only).
+   */
+  deleteOnSandboxTermination?: boolean;
+  /**
+   * Kubernetes StorageClass name for auto-created PVCs.
+   * Null means use cluster default. Ignored for Docker.
+   */
+  storageClass?: string | null;
+  /**
+   * Capacity request for auto-created PVCs (e.g. "1Gi").
+   * Ignored for Docker.
+   */
+  storage?: string | null;
+  /**
+   * Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]).
+   * Ignored for Docker.
+   */
+  accessModes?: string[] | null;
 }
 
 /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -397,15 +397,27 @@ class Host private constructor(
 }
 
 /**
- * Kubernetes PersistentVolumeClaim mount backend.
+ * Platform-managed named volume backend.
  *
- * References an existing PVC in the same namespace as the sandbox pod.
- * Only available in Kubernetes runtime.
+ * Runtime-neutral abstraction for referencing a pre-existing named volume:
+ * - Kubernetes: maps to a PersistentVolumeClaim in the same namespace.
+ * - Docker: maps to a Docker named volume.
  *
- * @property claimName Name of the PersistentVolumeClaim in the same namespace
+ * @property claimName Name of the platform volume. In Kubernetes this is the PVC name;
+ * in Docker this is the named volume name.
+ * @property createIfNotExists When true (default), auto-create volume if absent.
+ * @property deleteOnSandboxTermination When true, delete auto-created Docker volume on sandbox deletion.
+ * @property storageClass Kubernetes StorageClass for auto-created PVCs. Null means default class.
+ * @property storage PVC storage request for auto-created PVCs (e.g. "1Gi").
+ * @property accessModes Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]).
  */
 class PVC private constructor(
     val claimName: String,
+    val createIfNotExists: Boolean,
+    val deleteOnSandboxTermination: Boolean,
+    val storageClass: String?,
+    val storage: String?,
+    val accessModes: List<String>?,
 ) {
     companion object {
         @JvmStatic
@@ -417,6 +429,11 @@ class PVC private constructor(
 
     class Builder {
         private var claimName: String? = null
+        private var createIfNotExists: Boolean = true
+        private var deleteOnSandboxTermination: Boolean = false
+        private var storageClass: String? = null
+        private var storage: String? = null
+        private var accessModes: List<String>? = null
 
         fun claimName(claimName: String): Builder {
             require(claimName.isNotBlank()) { "Claim name cannot be blank" }
@@ -424,9 +441,46 @@ class PVC private constructor(
             return this
         }
 
+        fun createIfNotExists(createIfNotExists: Boolean): Builder {
+            this.createIfNotExists = createIfNotExists
+            return this
+        }
+
+        fun deleteOnSandboxTermination(deleteOnSandboxTermination: Boolean): Builder {
+            this.deleteOnSandboxTermination = deleteOnSandboxTermination
+            return this
+        }
+
+        fun storageClass(storageClass: String?): Builder {
+            this.storageClass = storageClass
+            return this
+        }
+
+        fun storage(storage: String?): Builder {
+            this.storage = storage
+            return this
+        }
+
+        fun accessModes(accessModes: List<String>?): Builder {
+            this.accessModes = accessModes
+            return this
+        }
+
+        fun accessModes(vararg accessModes: String): Builder {
+            this.accessModes = accessModes.toList()
+            return this
+        }
+
         fun build(): PVC {
             val claimNameValue = claimName ?: throw IllegalArgumentException("Claim name must be specified")
-            return PVC(claimName = claimNameValue)
+            return PVC(
+                claimName = claimNameValue,
+                createIfNotExists = createIfNotExists,
+                deleteOnSandboxTermination = deleteOnSandboxTermination,
+                storageClass = storageClass,
+                storage = storage,
+                accessModes = accessModes,
+            )
         }
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -193,7 +193,14 @@ internal object SandboxModelConverter {
      * Converts Domain PVC -> API PVC
      */
     fun PVC.toApiPVC(): ApiPVC {
-        return ApiPVC(claimName = this.claimName)
+        return ApiPVC(
+            claimName = this.claimName,
+            createIfNotExists = this.createIfNotExists,
+            deleteOnSandboxTermination = this.deleteOnSandboxTermination,
+            storageClass = this.storageClass,
+            storage = this.storage,
+            accessModes = this.accessModes,
+        )
     }
 
     /**

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -109,7 +109,14 @@ class SandboxModelConverter:
 
         api_pvc = UNSET
         if volume.pvc is not None:
-            api_pvc = ApiPVC(claim_name=volume.pvc.claim_name)
+            api_pvc = ApiPVC(
+                claim_name=volume.pvc.claim_name,
+                create_if_not_exists=volume.pvc.create_if_not_exists,
+                delete_on_sandbox_termination=volume.pvc.delete_on_sandbox_termination,
+                storage_class=volume.pvc.storage_class,
+                storage=volume.pvc.storage,
+                access_modes=volume.pvc.access_modes,
+            )
 
         api_ossfs = UNSET
         if volume.ossfs is not None and volume.ossfs.access_key_id is not None and volume.ossfs.access_key_secret is not None:

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/pvc.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/pvc.py
@@ -39,20 +39,46 @@ class PVC:
             claim_name (str): Name of the volume on the target platform.
                 In Kubernetes this is the PVC name; in Docker this is the named
                 volume name. Must be a valid DNS label.
+            create_if_not_exists (bool): When true (default), auto-create the volume if it does not exist.
+            delete_on_sandbox_termination (bool): When true, auto-created Docker volume is removed on sandbox
+                deletion. Ignored for Kubernetes PVCs.
+            storage_class (str | None): Kubernetes StorageClass for auto-created PVCs. Null means cluster default.
+                Ignored for Docker.
+            storage (str | None): Storage capacity request for auto-created PVCs (e.g. "1Gi"). Ignored for Docker.
+            access_modes (list[str] | None): Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]). Ignored
+                for Docker.
     """
 
     claim_name: str
+    create_if_not_exists: bool = True
+    delete_on_sandbox_termination: bool = False
+    storage_class: str | None = None
+    storage: str | None = None
+    access_modes: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         claim_name = self.claim_name
+        create_if_not_exists = self.create_if_not_exists
+        delete_on_sandbox_termination = self.delete_on_sandbox_termination
+        storage_class = self.storage_class
+        storage = self.storage
+        access_modes = self.access_modes
 
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
                 "claimName": claim_name,
+                "createIfNotExists": create_if_not_exists,
+                "deleteOnSandboxTermination": delete_on_sandbox_termination,
             }
         )
+        if storage_class is not None:
+            field_dict["storageClass"] = storage_class
+        if storage is not None:
+            field_dict["storage"] = storage
+        if access_modes is not None:
+            field_dict["accessModes"] = access_modes
 
         return field_dict
 
@@ -60,9 +86,19 @@ class PVC:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         claim_name = d.pop("claimName")
+        create_if_not_exists = d.pop("createIfNotExists", True)
+        delete_on_sandbox_termination = d.pop("deleteOnSandboxTermination", False)
+        storage_class = d.pop("storageClass", None)
+        storage = d.pop("storage", None)
+        access_modes = d.pop("accessModes", None)
 
         pvc = cls(
             claim_name=claim_name,
+            create_if_not_exists=create_if_not_exists,
+            delete_on_sandbox_termination=delete_on_sandbox_termination,
+            storage_class=storage_class,
+            storage=storage,
+            access_modes=access_modes,
         )
 
         return pvc

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -177,15 +177,55 @@ class Host(BaseModel):
 
 class PVC(BaseModel):
     """
-    Kubernetes PersistentVolumeClaim mount backend.
+    Platform-managed named volume backend.
 
-    References an existing PVC in the same namespace as the sandbox pod.
-    Only available in Kubernetes runtime.
+    Runtime-neutral abstraction for referencing a pre-existing named volume:
+    - Kubernetes: maps to a PersistentVolumeClaim in the same namespace.
+    - Docker: maps to a Docker named volume.
     """
 
     claim_name: str = Field(
-        description="Name of the PersistentVolumeClaim in the same namespace.",
+        description=(
+            "Name of the platform volume. In Kubernetes this is the PVC name; "
+            "in Docker this is the named volume name."
+        ),
         alias="claimName",
+    )
+    create_if_not_exists: bool = Field(
+        default=True,
+        alias="createIfNotExists",
+        description="When true, auto-create the volume if it does not exist.",
+    )
+    delete_on_sandbox_termination: bool = Field(
+        default=False,
+        alias="deleteOnSandboxTermination",
+        description=(
+            "When true, auto-created Docker volume is removed on sandbox deletion. "
+            "Ignored for Kubernetes PVCs."
+        ),
+    )
+    storage_class: str | None = Field(
+        default=None,
+        alias="storageClass",
+        description=(
+            "Kubernetes StorageClass for auto-created PVCs. "
+            "Null means cluster default. Ignored for Docker."
+        ),
+    )
+    storage: str | None = Field(
+        default=None,
+        description=(
+            "Storage capacity request for auto-created PVCs (e.g. '1Gi'). "
+            "Ignored for Docker."
+        ),
+    )
+    access_modes: list[str] | None = Field(
+        default=None,
+        alias="accessModes",
+        description=(
+            "Access modes for auto-created PVCs (e.g. ['ReadWriteOnce']). "
+            "Ignored for Docker."
+        ),
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -425,7 +425,7 @@ class Sandbox:
                 Prefer namespaced keys (e.g. ``storage.id``).
             entrypoint: Command to run as entrypoint
             volumes: Optional list of volume mounts for persistent storage.
-                Each volume specifies a backend (host path or PVC) and mount configuration.
+                Each volume specifies a backend (host path, PVC, or OSSFS) and mount configuration.
             connection_config: Connection configuration
             health_check: Custom async health check function
             health_check_polling_interval: Time between health check attempts


### PR DESCRIPTION
# Summary
- sync PVC auto-provisioning fields across language models
- sdk changes for #661 

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered