### PR TITLE
fix(k8s): replace blocking time.sleep with asyncio.sleep in _wait_for_sandbox_ready  

### DIFF
--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -196,7 +196,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 
                 if not workload:
                     logger.debug(f"Workload not found yet for sandbox {sandbox_id}")
-                    time.sleep(poll_interval_seconds)
+                    await asyncio.sleep(poll_interval_seconds)
                     continue
                 
                 status_info = _normalize_create_status(


### PR DESCRIPTION
## Problem

In `_wait_for_sandbox_ready`, the polling loop has two `sleep` branches with inconsistent behavior:

```python
if not workload:
    time.sleep(poll_interval_seconds)    # blocks the event loop
    continue

# ...

await asyncio.sleep(poll_interval_seconds)  # correct async sleep
```

When a workload is not yet visible in the K8s API immediately after creation, the code falls into the `time.sleep` branch. Since `_wait_for_sandbox_ready` is an `async` method, this **blocks the entire event loop** for `poll_interval_seconds` (default: 1s) per iteration.

## Impact

- FastAPI cannot handle any other requests during the blocked period, including `/health`
- Kubernetes liveness probe times out → pod is killed and restarted
- Affects every sandbox creation under K8s runtime, since the workload-not-found window occurs naturally right after creation

## Fix

Replace `time.sleep` with `await asyncio.sleep` in the `not workload` branch, consistent with the sleep call later in the same loop.

**File**: `server/opensandbox_server/services/k8s/kubernetes_service.py:199`

```python
# Before
time.sleep(poll_interval_seconds)

# After
await asyncio.sleep(poll_interval_seconds)
```
