### PR TITLE
feat(release): sign and attest release artifacts

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish-pypi:
@@ -50,6 +53,12 @@ jobs:
         working-directory: cli
         run: |
           uv build
+
+      - name: Attest built package
+        if: startsWith(github.ref, 'refs/tags/cli/v')
+        uses: actions/attest@v4
+        with:
+          subject-path: cli/dist/*
 
       - name: Publish to PyPI
         working-directory: cli

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -4,6 +4,9 @@ permissions:
   # required for bump step to push branch and create PR
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 on:
   workflow_dispatch:
@@ -45,6 +48,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install Cosign
+        if: github.ref_type == 'tag'
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -93,6 +100,9 @@ jobs:
           df -h
 
       - name: Build and push to registries
+        id: build
+        env:
+          BUILD_METADATA_FILE: ${{ runner.temp }}/opensandbox-component-image-metadata.json
         run: |
           COMPONENT="${{ steps.parse_tag.outputs.component }}"
           IMAGE_TAG="${{ steps.parse_tag.outputs.image_tag }}"
@@ -115,6 +125,45 @@ jobs:
           export COMPONENT=$COMPONENT
           chmod +x build.sh
           ./build.sh
+
+          DIGEST="$(jq -r '."containerimage.digest" // empty' "$BUILD_METADATA_FILE")"
+          if [[ -z "$DIGEST" ]]; then
+            echo "Unable to resolve image digest from $BUILD_METADATA_FILE" >&2
+            cat "$BUILD_METADATA_FILE" >&2
+            exit 1
+          fi
+
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "dockerhub_image=docker.io/opensandbox/$COMPONENT" >> "$GITHUB_OUTPUT"
+          echo "acr_image=sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/$COMPONENT" >> "$GITHUB_OUTPUT"
+
+      - name: Sign release images
+        if: github.ref_type == 'tag' && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKERHUB_IMAGE: ${{ steps.build.outputs.dockerhub_image }}
+          ACR_IMAGE: ${{ steps.build.outputs.acr_image }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${DOCKERHUB_IMAGE}@${DIGEST}" "${ACR_IMAGE}@${DIGEST}"
+
+      - name: Attest Docker Hub image
+        if: github.ref_type == 'tag' && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.build.outputs.dockerhub_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: Attest ACR image
+        if: github.ref_type == 'tag' && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.build.outputs.acr_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
 
       - name: Bump component version in repo
         if: steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''

--- a/.github/workflows/publish-csharp-sdks.yml
+++ b/.github/workflows/publish-csharp-sdks.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish:
@@ -63,6 +66,12 @@ jobs:
             -p:ContinuousIntegrationBuild=true \
             ${EXTRA_PACK_ARGS} \
             --output ./artifacts/${{ matrix.sdk.name }}
+
+      - name: Attest built package
+        if: startsWith(github.ref, format('refs/tags/csharp/{0}/v', matrix.sdk.tagPrefix))
+        uses: actions/attest@v4
+        with:
+          subject-path: ./artifacts/${{ matrix.sdk.name }}/*.nupkg
 
       - name: Publish to NuGet
         if: startsWith(github.ref, format('refs/tags/csharp/{0}/v', matrix.sdk.tagPrefix))

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -115,8 +118,13 @@ jobs:
           CHART_PATH="${{ steps.chart_path.outputs.path }}"
           helm package $CHART_PATH
 
+      - name: Attest packaged Helm chart
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ steps.parse_tag.outputs.component }}-*.tgz
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}
           name: Helm Chart ${{ steps.parse_tag.outputs.component }} ${{ steps.chart_version.outputs.version }} (App v${{ steps.parse_tag.outputs.app_version }})

--- a/.github/workflows/publish-js-sdks.yml
+++ b/.github/workflows/publish-js-sdks.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish:
@@ -63,10 +66,31 @@ jobs:
         working-directory: sdks
         run: corepack pnpm --filter ${{ matrix.sdk.packageName }}... --sort run build
 
+      - name: Pack SDK
+        if: startsWith(github.ref, format('refs/tags/js/{0}/v', matrix.sdk.tagPrefix))
+        id: pack
+        working-directory: ${{ matrix.sdk.workingDirectory }}
+        run: |
+          set -euo pipefail
+          PACK_DIR="${GITHUB_WORKSPACE}/dist/npm/${{ matrix.sdk.name }}"
+          mkdir -p "$PACK_DIR"
+          corepack pnpm pack --pack-destination "$PACK_DIR"
+          PACKAGE_TARBALL="$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)"
+          if [[ -z "$PACKAGE_TARBALL" ]]; then
+            echo "No package tarball was produced in $PACK_DIR" >&2
+            exit 1
+          fi
+          echo "tarball=$PACKAGE_TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Attest packed SDK
+        if: startsWith(github.ref, format('refs/tags/js/{0}/v', matrix.sdk.tagPrefix))
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ steps.pack.outputs.tarball }}
+
       - name: Publish to npm
         if: startsWith(github.ref, format('refs/tags/js/{0}/v', matrix.sdk.tagPrefix))
-        working-directory: ${{ matrix.sdk.workingDirectory }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          corepack pnpm publish --access public --no-git-checks
+          corepack pnpm publish "${{ steps.pack.outputs.tarball }}" --access public --no-git-checks

--- a/.github/workflows/publish-python-sdks.yml
+++ b/.github/workflows/publish-python-sdks.yml
@@ -2,6 +2,9 @@ name: Publish Python SDKs
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 on:
   push:
@@ -38,6 +41,12 @@ jobs:
         run: |
           uv build
 
+      - name: Attest built package
+        if: startsWith(github.ref, 'refs/tags/python/sandbox/v')
+        uses: actions/attest@v4
+        with:
+          subject-path: sdks/sandbox/python/dist/*
+
       - name: Publish to PyPI
         working-directory: sdks/sandbox/python
         env:
@@ -67,6 +76,12 @@ jobs:
         run: |
           uv build
 
+      - name: Attest built package
+        if: startsWith(github.ref, 'refs/tags/python/code-interpreter/v')
+        uses: actions/attest@v4
+        with:
+          subject-path: sdks/code-interpreter/python/dist/*
+
       - name: Publish to PyPI
         working-directory: sdks/code-interpreter/python
         env:
@@ -95,6 +110,12 @@ jobs:
         working-directory: sdks/mcp/sandbox/python
         run: |
           uv build
+
+      - name: Attest built package
+        if: startsWith(github.ref, 'refs/tags/python/mcp/sandbox/v')
+        uses: actions/attest@v4
+        with:
+          subject-path: sdks/mcp/sandbox/python/dist/*
 
       - name: Publish to PyPI
         working-directory: sdks/mcp/sandbox/python

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish-pypi:
@@ -31,6 +34,12 @@ jobs:
         run: |
           uv build
 
+      - name: Attest built package
+        if: startsWith(github.ref, 'refs/tags/server/v')
+        uses: actions/attest@v4
+        with:
+          subject-path: server/dist/*
+
       - name: Publish to PyPI
         working-directory: server
         env:
@@ -49,6 +58,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install Cosign
+        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/server/v')
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -84,12 +97,53 @@ jobs:
           fi
 
       - name: Build and push to registries
+        id: build
         working-directory: server
         env:
           TAG: ${{ steps.parse_tag.outputs.image_tag }}
+          BUILD_METADATA_FILE: ${{ runner.temp }}/opensandbox-server-image-metadata.json
         run: |
           chmod +x build.sh
           ./build.sh
+
+          DIGEST="$(jq -r '."containerimage.digest" // empty' "$BUILD_METADATA_FILE")"
+          if [[ -z "$DIGEST" ]]; then
+            echo "Unable to resolve image digest from $BUILD_METADATA_FILE" >&2
+            cat "$BUILD_METADATA_FILE" >&2
+            exit 1
+          fi
+
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "dockerhub_image=docker.io/opensandbox/server" >> "$GITHUB_OUTPUT"
+          echo "acr_image=sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/server" >> "$GITHUB_OUTPUT"
+
+      - name: Sign release images
+        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/server/v') && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKERHUB_IMAGE: ${{ steps.build.outputs.dockerhub_image }}
+          ACR_IMAGE: ${{ steps.build.outputs.acr_image }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${DOCKERHUB_IMAGE}@${DIGEST}" "${ACR_IMAGE}@${DIGEST}"
+
+      - name: Attest Docker Hub image
+        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/server/v') && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.build.outputs.dockerhub_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: Attest ACR image
+        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/server/v') && steps.parse_tag.outputs.image_tag != 'latest' && steps.parse_tag.outputs.image_tag != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.build.outputs.acr_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
 
   bump-server-chart:
     if: startsWith(github.ref, 'refs/tags/server/v')

--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -17,6 +17,7 @@ on:
           - java/code-interpreter
           - csharp/sandbox
           - csharp/code-interpreter
+          - sdks/sandbox/go
           - cli
           - server
           - docker/execd
@@ -62,6 +63,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   release:
@@ -76,6 +80,7 @@ jobs:
         run: chmod +x scripts/release/create-release.sh
 
       - name: Run generic release script
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -116,3 +121,50 @@ jobs:
           fi
 
           scripts/release/create-release.sh "${ARGS[@]}"
+
+      - name: Create release source archive
+        if: ${{ inputs.dry_run == false }}
+        id: source_archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          SAFE_TAG="$(printf '%s' "$RELEASE_TAG" | tr '/:' '--')"
+          ARCHIVE_NAME="opensandbox-${SAFE_TAG}.tar.gz"
+          ARCHIVE_DIR="dist/release-source"
+
+          mkdir -p "$ARCHIVE_DIR"
+          git archive \
+            --format=tar.gz \
+            --prefix="opensandbox-${SAFE_TAG}/" \
+            -o "${ARCHIVE_DIR}/${ARCHIVE_NAME}" \
+            "$RELEASE_TAG"
+
+          (
+            cd "$ARCHIVE_DIR"
+            sha256sum "$ARCHIVE_NAME" > SHA256SUMS
+          )
+
+          echo "archive_path=${ARCHIVE_DIR}/${ARCHIVE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "checksums_path=${ARCHIVE_DIR}/SHA256SUMS" >> "$GITHUB_OUTPUT"
+
+      - name: Attest source release artifacts
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            ${{ steps.source_archive.outputs.archive_path }}
+            ${{ steps.source_archive.outputs.checksums_path }}
+
+      - name: Upload source release artifacts
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" \
+            "${{ steps.source_archive.outputs.archive_path }}" \
+            "${{ steps.source_archive.outputs.checksums_path }}" \
+            --clobber

--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -122,6 +122,29 @@ jobs:
 
           scripts/release/create-release.sh "${ARGS[@]}"
 
+      - name: Verify release tag on origin
+        if: ${{ inputs.dry_run == false }}
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          local_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          remote_commit="$(git ls-remote origin "refs/tags/${RELEASE_TAG}^{}" | awk 'NR == 1 { print $1 }')"
+
+          if [[ -z "$remote_commit" ]]; then
+            remote_commit="$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | awk 'NR == 1 { print $1 }')"
+          fi
+
+          if [[ -z "$remote_commit" ]]; then
+            echo "::error::Release tag '${RELEASE_TAG}' does not exist on origin. Re-run with push_tag=true or push the tag before publishing source artifacts."
+            exit 1
+          fi
+
+          if [[ "$local_commit" != "$remote_commit" ]]; then
+            echo "::error::Local release tag '${RELEASE_TAG}' resolves to ${local_commit}, but origin resolves to ${remote_commit}. Refusing to publish source artifacts."
+            exit 1
+          fi
+
       - name: Create release source archive
         if: ${{ inputs.dry_run == false }}
         id: source_archive

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ For detailed architecture, see [docs/architecture.md](docs/architecture.md).
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) – Overall architecture & design philosophy
+- [docs/release-verification.md](docs/release-verification.md) - Release signing and artifact verification
 - [oseps/README.md](oseps/README.md) – OpenSandbox Enhancement Proposals
 - SDK
   - Sandbox base SDK ([Java/Kotlin SDK](sdks/sandbox/kotlin/README.md), [Python SDK](sdks/sandbox/python/README.md), [JavaScript/TypeScript SDK](sdks/sandbox/javascript/README.md), [C#/.NET SDK](sdks/sandbox/csharp/README.md)), [Go SDK](sdks/sandbox/go/README.md) - includes sandbox lifecycle, command execution, file operations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,13 @@ The OpenSandbox team takes security seriously. If you discover a security vulner
 
 Only the latest release and main branch are actively supported with security updates.
 
+## Release Signatures
+
+OpenSandbox signs public release outputs with GitHub/Sigstore attestations,
+cosign keyless container signatures, and Maven Central package signatures where
+applicable. See [Release Verification](docs/release-verification.md) for the
+trusted signer identities and verification commands.
+
 ## Security Best Practices
 
 When deploying OpenSandbox:

--- a/components/egress/build.sh
+++ b/components/egress/build.sh
@@ -35,12 +35,14 @@ TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
 BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/egress-image-metadata.json}
 BUILD_ARGS=()
 for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
   build_arg_if_set "${name}"
 done
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 docker buildx rm egress-builder || true
 docker buildx create --use --name egress-builder
@@ -62,5 +64,6 @@ docker buildx build \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \
   --platform linux/amd64,linux/arm64 \
+  --metadata-file "${BUILD_METADATA_FILE}" \
   --push \
   .

--- a/components/execd/build.sh
+++ b/components/execd/build.sh
@@ -35,6 +35,7 @@ TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
 BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/execd-image-metadata.json}
 BUILD_ARGS=()
 for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
   build_arg_if_set "${name}"
@@ -42,6 +43,7 @@ done
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 docker buildx rm execd-builder || true
 
@@ -66,5 +68,6 @@ docker buildx build \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \
   --platform linux/amd64,linux/arm64 \
+  --metadata-file "${BUILD_METADATA_FILE}" \
   --push \
   .

--- a/components/ingress/build.sh
+++ b/components/ingress/build.sh
@@ -35,6 +35,7 @@ TAG=${TAG:-latest}
 VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
 BUILD_TIME=${BUILD_TIME:-$(default_build_time)}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/ingress-image-metadata.json}
 BUILD_ARGS=()
 for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
   build_arg_if_set "${name}"
@@ -42,6 +43,7 @@ done
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$0")/../..")
 cd "${REPO_ROOT}"
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 docker buildx rm ingress-builder || true
 
@@ -66,5 +68,6 @@ docker buildx build \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg BUILD_TIME="${BUILD_TIME}" \
   --platform linux/amd64,linux/arm64 \
+  --metadata-file "${BUILD_METADATA_FILE}" \
   --push \
   .

--- a/docs/.vitepress/scripts/docs-manifest.mjs
+++ b/docs/.vitepress/scripts/docs-manifest.mjs
@@ -69,6 +69,15 @@ const manualEntries = [
     titleZh: "架构设计",
   },
   {
+    key: "guide-release-verification",
+    sectionId: "overview",
+    slug: "overview/release-verification",
+    enPath: "docs/release-verification.md",
+    zhPath: null,
+    titleEn: "Release Verification",
+    titleZh: "发布验签",
+  },
+  {
     key: "guide-network",
     sectionId: "modules",
     slug: "design/single-host-network",

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -5,6 +5,8 @@ This repository uses tag-driven publish workflows. The script below standardizes
 - canonical tag creation for each release target
 - release note generation from previous release to current commit
 - GitHub Release create/update
+- signed source archive upload and provenance attestation in the Generic
+  Release workflow
 
 Script path:
 
@@ -21,6 +23,7 @@ Script path:
 - `java/code-interpreter`
 - `csharp/sandbox`
 - `csharp/code-interpreter`
+- `sdks/sandbox/go`
 - `cli`
 - `server`
 - `docker/execd`
@@ -39,6 +42,7 @@ The script aligns with existing workflow triggers:
 - v-prefixed tags:
   - `<target>/v<version>` for SDK/CLI/Server targets
   - examples: `js/sandbox/v1.0.5`, `server/v0.2.0`
+  - Go SDK example: `sdks/sandbox/go/v1.0.0`
 - plain suffix tags:
   - `<target>/<version>` for docker/k8s/helm targets
   - examples: `docker/execd/v0.3.0`, `helm/opensandbox/0.1.0`
@@ -80,6 +84,9 @@ Options:
 - `--initial-release`: allow no previous tag; use full history
 - `--dry-run`: render computed tag/range/notes without side effects
 - `--push`: push created tag to origin
+- `--sign-tag`: create a cryptographically signed git tag using the local git
+  signing configuration. This is intended for local release-operator use, not
+  the hosted GitHub Actions release workflow.
 
 ## Path Filtering Strategy
 
@@ -183,6 +190,10 @@ If `--dry-run` is enabled, the script never creates/pushes tags and never create
 
 - The script creates/updates GitHub Release only when not in `--dry-run`.
 - Tag push is opt-in (`--push`), preventing accidental workflow trigger.
+- Tag signing is opt-in (`--sign-tag`) because it requires release-operator git
+  signing keys. The hosted GitHub Actions release workflow does not expose this
+  option. Official release artifacts are still signed by the GitHub release
+  workflows through Sigstore/GitHub attestations.
 - If previous tag cannot be found, script fails unless `--from-tag` or `--initial-release` is provided.
 
 ## GitHub Actions Entry
@@ -215,3 +226,9 @@ Recommended first run in UI:
 - keep `push_tag=false`
 - verify the generated release notes preview in logs
 - rerun with `dry_run=false` and `push_tag=true` when confirmed
+
+When `dry_run=false`, `.github/workflows/release-generic.yml` uploads an
+explicit `opensandbox-<tag>.tar.gz` source archive and `SHA256SUMS` file to the
+GitHub Release, then signs both files with GitHub/Sigstore provenance
+attestations. See [Release Verification](release-verification.md) for user
+verification commands and release signing coverage.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,221 @@
+# Release Verification
+
+OpenSandbox signs public release outputs without changing the normal install
+commands. Verification is optional for day-to-day use, but supported for users
+who need supply chain integrity checks.
+
+This process applies to releases produced after the signing workflows were
+introduced. Older releases may not have attestations or signatures.
+
+## Signing Model
+
+OpenSandbox uses these signing paths:
+
+- Source code releases: the Generic Release workflow uploads an explicit
+  `opensandbox-<tag>.tar.gz` source archive and `SHA256SUMS` file to the GitHub
+  Release, then creates GitHub/Sigstore provenance attestations for both files.
+- Container images: the component and server image workflows sign Docker Hub
+  and ACR image digests with `cosign` keyless signing, and publish provenance
+  attestations to the registries.
+- Python and CLI packages: wheels and source distributions are attested before
+  `uv publish`.
+- JavaScript packages: the workflow runs `pnpm pack`, attests the generated npm
+  tarball, and publishes that same tarball.
+- C# packages: NuGet `.nupkg` files are attested before publication.
+- Go SDK modules: the `sdks/sandbox/go/v<version>` source release archive is
+  attested by the Generic Release workflow.
+- Helm charts: packaged chart `.tgz` files are attested before upload to the
+  GitHub Release.
+- Java/Kotlin packages: Maven Central publications are signed by the Gradle
+  Maven publish signing configuration. Download the `.asc` signature next to
+  the Maven artifact and verify it with OpenPGP tooling.
+
+Release tags may also be signed with `scripts/release/create-release.sh
+--sign-tag` when the release operator has a local git signing key configured.
+Do not rely on signed tags alone for generated deliverables; verify the
+artifact you are installing.
+
+## Trust Roots and Keys
+
+Most OpenSandbox release signatures are keyless Sigstore signatures created by
+GitHub Actions OpenID Connect (OIDC). There is no long-lived OpenSandbox private
+key for these signatures, so there is no project public key file to download.
+The public certificates and signed bundles are retrieved by `gh` or `cosign`
+from GitHub's attestation service, OCI registries, and Sigstore transparency
+infrastructure.
+
+Expected identity values:
+
+- Repository: `alibaba/OpenSandbox`
+- OIDC issuer: `https://token.actions.githubusercontent.com`
+- Source release workflow: `alibaba/OpenSandbox/.github/workflows/release-generic.yml`
+- Component image workflow: `alibaba/OpenSandbox/.github/workflows/publish-components.yml`
+- Server image workflow: `alibaba/OpenSandbox/.github/workflows/publish-server.yml`
+- CLI package workflow: `alibaba/OpenSandbox/.github/workflows/publish-cli.yml`
+- Python package workflow: `alibaba/OpenSandbox/.github/workflows/publish-python-sdks.yml`
+- JavaScript package workflow: `alibaba/OpenSandbox/.github/workflows/publish-js-sdks.yml`
+- C# package workflow: `alibaba/OpenSandbox/.github/workflows/publish-csharp-sdks.yml`
+- Helm chart workflow: `alibaba/OpenSandbox/.github/workflows/publish-helm-chart.yml`
+
+If you run the release workflows from a downstream fork, replace
+`alibaba/OpenSandbox` in the verification commands with that fork's
+`owner/repository` identity.
+
+Private signing material is not stored in GitHub Releases, Docker Hub, ACR,
+PyPI, npm, Maven Central, NuGet, or Helm chart downloads. Java/Kotlin Maven
+Central signing keys are held only in GitHub Actions secrets.
+
+## Verify Source Releases
+
+Set the release tag first:
+
+```bash
+TAG="server/v0.1.13"
+SAFE_TAG="${TAG//\//-}"
+```
+
+Download the signed source archive and checksum file:
+
+```bash
+gh release download "$TAG" \
+  --repo alibaba/OpenSandbox \
+  --pattern "opensandbox-${SAFE_TAG}.tar.gz" \
+  --pattern "SHA256SUMS"
+```
+
+Check the archive digest:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+Verify the source archive attestation:
+
+```bash
+gh attestation verify "opensandbox-${SAFE_TAG}.tar.gz" \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/release-generic.yml
+```
+
+Verify the checksum file attestation:
+
+```bash
+gh attestation verify SHA256SUMS \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/release-generic.yml
+```
+
+The Generic Release workflow is started with `workflow_dispatch`, so its
+provenance `source-ref` is the ref selected when the workflow was dispatched
+(normally `refs/heads/main`), not the release tag created by the job.
+
+## Verify Container Images
+
+Install `cosign` and `gh`, then resolve the image digest. Always verify by
+digest, not by mutable tag alone.
+
+```bash
+IMAGE="docker.io/opensandbox/execd"
+TAG="v1.0.15"
+DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{.Manifest.Digest}}')"
+IMAGE_REF="${IMAGE}@${DIGEST}"
+```
+
+Verify the cosign keyless signature:
+
+```bash
+cosign verify "$IMAGE_REF" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/alibaba/OpenSandbox/.github/workflows/publish-components.yml@refs/tags/(docker|k8s)/[^/]+/v?[0-9].*$'
+```
+
+Verify the registry provenance attestation:
+
+```bash
+gh attestation verify "oci://${IMAGE_REF}" \
+  --repo alibaba/OpenSandbox \
+  --bundle-from-oci \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-components.yml
+```
+
+For the server image, use `docker.io/opensandbox/server` and the server workflow:
+
+```bash
+IMAGE="docker.io/opensandbox/server"
+TAG="v0.1.13"
+DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{.Manifest.Digest}}')"
+IMAGE_REF="${IMAGE}@${DIGEST}"
+
+cosign verify "$IMAGE_REF" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/alibaba/OpenSandbox/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$'
+```
+
+ACR images use the same digest and identity checks with the ACR image name, for
+example:
+
+```bash
+IMAGE="sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd"
+```
+
+## Verify Packages
+
+Download the package file from its normal package registry, then verify the
+attestation against the OpenSandbox repository and the expected release tag.
+
+Python and CLI packages:
+
+```bash
+python -m pip download opensandbox-server==0.1.13 --no-deps
+gh attestation verify opensandbox_server-0.1.13*.whl \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-server.yml \
+  --source-ref refs/tags/server/v0.1.13
+```
+
+JavaScript packages:
+
+```bash
+npm pack @alibaba-group/opensandbox@0.1.7
+gh attestation verify alibaba-group-opensandbox-0.1.7.tgz \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-js-sdks.yml \
+  --source-ref refs/tags/js/sandbox/v0.1.7
+```
+
+C# packages:
+
+```bash
+gh attestation verify Alibaba.OpenSandbox.1.0.0.nupkg \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-csharp-sdks.yml \
+  --source-ref refs/tags/csharp/sandbox/v1.0.0
+```
+
+Helm charts:
+
+```bash
+gh release download helm/opensandbox/0.1.0 \
+  --repo alibaba/OpenSandbox \
+  --pattern 'opensandbox-*.tgz'
+gh attestation verify opensandbox-*.tgz \
+  --repo alibaba/OpenSandbox \
+  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-helm-chart.yml
+```
+
+When Helm charts are released through `workflow_dispatch`, their provenance
+`source-ref` is the selected dispatch ref. Tag-triggered Helm releases have a
+tag `source-ref`.
+
+Java/Kotlin Maven artifacts:
+
+```bash
+curl -O https://repo1.maven.org/maven2/com/alibaba/opensandbox/sandbox/1.0.10/sandbox-1.0.10.jar
+curl -O https://repo1.maven.org/maven2/com/alibaba/opensandbox/sandbox/1.0.10/sandbox-1.0.10.jar.asc
+KEY_ID="$(gpg --list-packets sandbox-1.0.10.jar.asc | awk '/keyid/ { print $NF; exit }')"
+gpg --keyserver hkps://keys.openpgp.org --recv-keys "$KEY_ID"
+gpg --verify sandbox-1.0.10.jar.asc sandbox-1.0.10.jar
+```
+
+If verification cannot find an attestation for a release that predates this
+process, use a newer release as the signed release evidence.

--- a/kubernetes/build.sh
+++ b/kubernetes/build.sh
@@ -26,10 +26,12 @@ build_arg_if_set() {
 TAG=${TAG:-latest}
 COMPONENT=${COMPONENT:-controller}
 PUSH=${PUSH:-true}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/${COMPONENT}-image-metadata.json}
 BUILD_ARGS=()
 for name in GOFLAGS LDFLAGS CGO_ENABLED CC CXX CFLAGS CXXFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS; do
     build_arg_if_set "${name}"
 done
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 DOCKERHUB_REPO="opensandbox"
 ACR_REPO="sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox"
@@ -65,6 +67,7 @@ if [ "$PUSH" == "true" ]; then
         "${BUILD_ARGS[@]}" \
         -t "${DOCKERHUB_REPO}/${IMAGE_NAME}:${TAG}" \
         -t "${ACR_REPO}/${IMAGE_NAME}:${TAG}" \
+        --metadata-file "${BUILD_METADATA_FILE}" \
         --push \
         -f Dockerfile \
         .

--- a/sandboxes/code-interpreter/build.sh
+++ b/sandboxes/code-interpreter/build.sh
@@ -16,6 +16,8 @@
 set -ex
 
 TAG=${TAG:-latest}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/code-interpreter-image-metadata.json}
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 docker buildx rm code-interpreter-builder || true
 
@@ -35,5 +37,6 @@ docker buildx build \
   -t opensandbox/code-interpreter:${TAG} \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:${TAG} \
   --platform linux/amd64,linux/arm64 \
+  --metadata-file "${BUILD_METADATA_FILE}" \
   --push \
   .

--- a/scripts/release/create-release.sh
+++ b/scripts/release/create-release.sh
@@ -32,6 +32,7 @@ Required:
                         java/code-interpreter
                         csharp/sandbox
                         csharp/code-interpreter
+                        sdks/sandbox/go
                         cli
                         server
                         docker/execd
@@ -52,6 +53,8 @@ Options:
   --push                Push tag to origin (required to trigger tag-based workflows).
   --dry-run             Print computed results without creating tag/release.
   --initial-release     Allow release without previous tag (uses full history).
+  --sign-tag            Create a cryptographically signed git tag using the local
+                        git signing configuration. Defaults to an annotated tag.
   --help                Show this help.
 
 Examples:
@@ -232,6 +235,7 @@ DRY_RUN=false
 PUSH_TAG=false
 INITIAL_RELEASE=false
 NO_PATH_FILTER=false
+SIGN_TAG=false
 CUSTOM_PATH_FILTERS=()
 
 while [[ $# -gt 0 ]]; do
@@ -266,6 +270,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --push)
       PUSH_TAG=true
+      shift
+      ;;
+    --sign-tag)
+      SIGN_TAG=true
       shift
       ;;
     --initial-release)
@@ -354,6 +362,13 @@ case "$TARGET" in
     WORKFLOW_HINT=".github/workflows/publish-csharp-sdks.yml"
     TARGET_PATH_FILTERS=("sdks/code-interpreter/csharp" "specs/execd-api.yaml")
     ;;
+  sdks/sandbox/go|go/sandbox)
+    TARGET="sdks/sandbox/go"
+    TAG_NEEDS_V=true
+    DISPLAY_NAME="Go Sandbox SDK"
+    WORKFLOW_HINT=".github/workflows/release-generic.yml"
+    TARGET_PATH_FILTERS=("sdks/sandbox/go" "specs/sandbox-lifecycle.yml")
+    ;;
   cli)
     TAG_NEEDS_V=true
     DISPLAY_NAME="OpenSandbox CLI"
@@ -416,6 +431,14 @@ else
   NEW_TAG="${TARGET}/${VERSION}"
   TAG_PREFIX="${TARGET}/"
   VERSION_LABEL="$VERSION"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "tag=${NEW_TAG}"
+    echo "display_name=${DISPLAY_NAME}"
+    echo "version_label=${VERSION_LABEL}"
+  } >>"${GITHUB_OUTPUT}"
 fi
 
 if [[ -n "$FROM_TAG" ]] && ! git rev-parse -q --verify "refs/tags/${FROM_TAG}" >/dev/null; then
@@ -642,8 +665,13 @@ fi
 if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
   warn "Tag '${NEW_TAG}' already exists. Reusing existing tag."
 else
-  git tag -a "$NEW_TAG" -m "release: ${DISPLAY_NAME} ${VERSION_LABEL}"
-  log "Created tag: ${NEW_TAG}"
+  if [[ "$SIGN_TAG" == true ]]; then
+    git tag -s "$NEW_TAG" -m "release: ${DISPLAY_NAME} ${VERSION_LABEL}"
+    log "Created signed tag: ${NEW_TAG}"
+  else
+    git tag -a "$NEW_TAG" -m "release: ${DISPLAY_NAME} ${VERSION_LABEL}"
+    log "Created annotated tag: ${NEW_TAG}"
+  fi
 fi
 
 if [[ "$PUSH_TAG" == true ]]; then

--- a/scripts/release/create-release.sh
+++ b/scripts/release/create-release.sh
@@ -82,6 +82,18 @@ require_cmd() {
   command -v "$cmd" >/dev/null 2>&1 || die "Missing required command: $cmd"
 }
 
+remote_tag_commit() {
+  local tag="$1"
+  local commit
+
+  commit="$(git ls-remote origin "refs/tags/${tag}^{}" | awk 'NR == 1 { print $1 }')"
+  if [[ -z "$commit" ]]; then
+    commit="$(git ls-remote origin "refs/tags/${tag}" | awk 'NR == 1 { print $1 }')"
+  fi
+
+  printf '%s' "$commit"
+}
+
 is_semver_like() {
   local version="${1#v}"
   [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]
@@ -681,6 +693,15 @@ else
   warn "Tag not pushed. Use --push to trigger tag-based publish workflows."
 fi
 
+LOCAL_TAG_COMMIT="$(git rev-parse "${NEW_TAG}^{commit}")"
+REMOTE_TAG_COMMIT="$(remote_tag_commit "$NEW_TAG")"
+if [[ -z "$REMOTE_TAG_COMMIT" ]]; then
+  die "Tag '${NEW_TAG}' does not exist on origin. Pass --push or push the tag before creating a GitHub Release."
+fi
+if [[ "$LOCAL_TAG_COMMIT" != "$REMOTE_TAG_COMMIT" ]]; then
+  die "Local tag '${NEW_TAG}' resolves to ${LOCAL_TAG_COMMIT}, but origin resolves to ${REMOTE_TAG_COMMIT}. Refusing to create or update the GitHub Release."
+fi
+
 RELEASE_TITLE="${DISPLAY_NAME} ${VERSION_LABEL}"
 if gh release view "$NEW_TAG" >/dev/null 2>&1; then
   gh release edit "$NEW_TAG" \
@@ -689,6 +710,7 @@ if gh release view "$NEW_TAG" >/dev/null 2>&1; then
   log "Updated GitHub Release: ${NEW_TAG}"
 else
   gh release create "$NEW_TAG" \
+    --verify-tag \
     --title "$RELEASE_TITLE" \
     --notes-file "$NOTES_FILE"
   log "Created GitHub Release: ${NEW_TAG}"

--- a/server/build.sh
+++ b/server/build.sh
@@ -16,6 +16,8 @@
 set -ex
 
 TAG=${TAG:-latest}
+BUILD_METADATA_FILE=${BUILD_METADATA_FILE:-build/server-image-metadata.json}
+mkdir -p "$(dirname "${BUILD_METADATA_FILE}")"
 
 docker buildx rm server-builder || true
 
@@ -35,5 +37,6 @@ docker buildx build \
   -t sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/server:${TAG} \
   "${LATEST_TAGS[@]}" \
   --platform linux/amd64,linux/arm64 \
+  --metadata-file "${BUILD_METADATA_FILE}" \
   --push \
   .


### PR DESCRIPTION
# Summary
- Add Sigstore/GitHub attestations for source archives, Python/CLI packages, JavaScript package tarballs, NuGet packages, Helm charts, and container image digests.
- Add cosign keyless signing for Docker Hub and ACR release images, using buildx metadata to sign immutable digests.
- Extend release automation with source archive/checksum upload after attestation, optional local signed-tag support, and Go SDK release target coverage.
- Document release verification commands, signer identities, and keyless trust roots for users.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Manual/static verification run locally:
- `bash -n scripts/release/create-release.sh components/execd/build.sh components/ingress/build.sh components/egress/build.sh server/build.sh kubernetes/build.sh sandboxes/code-interpreter/build.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`
- `actionlint` on the changed release/publish workflows
- `git diff --check`
- `scripts/release/create-release.sh --target server --version 999.999.999 --dry-run --initial-release`
- `scripts/release/create-release.sh --target helm/opensandbox --version 999.999.999 --dry-run --initial-release`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

No issue is linked. Motivation: support cryptographically signed public release artifacts and documented verification for OpenSSF Best Practices release-signing requirements. Existing install and release tag names remain unchanged.