### PR TITLE
fix(server): pass GPU resource limits to Docker containers

### DIFF
--- a/server/opensandbox_server/services/docker.py
+++ b/server/opensandbox_server/services/docker.py
@@ -40,6 +40,7 @@ from uuid import uuid4
 
 import docker
 from docker.errors import DockerException, ImageNotFound, NotFound as DockerNotFound
+from docker.types import DeviceRequest
 from fastapi import HTTPException, status
 
 from opensandbox_server.extensions import (
@@ -105,6 +106,7 @@ from opensandbox_server.services.endpoint_auth import (
 )
 from opensandbox_server.services.helpers import (
     matches_filter,
+    parse_gpu_request,
     parse_memory_limit,
     parse_nano_cpus,
     parse_timestamp,
@@ -1170,7 +1172,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
                 auto_created_volumes, separators=(",", ":"),
             )
         image_uri, auth_config = self._resolve_image_auth(request, sandbox_id)
-        mem_limit, nano_cpus = self._resolve_resource_limits(request)
+        mem_limit, nano_cpus, gpu_count = self._resolve_resource_limits(request)
         egress_token: Optional[str] = None
         requested_windows_profile = is_windows_platform(request.platform)
 
@@ -1191,9 +1193,12 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
             # For dockur/windows profile, resourceLimits are translated to
             # guest envs (RAM_SIZE/CPU_CORES/DISK_SIZE). Avoid applying
             # container cgroup memory/cpu limits to the outer Linux container,
-            # which can OOM-kill QEMU during installation/runtime.
+            # which can OOM-kill QEMU during installation/runtime. GPU
+            # passthrough is likewise suppressed: the Windows guest runs inside
+            # QEMU and would not see GPUs exposed to the outer container.
             effective_mem_limit = None if requested_windows_profile else mem_limit
             effective_nano_cpus = None if requested_windows_profile else nano_cpus
+            effective_gpu_count = None if requested_windows_profile else gpu_count
 
             # Build volume bind mounts from request volumes.
             # pvc_inspect_cache carries Docker volume inspect data from the
@@ -1230,7 +1235,8 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
                 labels[SANDBOX_EMBEDDING_PROXY_PORT_LABEL] = str(host_execd_port)
                 labels[SANDBOX_HTTP_PORT_LABEL] = str(host_http_port)
                 host_config_kwargs = self._base_host_config_kwargs(
-                    effective_mem_limit, effective_nano_cpus, f"container:{sidecar_container.id}"
+                    effective_mem_limit, effective_nano_cpus, f"container:{sidecar_container.id}",
+                    gpu_count=effective_gpu_count,
                 )
                 # Container network namespace is shared with sidecar. Docker rejects
                 # exposing ports on the main container in "container:<id>" mode.
@@ -1242,7 +1248,8 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
                     host_config_kwargs["cap_drop"] = list(cap_drop)
             else:
                 host_config_kwargs = self._base_host_config_kwargs(
-                    effective_mem_limit, effective_nano_cpus, self.network_mode
+                    effective_mem_limit, effective_nano_cpus, self.network_mode,
+                    gpu_count=effective_gpu_count,
                 )
                 if self.network_mode != HOST_NETWORK_MODE:
                     port_bindings = allocate_port_bindings(exposed_ports)
@@ -2250,17 +2257,19 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
 
     def _resolve_resource_limits(
         self, request: CreateSandboxRequest
-    ) -> tuple[Optional[int], Optional[int]]:
+    ) -> tuple[Optional[int], Optional[int], Optional[int]]:
         resource_limits = request.resource_limits.root or {}
         mem_limit = parse_memory_limit(resource_limits.get("memory"))
         nano_cpus = parse_nano_cpus(resource_limits.get("cpu"))
-        return mem_limit, nano_cpus
+        gpu_count = parse_gpu_request(resource_limits.get("gpu"))
+        return mem_limit, nano_cpus, gpu_count
 
     def _base_host_config_kwargs(
         self,
         mem_limit: Optional[int],
         nano_cpus: Optional[int],
         network_mode: str,
+        gpu_count: Optional[int] = None,
     ) -> Dict[str, Any]:
         host_config_kwargs: Dict[str, Any] = {"network_mode": network_mode}
         security_opts: list[str] = []
@@ -2281,6 +2290,13 @@ class DockerSandboxService(DockerDiagnosticsMixin, OSSFSMixin, SandboxService, E
             host_config_kwargs["mem_limit"] = mem_limit
         if nano_cpus:
             host_config_kwargs["nano_cpus"] = nano_cpus
+        if gpu_count:
+            # Honors host toolchains such as nvidia-container-toolkit. The Docker
+            # Engine returns a clear error at container create time if the host
+            # cannot satisfy the request, so failure is surfaced rather than silent.
+            host_config_kwargs["device_requests"] = [
+                DeviceRequest(count=gpu_count, capabilities=[["gpu"]])
+            ]
         # Inject secure runtime into host_config
         if self.docker_runtime:
             logger.info(

--- a/server/opensandbox_server/services/helpers.py
+++ b/server/opensandbox_server/services/helpers.py
@@ -93,6 +93,31 @@ def parse_nano_cpus(value: Optional[str]) -> Optional[int]:
     return int(cpus * 1_000_000_000)
 
 
+def parse_gpu_request(value: Optional[str]) -> Optional[int]:
+    """Convert GPU limit string to a device count.
+
+    Accepts a positive integer string (e.g. ``"1"``, ``"2"``) or the literal
+    ``"all"`` to request every available GPU. Returns ``-1`` for ``"all"``
+    (the sentinel the Docker Engine uses for unbounded device requests),
+    a positive int for a numeric count, and ``None`` when unset or the
+    value cannot be parsed.
+    """
+    if not value:
+        return None
+    gpu_str = value.strip().lower()
+    if gpu_str == "all":
+        return -1
+    try:
+        count = int(gpu_str)
+    except ValueError:
+        logger.warning("Invalid GPU limit format '%s'; ignoring.", value)
+        return None
+    if count <= 0:
+        logger.warning("GPU limit must be positive. Got '%s'. Ignoring.", value)
+        return None
+    return count
+
+
 def parse_timestamp(timestamp: Optional[str]) -> datetime:
     """
     Parse RFC3339 timestamp into timezone-aware datetime. Fallback to now.
@@ -199,6 +224,7 @@ def format_ingress_endpoint(
 __all__ = [
     "parse_memory_limit",
     "parse_nano_cpus",
+    "parse_gpu_request",
     "parse_timestamp",
     "normalize_external_endpoint_url",
     "format_ingress_endpoint",

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -47,7 +47,12 @@ from opensandbox_server.services.constants import (
     SandboxErrorCodes,
 )
 from opensandbox_server.services.docker import DockerSandboxService, PendingSandbox
-from opensandbox_server.services.helpers import parse_memory_limit, parse_nano_cpus, parse_timestamp
+from opensandbox_server.services.helpers import (
+    parse_gpu_request,
+    parse_memory_limit,
+    parse_nano_cpus,
+    parse_timestamp,
+)
 from opensandbox_server.api.schema import (
     CreateSandboxRequest,
     CreateSandboxResponse,
@@ -82,6 +87,17 @@ def test_parse_nano_cpus():
     assert parse_nano_cpus("500m") == 500_000_000
     assert parse_nano_cpus("2") == 2_000_000_000
     assert parse_nano_cpus("bad") is None
+
+def test_parse_gpu_request():
+    assert parse_gpu_request("1") == 1
+    assert parse_gpu_request("4") == 4
+    assert parse_gpu_request("all") == -1
+    assert parse_gpu_request("ALL") == -1
+    assert parse_gpu_request(None) is None
+    assert parse_gpu_request("") is None
+    assert parse_gpu_request("0") is None
+    assert parse_gpu_request("-1") is None
+    assert parse_gpu_request("bad") is None
 
 def test_parse_timestamp_defaults_on_invalid():
     ts = parse_timestamp("0001-01-01T00:00:00Z")
@@ -155,6 +171,82 @@ async def test_create_sandbox_applies_security_defaults(mock_docker):
     assert "no-new-privileges:true" in host_config.get("security_opt", [])
     assert host_config.get("cap_drop") == service.app_config.docker.drop_capabilities
     assert host_config.get("pids_limit") == service.app_config.docker.pids_limit
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker")
+async def test_create_sandbox_passes_gpu_device_requests(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_client.api.create_container.return_value = {"Id": "cid"}
+    mock_client.containers.get.return_value = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    request = CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.11"),
+        timeout=120,
+        resourceLimits=ResourceLimits(root={"gpu": "2"}),
+        env={},
+        metadata={},
+        entrypoint=["python"],
+    )
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+        patch(
+            "opensandbox_server.services.docker.allocate_port_bindings",
+            return_value={
+                "44772": ("0.0.0.0", 40001),
+                "8080": ("0.0.0.0", 40002),
+            },
+        ),
+    ):
+        await service.create_sandbox(request)
+
+    create_host_config_kwargs = mock_client.api.create_host_config.call_args.kwargs
+    device_requests = create_host_config_kwargs.get("device_requests")
+    assert device_requests is not None
+    assert len(device_requests) == 1
+    # DeviceRequest is a dict subclass keyed with the Docker Engine's
+    # capitalized field names.
+    assert device_requests[0]["Count"] == 2
+    assert device_requests[0]["Capabilities"] == [["gpu"]]
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker")
+async def test_create_sandbox_without_gpu_omits_device_requests(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_client.api.create_container.return_value = {"Id": "cid"}
+    mock_client.containers.get.return_value = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    request = CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.11"),
+        timeout=120,
+        resourceLimits=ResourceLimits(root={}),
+        env={},
+        metadata={},
+        entrypoint=["python"],
+    )
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_prepare_sandbox_runtime"),
+        patch(
+            "opensandbox_server.services.docker.allocate_port_bindings",
+            return_value={
+                "44772": ("0.0.0.0", 40001),
+                "8080": ("0.0.0.0", 40002),
+            },
+        ),
+    ):
+        await service.create_sandbox(request)
+
+    create_host_config_kwargs = mock_client.api.create_host_config.call_args.kwargs
+    assert "device_requests" not in create_host_config_kwargs
 
 @pytest.mark.parametrize(
     "runtime_exc, expected_status, expect_wrapped_error",


### PR DESCRIPTION
# Summary
- `CreateSandboxRequest.resourceLimits.gpu` is documented in the schema (`server/opensandbox_server/api/schema.py` example and the `ResourceLimits` SDK docstring) but the Docker runtime silently dropped it: `_resolve_resource_limits` only parsed `cpu`/`memory` and `_base_host_config_kwargs` never emitted `device_requests`.
- Adds `parse_gpu_request` in `services/helpers.py` (accepts positive integers or `"all"` → `-1` sentinel, mirroring `parse_nano_cpus` validation style) and threads the parsed count through `_resolve_resource_limits` and `_base_host_config_kwargs`, which now attaches a single `DeviceRequest(count=N, capabilities=[["gpu"]])`.
- For the `dockur/windows` profile the GPU request is suppressed on the outer container, consistent with how cpu/memory limits are already handled there (a Windows guest inside QEMU wouldn't see GPUs exposed to the outer Linux container).
- Fixes #774.

**Scope note:** The Kubernetes path has the same gap (`resources.limits["nvidia.com/gpu"]` is also not wired up). Intentionally left out of scope for this PR — happy to file a follow-up issue/PR if desired.

**Failure mode:** Hosts without the required toolchain (e.g. missing `nvidia-container-toolkit`) surface an explicit Docker Engine error at container create time, so GPU request failures remain visible rather than silent.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Focused checks from `server/AGENTS.md`:

```
uv run ruff check
uv run pytest tests/test_docker_service.py tests/test_schema.py tests/test_docker_windows_profile.py
```

Added tests:
- `test_parse_gpu_request` — unit tests for the new helper (positive ints, `"all"` sentinel, rejection of `None`/`""`/`0`/`-1`/non-numeric values).
- `test_create_sandbox_passes_gpu_device_requests` — asserts `device_requests` reaches `create_host_config` with the correct `Count` and `Capabilities` when `resourceLimits.gpu="2"` is set.
- `test_create_sandbox_without_gpu_omits_device_requests` — regression guard: the default (no `gpu` key) must not emit `device_requests`.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

Backward compatible — `resourceLimits.gpu` was previously a silently-ignored key. Clients that passed it now get it honored; clients that didn't pass it observe no change.

# Checklist
- [x] Linked Issue or clearly described motivation — #774
- [ ] Added/updated docs (if needed) — schema example and SDK docstring already documented `gpu`; no doc changes needed.
- [x] Added/updated tests (if needed)
- [x] Security impact considered — GPU passthrough exposes host devices into the sandbox. The change is opt-in (only triggered when a caller requests it), respects all existing security gates (`no_new_privileges`, `cap_drop`, seccomp/AppArmor, pids limit, configured runtime), and does not weaken the default posture.
- [x] Backward compatibility considered