### PR TITLE
fix(egress): check uid/gid fit in int before ParseUint cast

### DIFF
--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -69,10 +69,10 @@ func LookupUser(userName string) (uid, gid int, home string, err error) {
 		return 0, 0, "", err
 	}
 	if uid64 > uint64(math.MaxInt) {
-		return 0, 0, "", fmt.Errorf("mitmproxy: uid %d overflows int", uid64)
+		return 0, 0, "", fmt.Errorf("mitmproxy: UID %d overflows int", uid64)
 	}
 	if gid64 > uint64(math.MaxInt) {
-		return 0, 0, "", fmt.Errorf("mitmproxy: gid %d overflows int", gid64)
+		return 0, 0, "", fmt.Errorf("mitmproxy: GID %d overflows int", gid64)
 	}
 	return int(uid64), int(gid64), u.HomeDir, nil
 }

--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -16,6 +16,7 @@ package mitmproxy
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"os/user"
@@ -66,6 +67,12 @@ func LookupUser(userName string) (uid, gid int, home string, err error) {
 	gid64, err := strconv.ParseUint(u.Gid, 10, 32)
 	if err != nil {
 		return 0, 0, "", err
+	}
+	if uid64 > uint64(math.MaxInt) {
+		return 0, 0, "", fmt.Errorf("mitmproxy: uid %d overflows int", uid64)
+	}
+	if gid64 > uint64(math.MaxInt) {
+		return 0, 0, "", fmt.Errorf("mitmproxy: gid %d overflows int", gid64)
 	}
 	return int(uid64), int(gid64), u.HomeDir, nil
 }


### PR DESCRIPTION
# Summary
- LookupUser parsed passwd uid/gid with `strconv.ParseUint` into `uint64`. Casting to int without a range check triggers gosec G115 and can misrepresent values when int is 32-bit. Reject ids above `math.MaxInt` with a clear error instead of truncating.
- fixes https://github.com/alibaba/OpenSandbox/security/code-scanning/147 and https://github.com/alibaba/OpenSandbox/security/code-scanning/148

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered