### PR TITLE
docs(readme): add lightweight project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,32 +298,22 @@ For detailed architecture, see [docs/architecture.md](docs/architecture.md).
 - [sdks/mcp/sandbox/python/README.md](sdks/mcp/sandbox/python/README.md) - MCP server installation and client setup
 - [specs/README.md](specs/README.md) - OpenAPI definitions for sandbox lifecycle API and sandbox execution API
 - [server/README.md](server/README.md) - Sandbox server startup and configuration; supports Docker and Kubernetes runtimes
+- [ROADMAP.md](ROADMAP.md) - Lightweight project roadmap and planning process
 
 ## License
 
 This project is open source under the [Apache 2.0 License](LICENSE).
 
-## Roadmap [2026.03]
+## Roadmap
 
-### SDK
-
-- [x] **Sandbox client connection pool** - Client-side sandbox connection pool management, providing pre-provisioned sandboxes to obtain an environment at X ms. Implemented for Kotlin `SandboxPool` and documented in the [Kotlin SDK README](sdks/sandbox/kotlin/README.md#6-sandbox-pool-client-side). Related PRs: [#301](https://github.com/alibaba/OpenSandbox/pull/301), [#393](https://github.com/alibaba/OpenSandbox/pull/393), [#617](https://github.com/alibaba/OpenSandbox/pull/617).
-- [x] **Go SDK** - Go client SDK for sandbox lifecycle management, command execution, and file operations. See the [Go SDK README](sdks/sandbox/go/README.md). Related PRs: [#597](https://github.com/alibaba/OpenSandbox/pull/597), [#683](https://github.com/alibaba/OpenSandbox/pull/683), [#707](https://github.com/alibaba/OpenSandbox/pull/707).
-
-### Sandbox Runtime
-
-- [x] **Persistent volumes** - Mountable persistent volumes for sandboxes. See [Proposal 0003](oseps/0003-volume-and-volumebinding-support.md), [Docker PVC / named volumes](examples/docker-pvc-volume-mount/README.md), [Docker OSSFS](examples/docker-ossfs-volume-mount/README.md), and [Kubernetes PVC](examples/kubernetes-pvc-volume-mount/README.md). Related PRs: [#166](https://github.com/alibaba/OpenSandbox/pull/166), [#233](https://github.com/alibaba/OpenSandbox/pull/233), [#424](https://github.com/alibaba/OpenSandbox/pull/424), [#515](https://github.com/alibaba/OpenSandbox/pull/515), [#563](https://github.com/alibaba/OpenSandbox/pull/563).
-- [ ] **Local lightweight sandbox** - Lightweight sandbox for AI tools running directly on PCs.
-- [x] **Secure Container** - Secure sandbox for AI Agents running inside container. See the [Secure Container Runtime Guide](docs/secure-container.md). Related PRs: [#177](https://github.com/alibaba/OpenSandbox/pull/177), [#249](https://github.com/alibaba/OpenSandbox/pull/249), [#417](https://github.com/alibaba/OpenSandbox/pull/417).
-
-### Deployment
-
-- [x] **Guide** - Deployment guide for self-hosted Kubernetes cluster. See the [Kubernetes README](kubernetes/README.md) and Helm chart docs in [kubernetes/charts/](kubernetes/charts/). Related PRs: [#232](https://github.com/alibaba/OpenSandbox/pull/232), [#302](https://github.com/alibaba/OpenSandbox/pull/302), [#342](https://github.com/alibaba/OpenSandbox/pull/342).
+See [ROADMAP.md](ROADMAP.md) for the current project roadmap, planning scope,
+and how roadmap items are managed.
 
 ## Contact and Discussion
 
 - Issues: Submit bugs, feature requests, or design discussions through GitHub Issues
 - DingTalk: Join the [OpenSandbox technical discussion group](https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11)
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=alibaba/OpenSandbox&type=date&legend=top-left)](https://www.star-history.com/#alibaba/OpenSandbox&type=date&legend=top-left)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,81 @@
+# OpenSandbox Roadmap
+
+Last updated: 2026-04-28
+
+This roadmap describes the intended project direction for roughly the next 12
+months. It is a planning guide, not a release commitment. Implementation details
+are tracked through GitHub Issues, pull requests, and OpenSandbox Enhancement
+Proposals (OSEPs).
+
+## Principles
+
+- Keep public API contracts, SDKs, CLI behavior, implementation, examples, and
+  documentation aligned.
+- Prefer additive, backward-compatible changes for public interfaces.
+- Use the OSEP process for major architecture, API, runtime, or security-model
+  changes.
+- Keep roadmap items focused on project direction instead of using this file as
+  a full backlog.
+- Move completed work into release notes, OSEP status, or stable documentation
+  instead of keeping long historical task lists here.
+
+## Current Focus: 2026 H1-H2
+
+### Sandbox Runtime
+
+| Area | Status | Tracking | Notes |
+|------|--------|----------|-------|
+| Local lightweight sandbox | Planned | TBD | Lightweight sandbox runtime for AI tools running directly on PCs. |
+| Persistent volumes | Implementing | [OSEP-0003](oseps/0003-volume-and-volumebinding-support.md) | Close remaining runtime/backend gaps from OSEP-0003 before treating volume support as mature. |
+| Secure container runtime | Maturing | [OSEP-0004](oseps/0004-secure-container-runtime.md), [secure container guide](docs/secure-container.md) | Continue hardening isolation guidance and deployment practices. |
+| Pause and resume via rootfs snapshot | Implementing | [OSEP-0008](oseps/0008-pause-resume-rootfs-snapshot.md) | Improve lifecycle support for stateful sandbox workflows. |
+| Secure endpoint access | Implemented / maturing | [OSEP-0011](oseps/0011-secure-access-endpoint.md) | Keep endpoint security behavior aligned across server, SDKs, and docs. |
+
+### SDKs and Developer Experience
+
+| Area | Status | Tracking | Notes |
+|------|--------|----------|-------|
+| SDK parity | Ongoing | [sdks/](sdks/), [specs/](specs/README.md) | Keep Python, Go, Kotlin, JavaScript/TypeScript, and C# SDKs aligned with public specs. |
+| Client-side sandbox pool | Implementing / maturing | [OSEP-0005](oseps/0005-client-side-sandbox-pool.md) | Expand behavior consistency, tests, and documentation where practical. |
+| CLI usability | Planned | [cli/](cli/README.md) | Improve common sandbox lifecycle workflows and developer ergonomics. |
+| Developer console | Implementable | [OSEP-0006](oseps/0006-developer-console.md) | Provide a clearer operational surface for sandbox users and maintainers. |
+
+### Observability and Operations
+
+| Area | Status | Tracking | Notes |
+|------|--------|----------|-------|
+| OpenTelemetry metrics and logs | Implementing | [OSEP-0010](oseps/0010-opentelemetry-instrumentation.md) | Add observability across execd, ingress, and egress. |
+| Agent in-sandbox audit trail | Planned | TBD / OSEP needed | Define auditable records for agent actions inside sandboxes, such as command/session execution, file operations, network access, identity context, retention, and privacy boundaries. |
+| Kubernetes deployment | Ongoing | [kubernetes/](kubernetes/README.md), [Helm charts](kubernetes/charts/) | Keep self-hosted deployment, chart, and operational documentation current. |
+| Network isolation guidance | Ongoing | [network isolation guide](docs/network-isolation-for-kubernetes.md) | Continue documenting safe defaults and practical isolation patterns. |
+
+### Public Contracts and Governance
+
+| Area | Status | Tracking | Notes |
+|------|--------|----------|-------|
+| Lifecycle API stability | Ongoing | [specs/](specs/README.md), [OSEPs](oseps/README.md) | Preserve compatibility and require clear migration paths for user-visible changes. |
+| Security documentation | Ongoing | [SECURITY.md](SECURITY.md), [docs/](docs/) | Keep vulnerability reporting, security expectations, and deployment guidance current. |
+| Open project governance | Ongoing | [GOVERNANCE.md](GOVERNANCE.md), [CONTRIBUTING.md](CONTRIBUTING.md) | Maintain a lightweight, public decision process as the project grows. |
+
+## Not Currently Planned
+
+- Declaring a stable v1 API before lifecycle semantics, runtime behavior, and
+  SDK compatibility are mature enough to support it.
+- Breaking public specs, SDK interfaces, CLI behavior, or documented workflows
+  without an OSEP and migration path.
+- Provider-specific features that cannot be documented, tested, or isolated
+  cleanly from the public API surface.
+- Heavy release-train governance before the project has enough maintainer
+  capacity to keep that process current.
+
+## How Roadmap Items Are Managed
+
+- Small work is tracked as GitHub Issues and pull requests.
+- Major features, architecture changes, public API changes, runtime behavior
+  changes, and security-model changes start with an OSEP.
+- Active roadmap entries should link to an issue, PR, OSEP, or documentation
+  page once a stable tracking location exists.
+- Completed work should be reflected in release notes, implemented OSEPs, and
+  user documentation rather than remaining as an active roadmap item.
+- Maintainers should review this file at least quarterly, or whenever a major
+  OSEP changes status.


### PR DESCRIPTION
# Summary
- Adds root-level `ROADMAP.md` as a lightweight planning document for the next roughly 12 months.
- Replaces the long README roadmap snapshot with a stable roadmap entry point.
- Documents roadmap principles, current focus areas, non-goals, and how roadmap items are managed through Issues, PRs, and OSEPs.

# Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification: `git diff --check`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

No specific issue is linked. Motivation: make project roadmap management more visible, lightweight, and aligned with existing governance and OSEP processes.