### PR TITLE
fix(e2e): add EXECD_API_GRACE_SHUTDOWN=3s and EXECD_JUPYTER_IDLE_POLL_INTERVAL=1s to all test sandbox creations

### DIFF
--- a/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
@@ -686,7 +686,9 @@ public sealed class CodeInterpreterE2ETestFixture : IAsyncLifetime
                 ["JAVA_VERSION"] = "21",
                 ["NODE_VERSION"] = "22",
                 ["PYTHON_VERSION"] = "3.12",
-                ["EXECD_LOG_FILE"] = "/tmp/opensandbox-e2e/logs/execd.log"
+                ["EXECD_LOG_FILE"] = "/tmp/opensandbox-e2e/logs/execd.log",
+                ["EXECD_API_GRACE_SHUTDOWN"] = "3s",
+                ["EXECD_JUPYTER_IDLE_POLL_INTERVAL"] = "1s"
             },
             Volumes = new[]
             {

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -1111,7 +1111,7 @@ public sealed class SandboxE2ETestFixture : IAsyncLifetime
             TimeoutSeconds = _baseFixture.DefaultTimeoutSeconds,
             ReadyTimeoutSeconds = _baseFixture.DefaultReadyTimeoutSeconds,
             Metadata = new Dictionary<string, string> { ["tag"] = "csharp-e2e-test" },
-            Env = new Dictionary<string, string> { ["E2E_TEST"] = "true" },
+            Env = new Dictionary<string, string> { ["E2E_TEST"] = "true", ["EXECD_API_GRACE_SHUTDOWN"] = "3s", ["EXECD_JUPYTER_IDLE_POLL_INTERVAL"] = "1s" },
             HealthCheckPollingInterval = 500
         });
     }

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxManagerE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxManagerE2ETests.cs
@@ -234,7 +234,7 @@ public sealed class SandboxManagerE2ETestFixture : IAsyncLifetime
             TimeoutSeconds = _baseFixture.DefaultTimeoutSeconds,
             ReadyTimeoutSeconds = _baseFixture.DefaultReadyTimeoutSeconds,
             Metadata = metadata,
-            Env = new Dictionary<string, string> { ["E2E_TEST"] = "true" },
+            Env = new Dictionary<string, string> { ["E2E_TEST"] = "true", ["EXECD_API_GRACE_SHUTDOWN"] = "3s", ["EXECD_JUPYTER_IDLE_POLL_INTERVAL"] = "1s" },
             HealthCheckPollingInterval = 500
         });
     }

--- a/tests/go/base_e2e_test.go
+++ b/tests/go/base_e2e_test.go
@@ -81,6 +81,7 @@ func createTestSandbox(t *testing.T) (context.Context, *opensandbox.Sandbox) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { sb.Kill(context.Background()) })

--- a/tests/go/concurrent_e2e_test.go
+++ b/tests/go/concurrent_e2e_test.go
@@ -45,6 +45,7 @@ func TestConcurrent_CreateFiveSandboxes(t *testing.T) {
 			defer wg.Done()
 			sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 				Image: getSandboxImage(),
+				Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 				Metadata: map[string]string{
 					"test":  "go-e2e-concurrent",
 					"index": fmt.Sprintf("%d", idx),

--- a/tests/go/e2e_test.go
+++ b/tests/go/e2e_test.go
@@ -61,6 +61,7 @@ func TestE2E_FullLifecycle(t *testing.T) {
 			"cpu":    "500m",
 			"memory": "256Mi",
 		},
+		Env: map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Metadata: map[string]string{
 			"test": "go-e2e",
 		},
@@ -200,6 +201,7 @@ func TestE2E_PauseResume(t *testing.T) {
 	// 1. Create sandbox via high-level API
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image:    getDefaultImage(),
+		Env:      map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Metadata: map[string]string{"test": "go-e2e-pause-resume"},
 	})
 	require.NoError(t, err)
@@ -266,6 +268,7 @@ func TestE2E_ManualCleanup(t *testing.T) {
 	// 1. Create sandbox with ManualCleanup (no auto-expiration)
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image:         getDefaultImage(),
+		Env:           map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		ManualCleanup: true,
 		Metadata:      map[string]string{"test": "go-e2e-manual-cleanup"},
 	})
@@ -290,6 +293,7 @@ func TestE2E_ManualCleanup(t *testing.T) {
 	// 4. Compare with a normal sandbox that should have an expiration
 	sbWithTimeout, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image:    getDefaultImage(),
+		Env:      map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Metadata: map[string]string{"test": "go-e2e-with-timeout"},
 	})
 	require.NoError(t, err)

--- a/tests/go/manager_e2e_test.go
+++ b/tests/go/manager_e2e_test.go
@@ -48,6 +48,7 @@ func TestManager_ListByState(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Metadata: map[string]string{
 			"test": "go-e2e-manager",
 		},
@@ -78,6 +79,7 @@ func TestManager_GetAndKill(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 
@@ -100,6 +102,7 @@ func TestManager_PauseAndResume(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())
@@ -145,6 +148,7 @@ func TestManager_RenewSandbox(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())

--- a/tests/go/sandbox_e2e_test.go
+++ b/tests/go/sandbox_e2e_test.go
@@ -30,6 +30,7 @@ func TestSandbox_CreateAndKill(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image:      getSandboxImage(),
+		Env:        map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Entrypoint: []string{"tail", "-f", "/dev/null"},
 		ResourceLimits: opensandbox.ResourceLimits{
 			"cpu":    "500m",
@@ -92,6 +93,7 @@ func TestSandbox_ConnectToExisting(t *testing.T) {
 
 	sb1, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb1.Kill(context.Background())
@@ -137,6 +139,7 @@ func TestSandbox_ManualCleanup(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())
@@ -153,6 +156,7 @@ func TestSandbox_NetworkPolicyCreate(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		NetworkPolicy: &opensandbox.NetworkPolicy{
 			DefaultAction: "deny",
 			Egress: []opensandbox.NetworkRule{
@@ -175,6 +179,7 @@ func TestSandbox_PauseAndResume(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())

--- a/tests/go/scenario_agent_e2e_test.go
+++ b/tests/go/scenario_agent_e2e_test.go
@@ -125,6 +125,7 @@ func TestScenario_SimpleAgentLoop(t *testing.T) {
 	config := getConnectionConfig(t)
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())
@@ -182,6 +183,7 @@ func TestScenario_CodeInterpreterAgent(t *testing.T) {
 	ci, err := opensandbox.CreateCodeInterpreter(ctx, config, opensandbox.CodeInterpreterCreateOptions{
 		ReadyTimeout:        60 * time.Second,
 		HealthCheckInterval: 500 * time.Millisecond,
+		Env:                 map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer ci.Kill(context.Background())
@@ -252,6 +254,7 @@ func TestScenario_SandboxToolUse(t *testing.T) {
 	config := getConnectionConfig(t)
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 	})
 	require.NoError(t, err)
 	defer sb.Kill(context.Background())

--- a/tests/go/volume_e2e_test.go
+++ b/tests/go/volume_e2e_test.go
@@ -48,6 +48,7 @@ func TestVolume_HostMount(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image:        getSandboxImage(),
+		Env:          map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		ReadyTimeout: 60 * time.Second,
 		Volumes: []opensandbox.Volume{
 			{
@@ -84,6 +85,7 @@ func TestVolume_HostMountReadOnly(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Volumes: []opensandbox.Volume{
 			{
 				Name:      "test-host-ro",
@@ -118,6 +120,7 @@ func TestVolume_PVCMount(t *testing.T) {
 
 	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
 		Image: getSandboxImage(),
+		Env:   map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
 		Volumes: []opensandbox.Volume{
 			{
 				Name:      "test-pvc-vol",

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CodeInterpreterE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CodeInterpreterE2ETest.java
@@ -144,6 +144,8 @@ public class CodeInterpreterE2ETest extends BaseE2ETest {
                         .env("NODE_VERSION", "22")
                         .env("PYTHON_VERSION", "3.12")
                         .env("EXECD_LOG_FILE", "/tmp/opensandbox-e2e/logs/execd.log")
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .healthCheckPollingInterval(Duration.ofMillis(500))
                         .volume(volume)
                         .build();

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -65,6 +65,8 @@ public class SandboxE2ETest extends BaseE2ETest {
                         .readyTimeout(Duration.ofSeconds(60))
                         .metadata(metadataMap)
                         .env("E2E_TEST", "true")
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .healthCheckPollingInterval(Duration.ofMillis(500))
                         .build();
     }

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxManagerE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxManagerE2ETest.java
@@ -68,6 +68,8 @@ public class SandboxManagerE2ETest extends BaseE2ETest {
                         .readyTimeout(Duration.ofSeconds(60))
                         .metadata(Map.of("tag", tag, "team", "t1", "env", "prod"))
                         .env("E2E_TEST", "true")
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .healthCheckPollingInterval(Duration.ofMillis(500))
                         .build();
         s2 =
@@ -79,6 +81,8 @@ public class SandboxManagerE2ETest extends BaseE2ETest {
                         .readyTimeout(Duration.ofSeconds(60))
                         .metadata(Map.of("tag", tag, "team", "t1", "env", "dev"))
                         .env("E2E_TEST", "true")
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .healthCheckPollingInterval(Duration.ofMillis(500))
                         .build();
         s3 =
@@ -90,6 +94,8 @@ public class SandboxManagerE2ETest extends BaseE2ETest {
                         .readyTimeout(Duration.ofSeconds(60))
                         .metadata(Map.of("tag", tag, "env", "prod"))
                         .env("E2E_TEST", "true")
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .healthCheckPollingInterval(Duration.ofMillis(500))
                         .build();
 

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolPseudoDistributedE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolPseudoDistributedE2ETest.java
@@ -405,7 +405,7 @@ public class SandboxPoolPseudoDistributedE2ETest extends BaseE2ETest {
                         .image(getSandboxImage())
                         .entrypoint(List.of("tail -f /dev/null"))
                         .metadata(Map.of("tag", tag, "suite", "sandbox-pool-pseudo-dist-e2e"))
-                        .env(Map.of("E2E_TEST", "true"))
+                        .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                         .build();
         return SandboxPool.builder()
                 .poolName(poolName)

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolSingleNodeE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolSingleNodeE2ETest.java
@@ -86,7 +86,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                         .image(getSandboxImage())
                         .entrypoint(List.of("tail -f /dev/null"))
                         .metadata(Map.of("tag", tag, "suite", "sandbox-pool-e2e"))
-                        .env(Map.of("E2E_TEST", "true"))
+                        .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                         .build();
         pool =
                 SandboxPool.builder()
@@ -541,7 +541,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             tagA,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .reconcileInterval(Duration.ofSeconds(2))
                             .drainTimeout(Duration.ofMillis(200))
@@ -580,7 +580,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             tagB,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .reconcileInterval(Duration.ofSeconds(2))
                             .drainTimeout(Duration.ofMillis(200))
@@ -700,7 +700,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             badTag,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .degradedThreshold(1)
                             .reconcileInterval(Duration.ofSeconds(1))
@@ -764,7 +764,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             badTag,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .degradedThreshold(1)
                             .reconcileInterval(Duration.ofSeconds(1))
@@ -826,7 +826,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             goodTag,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .reconcileInterval(Duration.ofSeconds(2))
                             .drainTimeout(Duration.ofMillis(100))
@@ -898,7 +898,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                                                             preparedTag,
                                                             "suite",
                                                             "sandbox-pool-e2e"))
-                                            .env(Map.of("E2E_TEST", "true"))
+                                            .env(Map.of("E2E_TEST", "true", "EXECD_API_GRACE_SHUTDOWN", "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s"))
                                             .build())
                             .warmupSandboxPreparer(
                                     sandbox ->

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxSecureAccessE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxSecureAccessE2ETest.java
@@ -59,6 +59,8 @@ public class SandboxSecureAccessE2ETest extends BaseE2ETest {
                         .timeout(Duration.ofMinutes(2))
                         .readyTimeout(Duration.ofSeconds(60))
                         .secureAccess()
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .metadata(Map.of("tag", "secure-access-java-e2e-test"))
                         .build();
 
@@ -125,6 +127,8 @@ public class SandboxSecureAccessE2ETest extends BaseE2ETest {
                         .image(getSandboxImage())
                         .timeout(Duration.ofMinutes(2))
                         .readyTimeout(Duration.ofSeconds(60))
+                        .env("EXECD_API_GRACE_SHUTDOWN", "3s")
+                        .env("EXECD_JUPYTER_IDLE_POLL_INTERVAL", "1s")
                         .metadata(Map.of("tag", "non-secure-access-java-e2e-test"))
                         .build();
 

--- a/tests/javascript/tests/test_code_interpreter_e2e.test.ts
+++ b/tests/javascript/tests/test_code_interpreter_e2e.test.ts
@@ -50,6 +50,7 @@ function sandboxCreateOptions() {
       NODE_VERSION: "22",
       PYTHON_VERSION: "3.12",
       EXECD_LOG_FILE: "/tmp/opensandbox-e2e/logs/execd.log",
+      EXECD_API_GRACE_SHUTDOWN: "3s", EXECD_JUPYTER_IDLE_POLL_INTERVAL: "1s",
     },
     healthCheckPollingInterval: 200,
     volumes: [

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -57,6 +57,8 @@ beforeAll(async () => {
       JAVA_VERSION: "21",
       NODE_VERSION: "22",
       PYTHON_VERSION: "3.12",
+      EXECD_API_GRACE_SHUTDOWN: "3s",
+      EXECD_JUPYTER_IDLE_POLL_INTERVAL: "1s",
     },
     healthCheckPollingInterval: 200,
   });

--- a/tests/javascript/tests/test_sandbox_manager_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_manager_e2e.test.ts
@@ -72,17 +72,20 @@ beforeAll(async () => {
   s1 = await Sandbox.create({
     ...common,
     metadata: { tag, team: "t1", env: "prod" },
-    env: { E2E_TEST: "true", CASE: "mgr-s1" },
+    env: { E2E_TEST: "true", CASE: "mgr-s1", EXECD_API_GRACE_SHUTDOWN: "3s",
+      EXECD_JUPYTER_IDLE_POLL_INTERVAL: "1s" },
   });
   s2 = await Sandbox.create({
     ...common,
     metadata: { tag, team: "t1", env: "dev" },
-    env: { E2E_TEST: "true", CASE: "mgr-s2" },
+    env: { E2E_TEST: "true", CASE: "mgr-s2", EXECD_API_GRACE_SHUTDOWN: "3s",
+      EXECD_JUPYTER_IDLE_POLL_INTERVAL: "1s" },
   });
   s3 = await Sandbox.create({
     ...common,
     metadata: { tag, env: "prod" },
-    env: { E2E_TEST: "true", CASE: "mgr-s3" },
+    env: { E2E_TEST: "true", CASE: "mgr-s3", EXECD_API_GRACE_SHUTDOWN: "3s",
+      EXECD_JUPYTER_IDLE_POLL_INTERVAL: "1s" },
   });
 
   expect(await s1.isHealthy()).toBe(true);

--- a/tests/python/tests/test_code_interpreter_e2e.py
+++ b/tests/python/tests/test_code_interpreter_e2e.py
@@ -380,6 +380,8 @@ class TestCodeInterpreterE2E:
                 "NODE_VERSION": "22",
                 "PYTHON_VERSION": "3.12",
                 "EXECD_LOG_FILE": "/tmp/opensandbox-e2e/logs/execd.log",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
             volumes=[
@@ -431,6 +433,8 @@ class TestCodeInterpreterE2E:
                 "NODE_VERSION": "22",
                 "PYTHON_VERSION": "3.12",
                 "EXECD_LOG_FILE": "/tmp/opensandbox-e2e/logs/execd.log",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
             volumes=[

--- a/tests/python/tests/test_code_interpreter_e2e_sync.py
+++ b/tests/python/tests/test_code_interpreter_e2e_sync.py
@@ -307,6 +307,8 @@ class TestCodeInterpreterE2ESync:
                 "NODE_VERSION": "22",
                 "PYTHON_VERSION": "3.12",
                 "EXECD_LOG_FILE": "/tmp/opensandbox-e2e/logs/execd.log",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
             volumes=[
@@ -357,6 +359,8 @@ class TestCodeInterpreterE2ESync:
                 "NODE_VERSION": "22",
                 "PYTHON_VERSION": "3.12",
                 "EXECD_LOG_FILE": "/tmp/opensandbox-e2e/logs/execd.log",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
             volumes=[

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -154,7 +154,9 @@ class TestSandboxE2E:
                 "GO_VERSION": "1.25",
                 "JAVA_VERSION": "21",
                 "NODE_VERSION": "22",
-                "PYTHON_VERSION": "3.12"
+                "PYTHON_VERSION": "3.12",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
             secure_access=is_secure_access_verifiable(),

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -157,6 +157,8 @@ class TestSandboxE2ESync:
                 "JAVA_VERSION": "21",
                 "NODE_VERSION": "22",
                 "PYTHON_VERSION": "3.12",
+                "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s",
             },
             health_check_polling_interval=timedelta(milliseconds=500),
         )

--- a/tests/python/tests/test_sandbox_manager_e2e.py
+++ b/tests/python/tests/test_sandbox_manager_e2e.py
@@ -116,7 +116,8 @@ class TestSandboxManagerE2E:
             connection_config=cls.connection_config,
             image=get_sandbox_image(),
             metadata={"tag": cls.tag, "team": "t1", "env": "prod"},
-            env={"E2E_TEST": "true", "CASE": "mgr-s1"},
+            env={"E2E_TEST": "true", "CASE": "mgr-s1", "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
             timeout=timedelta(minutes=5),
             ready_timeout=timedelta(seconds=60),
         )
@@ -124,7 +125,8 @@ class TestSandboxManagerE2E:
             connection_config=cls.connection_config,
             image=get_sandbox_image(),
             metadata={"tag": cls.tag, "team": "t1", "env": "dev"},
-            env={"E2E_TEST": "true", "CASE": "mgr-s2"},
+            env={"E2E_TEST": "true", "CASE": "mgr-s2", "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
             timeout=timedelta(minutes=5),
             ready_timeout=timedelta(seconds=60),
         )
@@ -132,7 +134,8 @@ class TestSandboxManagerE2E:
             connection_config=cls.connection_config,
             image=get_sandbox_image(),
             metadata={"tag": cls.tag, "env": "prod"},
-            env={"E2E_TEST": "true", "CASE": "mgr-s3"},
+            env={"E2E_TEST": "true", "CASE": "mgr-s3", "EXECD_API_GRACE_SHUTDOWN": "3s",
+                "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s"},
             timeout=timedelta(minutes=5),
             ready_timeout=timedelta(seconds=60),
         )

--- a/tests/python/tests/test_sandbox_manager_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_manager_e2e_sync.py
@@ -62,7 +62,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "team": "t1", "env": "prod"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s1"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s1"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
             s2 = SandboxSync.create(
@@ -72,7 +72,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "team": "t1", "env": "dev"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s2"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s2"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
             s3 = SandboxSync.create(
@@ -82,7 +82,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "env": "prod"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s3"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s3"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
 
@@ -170,7 +170,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "team": "t1", "env": "prod"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s1"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s1"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
             s2 = SandboxSync.create(
@@ -180,7 +180,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "team": "t1", "env": "dev"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s2"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s2"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
             s3 = SandboxSync.create(
@@ -190,7 +190,7 @@ class TestSandboxManagerE2ESync:
                 timeout=timedelta(minutes=5),
                 ready_timeout=timedelta(seconds=60),
                 metadata={"tag": tag, "env": "prod"},
-                env={"E2E_TEST": "true", "CASE": "mgr-s3"},
+                env={"E2E_TEST": "true", "EXECD_API_GRACE_SHUTDOWN": "3s", "EXECD_JUPYTER_IDLE_POLL_INTERVAL": "1s", "CASE": "mgr-s3"},
                 health_check_polling_interval=timedelta(milliseconds=500),
             )
 


### PR DESCRIPTION
# Summary
- add EXECD_API_GRACE_SHUTDOWN=3s and EXECD_JUPYTER_IDLE_POLL_INTERVAL=1s to all test sandbox creations
- closes #724 

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered