### PR TITLE
hotfix(execd): enlarge mitmproxy certs wait time to 30s

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -61,7 +61,7 @@ trust_mitm_ca() {
 MITM_CA="/opt/opensandbox/mitmproxy-ca-cert.pem"
 if is_truthy "${OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT:-}"; then
 	i=0
-	while [ "$i" -lt 10 ]; do
+	while [ "$i" -lt 30 ]; do
 		if [ -f "$MITM_CA" ] && [ -s "$MITM_CA" ]; then
 			break
 		fi


### PR DESCRIPTION
# Summary
- enlarge mitmproxy certs wait time to 30s

# Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered