### PR TITLE
feature(server,helm): support env override for api_key

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -106,7 +106,7 @@ spec:
           env:
             - name: SANDBOX_CONFIG_PATH
               value: "/etc/opensandbox/config.toml"
-            {{- with .Values.extraEnv }}
+            {{- with .Values.server.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:

--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -106,6 +106,9 @@ spec:
           env:
             - name: SANDBOX_CONFIG_PATH
               value: "/etc/opensandbox/config.toml"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/opensandbox/config.toml

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -12,16 +12,16 @@ namespaceOverride: ""
 # -- Image pull secrets for the server deployment. Each entry: {name: <secret-name>}.
 imagePullSecrets: []
 
-# -- Additional environment variables for the server container.
-extraEnv: []
-# - name: OPENSANDBOX_SERVER_API_KEY
-#   valueFrom:
-#     secretKeyRef:
-#       name: opensandbox-api-key
-#       key: api-key
-
 # Server configuration
 server:
+  # -- Additional environment variables for the server container.
+  env: []
+  # - name: OPENSANDBOX_SERVER_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: opensandbox-api-key
+  #       key: api-key
+
   # -- Server image configuration
   image:
     repository: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/server

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -12,6 +12,14 @@ namespaceOverride: ""
 # -- Image pull secrets for the server deployment. Each entry: {name: <secret-name>}.
 imagePullSecrets: []
 
+# -- Additional environment variables for the server container.
+extraEnv: []
+# - name: OPENSANDBOX_SERVER_API_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: opensandbox-api-key
+#       key: api-key
+
 # Server configuration
 server:
   # -- Server image configuration

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -295,6 +295,7 @@ These are read by the server or runtime code in addition to the TOML file:
 | Variable | Where used | Description |
 |----------|------------|-------------|
 | `SANDBOX_CONFIG_PATH` | `config.py`, CLI | Path to the TOML file. Overrides the default `~/.sandbox.toml` when set. |
+| `OPENSANDBOX_SERVER_API_KEY` | `config.py` | Overrides the API key from the TOML file. |
 | `DOCKER_HOST` | Docker service | Standard Docker daemon address (e.g. `unix:///var/run/docker.sock`). |
 | `PENDING_FAILURE_TTL` | Docker service | Seconds to retain **failed Pending** sandboxes before cleanup; default **`3600`**. |
 

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -41,6 +41,8 @@ logger = logging.getLogger(__name__)
 CONFIG_ENV_VAR = "SANDBOX_CONFIG_PATH"
 DEFAULT_CONFIG_PATH = Path.home() / ".sandbox.toml"
 
+API_KEY_ENV_VAR = "OPENSANDBOX_SERVER_API_KEY"
+
 _HOSTNAME_RE = re.compile(r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?:\.(?!-)[A-Za-z0-9-]{1,63})*$")
 _WILDCARD_DOMAIN_RE = re.compile(r"^\*\.(?!-)[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{1,63})+$")
 _IPV4_WITH_PORT_RE = re.compile(r"^(?P<ip>(?:\d{1,3}\.){3}\d{1,3})(?::(?P<port>\d{1,5}))?$")
@@ -883,6 +885,12 @@ def _load_toml_data(path: Path) -> dict[str, Any]:
         raise
 
 
+def _apply_env_overrides(config: AppConfig) -> None:
+    """Apply environment variable overrides to parsed configuration."""
+    if env_api_key := os.environ.get(API_KEY_ENV_VAR):
+        config.server.api_key = env_api_key
+
+
 def load_config(path: str | Path | None = None) -> AppConfig:
     """
     Load configuration from TOML file and store it globally.
@@ -909,6 +917,7 @@ def load_config(path: str | Path | None = None) -> AppConfig:
         logger.error("Invalid configuration in %s: %s", resolved_path, exc)
         raise
 
+    _apply_env_overrides(_config)
     _config_path = resolved_path
     return _config
 

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -887,8 +887,8 @@ def _load_toml_data(path: Path) -> dict[str, Any]:
 
 def _apply_env_overrides(config: AppConfig) -> None:
     """Apply environment variable overrides to parsed configuration."""
-    if env_api_key := os.environ.get(API_KEY_ENV_VAR):
-        config.server.api_key = env_api_key
+    if API_KEY_ENV_VAR in os.environ:
+        config.server.api_key = os.environ[API_KEY_ENV_VAR]
 
 
 def load_config(path: str | Path | None = None) -> AppConfig:

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -84,6 +84,73 @@ def test_load_config_from_file(tmp_path, monkeypatch):
     assert loaded.kubernetes is not None
 
 
+def test_load_config_env_override_api_key(tmp_path, monkeypatch):
+    """OPENSANDBOX_SERVER_API_KEY should override server.api_key from TOML."""
+    _reset_config(monkeypatch)
+    monkeypatch.setenv("OPENSANDBOX_SERVER_API_KEY", "env-secret-key")
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+        api_key = "toml-secret-key"
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.api_key == "env-secret-key"
+
+
+def test_load_config_env_api_key_without_toml_key(tmp_path, monkeypatch):
+    """OPENSANDBOX_SERVER_API_KEY should work even when TOML omits api_key."""
+    _reset_config(monkeypatch)
+    monkeypatch.setenv("OPENSANDBOX_SERVER_API_KEY", "env-only-key")
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.api_key == "env-only-key"
+
+
+def test_load_config_without_env_uses_toml_api_key(tmp_path, monkeypatch):
+    """When OPENSANDBOX_SERVER_API_KEY is unset, TOML api_key should be used."""
+    _reset_config(monkeypatch)
+    toml = textwrap.dedent(
+        """
+        [server]
+        host = "127.0.0.1"
+        port = 9000
+        api_key = "toml-secret-key"
+
+        [runtime]
+        type = "docker"
+        execd_image = "opensandbox/execd:test"
+        """
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(toml)
+
+    loaded = config_module.load_config(config_path)
+    assert loaded.server.api_key == "toml-secret-key"
+
+
 def test_docker_runtime_disallows_kubernetes_block():
     server_cfg = ServerConfig()
     runtime_cfg = RuntimeConfig(type="docker", execd_image="busybox:latest")


### PR DESCRIPTION
# Summary
Add OPENSANDBOX_SERVER_API_KEY environment variable to override server.api_key from TOML config.

# Problem
Previously, OpenSandbox only supported API key configuration via a config file. However, in environments such as Kubernetes, secrets are typically injected via environment variables, making it difficult to integrate OpenSandbox securely without additional workarounds.

# Changes
- Add _apply_env_overrides() to apply env vars after parsing
- Define API_KEY_ENV_VAR constant for the environment variable name
- Accept extraEnv in server Helm chart

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
