### PR TITLE
test(server): enforce coverage threshold

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -41,7 +41,19 @@ jobs:
           cd server
           uv sync --all-groups
           uv run ruff check
-          uv run pytest
+          mkdir -p reports
+          uv run pytest \
+            --cov=opensandbox_server \
+            --cov-report=term \
+            --cov-report=xml:reports/coverage.xml \
+            --cov-fail-under=80
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-coverage-${{ matrix.os }}
+          path: server/reports/coverage.xml
 
   docker-smoke:
     strategy:

--- a/server/DEVELOPMENT.md
+++ b/server/DEVELOPMENT.md
@@ -206,7 +206,7 @@ uv run pytest
 uv run pytest tests/test_docker_service.py
 
 # With coverage
-uv run pytest --cov=opensandbox_server --cov-report=html
+uv run pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80
 ```
 
 ### Writing Tests

--- a/server/README.md
+++ b/server/README.md
@@ -257,7 +257,7 @@ uv run pytest
 
 **Run with coverage**:
 ```bash
-uv run pytest --cov=opensandbox_server --cov-report=html
+uv run pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80
 ```
 
 **Run specific test**:

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from kubernetes.client import V1ResourceRequirements
+
+from opensandbox_server.services.constants import SANDBOX_ID_LABEL
+from opensandbox_server.services.k8s.k8s_diagnostics import (
+    K8sDiagnosticsMixin,
+    _parse_since,
+)
+
+
+class _DiagnosticsService(K8sDiagnosticsMixin):
+    def __init__(self, pods):
+        self.namespace = "sandbox-system"
+        self.k8s_client = MagicMock()
+        self.k8s_client.list_pods.return_value = pods
+        self.core_v1 = MagicMock()
+        self.k8s_client.get_core_v1_api.return_value = self.core_v1
+
+
+def _status(
+    *,
+    running=None,
+    waiting=None,
+    terminated=None,
+    last_terminated=None,
+):
+    return SimpleNamespace(
+        name="main",
+        ready=True,
+        restart_count=2,
+        image="python:3.12",
+        state=SimpleNamespace(
+            running=running,
+            waiting=waiting,
+            terminated=terminated,
+        ),
+        last_state=SimpleNamespace(terminated=last_terminated),
+    )
+
+
+def _pod(container_statuses=None, init_container_statuses=None, conditions=None):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            name="pod-1",
+            namespace="sandbox-system",
+            labels={SANDBOX_ID_LABEL: "sbx-1", "app": "opensandbox"},
+        ),
+        spec=SimpleNamespace(
+            node_name="node-1",
+            runtime_class_name="gvisor",
+            containers=[
+                SimpleNamespace(
+                    name="main",
+                    resources=V1ResourceRequirements(
+                        requests={"cpu": "500m"},
+                        limits={"memory": "512Mi"},
+                    ),
+                )
+            ],
+        ),
+        status=SimpleNamespace(
+            phase="Running",
+            pod_ip="10.1.2.3",
+            host_ip="192.168.1.10",
+            start_time="2026-01-01T00:00:00Z",
+            container_statuses=container_statuses or [],
+            init_container_statuses=init_container_statuses or [],
+            conditions=conditions or [],
+        ),
+    )
+
+
+def test_parse_since_supports_units_and_default() -> None:
+    assert _parse_since("5m") == 300
+    assert _parse_since("2 h") == 7200
+    assert _parse_since("invalid") == 600
+
+
+def test_find_pod_uses_label_selector_and_maps_errors() -> None:
+    service = _DiagnosticsService([_pod()])
+
+    pod = service._find_pod_for_sandbox("sbx-1")
+
+    assert pod.metadata.name == "pod-1"
+    service.k8s_client.list_pods.assert_called_once_with(
+        namespace="sandbox-system",
+        label_selector=f"{SANDBOX_ID_LABEL}=sbx-1",
+    )
+
+    service.k8s_client.list_pods.return_value = []
+    with pytest.raises(HTTPException) as not_found:
+        service._find_pod_for_sandbox("missing")
+    assert not_found.value.status_code == 404
+
+    service.k8s_client.list_pods.side_effect = RuntimeError("api down")
+    with pytest.raises(HTTPException) as api_error:
+        service._find_pod_for_sandbox("sbx-1")
+    assert api_error.value.status_code == 500
+
+
+def test_get_sandbox_logs_passes_tail_and_since() -> None:
+    service = _DiagnosticsService([_pod()])
+    service.core_v1.read_namespaced_pod_log.return_value = "log line"
+
+    assert service.get_sandbox_logs("sbx-1", tail=10, since="1h") == "log line"
+
+    service.core_v1.read_namespaced_pod_log.assert_called_once_with(
+        name="pod-1",
+        namespace="sandbox-system",
+        tail_lines=10,
+        timestamps=True,
+        since_seconds=3600,
+    )
+
+
+def test_get_sandbox_logs_returns_placeholder_for_empty_output() -> None:
+    service = _DiagnosticsService([_pod()])
+    service.core_v1.read_namespaced_pod_log.return_value = ""
+
+    assert service.get_sandbox_logs("sbx-1") == "(no logs)"
+
+
+def test_get_sandbox_inspect_formats_runtime_statuses_and_resources() -> None:
+    running_status = _status(running=SimpleNamespace(started_at="2026-01-01T00:00:01Z"))
+    waiting_status = _status(waiting=SimpleNamespace(reason="ImagePullBackOff", message="pull failed"))
+    terminated_status = _status(
+        terminated=SimpleNamespace(exit_code=1, reason="Error", message="boom"),
+        last_terminated=SimpleNamespace(exit_code=2, reason="PreviousError"),
+    )
+    init_status = _status(terminated=SimpleNamespace(exit_code=0, reason="Completed"))
+    waiting_init = _status(waiting=SimpleNamespace(reason="PodInitializing"))
+    condition = SimpleNamespace(type="Ready", status="False", reason="ContainersNotReady", message="not ready")
+    service = _DiagnosticsService(
+        [
+            _pod(
+                container_statuses=[running_status, waiting_status, terminated_status],
+                init_container_statuses=[init_status, waiting_init],
+                conditions=[condition],
+            )
+        ]
+    )
+
+    output = service.get_sandbox_inspect("sbx-1")
+
+    assert "Pod Name:       pod-1" in output
+    assert "Runtime Class:  gvisor" in output
+    assert "State:          Running (since 2026-01-01T00:00:01Z)" in output
+    assert "Waiting (ImagePullBackOff)" in output
+    assert "Terminated (exit=1, reason=Error)" in output
+    assert "Last State:     Terminated (exit=2, reason=PreviousError)" in output
+    assert "Init Containers:" in output
+    assert "Ready: False (reason=ContainersNotReady)" in output
+    assert f"{SANDBOX_ID_LABEL}=sbx-1" in output
+    assert "Requests: {'cpu': '500m'}" in output
+    assert "Limits:   {'memory': '512Mi'}" in output
+
+
+def test_get_sandbox_events_formats_events_and_empty_result() -> None:
+    service = _DiagnosticsService([_pod()])
+    service.core_v1.list_namespaced_event.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                last_timestamp="2026-01-01T00:00:00Z",
+                event_time=None,
+                first_timestamp=None,
+                type="Warning",
+                reason="Failed",
+                message="container failed",
+            ),
+            SimpleNamespace(
+                last_timestamp=None,
+                event_time="2026-01-01T00:00:01Z",
+                first_timestamp=None,
+                type="Normal",
+                reason=None,
+                message=None,
+            ),
+        ]
+    )
+
+    output = service.get_sandbox_events("sbx-1", limit=2)
+
+    assert "[2026-01-01T00:00:00Z] Warning" in output
+    assert "Failed" in output
+    assert "container failed" in output
+    assert "N/A" in output
+    service.core_v1.list_namespaced_event.assert_called_once_with(
+        namespace="sandbox-system",
+        field_selector="involvedObject.name=pod-1",
+        limit=2,
+    )
+
+    service.core_v1.list_namespaced_event.return_value = SimpleNamespace(items=[])
+    assert service.get_sandbox_events("sbx-1") == "(no events)"

--- a/server/tests/test_docker_diagnostics.py
+++ b/server/tests/test_docker_diagnostics.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from opensandbox_server.services.docker_diagnostics import (
+    DockerDiagnosticsMixin,
+    _parse_since_to_timestamp,
+)
+
+
+class _DiagnosticsService(DockerDiagnosticsMixin):
+    def __init__(self, container):
+        self.container = container
+
+    def _get_container_by_sandbox_id(self, sandbox_id: str):
+        assert sandbox_id == "sbx-1"
+        return self.container
+
+
+def _container(attrs: dict):
+    return SimpleNamespace(
+        id="abcdef1234567890",
+        name="opensandbox-sbx-1",
+        attrs=attrs,
+        logs=MagicMock(return_value=b"2026-01-01T00:00:00Z booted\n"),
+    )
+
+
+def test_parse_since_to_timestamp_uses_valid_units_and_default() -> None:
+    with patch("opensandbox_server.services.docker_diagnostics.time.time", return_value=1000):
+        assert _parse_since_to_timestamp("2m") == 880
+        assert _parse_since_to_timestamp("1 h") == -2600
+        assert _parse_since_to_timestamp("nonsense") == 400
+
+
+def test_get_sandbox_logs_decodes_bytes_and_passes_since() -> None:
+    container = _container({"State": {}})
+    service = _DiagnosticsService(container)
+
+    with patch(
+        "opensandbox_server.services.docker_diagnostics._parse_since_to_timestamp",
+        return_value=123,
+    ):
+        result = service.get_sandbox_logs("sbx-1", tail=25, since="5m")
+
+    assert result == "2026-01-01T00:00:00Z booted\n"
+    container.logs.assert_called_once_with(tail=25, timestamps=True, since=123)
+
+
+def test_get_sandbox_logs_returns_placeholder_for_empty_output() -> None:
+    container = _container({"State": {}})
+    container.logs.return_value = ""
+    service = _DiagnosticsService(container)
+
+    assert service.get_sandbox_logs("sbx-1") == "(no logs)"
+
+
+def test_get_sandbox_inspect_formats_state_resources_ports_and_safe_env() -> None:
+    container = _container(
+        {
+            "Created": "2026-01-01T00:00:00Z",
+            "State": {
+                "Status": "running",
+                "Running": True,
+                "Paused": False,
+                "OOMKilled": False,
+                "ExitCode": 0,
+                "StartedAt": "2026-01-01T00:00:01Z",
+                "FinishedAt": "0001-01-01T00:00:00Z",
+                "Error": "minor warning",
+            },
+            "Config": {
+                "Image": "python:3.12",
+                "Labels": {"b": "2", "a": "1"},
+                "Env": ["PLAIN=value", "API_TOKEN=secret"],
+            },
+            "NetworkSettings": {
+                "Networks": {"bridge": {"IPAddress": "172.17.0.2"}},
+                "Ports": {
+                    "80/tcp": [{"HostIp": "127.0.0.1", "HostPort": "8080"}],
+                    "81/tcp": None,
+                },
+            },
+            "HostConfig": {
+                "NanoCpus": 2_000_000_000,
+                "Memory": 512 * 1024 * 1024,
+                "PidsLimit": 256,
+            },
+        }
+    )
+    service = _DiagnosticsService(container)
+
+    output = service.get_sandbox_inspect("sbx-1")
+
+    assert "Container ID:   abcdef123456" in output
+    assert "CPU:          2.00 cores" in output
+    assert "Memory:       512 MiB" in output
+    assert "bridge: 172.17.0.2" in output
+    assert "80/tcp -> 127.0.0.1:8080" in output
+    assert "81/tcp (not bound)" in output
+    assert "a=1" in output
+    assert "PLAIN=value" in output
+    assert "API_TOKEN=***" in output
+
+
+def test_get_sandbox_events_reports_state_health_and_fallback() -> None:
+    container = _container(
+        {
+            "Created": "2026-01-01T00:00:00Z",
+            "State": {
+                "Status": "exited",
+                "StartedAt": "2026-01-01T00:00:01Z",
+                "FinishedAt": "2026-01-01T00:00:02Z",
+                "OOMKilled": True,
+                "ExitCode": 137,
+                "Error": "killed",
+                "Health": {
+                    "Status": "unhealthy",
+                    "Log": [
+                        {"Start": "t1", "ExitCode": 1, "Output": "failed\n"},
+                        {"Start": "t2", "ExitCode": 0, "Output": "ok\n"},
+                    ],
+                },
+            },
+        }
+    )
+    service = _DiagnosticsService(container)
+
+    output = service.get_sandbox_events("sbx-1", limit=1)
+
+    assert "OOMKilled" in output
+    assert "Exited with code 137" in output
+    assert "Error - killed" in output
+    assert "Health:     unhealthy" in output
+    assert "[t2] exit=0 ok" in output
+    assert "[t1]" not in output
+
+    quiet = _DiagnosticsService(_container({"State": {"Status": "running"}}))
+    assert "(no notable events)" in quiet.get_sandbox_events("sbx-1")

--- a/server/tests/test_runtime_resolver.py
+++ b/server/tests/test_runtime_resolver.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from opensandbox_server.config import AppConfig, RuntimeConfig, SecureRuntimeConfig
+from opensandbox_server.services.runtime_resolver import (
+    SecureRuntimeResolver,
+    validate_secure_runtime_on_startup,
+)
+
+
+def _config(runtime_type: str = "docker", secure_runtime=None):
+    return AppConfig(
+        runtime=RuntimeConfig(type=runtime_type, execd_image="opensandbox/execd:test"),
+        secure_runtime=secure_runtime,
+    )
+
+
+def test_secure_runtime_resolver_disabled_without_runtime() -> None:
+    resolver = SecureRuntimeResolver(_config())
+
+    assert resolver.is_enabled() is False
+    assert resolver.get_docker_runtime() is None
+    assert resolver.get_k8s_runtime_class() is None
+
+
+def test_secure_runtime_resolver_prefers_explicit_values_and_defaults() -> None:
+    docker_resolver = SecureRuntimeResolver(
+        _config(secure_runtime=SecureRuntimeConfig(type="gvisor", docker_runtime="custom-runsc"))
+    )
+    k8s_resolver = SecureRuntimeResolver(
+        _config(
+            runtime_type="kubernetes",
+            secure_runtime=SecureRuntimeConfig(type="kata", k8s_runtime_class="kata-custom"),
+        )
+    )
+    default_docker = SecureRuntimeResolver(
+        _config(secure_runtime=SecureRuntimeConfig(type="gvisor", k8s_runtime_class="gvisor"))
+    )
+    default_k8s = SecureRuntimeResolver(
+        _config(
+            runtime_type="kubernetes",
+            secure_runtime=SecureRuntimeConfig(type="kata", docker_runtime="kata-runtime"),
+        )
+    )
+
+    assert docker_resolver.is_enabled() is True
+    assert docker_resolver.get_docker_runtime() == "custom-runsc"
+    assert k8s_resolver.get_k8s_runtime_class() == "kata-custom"
+    assert default_docker.get_docker_runtime() == "runsc"
+    assert default_k8s.get_k8s_runtime_class() == "kata-qemu"
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_skips_when_disabled() -> None:
+    docker_client = MagicMock()
+
+    await validate_secure_runtime_on_startup(_config(), docker_client=docker_client)
+
+    docker_client.info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_checks_docker_runtime() -> None:
+    docker_client = MagicMock()
+    docker_client.info.return_value = {"Runtimes": {"runsc": {"path": "/usr/bin/runsc"}}}
+    config = _config(
+        secure_runtime=SecureRuntimeConfig(type="gvisor", docker_runtime="runsc")
+    )
+
+    await validate_secure_runtime_on_startup(config, docker_client=docker_client)
+
+    docker_client.info.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_rejects_missing_docker_runtime() -> None:
+    docker_client = MagicMock()
+    docker_client.info.return_value = {"Runtimes": {"runc": {}}}
+    config = _config(
+        secure_runtime=SecureRuntimeConfig(type="gvisor", docker_runtime="runsc")
+    )
+
+    with pytest.raises(ValueError, match="runsc"):
+        await validate_secure_runtime_on_startup(config, docker_client=docker_client)
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_allows_missing_docker_client() -> None:
+    config = _config(
+        secure_runtime=SecureRuntimeConfig(type="gvisor", docker_runtime="runsc")
+    )
+
+    await validate_secure_runtime_on_startup(config, docker_client=None)
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_checks_k8s_runtime_class() -> None:
+    k8s_client = MagicMock()
+    config = _config(
+        runtime_type="kubernetes",
+        secure_runtime=SecureRuntimeConfig(type="gvisor", k8s_runtime_class="gvisor"),
+    )
+
+    await validate_secure_runtime_on_startup(config, k8s_client=k8s_client)
+
+    k8s_client.read_runtime_class.assert_called_once_with("gvisor")
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_rejects_missing_k8s_runtime_class() -> None:
+    k8s_client = MagicMock()
+    k8s_client.read_runtime_class.side_effect = ApiException(status=404)
+    config = _config(
+        runtime_type="kubernetes",
+        secure_runtime=SecureRuntimeConfig(type="gvisor", k8s_runtime_class="gvisor"),
+    )
+
+    with pytest.raises(ValueError, match="RuntimeClass 'gvisor'"):
+        await validate_secure_runtime_on_startup(config, k8s_client=k8s_client)
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_reraises_k8s_api_errors() -> None:
+    k8s_client = MagicMock()
+    k8s_client.read_runtime_class.side_effect = ApiException(status=500)
+    config = _config(
+        runtime_type="kubernetes",
+        secure_runtime=SecureRuntimeConfig(type="gvisor", k8s_runtime_class="gvisor"),
+    )
+
+    with pytest.raises(ApiException):
+        await validate_secure_runtime_on_startup(config, k8s_client=k8s_client)
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_allows_missing_k8s_client() -> None:
+    config = _config(
+        runtime_type="kubernetes",
+        secure_runtime=SecureRuntimeConfig(type="gvisor", k8s_runtime_class="gvisor"),
+    )
+
+    await validate_secure_runtime_on_startup(config, k8s_client=None)
+
+
+@pytest.mark.asyncio
+async def test_validate_secure_runtime_skips_unknown_runtime_type() -> None:
+    config = SimpleNamespace(
+        runtime=SimpleNamespace(type="custom"),
+        secure_runtime=SimpleNamespace(
+            type="gvisor",
+            docker_runtime="runsc",
+            k8s_runtime_class=None,
+        ),
+    )
+
+    await validate_secure_runtime_on_startup(config)


### PR DESCRIPTION
# Summary
- Enforce the server CI coverage gate with `pytest-cov` and `--cov-fail-under=80`.
- Upload the server `coverage.xml` report from the server test workflow for coverage evidence.
- Add focused server tests for Docker diagnostics, Kubernetes diagnostics, and secure runtime resolution so the full `opensandbox_server` package exceeds 80% statement coverage.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:
- `cd server && uv run ruff check`
- `cd server && uv run pytest --cov=opensandbox_server --cov-report=term --cov-report=xml:reports/coverage.xml --cov-fail-under=80` (`972 passed`, total coverage `80.28%`)

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
