### PR TITLE
feat(server): refine deleting snapshots

### DIFF
--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -196,9 +196,6 @@ class PersistedSnapshotService(SnapshotService):
                 },
             )
 
-        if record.status.state == SnapshotState.DELETING:
-            return
-
         if record.status.state == SnapshotState.CREATING:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -207,6 +204,11 @@ class PersistedSnapshotService(SnapshotService):
                     "message": f"Snapshot {snapshot_id} is still being created and cannot be deleted",
                 },
             )
+
+        if record.status.state != SnapshotState.DELETING:
+            record = self._mark_snapshot_deleting(record)
+            if record is None:
+                return
 
         self._snapshot_runtime.delete_snapshot(
             snapshot_id,
@@ -229,6 +231,43 @@ class PersistedSnapshotService(SnapshotService):
         from opensandbox_server.api.schema import PaginationRequest
 
         return PaginationRequest()
+
+    def _mark_snapshot_deleting(self, record: SnapshotRecord) -> SnapshotRecord | None:
+        now = datetime.now(timezone.utc)
+        deleting_record = SnapshotRecord(
+            id=record.id,
+            source_sandbox_id=record.source_sandbox_id,
+            name=record.name,
+            description=record.description,
+            restore_config=record.restore_config,
+            status=SnapshotStatusRecord(
+                state=SnapshotState.DELETING,
+                reason="snapshot_delete_requested",
+                message="Snapshot deletion requested.",
+                last_transition_at=now,
+            ),
+            created_at=record.created_at,
+            updated_at=now,
+        )
+        if self._snapshot_repository.update_if_state(
+            deleting_record,
+            record.status.state,
+        ):
+            return deleting_record
+
+        current_record = self._snapshot_repository.get(record.id)
+        if current_record is None:
+            return None
+        if current_record.status.state == SnapshotState.DELETING:
+            return current_record
+
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "SNAPSHOT::INVALID_STATE",
+                "message": f"Snapshot {record.id} changed state and cannot be deleted",
+            },
+        )
 
     def _create_snapshot_worker(self, record: SnapshotRecord) -> None:
         try:

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -381,7 +381,14 @@ def test_snapshot_service_deletes_runtime_artifact_before_metadata(tmp_path) -> 
         runtime.calls.append((snapshot_id, sandbox_id))
         return ready_status
 
+    def delete_snapshot(snapshot_id: str, image: str | None = None) -> None:
+        stored = repo.get(snapshot_id)
+        assert stored is not None
+        assert stored.status.state == SnapshotState.DELETING
+        runtime.delete_calls.append((snapshot_id, image))
+
     runtime.create_snapshot = create_snapshot
+    runtime.delete_snapshot = delete_snapshot
     created = service.create_snapshot("sbx-001", CreateSnapshotRequest(name="checkpoint"))
 
     service.delete_snapshot(created.id)
@@ -420,8 +427,49 @@ def test_snapshot_service_propagates_snapshot_delete_conflict(tmp_path) -> None:
     with pytest.raises(HTTPException) as exc_info:
         service.delete_snapshot("snap-in-use")
 
+    stored = repo.get("snap-in-use")
     assert exc_info.value.status_code == 409
-    assert repo.get("snap-in-use") is not None
+    assert stored is not None
+    assert stored.status.state == SnapshotState.DELETING
+
+
+def test_snapshot_service_recovers_delete_after_runtime_cleanup_succeeds(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    runtime = StubSnapshotRuntime()
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=runtime,
+        snapshot_executor=ImmediateExecutor(),
+    )
+
+    record = _snapshot_record(
+        "snap-delete-crash",
+        SnapshotState.READY,
+        image="opensandbox-snapshots:snap-delete-crash",
+    )
+    repo.create(record)
+
+    original_delete = repo.delete
+
+    def crash_delete(snapshot_id: str) -> None:
+        raise RuntimeError("simulated metadata delete crash")
+
+    repo.delete = crash_delete
+    with pytest.raises(RuntimeError, match="simulated metadata delete crash"):
+        service.delete_snapshot("snap-delete-crash")
+
+    stored = repo.get("snap-delete-crash")
+    assert stored is not None
+    assert stored.status.state == SnapshotState.DELETING
+    assert runtime.delete_calls == [("snap-delete-crash", "opensandbox-snapshots:snap-delete-crash")]
+
+    repo.delete = original_delete
+    recovery_runtime = StubSnapshotRuntime()
+    PersistedSnapshotService(repo, StubSandboxService(), snapshot_runtime=recovery_runtime)
+
+    assert recovery_runtime.delete_calls == [("snap-delete-crash", "opensandbox-snapshots:snap-delete-crash")]
+    assert repo.get("snap-delete-crash") is None
 
 
 def test_snapshot_service_worker_cleans_up_snapshot_deleted_during_creation(tmp_path) -> None:


### PR DESCRIPTION
# Summary
- Persist snapshot records as `Deleting` before runtime cleanup, so interrupted deletes can be recovered instead of leaving stale `Ready` metadata.
- Reuse the existing startup recovery path for `Deleting` snapshots to retry idempotent runtime deletion and remove metadata once cleanup succeeds.
- Keep the final deleted state as resource absence: successful deletes still remove the SQLite record and subsequent GET returns 404.

# Testing
- [x] Unit tests: `uv run pytest tests/test_snapshot_service.py -q`
- [x] Route tests: `uv run pytest tests/test_routes_snapshots.py -q`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (not needed; no API shape change)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
