### PR TITLE
feat(sdk-go): support multi-file upload

### DIFF
--- a/sdks/sandbox/go/README.md
+++ b/sdks/sandbox/go/README.md
@@ -161,6 +161,7 @@ Created with `NewExecdClient(baseURL, accessToken string, opts ...Option)`.
 | `SearchFiles(ctx, dir, pattern)` | Search files by glob pattern |
 | `ReplaceInFiles(ctx, req)` | Text replacement in files |
 | `UploadFile(ctx, file, opts)` | Upload a file to the sandbox |
+| `UploadFiles(ctx, entries)` | Upload multiple files to the sandbox |
 | `DownloadFile(ctx, remotePath, rangeHeader)` | Download a file from the sandbox |
 
 **Directory Operations:**

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"strconv"
@@ -248,13 +249,26 @@ func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) er
 	return e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, nil)
 }
 
+// UploadFileOptions configures the destination path and multipart filename for an upload.
 type UploadFileOptions struct {
 	FileName string
 	Metadata FileMetadata
 }
 
+// UploadFileEntry describes one file part in a multi-file upload request.
+type UploadFileEntry struct {
+	File    io.Reader
+	Options UploadFileOptions
+}
+
+// UploadFile uploads a single file to the sandbox.
 func (e *ExecdClient) UploadFile(ctx context.Context, file io.Reader, opts UploadFileOptions) error {
-	req, bodyCloser, err := e.newUploadRequest(ctx, file, opts)
+	return e.UploadFiles(ctx, []UploadFileEntry{{File: file, Options: opts}})
+}
+
+// UploadFiles uploads one or more files to the sandbox in a single multipart request.
+func (e *ExecdClient) UploadFiles(ctx context.Context, entries []UploadFileEntry) error {
+	req, bodyCloser, err := e.newUploadFilesRequest(ctx, entries)
 	if err != nil {
 		return err
 	}
@@ -278,16 +292,17 @@ func (e *ExecdClient) UploadFile(ctx context.Context, file io.Reader, opts Uploa
 	return nil
 }
 
-func (e *ExecdClient) newUploadRequest(ctx context.Context, file io.Reader, opts UploadFileOptions) (*http.Request, io.Closer, error) {
-	if file == nil {
-		return nil, nil, &InvalidArgumentError{Field: "file", Message: "file reader is required"}
+func (e *ExecdClient) newUploadFilesRequest(ctx context.Context, entries []UploadFileEntry) (*http.Request, io.Closer, error) {
+	if len(entries) == 0 {
+		return nil, nil, &InvalidArgumentError{Field: "entries", Message: "at least one file entry is required"}
 	}
-	if opts.Metadata.Path == "" {
-		return nil, nil, &InvalidArgumentError{Field: "metadata.path", Message: "path is required"}
-	}
-	fileName := opts.FileName
-	if fileName == "" {
-		fileName = "file"
+	for i, entry := range entries {
+		if entry.File == nil {
+			return nil, nil, &InvalidArgumentError{Field: fmt.Sprintf("entries[%d].file", i), Message: "file reader is required"}
+		}
+		if entry.Options.Metadata.Path == "" {
+			return nil, nil, &InvalidArgumentError{Field: fmt.Sprintf("entries[%d].metadata.path", i), Message: "path is required"}
+		}
 	}
 
 	pr, pw := io.Pipe()
@@ -295,28 +310,38 @@ func (e *ExecdClient) newUploadRequest(ctx context.Context, file io.Reader, opts
 	contentType := writer.FormDataContentType()
 
 	go func() {
-		metaJSON, err := json.Marshal(opts.Metadata)
-		if err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("opensandbox: marshal metadata: %w", err))
-			return
-		}
-		metaPart, err := writer.CreateFormFile("metadata", "metadata")
-		if err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("opensandbox: create metadata part: %w", err))
-			return
-		}
-		if _, err := metaPart.Write(metaJSON); err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("opensandbox: write metadata: %w", err))
-			return
-		}
-		filePart, err := writer.CreateFormFile("file", fileName)
-		if err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("opensandbox: create file part: %w", err))
-			return
-		}
-		if _, err := io.Copy(filePart, file); err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("opensandbox: write file: %w", err))
-			return
+		for i, entry := range entries {
+			metaJSON, err := json.Marshal(entry.Options.Metadata)
+			if err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("opensandbox: marshal metadata for entry %d: %w", i, err))
+				return
+			}
+			metaHeader := make(textproto.MIMEHeader)
+			metaHeader.Set("Content-Disposition", `form-data; name="metadata"; filename="metadata"`)
+			metaHeader.Set("Content-Type", "application/json")
+			metaPart, err := writer.CreatePart(metaHeader)
+			if err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("opensandbox: create metadata part for entry %d: %w", i, err))
+				return
+			}
+			if _, err := metaPart.Write(metaJSON); err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("opensandbox: write metadata for entry %d: %w", i, err))
+				return
+			}
+
+			fileName := entry.Options.FileName
+			if fileName == "" {
+				fileName = "file"
+			}
+			filePart, err := writer.CreateFormFile("file", fileName)
+			if err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("opensandbox: create file part for entry %d: %w", i, err))
+				return
+			}
+			if _, err := io.Copy(filePart, entry.File); err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("opensandbox: write file for entry %d: %w", i, err))
+				return
+			}
 		}
 		if err := writer.Close(); err != nil {
 			_ = pw.CloseWithError(fmt.Errorf("opensandbox: close multipart: %w", err))

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -761,6 +761,66 @@ func TestUploadFile_WithReader(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUploadFiles(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/files/upload", r.URL.Path)
+		require.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data"))
+
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		metadataParts := r.MultipartForm.File["metadata"]
+		fileParts := r.MultipartForm.File["file"]
+		require.Len(t, metadataParts, 2)
+		require.Len(t, fileParts, 2)
+
+		wantPaths := []string{"/sandbox/a.txt", "/sandbox/b.txt"}
+		wantFileNames := []string{"a.txt", "custom-b.txt"}
+		wantContents := []string{"alpha", "bravo"}
+
+		for i := range metadataParts {
+			metaFile, err := metadataParts[i].Open()
+			require.NoError(t, err)
+			require.Equal(t, "application/json", metadataParts[i].Header.Get("Content-Type"))
+			metaBytes, err := io.ReadAll(metaFile)
+			require.NoError(t, err)
+			require.NoError(t, metaFile.Close())
+
+			var meta FileMetadata
+			require.NoError(t, json.Unmarshal(metaBytes, &meta))
+			require.Equal(t, wantPaths[i], meta.Path)
+			require.Equal(t, 600+i, meta.Mode)
+
+			filePart, err := fileParts[i].Open()
+			require.NoError(t, err)
+			data, err := io.ReadAll(filePart)
+			require.NoError(t, err)
+			require.NoError(t, filePart.Close())
+			require.Equal(t, wantFileNames[i], fileParts[i].Filename)
+			require.Equal(t, wantContents[i], string(data))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.UploadFiles(context.Background(), []UploadFileEntry{
+		{
+			File: strings.NewReader("alpha"),
+			Options: UploadFileOptions{
+				FileName: "a.txt",
+				Metadata: FileMetadata{Path: "/sandbox/a.txt", Mode: 600},
+			},
+		},
+		{
+			File: strings.NewReader("bravo"),
+			Options: UploadFileOptions{
+				FileName: "custom-b.txt",
+				Metadata: FileMetadata{Path: "/sandbox/b.txt", Mode: 601},
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
 func TestGetMetrics(t *testing.T) {
 	want := Metrics{
 		CPUCount:   4,

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -60,11 +60,20 @@ func (s *Sandbox) SetPermissions(ctx context.Context, req PermissionsRequest) er
 	return s.execd.SetPermissions(ctx, req)
 }
 
+// UploadFile uploads a single file to the sandbox.
 func (s *Sandbox) UploadFile(ctx context.Context, file io.Reader, opts UploadFileOptions) error {
 	if s.execd == nil {
 		return fmt.Errorf("opensandbox: execd client not initialized")
 	}
 	return s.execd.UploadFile(ctx, file, opts)
+}
+
+// UploadFiles uploads one or more files to the sandbox in a single multipart request.
+func (s *Sandbox) UploadFiles(ctx context.Context, entries []UploadFileEntry) error {
+	if s.execd == nil {
+		return fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.UploadFiles(ctx, entries)
 }
 
 // DownloadFile downloads a file from the sandbox.


### PR DESCRIPTION
## Summary
- add Go SDK `UploadFiles` for multipart multi-file uploads using execd's existing `/files/upload` multi-file contract
- keep `UploadFile` as a single-file convenience wrapper over the batch implementation
- expose the new helper on `Sandbox` and document it

## Notes
- `/files/download` is still a single-file streaming API, so this PR does not add a loop-based `DownloadFiles` helper.

## Tests
- `cd sdks/sandbox/go && go test ./...`