### PR TITLE
docs: document coding standards enforcement

### DIFF
--- a/.github/workflows/egress-test.yaml.yml
+++ b/.github/workflows/egress-test.yaml.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           go-version: '1.25.9'
 
+      - name: Check gofmt
+        working-directory: components/egress
+        run: |
+          files="$(gofmt -l . ../internal)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
       - name: Run Build
         working-directory: components/egress
         run: |

--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           go-version: '1.25.9'
 
+      - name: Check gofmt
+        working-directory: components/execd
+        run: |
+          files="$(gofmt -l . ../internal)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
       - name: Run golint
         working-directory: components/execd
         run: |

--- a/.github/workflows/ingress-test.yaml
+++ b/.github/workflows/ingress-test.yaml
@@ -25,6 +25,15 @@ jobs:
         with:
           go-version: '1.25.9'
 
+      - name: Check gofmt
+        working-directory: components/ingress
+        run: |
+          files="$(gofmt -l . ../internal)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
       - name: Run golint
         working-directory: components/ingress
         run: |

--- a/.github/workflows/kubernetes-test.yml
+++ b/.github/workflows/kubernetes-test.yml
@@ -49,6 +49,15 @@ jobs:
         with:
           go-version: '1.24.0'
 
+      - name: Check gofmt
+        working-directory: kubernetes
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
       - name: Run golint
         working-directory: kubernetes
         run: |

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -375,6 +375,15 @@ jobs:
         with:
           go-version: "1.20"
 
+      - name: Check gofmt
+        working-directory: sdks/sandbox/go
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
       - name: Run go vet
         working-directory: sdks/sandbox/go
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,6 +376,49 @@ dotnet build OpenSandbox.CodeInterpreter.sln --configuration Release /warnaserro
 - **Error Messages**: Provide actionable error messages with context
 - **Logging**: Use appropriate log levels (DEBUG, INFO, WARNING, ERROR)
 
+## Build System Standards
+
+OpenSandbox produces native Go binaries for `components/execd`, `components/ingress`,
+`components/egress`, `kubernetes`, and `sdks/sandbox/go`. These build systems must
+preserve caller-provided build flags and only append project-required flags.
+
+### Build Variables
+
+- Go builds pass caller-provided `GOFLAGS` to `go build` and append project flags such as `-trimpath` and `-buildvcs=false`.
+- Go linker builds pass caller-provided `LDFLAGS` to `go build -ldflags` and append project metadata flags.
+- When CGO is enabled, the Go toolchain honors `CC`, `CXX`, `CGO_CFLAGS`, `CGO_CXXFLAGS`, and `CGO_LDFLAGS`. Docker-based builds also accept `CFLAGS` and `CXXFLAGS` as fallbacks for `CGO_CFLAGS` and `CGO_CXXFLAGS`.
+- Docker build scripts forward these variables as build arguments when they are present in the environment.
+
+### Debug Information
+
+Default project builds must not strip debug information. Do not add `strip`,
+`install -s`, or Go linker flags such as `-s -w` to the default build path.
+Distribution-specific packaging may strip binaries only outside the default
+developer and CI build path.
+
+### Build Dependency Graph
+
+Use package-aware build tools instead of recursive independent builds:
+
+- Go packages are built through `go build ./...` or explicit Go package entry points.
+- Kotlin projects use Gradle task dependencies.
+- JavaScript and TypeScript SDKs use pnpm workspace dependencies.
+- C# SDKs use solution/project references through `dotnet build`.
+
+Subdirectory-specific Make targets may delegate to these tools, but they must not
+replace the build tool's dependency graph with independent recursive directory
+builds where cross-directory dependencies exist.
+
+### Repeatable Builds
+
+Native Go binary builds include `-trimpath`, `-buildvcs=false`, and `-ldflags`
+with `-buildid= -B none` so that source paths, VCS metadata, and build IDs or
+Mach-O UUIDs do not make binaries differ. For repeatable release metadata, set `SOURCE_DATE_EPOCH`
+or set `BUILD_TIME`, `VERSION`, and `GIT_COMMIT` explicitly before invoking
+Makefile or Docker build scripts. When `SOURCE_DATE_EPOCH` is set and
+`BUILD_TIME` is unset, build scripts derive `BUILD_TIME` from
+`SOURCE_DATE_EPOCH`.
+
 ## Testing Guidelines
 
 ### Test Coverage Requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,10 +226,37 @@ refactor(sdk): simplify filesystem API
 
 ## Coding Standards
 
-### Python (Server, Python SDKs)
+Contributions are required to generally comply with the coding standards for
+the language and component they touch. Generated files are excluded where the
+local tool configuration excludes them; update the source specification or
+generator and regenerate those files instead of hand-editing generated output.
 
-- **Style Guide**: Follow [PEP 8](https://pep8.org/)
-- **Formatter**: Use `ruff` for formatting and linting
+### Required Style Guides
+
+| Area | Primary language | Required style guide |
+| --- | --- | --- |
+| Server, CLI, Python SDKs, Python tests | Python | [PEP 8](https://peps.python.org/pep-0008/) plus Google-style docstrings for public APIs |
+| Go components, Kubernetes controller, Go SDK | Go | [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) |
+| JavaScript/TypeScript SDKs | JavaScript/TypeScript | [TypeScript ESLint recommended and stylistic rule sets](https://typescript-eslint.io/users/configs/) |
+| Kotlin SDKs | Kotlin | [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html) |
+| C# SDKs | C# | [Microsoft C# coding conventions](https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) |
+
+### Automated Enforcement
+
+| Area | Tooling and CI entry point |
+| --- | --- |
+| Server | `server/pyproject.toml`; `.github/workflows/server-test.yml` runs `uv run ruff check` |
+| CLI and Python SDKs | package `pyproject.toml` files; `.github/workflows/sdk-tests.yml` runs `uv run ruff check` and `uv run pyright` |
+| Go components and Kubernetes | `gofmt`, `go vet`, and `golangci-lint` where configured; component workflows run format, lint, build, and test checks |
+| Go SDK | `.github/workflows/sdk-tests.yml` runs `gofmt`, `go vet`, and tests |
+| JavaScript/TypeScript SDKs | `sdks/eslint.base.mjs` and package `eslint.config.mjs`; `.github/workflows/sdk-tests.yml` runs `pnpm run lint` and `pnpm run typecheck` |
+| Kotlin SDKs | Gradle Spotless with ktlint; `.github/workflows/sdk-tests.yml` runs `./gradlew spotlessCheck ...` |
+| C# SDKs | `.editorconfig`, `Directory.Build.props`, and .NET analyzers; `.github/workflows/sdk-tests.yml` runs `dotnet build ... /warnaserror` |
+
+### Python (Server, CLI, Python SDKs)
+
+- **Style Guide**: Follow [PEP 8](https://peps.python.org/pep-0008/)
+- **Linter/Formatter**: Use `ruff` for linting and formatting
 - **Type Hints**: Always use type hints for function signatures
 - **Docstrings**: Use Google-style docstrings for public APIs
 
@@ -259,13 +286,13 @@ def create_sandbox(
 
 ```bash
 cd server
-uv run ruff check src tests
-uv run ruff format src tests
+uv run ruff check
+uv run ruff format opensandbox_server tests
 ```
 
-### Go (execd)
+### Go (components, Kubernetes, Go SDK)
 
-- **Style Guide**: Follow [Effective Go](https://golang.org/doc/effective_go)
+- **Style Guide**: Follow [Effective Go](https://go.dev/doc/effective_go)
 - **Formatter**: Use `gofmt` for formatting
 - **Imports**: Organize in three groups (stdlib, third-party, internal)
 - **Error Handling**: Always handle errors explicitly
@@ -291,6 +318,20 @@ gofmt -w .
 make fmt
 ```
 
+### JavaScript/TypeScript (SDKs)
+
+- **Style Guide**: Follow the TypeScript ESLint recommended and stylistic rule sets configured in `sdks/eslint.base.mjs`
+- **Linter**: Use `eslint` for JavaScript/TypeScript linting
+- **Type Checking**: Run `tsc` with the package `tsconfig.json`
+
+**Running Checks:**
+
+```bash
+cd sdks
+pnpm run lint:js
+pnpm run typecheck:js
+```
+
 ### Java/Kotlin (Java/Kotlin SDKs)
 
 - **Style Guide**: Follow [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html)
@@ -305,6 +346,22 @@ suspend fun createSandbox(
 ): Sandbox {
     // Implementation
 }
+```
+
+### C# (C# SDKs)
+
+- **Style Guide**: Follow [Microsoft C# coding conventions](https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+- **Formatting**: Follow the SDK `.editorconfig` files
+- **Analyzers**: Keep .NET analyzers enabled and treat build warnings as errors in CI
+
+**Running Checks:**
+
+```bash
+cd sdks/sandbox/csharp
+dotnet build OpenSandbox.sln --configuration Release /warnaserror
+
+cd ../../code-interpreter/csharp
+dotnet build OpenSandbox.CodeInterpreter.sln --configuration Release /warnaserror
 ```
 
 ### General Guidelines

--- a/components/egress/Dockerfile
+++ b/components/egress/Dockerfile
@@ -19,6 +19,16 @@ WORKDIR /workspace
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
+ARG GOFLAGS=
+ARG LDFLAGS=
+ARG CGO_ENABLED=0
+ARG CC=
+ARG CXX=
+ARG CFLAGS=
+ARG CXXFLAGS=
+ARG CGO_CFLAGS=
+ARG CGO_CXXFLAGS=
+ARG CGO_LDFLAGS=
 
 # Copy only go mod/sum first for better caching
 COPY components/egress/go.mod components/egress/go.sum ./components/egress/
@@ -27,14 +37,20 @@ COPY components/internal ./components/internal
 
 WORKDIR /workspace/components/egress
 
-# Static-ish build (no cgo) to simplify runtime deps
-ENV CGO_ENABLED=0
+# Static-ish build (no cgo by default) to simplify runtime deps.
 RUN go mod download
 
 # Copy the rest of the egress sources
 COPY components/egress ./
-RUN CGO_ENABLED=0 go build \
-    -ldflags "-X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
+RUN if [ -n "${CC}" ]; then export CC; fi; \
+    if [ -n "${CXX}" ]; then export CXX; fi; \
+    export CGO_ENABLED="${CGO_ENABLED}" \
+           CGO_CFLAGS="${CGO_CFLAGS:-${CFLAGS}}" \
+           CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
+           CGO_LDFLAGS="${CGO_LDFLAGS}"; \
+    go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none \
+              -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /out/egress .

--- a/components/egress/build.sh
+++ b/components/egress/build.sh
@@ -15,10 +15,30 @@
 
 set -ex
 
+default_build_time() {
+  if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    date -u -d "@${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+      date -u -r "${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ"
+  else
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+  fi
+}
+
+build_arg_if_set() {
+  local name="$1"
+  if [[ -n "${!name+x}" ]]; then
+    BUILD_ARGS+=(--build-arg "${name}=${!name}")
+  fi
+}
+
 TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
-BUILD_TIME=${BUILD_TIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_ARGS=()
+for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
+  build_arg_if_set "${name}"
+done
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
 
@@ -37,6 +57,7 @@ docker buildx build \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:${TAG} \
   "${LATEST_TAGS[@]}" \
   -f components/egress/Dockerfile \
+  "${BUILD_ARGS[@]}" \
   --build-arg VERSION="${VERSION}" \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -19,6 +19,16 @@ WORKDIR /build
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
+ARG GOFLAGS=
+ARG LDFLAGS=
+ARG CGO_ENABLED=0
+ARG CC=
+ARG CXX=
+ARG CFLAGS=
+ARG CXXFLAGS=
+ARG CGO_CFLAGS=
+ARG CGO_CXXFLAGS=
+ARG CGO_LDFLAGS=
 
 # Prepare local modules to satisfy replace directives.
 COPY components/internal/go.mod components/internal/go.sum ./components/internal/
@@ -34,14 +44,22 @@ COPY components/execd ./components/execd
 
 WORKDIR /build/components/execd
 
-RUN CGO_ENABLED=0 go build \
-    -ldflags "-X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
+RUN if [ -n "${CC}" ]; then export CC; fi; \
+    if [ -n "${CXX}" ]; then export CXX; fi; \
+    export CGO_ENABLED="${CGO_ENABLED}" \
+           CGO_CFLAGS="${CGO_CFLAGS:-${CFLAGS}}" \
+           CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
+           CGO_LDFLAGS="${CGO_LDFLAGS}"; \
+    go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none \
+              -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/execd ./main.go
 
-RUN CGO_ENABLED=0 GOOS=windows go build \
-    -ldflags "-X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
+RUN CGO_ENABLED=0 GOOS=windows go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none \
+              -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/execd.exe ./main.go

--- a/components/execd/Makefile
+++ b/components/execd/Makefile
@@ -28,15 +28,18 @@ golint: fmt install-golint
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
-BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
+BUILD_TIME ?= $(shell if [ -n "$$SOURCE_DATE_EPOCH" ]; then date -u -d "@$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; else date -u +"%Y-%m-%dT%H:%M:%SZ"; fi)
+PROJECT_GOFLAGS := -trimpath -buildvcs=false
+PROJECT_LDFLAGS := -buildid= -B none -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.BuildTime=$(BUILD_TIME)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.GitCommit=$(GIT_COMMIT)'
+GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))
+GO_LDFLAGS := $(strip $(LDFLAGS) $(PROJECT_LDFLAGS))
 
 .PHONY: build
 build: vet ## Build the binary.
 	@mkdir -p bin
-	go build -ldflags "$(LDFLAGS)" -o bin/execd main.go
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" -o bin/execd main.go
 
 .PHONY: multi-build
 multi-build: vet ## Cross-compile for linux/windows/darwin amd64/arm64.
@@ -46,6 +49,6 @@ multi-build: vet ## Cross-compile for linux/windows/darwin amd64/arm64.
 			out=bin/execd_$(VERSION)_$${os}_$${arch}; \
 			[ "$${os}" = "windows" ] && out="$${out}.exe"; \
 			echo ">> building $${os}/$${arch} -> $${out}"; \
-			GOOS=$${os} GOARCH=$${arch} CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o "$${out}" main.go || exit $$?; \
+			GOOS=$${os} GOARCH=$${arch} CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" -o "$${out}" main.go || exit $$?; \
 		done; \
 	done

--- a/components/execd/build.sh
+++ b/components/execd/build.sh
@@ -15,10 +15,30 @@
 
 set -ex
 
+default_build_time() {
+  if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    date -u -d "@${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+      date -u -r "${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ"
+  else
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+  fi
+}
+
+build_arg_if_set() {
+  local name="$1"
+  if [[ -n "${!name+x}" ]]; then
+    BUILD_ARGS+=(--build-arg "${name}=${!name}")
+  fi
+}
+
 TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
-BUILD_TIME=${BUILD_TIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_ARGS=()
+for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
+  build_arg_if_set "${name}"
+done
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
@@ -41,6 +61,7 @@ docker buildx build \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:${TAG} \
   "${LATEST_TAGS[@]}" \
   -f components/execd/Dockerfile \
+  "${BUILD_ARGS[@]}" \
   --build-arg VERSION="${VERSION}" \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \

--- a/components/ingress/Dockerfile
+++ b/components/ingress/Dockerfile
@@ -19,6 +19,16 @@ WORKDIR /build
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
+ARG GOFLAGS=
+ARG LDFLAGS=
+ARG CGO_ENABLED=0
+ARG CC=
+ARG CXX=
+ARG CFLAGS=
+ARG CXXFLAGS=
+ARG CGO_CFLAGS=
+ARG CGO_CXXFLAGS=
+ARG CGO_LDFLAGS=
 
 COPY kubernetes ./kubernetes
 # Prepare local modules to satisfy replace directives.
@@ -36,8 +46,15 @@ COPY components/ingress/. ./components/ingress
 
 WORKDIR /build/components/ingress
 
-RUN CGO_ENABLED=0 go build \
-    -ldflags "-X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
+RUN if [ -n "${CC}" ]; then export CC; fi; \
+    if [ -n "${CXX}" ]; then export CXX; fi; \
+    export CGO_ENABLED="${CGO_ENABLED}" \
+           CGO_CFLAGS="${CGO_CFLAGS:-${CFLAGS}}" \
+           CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
+           CGO_LDFLAGS="${CGO_LDFLAGS}"; \
+    go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none \
+              -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/ingress ./main.go

--- a/components/ingress/Makefile
+++ b/components/ingress/Makefile
@@ -28,15 +28,18 @@ golint: fmt install-golint
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
-BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
+BUILD_TIME ?= $(shell if [ -n "$$SOURCE_DATE_EPOCH" ]; then date -u -d "@$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; else date -u +"%Y-%m-%dT%H:%M:%SZ"; fi)
+PROJECT_GOFLAGS := -trimpath -buildvcs=false
+PROJECT_LDFLAGS := -buildid= -B none -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.BuildTime=$(BUILD_TIME)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.GitCommit=$(GIT_COMMIT)'
+GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))
+GO_LDFLAGS := $(strip $(LDFLAGS) $(PROJECT_LDFLAGS))
 
 .PHONY: build
 build: vet ## Build the binary.
 	@mkdir -p bin
-	go build -ldflags "$(LDFLAGS)" -o bin/router main.go
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" -o bin/router main.go
 
 .PHONY: clean
 clean: ## Clean build artifacts.

--- a/components/ingress/build.sh
+++ b/components/ingress/build.sh
@@ -15,10 +15,30 @@
 
 set -ex
 
+default_build_time() {
+  if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    date -u -d "@${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+      date -u -r "${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ"
+  else
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+  fi
+}
+
+build_arg_if_set() {
+  local name="$1"
+  if [[ -n "${!name+x}" ]]; then
+    BUILD_ARGS+=(--build-arg "${name}=${!name}")
+  fi
+}
+
 TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
-BUILD_TIME=${BUILD_TIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_ARGS=()
+for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
+  build_arg_if_set "${name}"
+done
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
@@ -41,6 +61,7 @@ docker buildx build \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/ingress:${TAG} \
   "${LATEST_TAGS[@]}" \
   -f components/ingress/Dockerfile \
+  "${BUILD_ARGS[@]}" \
   --build-arg VERSION="${VERSION}" \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -16,6 +16,16 @@
 FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOFLAGS=
+ARG LDFLAGS=
+ARG CGO_ENABLED=0
+ARG CC=
+ARG CXX=
+ARG CFLAGS=
+ARG CXXFLAGS=
+ARG CGO_CFLAGS=
+ARG CGO_CXXFLAGS=
+ARG CGO_LDFLAGS=
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -38,7 +48,15 @@ COPY internal/ internal/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN echo "Building for $TARGETOS/$TARGETARCH"
 ARG PACKAGE=./cmd/controller
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o server ${PACKAGE}
+RUN if [ -n "${CC}" ]; then export CC; fi; \
+    if [ -n "${CXX}" ]; then export CXX; fi; \
+    export CGO_ENABLED="${CGO_ENABLED}" GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+           CGO_CFLAGS="${CGO_CFLAGS:-${CFLAGS}}" \
+           CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
+           CGO_LDFLAGS="${CGO_LDFLAGS}"; \
+    go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none" \
+    -o server ${PACKAGE}
 
 # Use golang image as base to ensure nsenter (util-linux) is available
 # distroless does not contain shell or nsenter

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -246,9 +246,13 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 ##@ Build
 
+PROJECT_GOFLAGS := -trimpath -buildvcs=false
+GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))
+GO_LDFLAGS := $(strip $(LDFLAGS) -buildid= -B none)
+
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager ./cmd/controller
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" -o bin/manager ./cmd/controller
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -256,7 +260,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: task-executor-build
 task-executor-build: ## Build task-executor binary.
-	go build -o bin/task-executor ./cmd/task-executor
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" -o bin/task-executor ./cmd/task-executor
 
 .PHONY: task-executor-run
 task-executor-run: ## Run task-executor from your host.

--- a/kubernetes/build.sh
+++ b/kubernetes/build.sh
@@ -15,10 +15,21 @@
 
 set -e
 
+build_arg_if_set() {
+    local name="$1"
+    if [[ -n "${!name+x}" ]]; then
+        BUILD_ARGS+=(--build-arg "${name}=${!name}")
+    fi
+}
+
 # Default values
 TAG=${TAG:-latest}
 COMPONENT=${COMPONENT:-controller}
 PUSH=${PUSH:-true}
+BUILD_ARGS=()
+for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
+    build_arg_if_set "${name}"
+done
 
 DOCKERHUB_REPO="opensandbox"
 ACR_REPO="sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox"
@@ -51,6 +62,7 @@ if [ "$PUSH" == "true" ]; then
     docker buildx build \
         --platform $PLATFORMS \
         $BUILD_ARG \
+        "${BUILD_ARGS[@]}" \
         -t "${DOCKERHUB_REPO}/${IMAGE_NAME}:${TAG}" \
         -t "${ACR_REPO}/${IMAGE_NAME}:${TAG}" \
         --push \
@@ -67,6 +79,7 @@ else
     docker buildx build \
         --platform linux/amd64 \
         $BUILD_ARG \
+        "${BUILD_ARGS[@]}" \
         -t ${IMAGE_NAME}:${TAG} \
         -f Dockerfile \
         --load \

--- a/sdks/code-interpreter/csharp/.editorconfig
+++ b/sdks/code-interpreter/csharp/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.cs]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/sdks/sandbox/go/Makefile
+++ b/sdks/sandbox/go/Makefile
@@ -1,5 +1,9 @@
 .PHONY: all build vet test lint generate
 
+PROJECT_GOFLAGS := -trimpath -buildvcs=false
+GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))
+GO_LDFLAGS := $(strip $(LDFLAGS) -buildid= -B none)
+
 all: build vet test
 
 generate:
@@ -9,7 +13,7 @@ generate:
 	@echo "Generated all API clients from OpenAPI specs"
 
 build:
-	go build ./...
+	go build $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" ./...
 
 vet:
 	go vet ./...


### PR DESCRIPTION
# Summary
- Document OpenSandbox coding standards and the automated enforcement points used by Ruff, ESLint, Spotless/ktlint, .NET analyzers, `go vet`, `golangci-lint`, and read-only `gofmt` checks.
- Add the missing C# code-interpreter SDK `.editorconfig` so the documented C# style is consistently enforced.
- Document build-system standards for native Go binaries and update Makefile/Docker build paths to preserve caller-provided build variables while appending project flags.
- Make native Go binary builds more repeatable with `-trimpath`, `-buildvcs=false`, `-buildid=`, `-B none`, and `SOURCE_DATE_EPOCH`/fixed metadata support.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification
  - `test -z "$(gofmt -l components/execd components/ingress components/egress components/internal kubernetes sdks/sandbox/go)"`
  - workflow YAML parse check with Ruby `YAML.load_file`
  - `bash -n components/execd/build.sh components/egress/build.sh components/ingress/build.sh kubernetes/build.sh`
  - `docker build --check` for execd, ingress, egress, and kubernetes Dockerfiles
  - Makefile dry-runs verified caller `GOFLAGS`/`LDFLAGS` are preserved and project flags are appended
  - repeatability checks built each native Go binary twice with fixed metadata and compared bytes
  - `git diff --check`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered