### PR TITLE
feat(execd): support EXECD_ACCESS_TOKEN env var for ServerAccessToken

### DIFF
--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -27,6 +27,7 @@ import (
 const (
 	jupyterHostEnv             = "JUPYTER_HOST"
 	jupyterTokenEnv            = "JUPYTER_TOKEN"
+	accessTokenEnv             = "EXECD_ACCESS_TOKEN"
 	gracefulShutdownTimeoutEnv = "EXECD_API_GRACE_SHUTDOWN"
 	jupyterIdlePollIntervalEnv = "EXECD_JUPYTER_IDLE_POLL_INTERVAL"
 )
@@ -50,6 +51,10 @@ func InitFlags() {
 
 	if jupyterTokenFromEnv := os.Getenv(jupyterTokenEnv); jupyterTokenFromEnv != "" {
 		JupyterServerToken = jupyterTokenFromEnv
+	}
+
+	if accessTokenFromEnv := os.Getenv(accessTokenEnv); accessTokenFromEnv != "" {
+		ServerAccessToken = accessTokenFromEnv
 	}
 
 	// Then define flags with current values as defaults

--- a/components/execd/pkg/flag/parser_test.go
+++ b/components/execd/pkg/flag/parser_test.go
@@ -39,3 +39,35 @@ func TestInitFlagsSanitizesNonPositiveJupyterIdlePollIntervalFromCLI(t *testing.
 
 	require.Equal(t, defaultPollInterval, JupyterIdlePollInterval)
 }
+
+func TestInitFlagsServerAccessTokenFromEnv(t *testing.T) {
+	previousArgs := os.Args
+	previousCommandLine := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{previousArgs[0]}
+	t.Cleanup(func() {
+		os.Args = previousArgs
+		flag.CommandLine = previousCommandLine
+	})
+	t.Setenv("EXECD_ACCESS_TOKEN", "test-token-from-env")
+
+	InitFlags()
+
+	require.Equal(t, "test-token-from-env", ServerAccessToken)
+}
+
+func TestInitFlagsCliOverridesEnvAccessToken(t *testing.T) {
+	previousArgs := os.Args
+	previousCommandLine := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{previousArgs[0], "--access-token=cli-token"}
+	t.Cleanup(func() {
+		os.Args = previousArgs
+		flag.CommandLine = previousCommandLine
+	})
+	t.Setenv("EXECD_ACCESS_TOKEN", "env-token")
+
+	InitFlags()
+
+	require.Equal(t, "cli-token", ServerAccessToken)
+}


### PR DESCRIPTION
# Summary
- `ServerAccessToken` can now be set via `EXECD_ACCESS_TOKEN` environment variable in addition to the existing --access-token CLI flag. CLI flag takes precedence when both are provided.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered