### PR TITLE
feat(osep): refine secure-access and signed route token spec

### DIFF
--- a/oseps/0011-secure-access-endpoint.md
+++ b/oseps/0011-secure-access-endpoint.md
@@ -3,106 +3,149 @@ title: Secure Access on GetEndpoint and Signed Endpoint
 authors:
   - "@Pangjiping"
 creation-date: 2026-04-19
-last-updated: 2026-04-20
-status: draft
+last-updated: 2026-04-21
+status: implementing
 ---
 
 # OSEP-0011: Secure Access on GetEndpoint and Signed Endpoint
 
 ## Summary
 
-Optional `secure_access` on sandbox create. **`GetSignedEndpoint(sandboxId, port)`** returns a URL that embeds a **route `signature`** (a **10-character** token). There is **no** `expires`, **no** signing of app path or query, and **no** DNS parent domain in the signed material. The wildcard parent domain is **routing-only**.
+Optional `secure_access` on sandbox create. There are **two** complementary mechanisms:
 
-The **`signature`** is:
+1. **Static header authorization (from `GetEndpoint`)** — when `secure_access` is enabled, **`GetEndpoint`** returns a stable opaque **`SecureAccessToken`**. Clients attach it to **all subsequent requests** as  
+   **`OPENSANDBOX-SECURE-ACCESS: <token>`**  
+   Ingress evaluates this header **before** route-signature verification, with **fail-fast** semantics when the header field is **present** but wrong (see § *Ingress verification*).
 
-1. **`hex8`** — first **8** characters of the lowercase hex encoding of **`SHA256(inner)`** (i.e. the first **4** bytes of the digest as hex).
-2. **`signed_key_id`** — the **last 2** characters of **`signature`**, **`[0-9a-z]`**, equal to the **`key_id`** of the `secret_bytes` row used to mint (typically the server **`active_key`**).
+2. **Route `signature` (short route token)** — a **9-character** value embedded in host / header / path: **`hex8`** (8 lowercase hex) + **`signed_key_id`** (**exactly 1** char **`[0-9a-z]`**).  
+   **Every signed route also carries an `expires` value:** Unix epoch seconds as **`uint64`**, encoded for routing and signing as **`expires_b36`**: **base-36** using **lowercase** digits **`0-9`** and letters **`a-z`**, **no leading zeros** (except **`expires_sec == 0`** is **`0`**). Equivalently (Go): **`strconv.FormatUint(expires_sec, 36)`** / **`strconv.ParseUint(s, 36, 64)`**. It appears in **`canonical_bytes`** and as its **own** `-`-delimited segment: **`{sandbox_id}-{port}-{expires_b36}-{signature}`**.  
+   **Minting** always requires an **`expires`** input (see API). Ingress enforces **`now ≤ expires_seconds`** after decoding.
 
-`GetEndpoint` may still return an opaque static **`OPENSANDBOX-SECURE-ACCESS`** header value (annotation / access token) when enabled. That header path is **separate** from the route **`signature`**.
+There is **no** signing of app path or query, and **no** DNS parent domain in the signed material. The wildcard parent domain is **routing-only**.
 
-## Signing algorithm (implementation order)
+## Static access token (`GetEndpoint`)
 
-### 1) Inputs and constraints
+When the sandbox has **`secure_access` enabled**, **`GetEndpoint(sandboxId)`** (or equivalent lifecycle response) includes **`SecureAccessToken`**.
 
-- **`sandbox_id`**: used verbatim in canonical (may contain `-`).
-- **`port`**: decimal integer in **`1..65535`**, **no leading zeros** (e.g. `08080` is invalid).
-- **`secret_bytes`**: raw decoded secret bytes for the chosen **`signed_key_id`** (same material ingress uses to verify).
+**Client rule:** for **every** follow-up request through the gateway:
 
-### 2) Build `canonical_bytes` (UTF-8)
-
-Concatenate **exactly** in this order, using a single **LF** (`\n`) between segments:
-
-```text
-v1\nshort\n{sandbox_id}\n{port}\n
+```http
+OPENSANDBOX-SECURE-ACCESS: <token>
 ```
 
-Equivalent explicit concatenation:
+**Ingress rule (secure sandbox):** define **header present** as: the **`OPENSANDBOX-SECURE-ACCESS`** field appears on the HTTP request (any value, including empty). Then:
+
+- If **present** and the value **matches** **`SecureAccessToken`** (constant-time compare) → **allow**; route-signature verification is **not** required.  
+- If **present** and the value **does not match** → **`401` immediately**; ingress **must not** fall through to route-signature verification (prevents “bad/stale header + valid signed URL” from being accepted).  
+- If **absent** → ingress may authenticate using the route **`signature`** path (when provided and valid).
+
+## `expires_b36` encoding
+
+Let **`expires_sec`** be **`uint64`** Unix epoch seconds (UTC).
+
+**`expires_b36`** is the **base-36** encoding of **`expires_sec`** using **lowercase** alphabet **`0-9a-z`**, with **no leading zeros**, except **`expires_sec == 0`** is encoded as **`0`**. Normative reference (Go): **`strconv.FormatUint(expires_sec, 36)`** for minting and **`strconv.ParseUint(segment, 36, 64)`** for ingress.
+
+- **Length:** **1** to **13** characters inclusive for any **`uint64`** value (max is **`18446744073709551615`** → **`3w5e11264sgsf`**).  
+- **Charset:** **`[0-9a-z]`** only; reject uppercase.  
+- **Routing segment** and **`canonical_bytes`** embed the **same** literal string (not decimal seconds).  
+- **Ingress:** reject empty, invalid charset, overflow on parse, or length **> 13** → **`400`**. Then **`401`** if **`now > expires_sec`**.
+
+> **Rationale:** Base36 is shorter than decimal for typical timestamps (e.g. **`2000000000`** → **`x2qxvk`**, 6 chars) while staying URL/host friendly without extra escaping.
+
+## Signing algorithm (signed routes **always** include `expires_b36`)
+
+### Inputs and constraints
+
+- **`sandbox_id`**: verbatim in canonical (may contain `-`).
+- **`port`**: decimal **`1..65535`**, **no leading zeros**.
+- **`expires_b36`**: **required** for any minted signed route; rules above.
+- **`secret_bytes`**: raw decoded secret for **`signed_key_id`** (see config: **`key_id`** is **1** char **`[0-9a-z]`**).
+
+### `canonical_bytes` (UTF-8)
+
+Always (note: **`{expires_b36}`** is base36, **not** decimal):
 
 ```text
-"v1" + "\n" + "short" + "\n" + sandbox_id + "\n" + decimal(port) + "\n"
+v1\nshort\n{sandbox_id}\n{port}\n{expires_b36}\n
 ```
 
-### 3) Build `inner` (length-prefixed byte concatenation)
+### `inner` and `signature`
 
-`BE32(x)` is **4** bytes, **big-endian** unsigned 32-bit integer **`x`**.
-
-```text
-inner = BE32(len(secret_bytes))
-     || secret_bytes
-     || BE32(len(canonical_bytes))
-     || canonical_bytes
-```
-
-### 4) Hash and mint `signature`
+`BE32(x)` = 4-byte big-endian uint32.
 
 ```text
-digest    = SHA256(inner)              // 32 bytes
-hex_all   = lowercase_hex(digest)      // 64 chars
+inner     = BE32(len(secret_bytes)) || secret_bytes || BE32(len(canonical_bytes)) || canonical_bytes
+digest    = SHA256(inner)
+hex_all   = lowercase_hex(digest)
 hex8      = hex_all[0:8]
-signature = hex8 + signed_key_id       // 10 chars total
+signature = hex8 + signed_key_id       // 9 chars total
 ```
 
-> The signature binds **`sandbox_id`**, **`port`**, and the signing key only — not the gateway hostname or DNS suffix.
+### Routing token (always four logical segments for **signed** routes)
+
+```text
+{sandbox-id}-{port}-{expires_b36}-{signature}
+```
+
+**Right-to-left parse:**
+
+1. **Last**: **`signature`** (**`[0-9a-f]{8}[0-9a-z]{1}`** — exactly **9** characters).
+2. **Second-to-last**: **`expires_b36`** (**`[0-9a-z]{1,13}`**, decode with **base 36** to **`uint64`**).
+3. **Third-to-last**: **`port`** (decimal, rules above).
+4. **Remaining** (joined with `-`): **`sandbox_id`**.
+
+**Unsigned legacy (no route signature):** **`{sandbox_id}-{port}`** — two segments only.
 
 ## API
 
 - **CreateSandbox:** `secure_access.enabled` (default `false`).
-- **GetSignedEndpoint(sandboxId, port):** returns `signed_endpoint` consistent with `[ingress.gateway].route.mode`, embedding **`signature`**.
+- **`GetEndpoint(sandboxId)`:** when secure access is on, includes **`SecureAccessToken`** for **`OPENSANDBOX-SECURE-ACCESS`**.
+- **Mint signed URL / host token (all require expiry input):**
+  - **`GET /sandboxes/{sandboxId}/endpoints/secure/{port}?expires=<unix_seconds>`** (and/or **`GetSignedEndpoint`** with the same query).  
+  - **`expires`** query is a **decimal `uint64`** Unix second (human-friendly). The server **normalizes** to **`expires_b36`** (rules above) for both **`canonical_bytes`** and the returned routing token.  
+  - Missing **`expires`** on mint → **`400`**.
 
-## Gateway routing (where the credential lives)
+Returned signed routing material always uses **`{sandbox_id}-{port}-{expires_b36}-{signature}`**.
+
+## Gateway routing
 
 ### Host / header token (split on `-` from the **right**)
 
-- **Three or more segments** `<sandbox-id>-<port>-<signature>`:
-  - **Last** segment: **`signature`** (must match **`[0-9a-f]{8}[0-9a-z]{2}`**).
-  - **Second-to-last**: **`port`** (rules above).
-  - **Everything before** (re-joined with `-`): **`sandbox_id`**.
-- **Two segments** `<sandbox-id>-<port>`: **unsigned** route; **`signature`** is empty (legacy compatibility).
+- **Signed:** **`{sandbox_id}-{port}-{expires_b36}-{signature}`**.
+- **Unsigned legacy:** **`{sandbox_id}-{port}`**.
 
-| Mode | Where |
-|------|-------|
-| **Wildcard** | Host: `{sandbox_id}-{port}-{signature}.<parent-domain>` (parent domain from gateway DNS only; not signed) |
-| **Header** | Header value only: `{sandbox_id}-{port}-{signature}` |
-| **URI** | Path: `/{sandbox_id}/{port}/{signature}/` + remainder to upstream |
+| Mode | Where | Example (illustrative) |
+|------|-------|-------------------------|
+| **Wildcard** | Host: `{sandbox_id}-{port}-{expires_b36}-{signature}.<parent>` | `my-sandbox-8080-x2qxvk-aabbccddk.sandbox.example.com` — **`expires_b36`** = **`x2qxvk`** (**`2000000000`** sec, Go **`FormatUint(..., 36)`**); **`signature`** = **`aabbccddk`**; parent = **`sandbox.example.com`**. |
+| **Header** | Value: same `-`-joined token | `my-sandbox-8080-x2qxvk-aabbccddk` |
+| **URI** | Prefix: `/{sandbox_id}/{port}/{expires_b36}/{signature}/` + upstream remainder | `/my-sandbox/8080/x2qxvk/aabbccddk/v1/status` — upstream after strip: **`/v1/status`**. |
 
-### URI parsing nuance
+### URI parsing
 
-- If the path matches **OSEP** shape (valid **`port`** in segment 2 and a valid 10-char **`signature`** in segment 3), treat segments 1–3 as routing prefix and the rest as upstream path.
-- Otherwise parse as **legacy** URI: first segment = **`sandbox_id`**, second = **`port`**, remainder (if any) = upstream path — **no** embedded **`signature`**.
-- For sandboxes that **do not** require secure access, an OSEP-shaped path may be **reinterpreted** as legacy so a normal path segment is not mistaken for **`signature`**.
+**Secure sandboxes (secure access required):**
 
-After successful authorization, strip the routing token from host / header / path prefix; forward the remaining path and query unchanged.
+- If segments 2–4 are syntactically valid **`port`**, **`expires_b36`**, **`signature`**, treat the path as **signed OSEP**: strip **`/{sandbox_id}/{port}/{expires_b36}/{signature}`** and forward the remainder + query unchanged.
+
+**Unsecured sandboxes (secure access not required) — legacy safeguard:**
+
+- Even when segments 2–4 **happen to match** the **`expires_b36`** / **`signature`** charset and length rules, ingress **must not** treat them as a signed routing prefix for forwarding purposes.
+- Instead, **re-parse the full path using legacy URI rules** (first segment = **`sandbox_id`**, second = **`port`**, **everything after** is the upstream path, including any segments that looked like **`expires_b36`** / **`signature`**). This preserves existing **unsigned** apps whose paths could collide with the signed shape and avoids silently rewriting upstream paths.
+
+**How to decide:** after resolving **`sandbox_id`** from the first path segment, consult **`GetEndpoint` / secure-access policy**. Apply the **signed OSEP** strip **only** when the sandbox **requires** secure access; otherwise apply **legacy** parsing for URI mode.
+
+**Legacy unsigned (always):** `/{sandbox_id}/{port}/…` when the path is not using the signed prefix **or** when legacy re-parse is mandated above.
+
+Strip the signed prefix **only** on the secure path; forward path + query unchanged relative to the chosen interpretation.
 
 ## Ingress verification
 
-1. Parse **`sandbox_id`**, **`port`**, optional route **`signature`** from host, header, or URI (per mode).
-2. **`GetEndpoint(sandbox_id)`** — determine whether the sandbox requires secure access and obtain **`SecureAccessToken`** (annotation) if any.
-3. **Unified access decision:**
-   - If the sandbox does **not** require secure access → allow.
-   - If it **does** require secure access:
-     - If **`OPENSANDBOX-SECURE-ACCESS`** is present → it **must** equal the sandbox token (constant-time compare) or **`401`**.
-     - Else if route **`signature`** is present → rebuild **`canonical_bytes`**, recompute **`hex8`**, verify against **`secret_bytes`** for **`signed_key_id`** from **`--secure-access-keys`** → **`401`** on mismatch or unknown key.
-     - Else **`401`** (signature required).
+1. **Parse routing input** (mode-dependent). For **URI** mode, a path may **syntactically** match **`/{sandbox_id}/{port}/{expires_b36}/{signature}/…`**; still resolve **`sandbox_id`** (at minimum the first segment) for lookup.
+2. **`GetEndpoint(sandbox_id)`** once: secure-access flag, **`SecureAccessToken`**, and backend endpoint.
+3. **URI mode + secure access not required:** **re-parse the full path using legacy URI rules** for **`sandbox_id`**, **`port`**, and upstream **`requestURI`** (§ *URI parsing* / unsecured safeguard). **Do not** strip **`expires_b36`** / **`signature`**-shaped segments from the forwarded path.
+4. **Secure access required** (final signed interpretation for URI / host / header):
+   - **Header branch:** if **`OPENSANDBOX-SECURE-ACCESS`** is **present** (see § *Static access token*): **match** → **allow**; **mismatch** → **`401`** (no route-signature fallback).
+   - **Signature branch:** if the header is **absent** and a signed route token is present: decode **`expires_sec`** from **`expires_b36`**, require **`now ≤ expires_sec`**, rebuild **`canonical_bytes`** with the **same** **`expires_b36`**, verify **`signature`** → **`401`** on failure; if no signed credential → **`401`**.
+5. **Secure access not required** (URI after step 3 legacy re-parse, or unsigned host/header shapes): **allow** without route-signature verification.
 
 ## Config
 
@@ -111,33 +154,30 @@ After successful authorization, strip the routing token from host / header / pat
 ```toml
 [ingress.secure_access]
 enabled = true
-active_key = "k1"                    # 2 chars, must exist in keys
+active_key = "a"                    # 1 char [0-9a-z], must exist in keys
 
 [[ingress.secure_access.keys]]
-key_id = "k1"
+key_id = "a"
 secret = "base64:..."
 
 [[ingress.secure_access.keys]]
-key_id = "k0"
+key_id = "b"
 secret = "base64:..."
 ```
 
-The server mints **`signature`** using **`secret_bytes`** for **`active_key`**.
-
-**Ingress:**
+**Ingress:** `--secure-access-keys` uses the same **1-character** `key_id` per segment, e.g. **`a=base64:...,b=base64:...`**.
 
 ```bash
 opensandbox-ingress --secure-access-enabled \
-  --secure-access-keys "k1=base64:...,k0=base64:..."
+  --secure-access-keys "a=base64:...,b=base64:..."
 ```
 
 ## Errors
 
-- **`400`:** malformed route / token shape, invalid **`port`**, invalid **`signature`** charset or length.
-- **`401`:** bad **`hex8`**, unknown **`signed_key_id`**, missing credential when required, or secure-access header mismatch.
-- **GetSignedEndpoint:** `404` / `403` when sandbox is missing or secure access is disabled.
+- **`400`:** missing **`expires`** on mint, malformed token, invalid **`expires_b36`** (empty / bad charset / length **> 13** / parse overflow), bad **`port`** / **`signature`**.
+- **`401`:** header mismatch, **`now > expires_sec`**, bad **`hex8`**, unknown key, missing credential when required.
 
 ## Tests
 
-- Unit: `inner` / `hex8`, right-split with hyphens in **`sandbox_id`**, two-segment unsigned host, URI OSEP vs legacy.
-- Integration: three route modes + one tampered hex → **`401`**.
+- Unit: `inner` / `hex8`, four-part right split with `-` in **`sandbox_id`**, **`expires_b36`** canonicalization (no leading zeros, **`0`** case, round-trip **`ParseUint(..., 36, 64)`**).
+- Integration: three modes; invalid **`expires_b36`** → **`400`**; past expiry → **`401`**; mint without **`expires`** → **`400`**.


### PR DESCRIPTION
# Summary
- refine secure-access and signed route token spec
- sign `expires`

# Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered