### PR TITLE
fix(server): pass GPU resource limits to Kubernetes pods

### DIFF
--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional
 
+from fastapi import HTTPException, status
 from kubernetes.client import (
     V1Container,
     V1EnvVar,
@@ -24,6 +25,8 @@ from kubernetes.client import (
 )
 
 from opensandbox_server.api.schema import ImageSpec
+from opensandbox_server.services.constants import SandboxErrorCodes
+from opensandbox_server.services.helpers import parse_gpu_request
 from opensandbox_server.services.k8s.egress_helper import (
     build_security_context_for_sandbox_container,
     prep_execd_init_for_egress,
@@ -32,6 +35,76 @@ from opensandbox_server.services.k8s.security_context import (
     build_security_context_from_dict,
     serialize_security_context_to_dict,
 )
+
+_GPU_RESOURCE_LIMIT_KEY = "gpu"
+# Canonical extended-resource name advertised by the NVIDIA device plugin.
+# Hardcoded for parity with the Docker runtime fix (#775), which targets
+# NVIDIA only via DeviceRequest capabilities=[["gpu"]]. Other vendor keys
+# (e.g. amd.com/gpu, gpu.intel.com/i915) can be added as a follow-up.
+_K8S_NVIDIA_GPU_RESOURCE = "nvidia.com/gpu"
+
+
+def _translate_resource_limits_for_k8s(
+    resource_limits: Dict[str, str],
+) -> Dict[str, str]:
+    """Translate request-level resource limits into Kubernetes resource keys.
+
+    The lifecycle API exposes a portable ``gpu`` key on ``resourceLimits``.
+    Kubernetes requires the canonical extended-resource name
+    (``nvidia.com/gpu``) so the device plugin can schedule the request;
+    otherwise the value is silently treated as an unknown extended resource.
+
+    Args:
+        resource_limits: Raw resource limits from the create request.
+
+    Returns:
+        A new dict with the ``gpu`` key translated to ``nvidia.com/gpu``
+        and any unparseable GPU value dropped. Other keys (cpu, memory, ...)
+        are passed through unchanged.
+
+    Raises:
+        HTTPException: If ``gpu`` is the ``"all"`` sentinel. Docker accepts
+            ``"all"`` (mapped to an unbounded DeviceRequest), but Kubernetes
+            extended resources require an integer count, so we surface a
+            400 rather than silently scheduling without a GPU.
+    """
+    if not resource_limits:
+        return {}
+
+    translated: Dict[str, str] = {
+        key: value
+        for key, value in resource_limits.items()
+        if key != _GPU_RESOURCE_LIMIT_KEY
+    }
+
+    raw_gpu = resource_limits.get(_GPU_RESOURCE_LIMIT_KEY)
+    if raw_gpu is None:
+        return translated
+
+    if raw_gpu.strip().lower() == "all":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "Kubernetes runtime requires resourceLimits.gpu to be a "
+                    "positive integer; 'all' is not supported."
+                ),
+            },
+        )
+
+    gpu_count = parse_gpu_request(raw_gpu)
+    if gpu_count is None or gpu_count <= 0:
+        # parse_gpu_request already logged a warning; drop the value rather
+        # than emitting an invalid extended-resource key onto the pod.
+        return translated
+
+    # str(int) is intentional: V1ResourceRequirements is typed Dict[str, str]
+    # in this codebase (cpu/memory are already strings like "1" / "512Mi"),
+    # and the Kubernetes API server's quantity parser accepts string integers
+    # for extended resources.
+    translated[_K8S_NVIDIA_GPU_RESOURCE] = str(gpu_count)
+    return translated
 def _build_execd_init_container(
     execd_image: str,
     execd_init_resources: Any,
@@ -83,11 +156,12 @@ def _build_main_container(
     env_vars = [V1EnvVar(name=k, value=v) for k, v in env.items()]
     env_vars.append(V1EnvVar(name="EXECD", value="/opt/opensandbox/bin/execd"))
 
+    translated_limits = _translate_resource_limits_for_k8s(resource_limits)
     resources = None
-    if resource_limits:
+    if translated_limits:
         resources = V1ResourceRequirements(
-            limits=resource_limits,
-            requests=resource_limits,
+            limits=translated_limits,
+            requests=translated_limits,
         )
 
     volume_mounts = [

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 from kubernetes.client import ApiException
 
 from opensandbox_server.api.schema import ImageSpec, NetworkPolicy, NetworkRule, PlatformSpec
@@ -123,6 +124,73 @@ class TestAgentSandboxProvider:
         selector = body["spec"]["podTemplate"]["spec"]["nodeSelector"]
         assert selector["kubernetes.io/os"] == "linux"
         assert selector["kubernetes.io/arch"] == "arm64"
+
+    def test_create_workload_translates_gpu_to_nvidia_extended_resource(self, mock_k8s_client):
+        provider = AgentSandboxProvider(mock_k8s_client, _app_config())
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi", "gpu": "2"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        resources = body["spec"]["podTemplate"]["spec"]["containers"][0]["resources"]
+
+        assert resources["limits"]["nvidia.com/gpu"] == "2"
+        assert resources["requests"]["nvidia.com/gpu"] == "2"
+        assert "gpu" not in resources["limits"]
+        assert "gpu" not in resources["requests"]
+
+    def test_create_workload_without_gpu_omits_nvidia_extended_resource(self, mock_k8s_client):
+        provider = AgentSandboxProvider(mock_k8s_client, _app_config())
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        resources = body["spec"]["podTemplate"]["spec"]["containers"][0]["resources"]
+
+        assert "nvidia.com/gpu" not in resources["limits"]
+        assert "nvidia.com/gpu" not in resources["requests"]
+
+    def test_create_workload_rejects_gpu_all_sentinel(self, mock_k8s_client):
+        provider = AgentSandboxProvider(mock_k8s_client, _app_config())
+
+        with pytest.raises(HTTPException) as excinfo:
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={"cpu": "1", "gpu": "all"},
+                labels={"opensandbox.io/id": "test-id"},
+                expires_at=None,
+                execd_image="execd:latest",
+            )
+        assert excinfo.value.status_code == 400
 
     def test_create_workload_rejects_windows_platform(self, mock_k8s_client):
         provider = AgentSandboxProvider(mock_k8s_client, _app_config())

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -16,6 +16,7 @@ import pytest
 from types import SimpleNamespace
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
+from fastapi import HTTPException
 from kubernetes.client import ApiException
 
 from opensandbox_server.api.schema import ImageSpec, ImageAuth, NetworkPolicy, NetworkRule, PlatformSpec
@@ -576,9 +577,77 @@ spec:
         
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         container = body["spec"]["template"]["spec"]["containers"][0]
-        
+
         assert "resources" not in container
-    
+
+    def test_create_workload_translates_gpu_to_nvidia_extended_resource(self, mock_k8s_client):
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi", "gpu": "2"},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        resources = body["spec"]["template"]["spec"]["containers"][0]["resources"]
+
+        assert resources["limits"]["nvidia.com/gpu"] == "2"
+        assert resources["requests"]["nvidia.com/gpu"] == "2"
+        # Raw key must not leak through as an unknown extended resource.
+        assert "gpu" not in resources["limits"]
+        assert "gpu" not in resources["requests"]
+
+    def test_create_workload_without_gpu_omits_nvidia_extended_resource(self, mock_k8s_client):
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "sandbox-test", "uid": "uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        resources = body["spec"]["template"]["spec"]["containers"][0]["resources"]
+
+        assert "nvidia.com/gpu" not in resources["limits"]
+        assert "nvidia.com/gpu" not in resources["requests"]
+
+    def test_create_workload_rejects_gpu_all_sentinel(self, mock_k8s_client):
+        provider = BatchSandboxProvider(mock_k8s_client)
+
+        with pytest.raises(HTTPException) as excinfo:
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={"cpu": "1", "gpu": "all"},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+            )
+        assert excinfo.value.status_code == 400
+
     # ===== Workload Query Tests =====
     
     def test_get_workload_finds_existing_sandbox(

--- a/server/tests/k8s/test_provider_common.py
+++ b/server/tests/k8s/test_provider_common.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi import HTTPException
+
+from opensandbox_server.services.constants import SandboxErrorCodes
+from opensandbox_server.services.k8s.provider_common import (
+    _translate_resource_limits_for_k8s,
+)
+
+
+def test_translate_resource_limits_passes_gpu_count():
+    result = _translate_resource_limits_for_k8s(
+        {"cpu": "1", "memory": "1Gi", "gpu": "2"}
+    )
+    assert result["nvidia.com/gpu"] == "2"
+
+
+def test_translate_resource_limits_strips_raw_gpu_key():
+    # Regression guard: the raw "gpu" key must not leak into the pod's
+    # V1ResourceRequirements where Kubernetes would treat it as an
+    # unknown extended resource.
+    result = _translate_resource_limits_for_k8s({"gpu": "2"})
+    assert "gpu" not in result
+    assert result == {"nvidia.com/gpu": "2"}
+
+
+def test_translate_resource_limits_preserves_cpu_memory():
+    result = _translate_resource_limits_for_k8s({"cpu": "500m", "memory": "512Mi"})
+    assert result == {"cpu": "500m", "memory": "512Mi"}
+
+
+def test_translate_resource_limits_no_gpu_key_unchanged():
+    inputs = {"cpu": "2", "memory": "4Gi"}
+    result = _translate_resource_limits_for_k8s(inputs)
+    assert result == inputs
+    # Must be a new dict — callers pass it to both limits= and requests=,
+    # and we don't want surprise mutation of the input.
+    assert result is not inputs
+
+
+def test_translate_resource_limits_rejects_all():
+    with pytest.raises(HTTPException) as excinfo:
+        _translate_resource_limits_for_k8s({"gpu": "all"})
+    assert excinfo.value.status_code == 400
+    detail = excinfo.value.detail
+    assert detail["code"] == SandboxErrorCodes.INVALID_PARAMETER
+    assert "positive integer" in detail["message"]
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "bad", ""])
+def test_translate_resource_limits_drops_invalid_gpu(bad_value):
+    result = _translate_resource_limits_for_k8s(
+        {"cpu": "1", "gpu": bad_value}
+    )
+    assert "nvidia.com/gpu" not in result
+    assert "gpu" not in result
+    assert result == {"cpu": "1"}
+
+
+def test_translate_resource_limits_empty_dict():
+    assert _translate_resource_limits_for_k8s({}) == {}


### PR DESCRIPTION
# Summary
- `CreateSandboxRequest.resourceLimits.gpu` is documented in the schema and honored by the Docker runtime (#775), but the Kubernetes runtime silently dropped it. `_build_main_container` in `services/k8s/provider_common.py` passed the raw `resource_limits` dict straight into `V1ResourceRequirements.limits` and `.requests`, so a `gpu` key flowed through unchanged. Kubernetes treats `gpu` as an unknown extended resource — the NVIDIA device plugin never sees the request, and pods schedule with no GPU. Both `AgentSandboxProvider` and `BatchSandboxProvider` route through this single chokepoint, so both K8s providers were affected.
- Adds `_translate_resource_limits_for_k8s` in `provider_common.py` that reuses the existing `parse_gpu_request` from `services/helpers.py`, translates the portable `gpu` key to the canonical `nvidia.com/gpu` extended-resource name, and pops the raw `gpu` key so it cannot leak onto the pod as an unknown resource. Hardcoding `nvidia.com/gpu` mirrors the NVIDIA-only scope of #775 (Docker `DeviceRequest capabilities=[["gpu"]]`); other vendor keys (`amd.com/gpu`, `gpu.intel.com/i915`) can be a follow-up.
- Rejects the `"all"` sentinel with `HTTP 400` rather than silently dropping it. Docker accepts `"all"` (unbounded `DeviceRequest`), but Kubernetes extended resources require an integer count, and silent fallback would mask the misconfiguration. Mirrors #775's "failures remain visible rather than silent" principle.
- Closes #781.

**Scope note:** The Kubernetes Windows profile path (`apply_windows_profile_overrides`) already strips the entire resources block via `pop("resources", None)`, so GPU on Windows is still implicitly suppressed on the outer pod — no separate change is needed there.

**Failure mode:** On clusters without the NVIDIA device plugin, the pod will surface a clear scheduling failure (Pod stays in `Pending` with `Insufficient nvidia.com/gpu`), so GPU request failures remain visible rather than silent.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests (see note below)
- [ ] e2e / manual verification

Focused checks from `server/AGENTS.md`:

```
uv run ruff check
uv run pytest tests/k8s/test_provider_common.py tests/k8s/test_agent_sandbox_provider.py tests/k8s/test_batchsandbox_provider.py
```

Result: **141 passed**, ruff clean, `uv run pyright` on the changed file: 0 errors / 0 warnings.

Broader validation per `server/AGENTS.md`: **`uv run pytest` (full server suite) — 787 passed**.

Added tests:
- `tests/k8s/test_provider_common.py` (new) — 7 unit tests covering positive int translation, raw-`gpu`-key strip regression, cpu/memory passthrough, no-`gpu` no-mutation guard, `"all"` rejection, parametrized invalid-value drop (`"0"`, `"-1"`, `"bad"`, `""`), and the empty-dict path.
- `tests/k8s/test_agent_sandbox_provider.py` — `test_create_workload_translates_gpu_to_nvidia_extended_resource`, `test_create_workload_without_gpu_omits_nvidia_extended_resource`, `test_create_workload_rejects_gpu_all_sentinel` (full provider path through `create_custom_object` mock).
- `tests/k8s/test_batchsandbox_provider.py` — same three tests on the BatchSandbox path.

**Integration / e2e note:** `tests/k8s/` are mock-based provider tests (no live cluster), matching the convention used in #775. End-to-end verification of the actual `nvidia.com/gpu` extended-resource scheduling requires a Kubernetes cluster with the NVIDIA device plugin and a GPU-capable node, which I do not have available locally. Happy to run a real-cluster verification if a maintainer can point me at a CI lane or fixture.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

Backward compatible — `resourceLimits.gpu` was previously a silently-ignored key on the Kubernetes runtime. Clients that passed it now get it honored; clients that didn't pass it observe no change. Clients that previously passed `"all"` (which was already silently dropped on K8s) now receive a clear `400` instead of an unobservable failure.

# Checklist
- [x] Linked Issue or clearly described motivation — #781
- [ ] Added/updated docs (if needed) — schema example and SDK docstring already documented `gpu`; no doc changes needed.
- [x] Added/updated tests (if needed) — helper unit tests + positive integration + regression guard on both K8s providers (mirrors #775's testing bar).
- [x] Security impact considered — GPU passthrough on K8s is opt-in (only triggered when a caller requests it), respects all existing security gates (security context, RBAC, namespace policies), and does not weaken the default posture. The translator strips unknown keys, so there is no path for arbitrary extended-resource injection through `resourceLimits`.
- [x] Backward compatibility considered