### PR TITLE
fix(sdk/python): Preserve sandbox create API error details

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
@@ -234,8 +234,11 @@ def _parse_error_body(body: Any) -> SandboxError | None:
                     message=body,
                 )
 
-        # Extract code and message from dict
+        # FastAPI HTTPException bodies are commonly wrapped as {"detail": {"code": ..., "message": ...}}.
         if isinstance(body, dict):
+            if isinstance(body.get("detail"), dict):
+                body = body["detail"]
+
             code: str | None = body.get("code")
             message: str | None = body.get("message")
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/response_handler.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/response_handler.py
@@ -28,7 +28,7 @@ import logging
 from http import HTTPStatus
 from typing import Any, TypeVar
 
-from opensandbox.exceptions import SandboxApiException
+from opensandbox.exceptions import SandboxApiException, SandboxError
 
 logger = logging.getLogger(__name__)
 
@@ -118,17 +118,27 @@ def handle_api_error(response_obj: Any, operation_name: str = "API call") -> Non
 
     if status_code >= 300:
         error_message = f"{operation_name} failed: HTTP {status_code}"
+        sandbox_error: SandboxError | None = None
 
         if hasattr(response_obj, "parsed") and response_obj.parsed is not None:
-            if hasattr(response_obj.parsed, "message"):
-                error_message = (
-                    f"{operation_name} failed: {response_obj.parsed.message}"
+            parsed = response_obj.parsed
+            parsed_code = getattr(parsed, "code", None)
+            parsed_message = getattr(parsed, "message", None)
+
+            if parsed_message:
+                error_message = f"{operation_name} failed: {parsed_message}"
+            elif parsed_code:
+                error_message = f"{operation_name} failed: {parsed_code}"
+
+            if parsed_code:
+                sandbox_error = SandboxError(
+                    code=str(parsed_code),
+                    message=str(parsed_message or ""),
                 )
-            elif hasattr(response_obj.parsed, "code"):
-                error_message = f"{operation_name} failed: {response_obj.parsed.code}"
 
         raise SandboxApiException(
             message=error_message,
             status_code=status_code,
             request_id=request_id,
+            error=sandbox_error,
         )

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -79,6 +79,7 @@ def test_parse_sandbox_error_from_invalid_utf8_bytes_fallback_message() -> None:
 
 def test_handle_api_error_raises_with_parsed_message() -> None:
     class Parsed:
+        code = "BAD_REQUEST"
         message = "bad request"
 
     class Resp:
@@ -90,6 +91,8 @@ def test_handle_api_error_raises_with_parsed_message() -> None:
         handle_api_error(Resp(), "Op")
     assert "bad request" in str(ei.value)
     assert ei.value.request_id == "req-123"
+    assert ei.value.error.code == "BAD_REQUEST"
+    assert ei.value.error.message == "bad request"
 
 
 def test_handle_api_error_noop_on_success() -> None:

--- a/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
@@ -202,6 +202,90 @@ async def test_create_sandbox_restore_from_snapshot(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_create_sandbox_http_error_preserves_wrapped_error_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensandbox.api.lifecycle.models.error_response import ErrorResponse
+
+    async def _fake_asyncio_detailed(*, client, body):
+        return _Resp(
+            status_code=409,
+            parsed=ErrorResponse(
+                code="K8S_API_ERROR",
+                message="Failed to create sandbox: pool exhausted",
+            ),
+        )
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.post_sandboxes.asyncio_detailed",
+        _fake_asyncio_detailed,
+    )
+
+    adapter = SandboxesAdapter(ConnectionConfig(domain="example.com:8080", api_key="k"))
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.create_sandbox(
+            spec=SandboxImageSpec("python:3.11"),
+            entrypoint=["/bin/sh"],
+            env={},
+            metadata={},
+            timeout=timedelta(seconds=3),
+            resource={"cpu": "100m"},
+            platform=None,
+            network_policy=None,
+            extensions={},
+            volumes=None,
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.error.code == "K8S_API_ERROR"
+    assert exc.error.message == "Failed to create sandbox: pool exhausted"
+    assert "pool exhausted" in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_unexpected_status_preserves_fastapi_detail_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensandbox.api.lifecycle.errors import UnexpectedStatus
+
+    async def _fake_asyncio_detailed(*, client, body):
+        raise UnexpectedStatus(
+            409,
+            b'{"detail":{"code":"K8S_API_ERROR","message":"Failed to create sandbox: pool exhausted"}}',
+        )
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.post_sandboxes.asyncio_detailed",
+        _fake_asyncio_detailed,
+    )
+
+    adapter = SandboxesAdapter(ConnectionConfig(domain="example.com:8080", api_key="k"))
+
+    with pytest.raises(SandboxApiException) as exc_info:
+        await adapter.create_sandbox(
+            spec=SandboxImageSpec("python:3.11"),
+            entrypoint=["/bin/sh"],
+            env={},
+            metadata={},
+            timeout=timedelta(seconds=3),
+            resource={"cpu": "100m"},
+            platform=None,
+            network_policy=None,
+            extensions={},
+            volumes=None,
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.error is not None
+    assert exc.error.code == "K8S_API_ERROR"
+    assert exc.error.message == "Failed to create sandbox: pool exhausted"
+    assert "HTTP 409" in str(exc)
+
+
+@pytest.mark.asyncio
 async def test_create_sandbox_empty_response_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _fake_asyncio_detailed(*, client, body):
         return _Resp(status_code=200, parsed=None)


### PR DESCRIPTION
## Summary
- preserve structured  details when Python sandbox creation returns an API error
- parse FastAPI-style wrapped error bodies in the Python exception converter so fallback error conversion keeps the original server context
- add regression coverage for both parsed lifecycle errors and unexpected-status error bodies

## Related
- refs #637

## Verification
- \
- \E902 No such file or directory (os error 2)
--> tests/test_converters_and_error_handling.py\:1:1

Found 1 error.
