### PR TITLE
fix(execd): sanitize sensitive data in command logs

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -161,7 +161,6 @@ if [ -z "$SHELL_BIN" ]; then
 	fi
 fi
 
-set -x
 if [ "$CMD" != "" ]; then
 	"$SHELL_BIN" -c "$CMD" &
 	CMD_PID=$!

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -91,5 +91,5 @@ func InitFlags() {
 
 	// Log final values
 	log.Info("Jupyter server host is: %s", JupyterServerHost)
-	log.Info("Jupyter server token is: %s", JupyterServerToken)
+	log.Info("Jupyter server token is: %s", log.MaskToken(JupyterServerToken))
 }

--- a/components/execd/pkg/log/sanitize.go
+++ b/components/execd/pkg/log/sanitize.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import "regexp"
+
+var sanitizePatterns = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	// === URL / header / connection-string patterns ===
+
+	// URL credentials: scheme://user:password@host
+	{
+		regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^/\s:@]+@`),
+		`${1}****:****@`,
+	},
+	// Authorization: Bearer/Basic/Token/ApiKey header value
+	{
+		regexp.MustCompile(`(?i)(Authorization\s*:\s*(?:Bearer|Basic|Token|ApiKey|apiKey)\s+)\S+`),
+		`${1}****`,
+	},
+	// Azure storage AccountKey / SharedAccessKey (stop at ; " ' whitespace)
+	{
+		regexp.MustCompile(`((?:Account|SharedAccess)Key\s*=\s*)[^;"'\s]+`),
+		`${1}****`,
+	},
+
+	// === Long-flag sensitive options: --flag value or --flag=value ===
+	// Flag names listed longest-first so RE2 picks the right match.
+	// Requiring [\s=] after the flag name prevents --password from matching
+	// --password-stdin (the trailing - isn't whitespace or =).
+
+	{
+		regexp.MustCompile(
+			`(--(?:access-key-id|access-key-secret|access-token|access-key|` +
+				`secret-access-key|secret-key|secret-id|secret|` +
+				`aws-secret-access-key|private-key|client-secret|refresh-token|` +
+				`sentry-token|credential|password|passwd|` +
+				`api-key|apikey|token|` +
+				`ak|sk))` +
+				`([\s=])\s*` +
+				`(?:"[^"]*"|'[^']*'|\S+)?`,
+		),
+		`${1}${2}****`,
+	},
+
+	// === Environment variable assignments with sensitive names ===
+
+	{
+		regexp.MustCompile(
+			`\b(PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|APIKEY|AUTH_TOKEN|ACCESS_TOKEN|` +
+				`PRIVATE_KEY|CLIENT_SECRET|REFRESH_TOKEN|CREDENTIAL|AUTH_KEY|SECRET_KEY|SECRET_ID|` +
+				// Cloud-provider specific
+				`ACCESS_KEY_ID|ACCESS_KEY_SECRET|SECRET_ACCESS_KEY|` +
+				`AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|` +
+				`ALIBABA_CLOUD_ACCESS_KEY_ID|ALIBABA_CLOUD_ACCESS_KEY_SECRET|ALIBABA_CLOUD_SECRET_KEY|` +
+				`ALICLOUD_ACCESS_KEY_ID|ALICLOUD_ACCESS_KEY_SECRET|ALICLOUD_SECRET_KEY|` +
+				`TENCENTCLOUD_SECRET_ID|TENCENTCLOUD_SECRET_KEY|` +
+				`HUAWEICLOUD_ACCESS_KEY_ID|HUAWEICLOUD_SECRET_ACCESS_KEY|` +
+				`CLOUD_ACCESS_KEY_ID|CLOUD_SECRET_KEY|CLOUD_API_KEY|CLOUD_API_SECRET|` +
+				`RAM_ACCESS_KEY_ID|RAM_ACCESS_KEY_SECRET|` +
+				`OTS_ACCESS_KEY_ID|OTS_ACCESS_KEY_SECRET|` +
+				`ACCOUNT_KEY|SHARED_ACCESS_KEY|AZURE_STORAGE_KEY|` +
+				`GCP_CREDENTIALS|GOOGLE_APPLICATION_CREDENTIALS|` +
+				`DOCKER_PASSWORD|DOCKER_TOKEN|REGISTRY_PASSWORD` +
+				`)\s*=\s*(?:"[^"]*"|'[^']*'|\S+)`,
+		),
+		`${1}=****`,
+	},
+
+	// === Bare cloud access key matching (prefix-specific, low false-positive) ===
+
+	// Alibaba Cloud AccessKey ID: LTAI + 16~32 alphanumeric
+	{
+		regexp.MustCompile(`\bLTAI[a-zA-Z0-9]{16,32}\b`),
+		`LTAI****`,
+	},
+	// AWS Access Key ID: AKIA + 16 uppercase
+	{
+		regexp.MustCompile(`\bAKIA[A-Z0-9]{16}\b`),
+		`AKIA****`,
+	},
+	// Tencent Cloud Secret ID: AKID + 16~48 alphanumeric
+	{
+		regexp.MustCompile(`\bAKID[a-zA-Z0-9]{16,48}\b`),
+		`AKID****`,
+	},
+}
+
+// SanitizeCommand masks sensitive values (passwords, tokens, keys, credentials)
+// in a shell command string so it is safe to log.
+func SanitizeCommand(cmd string) string {
+	for _, p := range sanitizePatterns {
+		cmd = p.re.ReplaceAllString(cmd, p.repl)
+	}
+	return cmd
+}
+
+// MaskToken returns a partially masked token for logging.
+// Shows first 4 and last 4 characters; returns "****" for tokens 8 chars or shorter.
+func MaskToken(token string) string {
+	if len(token) <= 8 {
+		return "****"
+	}
+	return token[:4] + "****" + token[len(token)-4:]
+}

--- a/components/execd/pkg/runtime/bash_session.go
+++ b/components/execd/pkg/runtime/bash_session.go
@@ -217,7 +217,7 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 	cmd.Stderr = cmd.Stdout
 
 	if err := cmd.Start(); err != nil {
-		log.Error("start bash session failed: %v (command: %q)", err, request.Code)
+		log.Error("start bash session failed: %v (command: %q)", err, log.SanitizeCommand(request.Code))
 		return fmt.Errorf("start bash: %w", err)
 	}
 	defer s.untrackCurrentProcess()
@@ -261,13 +261,13 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 	waitErr := cmd.Wait()
 
 	if scanErr != nil {
-		log.Error("read stdout failed: %v (command: %q)", scanErr, request.Code)
+		log.Error("read stdout failed: %v (command: %q)", scanErr, log.SanitizeCommand(request.Code))
 		return fmt.Errorf("read stdout: %w", scanErr)
 	}
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		log.Error("timeout after %s while running command: %q", wait, request.Code)
-		return fmt.Errorf("timeout after %s while running command %q", wait, request.Code)
+		log.Error("timeout after %s while running command: %q", wait, log.SanitizeCommand(request.Code))
+		return fmt.Errorf("timeout after %s", wait)
 	}
 
 	if exitCode == nil && cmd.ProcessState != nil {
@@ -287,7 +287,7 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 
 	var exitErr *exec.ExitError
 	if waitErr != nil && !errors.As(waitErr, &exitErr) {
-		log.Error("command wait failed: %v (command: %q)", waitErr, request.Code)
+		log.Error("command wait failed: %v (command: %q)", waitErr, log.SanitizeCommand(request.Code))
 		return waitErr
 	}
 
@@ -308,7 +308,7 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 				Traceback: []string{errMsg},
 			})
 		}
-		log.Error("CommandExecError: %s (command: %q)", errMsg, request.Code)
+		log.Error("CommandExecError: %s (command: %q)", errMsg, log.SanitizeCommand(request.Code))
 		return nil
 	}
 

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -105,7 +105,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	stderrPath := c.stderrFileName(session)
 
 	startAt := time.Now()
-	log.Info("received command: %v", request.Code)
+	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
@@ -240,7 +240,7 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	defer signal.Reset()
 
 	startAt := time.Now()
-	log.Info("received command: %v", request.Code)
+	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	shell := getShell()
 	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)

--- a/components/execd/pkg/runtime/command_windows.go
+++ b/components/execd/pkg/runtime/command_windows.go
@@ -43,7 +43,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	}
 
 	startAt := time.Now()
-	log.Info("received command: %v", request.Code)
+	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
@@ -121,7 +121,7 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	stderrPath := c.combinedOutputFileName(session)
 
 	startAt := time.Now()
-	log.Info("received command: %v", request.Code)
+	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	cmd := exec.CommandContext(ctx, "cmd", "/C", request.Code)
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)


### PR DESCRIPTION
# Summary
- Mask passwords, tokens, API keys, cloud access keys (LTAI/AKIA/AKID), Authorization headers, and URL credentials before logging user commands. Also mask the Jupyter auth token logged at startup.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered