### PR TITLE
feat(extensions): propagate opensandbox.extensions.* to Pod annotations

### DIFF
--- a/server/opensandbox_server/extensions/__init__.py
+++ b/server/opensandbox_server/extensions/__init__.py
@@ -16,10 +16,15 @@
 CreateSandbox ``extensions`` shared logic: well-known keys, HTTP validation, workload storage codec.
 """
 
-from opensandbox_server.extensions.codec import apply_access_renew_extend_seconds_to_mapping
+from opensandbox_server.extensions.codec import (
+    apply_access_renew_extend_seconds_to_mapping,
+    apply_extensions_to_annotations,
+)
 from opensandbox_server.extensions.keys import (
     ACCESS_RENEW_EXTEND_SECONDS_KEY,
     ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY,
+    EXTENSIONS_ANNOTATION_PREFIX,
+    ANNOTATION_METADATA_PREFIX,
 )
 from opensandbox_server.extensions.validation import (
     ACCESS_RENEW_EXTEND_SECONDS_MAX,
@@ -34,4 +39,7 @@ __all__ = [
     "ACCESS_RENEW_EXTEND_SECONDS_MAX",
     "validate_extensions",
     "apply_access_renew_extend_seconds_to_mapping",
+    "apply_extensions_to_annotations",
+    "EXTENSIONS_ANNOTATION_PREFIX",
+    "ANNOTATION_METADATA_PREFIX",
 ]

--- a/server/opensandbox_server/extensions/codec.py
+++ b/server/opensandbox_server/extensions/codec.py
@@ -19,6 +19,8 @@ from typing import Dict, MutableMapping, Optional
 from opensandbox_server.extensions.keys import (
     ACCESS_RENEW_EXTEND_SECONDS_KEY,
     ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY,
+    EXTENSIONS_ANNOTATION_PREFIX,
+    ANNOTATION_METADATA_PREFIX,
 )
 
 
@@ -42,3 +44,27 @@ def apply_access_renew_extend_seconds_to_mapping(
     if not s:
         return
     mapping[metadata_key] = s
+
+
+def apply_extensions_to_annotations(
+    annotations: MutableMapping[str, str],
+    extensions: Optional[Dict[str, str]],
+) -> None:
+    """
+    Propagate extension keys with ``opensandbox.extensions.`` prefix to Pod annotations.
+
+    For each extension key starting with EXTENSIONS_ANNOTATION_PREFIX, the value is
+    copied to annotations with ANNOTATION_METADATA_PREFIX prefix.
+
+    Example:
+        extensions = {"opensandbox.extensions.pool-ref": "my-pool"}
+        → annotations["opensandbox.io/extensions.pool-ref"] = "my-pool"
+    """
+    if not extensions:
+        return
+    for key, value in extensions.items():
+        if key.startswith(EXTENSIONS_ANNOTATION_PREFIX):
+            # Extract the suffix after the prefix
+            suffix = key[len(EXTENSIONS_ANNOTATION_PREFIX):]
+            annotation_key = ANNOTATION_METADATA_PREFIX + suffix
+            annotations[annotation_key] = value

--- a/server/opensandbox_server/extensions/keys.py
+++ b/server/opensandbox_server/extensions/keys.py
@@ -14,6 +14,12 @@
 
 """Well-known CreateSandboxRequest.extensions keys and workload storage keys."""
 
+# access.renew.extend.seconds extension key (annotation-based)
 ACCESS_RENEW_EXTEND_SECONDS_KEY = "access.renew.extend.seconds"
-# Kubernetes annotation or Docker label value (plain seconds string).
 ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY = "opensandbox.io/access-renew-extend-seconds"
+
+# Extensions to annotations transformation prefix
+# User-specified extension keys starting with EXTENSIONS_ANNOTATION_PREFIX
+# are automatically propagated to Pod annotations with ANNOTATION_METADATA_PREFIX
+EXTENSIONS_ANNOTATION_PREFIX = "opensandbox.extensions."
+ANNOTATION_METADATA_PREFIX = "opensandbox.io/extensions."

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -200,6 +200,10 @@ class BatchSandboxProvider(WorkloadProvider):
         spec: Dict[str, Any] = {
             "replicas": 1,
             "template": {
+                "metadata": {
+                    "labels": labels,
+                    "annotations": annotations or {},
+                },
                 "spec": pod_spec,
             },
         }

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -27,7 +27,10 @@ from typing import Optional, Dict, Any
 
 from fastapi import HTTPException, status
 
-from opensandbox_server.extensions import apply_access_renew_extend_seconds_to_mapping
+from opensandbox_server.extensions import (
+    apply_access_renew_extend_seconds_to_mapping,
+    apply_extensions_to_annotations,
+)
 from opensandbox_server.extensions.keys import ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY
 from opensandbox_server.api.schema import (
     CreateSandboxRequest,
@@ -420,6 +423,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         
         try:
             apply_access_renew_extend_seconds_to_mapping(context.annotations, request.extensions)
+            apply_extensions_to_annotations(context.annotations, request.extensions)
 
             ensure_volumes_valid(
                 request.volumes,

--- a/server/tests/test_extensions.py
+++ b/server/tests/test_extensions.py
@@ -22,9 +22,7 @@ from opensandbox_server.extensions import (
     ACCESS_RENEW_EXTEND_SECONDS_MIN,
     apply_access_renew_extend_seconds_to_mapping,
     apply_extensions_to_annotations,
-    validate_extensions,
-    EXTENSIONS_ANNOTATION_PREFIX,
-    ANNOTATION_METADATA_PREFIX,
+    validate_extensions
 )
 
 

--- a/server/tests/test_extensions.py
+++ b/server/tests/test_extensions.py
@@ -21,7 +21,10 @@ from opensandbox_server.extensions import (
     ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY,
     ACCESS_RENEW_EXTEND_SECONDS_MIN,
     apply_access_renew_extend_seconds_to_mapping,
+    apply_extensions_to_annotations,
     validate_extensions,
+    EXTENSIONS_ANNOTATION_PREFIX,
+    ANNOTATION_METADATA_PREFIX,
 )
 
 
@@ -95,3 +98,63 @@ class TestAccessRenewExtendSecondsStorage:
         m: dict[str, str] = {"x": "1"}
         assert apply_access_renew_extend_seconds_to_mapping(m, {"poolRef": "p"}) is None
         assert m == {"x": "1"}
+
+
+class TestExtensionsToAnnotations:
+    """Extensions with opensandbox.extensions. prefix are propagated to annotations."""
+
+    def test_single_extension_propagated(self):
+        annotations: dict[str, str] = {}
+        extensions = {"opensandbox.extensions.pool-ref": "my-pool"}
+        apply_extensions_to_annotations(annotations, extensions)
+        assert annotations == {"opensandbox.io/extensions.pool-ref": "my-pool"}
+
+    def test_multiple_extensions_propagated(self):
+        annotations: dict[str, str] = {}
+        extensions = {
+            "opensandbox.extensions.pool-ref": "my-pool",
+            "opensandbox.extensions.custom-key": "custom-value",
+        }
+        apply_extensions_to_annotations(annotations, extensions)
+        assert annotations == {
+            "opensandbox.io/extensions.pool-ref": "my-pool",
+            "opensandbox.io/extensions.custom-key": "custom-value",
+        }
+
+    def test_non_prefix_extension_not_propagated(self):
+        annotations: dict[str, str] = {}
+        extensions = {
+            "poolRef": "my-pool",
+            "other.key": "value",
+        }
+        apply_extensions_to_annotations(annotations, extensions)
+        assert annotations == {}
+
+    def test_mixed_extensions_propagated_only_prefix_keys(self):
+        annotations: dict[str, str] = {}
+        extensions = {
+            "opensandbox.extensions.pool-ref": "my-pool",
+            "poolRef": "ignored",
+            "access.renew.extend.seconds": "1800",
+        }
+        apply_extensions_to_annotations(annotations, extensions)
+        assert annotations == {"opensandbox.io/extensions.pool-ref": "my-pool"}
+
+    def test_empty_extensions_noop(self):
+        annotations: dict[str, str] = {"existing": "value"}
+        apply_extensions_to_annotations(annotations, None)
+        assert annotations == {"existing": "value"}
+
+    def test_empty_extensions_dict_noop(self):
+        annotations: dict[str, str] = {"existing": "value"}
+        apply_extensions_to_annotations(annotations, {})
+        assert annotations == {"existing": "value"}
+
+    def test_preserves_existing_annotations(self):
+        annotations: dict[str, str] = {"existing": "value"}
+        extensions = {"opensandbox.extensions.new-key": "new-value"}
+        apply_extensions_to_annotations(annotations, extensions)
+        assert annotations == {
+            "existing": "value",
+            "opensandbox.io/extensions.new-key": "new-value",
+        }


### PR DESCRIPTION
Add mechanism to propagate user-specified extensions with opensandbox.extensions. prefix to Pod annotations with opensandbox.io/extensions. prefix. This enables custom metadata from Kotlin SDK to be visible on Kubernetes Pod annotations.

Also fix BatchSandbox provider to include labels and annotations in Pod template metadata, ensuring they are passed to created Pods.

# Summary
- What is changing and why?

  This change enables custom metadata from Kotlin SDK extensions to be propagated to Kubernetes Pod annotations. Previously, user-specified extensions were only used for server-side logic (like poolRef) and were not visible on the created Pod. Now, extensions with `opensandbox.extensions.` prefix are automatically 
  copied to Pod annotations with `opensandbox.io/extensions.` prefix.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  Additionally, fixed a bug where BatchSandbox provider did not include metadata in Pod template, causing labels and annotations to not be passed to created Pods.        

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
