### PR TITLE
fix(chart/server): wire imagePullSecrets into ServiceAccount and Deployment

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -8,6 +8,10 @@ metadata:
   namespace: {{ include "opensandbox-server.namespace" . }}
   labels:
     {{- include "opensandbox-server.labels" . | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: {{ include "opensandbox-server.rbac.apiVersion" . }}
 kind: ClusterRole
@@ -80,6 +84,10 @@ spec:
         {{- include "opensandbox-server.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: opensandbox
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "opensandbox-server.serviceAccountName" . }}
       containers:
         - name: main

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -9,6 +9,9 @@ fullnameOverride: "opensandbox-server"
 # -- Override the namespace (default: opensandbox-system)
 namespaceOverride: ""
 
+# -- Image pull secrets for the server deployment. Each entry: {name: <secret-name>}.
+imagePullSecrets: []
+
 # Server configuration
 server:
   # -- Server image configuration


### PR DESCRIPTION
## Summary

- `opensandbox-server` chart did not wire `imagePullSecrets` into its ServiceAccount or Deployment templates, and did not declare the field in `values.yaml`. Deploys against a private registry therefore failed with `ErrImagePull` even when the user supplied pull secrets via values.
- This PR mirrors the pattern used by the sibling `opensandbox-controller` chart: declares `imagePullSecrets: []` at the top of `values.yaml`, and injects it into the ServiceAccount and into `Deployment.spec.template.spec`.

Fixes #767.

## Changes

- `kubernetes/charts/opensandbox-server/values.yaml`: add top-level `imagePullSecrets: []` with docstring.
- `kubernetes/charts/opensandbox-server/templates/server.yaml`: add `{{- with .Values.imagePullSecrets }}` injection in both the `ServiceAccount` block and the `Deployment.spec.template.spec`.

## Test plan

- [x] `helm template` on a values file with `imagePullSecrets: [{name: my-secret}]` — rendered output contains `imagePullSecrets` in both the SA and Deployment. `helm template` on a values file with no `imagePullSecrets` — rendered output contains no such field (no empty `imagePullSecrets: []`).
- [x] End-to-end `helm install` against a cluster pulling the server image from a private registry — pod becomes Ready without any post-install `kubectl patch` workaround.
- [ ] CI / existing chart tests pass (deferred to reviewers; no test files in the chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
