### PR TITLE
fix(execd): default listener to IPv4 only

### DIFF
--- a/components/execd/main.go
+++ b/components/execd/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -60,8 +61,13 @@ func main() {
 	controller.InitCodeRunner()
 	engine := web.NewRouter(flag.ServerAccessToken)
 	addr := fmt.Sprintf(":%d", flag.ServerPort)
-	log.Info("execd listening on %s", addr)
-	if err := engine.Run(addr); err != nil {
+	listener, err := net.Listen("tcp4", addr)
+	if err != nil {
+		log.Error("failed to listen on %s: %v", addr, err)
+		os.Exit(1)
+	}
+	log.Info("execd listening on %s (IPv4)", addr)
+	if err := engine.RunListener(listener); err != nil {
 		log.Error("failed to start execd server: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
# Summary
- Use `net.Listen("tcp4", addr)` instead of `engine.Run(addr)` to avoid binding to IPv6 dual-stack socket.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered