### PR TITLE
fix(Python SDK): Preserve null timeout for manual-cleanup sandboxes

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -261,7 +261,10 @@ class SandboxModelConverter:
             extensions=api_extensions,
             volumes=api_volumes,
         )
-        if timeout is not None:
+        if timeout is None:
+            # Preserve an explicit manual-cleanup request as JSON null.
+            request.timeout = None
+        else:
             request.timeout = int(timeout.total_seconds())
         return request
 

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -267,7 +267,7 @@ def test_platform_spec_rejects_windows_before_request_conversion() -> None:
         PlatformSpec(os="windows", arch="amd64")
 
 
-def test_sandbox_model_converter_omits_timeout_for_manual_cleanup() -> None:
+def test_sandbox_model_converter_preserves_null_timeout_for_manual_cleanup() -> None:
     req = SandboxModelConverter.to_api_create_sandbox_request(
         spec=SandboxImageSpec("python:3.11"),
         entrypoint=["/bin/sh"],
@@ -282,7 +282,7 @@ def test_sandbox_model_converter_omits_timeout_for_manual_cleanup() -> None:
     )
 
     dumped = req.to_dict()
-    assert "timeout" not in dumped
+    assert dumped["timeout"] is None
 
 
 def test_sandbox_model_converter_maps_platform_from_create_response() -> None:

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -289,6 +289,68 @@ async def test_create_resolves_egress_endpoint_and_builds_service(
 
 
 @pytest.mark.asyncio
+async def test_create_preserves_manual_cleanup_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CreateResponse:
+        id = "sbx-created"
+
+    class _SandboxServiceCreateStub:
+        def __init__(self) -> None:
+            self.create_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        async def create_sandbox(self, *args, **kwargs):
+            self.create_calls.append((args, kwargs))
+            return _CreateResponse()
+
+        async def get_sandbox_endpoint(
+            self, _sandbox_id, port: int, _use_server_proxy: bool = False
+        ) -> SandboxEndpoint:
+            return SandboxEndpoint(endpoint=f"sbx.internal:{port}")
+
+        async def kill_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+    class _FactoryStub:
+        def __init__(self, _connection_config: ConnectionConfig) -> None:
+            pass
+
+        def create_sandbox_service(self):
+            return sandbox_service
+
+        def create_filesystem_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_command_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_health_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_metrics_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_egress_service(self, _endpoint: SandboxEndpoint):
+            return _EgressServiceStub()
+
+    sandbox_service = _SandboxServiceCreateStub()
+    monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
+
+    sandbox = await Sandbox.create(
+        "python:3.11",
+        timeout=None,
+        skip_health_check=True,
+        connection_config=ConnectionConfig(),
+    )
+
+    assert sandbox.id == "sbx-created"
+    assert len(sandbox_service.create_calls) == 1
+    args, kwargs = sandbox_service.create_calls[0]
+    assert args[4] is None
+    assert kwargs == {}
+
+
+@pytest.mark.asyncio
 async def test_create_keeps_service_create_signature_backward_compatible(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
@@ -121,7 +121,7 @@ async def test_create_sandbox_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_sandbox_manual_cleanup_omits_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_sandbox_manual_cleanup_preserves_null_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
 
     async def _fake_asyncio_detailed(*, client, body):
@@ -147,7 +147,7 @@ async def test_create_sandbox_manual_cleanup_omits_timeout(monkeypatch: pytest.M
         volumes=None,
     )
 
-    assert "timeout" not in called["body"].to_dict()
+    assert called["body"].to_dict()["timeout"] is None
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
@@ -249,3 +249,64 @@ def test_sync_create_keeps_service_create_signature_backward_compatible(
         ),
         skip_health_check=True,
     )
+
+
+def test_sync_create_preserves_manual_cleanup_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CreateResponse:
+        id = "sync-created"
+
+    class _SandboxServiceCreateStub:
+        def __init__(self) -> None:
+            self.create_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def create_sandbox(self, *args, **kwargs):
+            self.create_calls.append((args, kwargs))
+            return _CreateResponse()
+
+        def get_sandbox_endpoint(
+            self, _sandbox_id, port: int, _use_server_proxy: bool = False
+        ) -> SandboxEndpoint:
+            return SandboxEndpoint(endpoint=f"sync-egress:{port}")
+
+        def kill_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+    class _FactoryStub:
+        def __init__(self, _connection_config: ConnectionConfigSync) -> None:
+            pass
+
+        def create_sandbox_service(self):
+            return sandbox_service
+
+        def create_filesystem_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_command_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_health_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_metrics_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_egress_service(self, _endpoint: SandboxEndpoint):
+            return _EgressServiceStub()
+
+    sandbox_service = _SandboxServiceCreateStub()
+    monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
+
+    sandbox = SandboxSync.create(
+        "python:3.11",
+        timeout=None,
+        skip_health_check=True,
+        connection_config=ConnectionConfigSync(),
+    )
+
+    assert sandbox.id == "sync-created"
+    assert len(sandbox_service.create_calls) == 1
+    args, kwargs = sandbox_service.create_calls[0]
+    assert args[4] is None
+    assert kwargs == {}


### PR DESCRIPTION
# Summary
- Preserve an explicit `timeout=None` manual-cleanup request as JSON `null` instead of omitting the field in Python SDK create requests.
- Add regression coverage for converter output, lifecycle adapter payload serialization, and async/sync high-level `Sandbox.create()` flows.
- This keeps the existing public `timeout: timedelta | None` API while making the wire payload match manual-cleanup intent.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:
- `cd sdks/sandbox/python && uv run pytest tests/test_converters_and_error_handling.py -q`
- `cd sdks/sandbox/python && uv run pytest tests/test_sandbox_service_adapter_lifecycle.py -q`
- `cd sdks/sandbox/python && uv run pytest tests/test_sandbox_business_logic.py -q`
- `cd sdks/sandbox/python && uv run pytest tests/test_sandbox_sync_business_logic.py -q`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

Refs #636