### PR TITLE
controller: support namespace-scoped cache via WATCH_NAMESPACE

### DIFF
--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -31,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -127,6 +128,22 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// buildWatchNamespaces parses a comma-separated list of namespaces and returns
+// a map suitable for cache.Options.DefaultNamespaces. Empty entries are ignored.
+// An empty result (nil or empty map) means "watch all namespaces" and callers
+// should leave cache.Options unset to preserve controller-runtime defaults.
+func buildWatchNamespaces(raw string) map[string]cache.Config {
+	result := map[string]cache.Config{}
+	for _, ns := range strings.Split(raw, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			continue
+		}
+		result[ns] = cache.Config{}
+	}
+	return result
+}
+
 // nolint:gocyclo
 func main() {
 	var metricsAddr string
@@ -152,6 +169,13 @@ func main() {
 
 	// Controller concurrency options
 	var concurrencyConfig ConcurrencyConfig
+
+	// Cache scope option. Empty means the manager watches all namespaces
+	// (the historical default). A non-empty comma-separated list restricts
+	// the shared informer cache to just those namespaces, which drastically
+	// reduces memory usage when the controller only needs to manage a subset
+	// of a large cluster.
+	var watchNamespaces string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -180,6 +204,11 @@ func main() {
 	flag.BoolVar(&logCompress, "log-compress", true, "Compress determines if the rotated log files should be compressed using gzip")
 	flag.Float64Var(&kubeClientQPS, "kube-client-qps", 100, "QPS for Kubernetes client rate limiter.")
 	flag.IntVar(&kubeClientBurst, "kube-client-burst", 200, "Burst for Kubernetes client rate limiter.")
+	flag.StringVar(&watchNamespaces, "watch-namespaces", os.Getenv("WATCH_NAMESPACE"),
+		"Comma-separated list of namespaces the manager should watch. "+
+			"Empty (default) watches all namespaces; providing a list restricts "+
+			"the shared informer cache to only those namespaces. Also reads the "+
+			"WATCH_NAMESPACE environment variable.")
 	flag.Var(&concurrencyConfig, "concurrency", "Controller concurrency settings in format: controller1=N;controller2=M. "+
 		"Available controllers: batchsandbox, pool. "+
 		"Example: --concurrency='batchsandbox=32;pool=128'")
@@ -302,7 +331,7 @@ func main() {
 		config.Burst = kubeClientBurst
 	}
 
-	mgr, err := ctrl.NewManager(config, ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -320,7 +349,19 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+	if nsMap := buildWatchNamespaces(watchNamespaces); len(nsMap) > 0 {
+		watched := make([]string, 0, len(nsMap))
+		for ns := range nsMap {
+			watched = append(watched, ns)
+		}
+		setupLog.Info("restricting manager cache to specific namespaces",
+			"namespaces", watched)
+		mgrOptions.Cache = cache.Options{DefaultNamespaces: nsMap}
+	} else {
+		setupLog.Info("manager cache is cluster-scoped (watching all namespaces)")
+	}
+	mgr, err := ctrl.NewManager(config, mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -129,19 +131,43 @@ func init() {
 }
 
 // buildWatchNamespaces parses a comma-separated list of namespaces and returns
-// a map suitable for cache.Options.DefaultNamespaces. Empty entries are ignored.
-// An empty result (nil or empty map) means "watch all namespaces" and callers
-// should leave cache.Options unset to preserve controller-runtime defaults.
-func buildWatchNamespaces(raw string) map[string]cache.Config {
+// a map suitable for cache.Options.DefaultNamespaces.
+//
+// Parsing rules (strict on purpose — this flag controls cache scope, so silently
+// accepting malformed input and falling back to cluster-wide would broaden
+// privileges rather than narrow them):
+//
+//   - A completely empty / whitespace-only input returns (nil, nil), which the
+//     caller treats as "watch all namespaces" (controller-runtime default).
+//   - A non-empty input that yields no valid tokens (e.g. ",", "   , , ")
+//     returns an error.
+//   - Empty segments inside a non-empty list (e.g. "ns-a,,ns-b") are rejected
+//     rather than silently skipped, to surface operator/templating mistakes.
+//   - Each token is trimmed and validated as a DNS-1123 label so typos like
+//     "prod_a" or an overlong name fail fast at startup.
+//   - Duplicates are collapsed (set semantics) since cache.Options treats the
+//     map as a set.
+func buildWatchNamespaces(raw string) (map[string]cache.Config, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
 	result := map[string]cache.Config{}
-	for _, ns := range strings.Split(raw, ",") {
-		ns = strings.TrimSpace(ns)
+	for i, seg := range strings.Split(raw, ",") {
+		ns := strings.TrimSpace(seg)
 		if ns == "" {
-			continue
+			return nil, fmt.Errorf("invalid watch-namespaces value %q: empty segment at position %d", raw, i)
+		}
+		if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid watch-namespaces value %q: %q is not a valid namespace name: %s", raw, ns, strings.Join(errs, "; "))
 		}
 		result[ns] = cache.Config{}
 	}
-	return result
+	if len(result) == 0 {
+		// Should be unreachable given the rules above, but keep a defensive
+		// guard so the function never returns (nil, nil) for a non-empty input.
+		return nil, fmt.Errorf("invalid watch-namespaces value %q: no valid namespaces after parsing", raw)
+	}
+	return result, nil
 }
 
 // nolint:gocyclo
@@ -350,11 +376,17 @@ func main() {
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 	}
-	if nsMap := buildWatchNamespaces(watchNamespaces); len(nsMap) > 0 {
+	nsMap, err := buildWatchNamespaces(watchNamespaces)
+	if err != nil {
+		setupLog.Error(err, "invalid watch-namespaces configuration")
+		os.Exit(1)
+	}
+	if len(nsMap) > 0 {
 		watched := make([]string, 0, len(nsMap))
 		for ns := range nsMap {
 			watched = append(watched, ns)
 		}
+		sort.Strings(watched)
 		setupLog.Info("restricting manager cache to specific namespaces",
 			"namespaces", watched)
 		mgrOptions.Cache = cache.Options{DefaultNamespaces: nsMap}

--- a/kubernetes/cmd/controller/main_test.go
+++ b/kubernetes/cmd/controller/main_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestBuildWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    []string // sorted list of namespaces; nil means cluster-wide (nil map)
+		wantErr bool
+	}{
+		{
+			name: "empty string returns cluster-wide",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "whitespace-only returns cluster-wide",
+			raw:  "   \t  ",
+			want: nil,
+		},
+		{
+			name: "single namespace",
+			raw:  "default",
+			want: []string{"default"},
+		},
+		{
+			name: "two namespaces",
+			raw:  "ns-a,ns-b",
+			want: []string{"ns-a", "ns-b"},
+		},
+		{
+			name: "surrounding whitespace is trimmed",
+			raw:  "  ns-a  ,   ns-b ",
+			want: []string{"ns-a", "ns-b"},
+		},
+		{
+			name: "duplicates are collapsed",
+			raw:  "ns-a,ns-a,ns-b",
+			want: []string{"ns-a", "ns-b"},
+		},
+		{
+			name:    "single comma rejected",
+			raw:     ",",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace between commas rejected",
+			raw:     " , , ",
+			wantErr: true,
+		},
+		{
+			name:    "empty segment in middle rejected",
+			raw:     "ns-a,,ns-b",
+			wantErr: true,
+		},
+		{
+			name:    "trailing empty segment rejected",
+			raw:     "ns-a,",
+			wantErr: true,
+		},
+		{
+			name:    "leading empty segment rejected",
+			raw:     ",ns-a",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase rejected (DNS-1123)",
+			raw:     "Default",
+			wantErr: true,
+		},
+		{
+			name:    "underscore rejected (DNS-1123)",
+			raw:     "bad_ns",
+			wantErr: true,
+		},
+		{
+			name:    "overlong name rejected (> 63 chars)",
+			raw:     strings.Repeat("a", 64),
+			wantErr: true,
+		},
+		{
+			name: "max-length name accepted (63 chars)",
+			raw:  strings.Repeat("a", 63),
+			want: []string{strings.Repeat("a", 63)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildWatchNamespaces(tc.raw)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("buildWatchNamespaces(%q): expected error, got nil (result=%v)", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildWatchNamespaces(%q): unexpected error: %v", tc.raw, err)
+			}
+
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("buildWatchNamespaces(%q): expected nil map (cluster-wide), got %v", tc.raw, got)
+				}
+				return
+			}
+
+			gotKeys := make([]string, 0, len(got))
+			for k := range got {
+				gotKeys = append(gotKeys, k)
+			}
+			sort.Strings(gotKeys)
+
+			if len(gotKeys) != len(tc.want) {
+				t.Fatalf("buildWatchNamespaces(%q): got %d keys %v, want %d keys %v",
+					tc.raw, len(gotKeys), gotKeys, len(tc.want), tc.want)
+			}
+			for i := range gotKeys {
+				if gotKeys[i] != tc.want[i] {
+					t.Fatalf("buildWatchNamespaces(%q): key[%d]=%q, want %q (full=%v)",
+						tc.raw, i, gotKeys[i], tc.want[i], gotKeys)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Both `BatchSandboxReconciler` and `PoolReconciler` declare `Owns(&corev1.Pod{})` in `SetupWithManager`. In `cmd/controller/main.go`, the manager is created without `Cache.DefaultNamespaces`, which means the underlying controller-runtime shared informer for Pods has **cluster-wide** scope.

This is controller-runtime's documented default and isn't wrong on its own. However, on a large shared cluster that hosts many unrelated workloads alongside OpenSandbox:

- The shared Pod informer performs a full `list+watch` of **every Pod in the cluster** on startup.
- The `Pod.ownerRefUID` field index (`internal/utils/fieldindex`) is built over that entire set.
- Cold-start memory usage grows with **cluster-wide Pod count**, not with the number of OpenSandbox-owned Pods, which can significantly increase startup memory pressure on multi-tenant clusters.

Observed symptom on a shared multi-tenant cluster where only one namespace contained OpenSandbox CRs:

- `opensandbox-controller-manager` crash-looped with `exitCode=137` / `reason=OOMKilled` within ~5s of startup. Logs only got as far as `register field index` / `starting manager` / `starting server name=health probe` before the kernel killed the process on cgroup memory limit.
- Raising the Pod memory limit helped but is a band-aid — headroom still has to cover *unrelated* cluster growth.

### Why this is safe to narrow

The current reconcile code already treats BatchSandbox/Pool/Pod as a same-namespace graph, so restricting the cache to the namespaces that actually contain OpenSandbox CRs does not remove any existing capability:

- `BatchSandbox.Spec.PoolRef` is just a name, with no namespace field
  ([apis/sandbox/v1alpha1/batchsandbox_types.go L34](https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/apis/sandbox/v1alpha1/batchsandbox_types.go#L34)).
- `PoolReconciler` lists `BatchSandbox` only within `pool.Namespace`
  ([internal/controller/pool_controller.go L146-L148](https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/internal/controller/pool_controller.go#L146-L148)).
- `PoolReconciler` maps back from `BatchSandbox` to `Pool` using `batchSandbox.Namespace`
  ([internal/controller/pool_controller.go L295](https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/internal/controller/pool_controller.go#L295)).
- `BatchSandboxReconciler` fetches owned Pods by `batchSbx.Namespace`
  ([internal/controller/batchsandbox_controller.go L342](https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/internal/controller/batchsandbox_controller.go#L342)).

So the cluster-wide cache is paying a cost that none of the reconcile paths actually consume.

## Change

Add an opt-in flag to narrow the manager cache to a specific set of namespaces.

- New flag `--watch-namespaces` (comma-separated list).
- Defaults to the `WATCH_NAMESPACE` environment variable (common operator convention).
- When non-empty, wires into `cache.Options.DefaultNamespaces`, producing a multi-namespace cache.
- When empty (or unset), behavior is **unchanged** — the manager stays cluster-scoped, preserving backward compatibility.

### Parser is fail-closed, not fail-open

The flag's purpose is least-privilege / smaller cache, so malformed input must not silently widen scope back to cluster-wide. `buildWatchNamespaces` rejects any malformed input with a clear error and the controller exits non-zero at startup:

| Input | Behavior |
|---|---|
| `""` (empty) | cluster-wide (explicit opt-out) |
| `"ns-a"` / `"ns-a,ns-b"` | namespace-scoped |
| `"  ns-a  ,  ns-b  "` | trimmed, namespace-scoped |
| `"ns-a,ns-a"` | de-duplicated to `{ns-a}` |
| `","`, `" , "`, `"ns-a,"`, `",ns-a"`, `"ns-a,,ns-b"` | **error, exit 1** (empty segment) |
| `"Default"`, `"bad_ns"`, 64-char name | **error, exit 1** (fails DNS-1123 label validation via `k8s.io/apimachinery/pkg/util/validation.IsDNS1123Label`) |

The startup log also sorts the namespace list before printing so the line is deterministic across restarts.

Example:

```yaml
# Deployment snippet
env:
  - name: WATCH_NAMESPACE
    value: "opensandbox"
```

or:

```
sandbox-controller --watch-namespaces=opensandbox,another-ns
```

Log line on startup:

```
restricting manager cache to specific namespaces  namespaces=[opensandbox]
```

vs. unset:

```
manager cache is cluster-scoped (watching all namespaces)
```

## Compatibility & risk

- Flag defaults to empty → no behavior change for existing users.
- No CRD / RBAC / Helm chart changes in this PR. Operators who opt in can tighten RBAC from `ClusterRole` to `Role`/`RoleBinding` in a follow-up; that is not required for the cache change itself to take effect.
- `Owns(&corev1.Pod{})` is unchanged. Pool / BatchSandbox reconcile logic is unchanged.
- `cache.Options.DefaultNamespaces` is compatible with the existing `Metrics` / `WebhookServer` manager options and with `fieldindex.RegisterFieldIndexes` — `multiNamespaceCache` supports `IndexField`.
- Note for future contributors: if webhook handlers are later added that need to read across namespaces via the manager cache, those webhooks would need to be scoped consistently with the configured watch-namespaces.
- Cost model caveat: `DefaultNamespaces` creates one cache/informer per namespace, so this flag is intended for "a small number of namespaces replaces one cluster-wide cache", not for arbitrarily long lists.

## Testing

- `go build ./cmd/controller/...` passes.
- `go vet ./cmd/controller/...` passes.
- New table-driven unit test `cmd/controller/main_test.go` covers 15 cases: empty, whitespace-only, single, multi, trim, duplicates, mid-empty / leading-empty / trailing-empty / single-comma / whitespace-between-commas (all rejected), uppercase (rejected), underscore (rejected), 64-char overlong (rejected), 63-char max-length (accepted). All pass under `go test -count=1 -v ./cmd/controller/...`.
- `--help` shows the new flag:

  ```
  -watch-namespaces string
      Comma-separated list of namespaces the manager should watch.
      Empty (default) watches all namespaces; providing a list restricts
      the shared informer cache to only those namespaces. Also reads the
      WATCH_NAMESPACE environment variable.
  ```

## Follow-ups (not in this PR, happy to do separately if accepted)

- Document the `WATCH_NAMESPACE` env / `--watch-namespaces` flag in `config/manager/manager.yaml` and the Helm chart so the feature is discoverable.
- Optional: make RBAC generation respect the watched-namespace set (emit `Role`/`RoleBinding` instead of `ClusterRole` when a scope is requested).

Happy to iterate on naming (`--watch-namespaces` vs `--namespaces` vs adopting the prometheus-operator style multi-flag split) or on defaults if maintainers prefer a different convention.
