### PR TITLE
fix(go-sdk): treat empty sse stream as error

### DIFF
--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1448,6 +1448,32 @@ func TestExecuteCode_SSE(t *testing.T) {
 	}
 }
 
+func TestExecuteCode_SSE_EmptyStream(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			assert.Fail(t, fmt.Sprintf("expected POST, got %s", r.Method))
+		}
+		if r.URL.Path != "/code" {
+			assert.Fail(t, fmt.Sprintf("expected /code, got %s", r.URL.Path))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.ExecuteCode(context.Background(), RunCodeRequest{
+		Context: &CodeContext{Language: "python"},
+		Code:    "2+2",
+	}, func(event StreamEvent) error {
+		return nil
+	})
+	if err == nil {
+		require.FailNow(t, "ExecuteCode should fail on empty SSE stream")
+	}
+	if !strings.Contains(err.Error(), "empty sse stream") {
+		assert.Fail(t, fmt.Sprintf("err = %v, want empty sse stream", err))
+	}
+}
+
 func TestExecuteCode_InContext(t *testing.T) {
 	ssePayload := `{"type":"stdout","text":"hello from context","timestamp":1000}` + "\n\n" +
 		`{"type":"execution_complete","timestamp":1001,"execution_time":10}` + "\n\n"

--- a/sdks/sandbox/go/streaming.go
+++ b/sdks/sandbox/go/streaming.go
@@ -51,6 +51,7 @@ func streamSSE(ctx context.Context, resp *http.Response, handler EventHandler) e
 
 	var current StreamEvent
 	var dataLines []string
+	eventCount := 0
 
 	for {
 		select {
@@ -66,9 +67,13 @@ func streamSSE(ctx context.Context, resp *http.Response, handler EventHandler) e
 				if err := handler(current); err != nil {
 					return err
 				}
+				eventCount++
 			}
 			if err := scanner.Err(); err != nil {
 				return fmt.Errorf("opensandbox: sse read: %w", err)
+			}
+			if eventCount == 0 {
+				return fmt.Errorf("opensandbox: empty sse stream")
 			}
 			return nil
 		}
@@ -82,6 +87,7 @@ func streamSSE(ctx context.Context, resp *http.Response, handler EventHandler) e
 				if err := handler(current); err != nil {
 					return err
 				}
+				eventCount++
 			}
 			// Reset for next event.
 			current = StreamEvent{}


### PR DESCRIPTION
Summary

  This PR fixes a bug in the Go sandbox SDK where an HTTP 200 SSE response with no events was treated as a successful execution.

  In that case, ExecuteCode / Execute could return an Execution object with all fields empty:

  - stdout=[]
  - stderr=[]
  - results=[]
  - error=nil
  - complete=nil

  That made upstream callers see a misleading “successful but empty” execution instead of an infrastructure-level failure.

  Root Cause

  In sdks/sandbox/go/streaming.go, streamSSE() returned nil whenever the response body ended cleanly, even if zero SSE events were ever received.

  So the flow was effectively:

  1. HTTP request succeeds with 200
  2. Response body closes without any SSE events
  3. streamSSE() returns nil
  4. SDK treats the execution as successful

  This matches the intermittent empty-execution behavior seen in real sandbox calls.

  Changes

  - Update streamSSE() to count dispatched SSE events
  - Return an explicit error when the stream ends with zero events:
      - opensandbox: empty sse stream
  - Add a Go SDK test covering ExecuteCode with a 200 text/event-stream response that contains no events

  Why This Fix

  An empty SSE stream is not a valid successful execution result for code execution APIs. Even failed executions should surface at least an error event, stderr output, or a
  terminal event. Treating an empty stream as success hides transport/proxy/execd issues and makes upstream diagnosis much harder.

  Validation

  Ran:

  go test ./...

  in:

  sdks/sandbox/go

  Impact

  After this change, callers of the Go SDK can distinguish:

  - real execution results
  - execution errors
  - infrastructure/proxy failures that manifest as empty SSE streams

  This makes retry/fallback behavior much safer and more explicit for sandbox clients.