### PR TITLE
fix(chart/controller): coerce kubeClient.qps/burst to int before gt comparison

### DIFF
--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -52,10 +52,10 @@ spec:
         {{- end }}
         - --health-probe-bind-address=:8081
         - --zap-log-level={{ .Values.controller.logLevel }}
-        {{- if and .Values.controller.kubeClient (gt .Values.controller.kubeClient.qps 0) }}
+        {{- if and .Values.controller.kubeClient (gt (int .Values.controller.kubeClient.qps) 0) }}
         - --kube-client-qps={{ .Values.controller.kubeClient.qps }}
         {{- end }}
-        {{- if and .Values.controller.kubeClient (gt .Values.controller.kubeClient.burst 0) }}
+        {{- if and .Values.controller.kubeClient (gt (int .Values.controller.kubeClient.burst) 0) }}
         - --kube-client-burst={{ .Values.controller.kubeClient.burst }}
         {{- end }}
         ports:


### PR DESCRIPTION
## Summary

- `helm install` failed with `error calling gt: incompatible types for comparison` whenever `controller.kubeClient.qps` / `burst` were supplied via `-f values.yaml`, because YAML numeric scalars coalesce to `float64` while the literal `0` on the other side of the `gt` is `int`.
- This PR wraps each operand in `(int …)` so the comparison always runs with matching types, regardless of whether the value arrived via `-f` or `--set`.

Fixes #770.

## Changes

- `kubernetes/charts/opensandbox-controller/templates/deployment.yaml`: cast `.Values.controller.kubeClient.qps` / `.burst` to `int` inside the two `gt` comparisons on lines 55 and 58.

## Test plan

- [x] `helm template opensandbox ./opensandbox -f values.yaml` with `opensandbox-controller.controller.kubeClient.qps: 100` — renders `--kube-client-qps=100` without error.
- [x] `helm template … --set opensandbox-controller.controller.kubeClient.qps=100` — still works (int case).
- [x] `helm template …` with no override — default values (`qps: 100`, `burst: 200`) render correctly.
- [x] End-to-end `helm install` with values file — controller pod starts and `--kube-client-qps=100 --kube-client-burst=200` appear in its args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
