### PR TITLE
feat(execd): accept both OpenSandbox-Execd-Token and X-EXECD-ACCESS-TOKEN headers

### DIFF
--- a/components/execd/pkg/web/model/header.go
+++ b/components/execd/pkg/web/model/header.go
@@ -15,6 +15,13 @@
 package model
 
 const (
-	// ApiAccessTokenHeader carries the auth token.
+	// ApiAccessTokenHeader carries the auth token (legacy).
 	ApiAccessTokenHeader = "X-EXECD-ACCESS-TOKEN"
+	// ApiAccessTokenHeaderV2 carries the auth token (current).
+	ApiAccessTokenHeaderV2 = "OpenSandbox-Execd-Token"
 )
+
+// AllAccessTokenHeaders returns all recognised access-token header names.
+func AllAccessTokenHeaders() []string {
+	return []string{ApiAccessTokenHeaderV2, ApiAccessTokenHeader}
+}

--- a/components/execd/pkg/web/router.go
+++ b/components/execd/pkg/web/router.go
@@ -125,10 +125,16 @@ func accessTokenMiddleware(token string) gin.HandlerFunc {
 			return
 		}
 
-		requestedToken := ctx.GetHeader(model.ApiAccessTokenHeader)
+		requestedToken := ""
+		for _, h := range model.AllAccessTokenHeaders() {
+			if v := ctx.GetHeader(h); v != "" {
+				requestedToken = v
+				break
+			}
+		}
 		if requestedToken == "" || requestedToken != token {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, map[string]any{
-				"error": "Unauthorized: invalid or missing header " + model.ApiAccessTokenHeader,
+				"error": "Unauthorized: invalid or missing access token header",
 			})
 			return
 		}

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -33,7 +33,7 @@ type ExecdClient struct {
 }
 
 // execdAuthHeader is the authentication header used by the Execd API.
-const execdAuthHeader = "X-EXECD-ACCESS-TOKEN"
+const execdAuthHeader = "OpenSandbox-Execd-Token"
 
 // NewExecdClient creates a new ExecdClient for the given base URL and access token.
 func NewExecdClient(baseURL, accessToken string, opts ...Option) *ExecdClient {

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -401,7 +401,7 @@ func TestSandbox_Resume(t *testing.T) {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/endpoints/"):
 			jsonResponse(w, http.StatusOK, Endpoint{
 				Endpoint: "http://execd.test:8080",
-				Headers:  map[string]string{"X-EXECD-ACCESS-TOKEN": "tok"},
+				Headers:  map[string]string{"OpenSandbox-Execd-Token": "tok"},
 			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -906,9 +906,9 @@ func TestLifecycleAuthHeader(t *testing.T) {
 
 func TestExecdAuthHeader(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got := r.Header.Get("X-EXECD-ACCESS-TOKEN")
+		got := r.Header.Get("OpenSandbox-Execd-Token")
 		if got != "my-execd-token" {
-			assert.Fail(t, fmt.Sprintf("X-EXECD-ACCESS-TOKEN = %q, want %q", got, "my-execd-token"))
+			assert.Fail(t, fmt.Sprintf("OpenSandbox-Execd-Token = %q, want %q", got, "my-execd-token"))
 		}
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/sdks/sandbox/go/sandbox.go
+++ b/sdks/sandbox/go/sandbox.go
@@ -407,11 +407,15 @@ func (s *Sandbox) resolveExecd(ctx context.Context) error {
 	token := ""
 	var extraHeaders map[string]string
 	if endpoint.Headers != nil {
-		token = endpoint.Headers["X-EXECD-ACCESS-TOKEN"]
-		// Preserve all endpoint headers (e.g. routing headers) except the auth token
+		// Prefer the current header; fall back to legacy.
+		token = endpoint.Headers["OpenSandbox-Execd-Token"]
+		if token == "" {
+			token = endpoint.Headers["X-EXECD-ACCESS-TOKEN"]
+		}
+		// Preserve all endpoint headers (e.g. routing headers) except auth tokens
 		extraHeaders = make(map[string]string, len(endpoint.Headers))
 		for k, v := range endpoint.Headers {
-			if k != "X-EXECD-ACCESS-TOKEN" {
+			if k != "OpenSandbox-Execd-Token" && k != "X-EXECD-ACCESS-TOKEN" {
 				extraHeaders[k] = v
 			}
 		}

--- a/specs/README.md
+++ b/specs/README.md
@@ -58,7 +58,7 @@ Defines best-effort troubleshooting descriptors for sandbox diagnostic logs and 
 
 **Code Execution API Inside Sandbox**
 
-Defines interfaces for executing code, commands, and file operations within sandbox environments, providing complete code interpreter and filesystem management capabilities. All endpoints require the `X-EXECD-ACCESS-TOKEN` header.
+Defines interfaces for executing code, commands, and file operations within sandbox environments, providing complete code interpreter and filesystem management capabilities. All endpoints require an auth header (`OpenSandbox-Execd-Token`; the legacy `X-EXECD-ACCESS-TOKEN` is also accepted).
 
 **Core Features:**
 - **Code Execution**: Stateful code execution supporting Python, JavaScript, and other languages with context lifecycle management
@@ -66,7 +66,7 @@ Defines interfaces for executing code, commands, and file operations within sand
 - **File Operations**: Complete CRUD operations for files and directories
 - **Real-time Streaming**: Real-time output streaming via SSE (Server-Sent Events)
 - **System Monitoring**: Real-time monitoring of CPU and memory metrics
-- **Access Control**: Token-based API authentication via `X-EXECD-ACCESS-TOKEN`
+- **Access Control**: Token-based API authentication via `OpenSandbox-Execd-Token` (legacy `X-EXECD-ACCESS-TOKEN` accepted)
 
 **Main Endpoint Categories:**
 

--- a/specs/README_zh.md
+++ b/specs/README_zh.md
@@ -58,7 +58,7 @@
 
 **沙箱内代码执行 API**
 
-定义了在沙箱环境内执行代码、命令和文件操作的接口，提供完整的代码解释器和文件系统管理能力。所有端点需要 `X-EXECD-ACCESS-TOKEN` 认证头。
+定义了在沙箱环境内执行代码、命令和文件操作的接口，提供完整的代码解释器和文件系统管理能力。所有端点需要认证头（`OpenSandbox-Execd-Token`；旧版 `X-EXECD-ACCESS-TOKEN` 同样接受）。
 
 **核心功能：**
 - **代码执行**：支持 Python、JavaScript 等多语言的有状态代码执行，并提供上下文生命周期管理
@@ -66,7 +66,7 @@
 - **文件操作**：完整的文件和目录 CRUD 操作（创建、读取、更新、删除）
 - **实时流式输出**：基于 SSE (Server-Sent Events) 的实时输出流
 - **系统监控**：CPU 和内存指标的实时监控
-- **访问控制**：通过 `X-EXECD-ACCESS-TOKEN` 进行 Token 认证
+- **访问控制**：通过 `OpenSandbox-Execd-Token` 进行 Token 认证（旧版 `X-EXECD-ACCESS-TOKEN` 同样支持）
 
 **主要端点分类：**
 

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -988,10 +988,12 @@ components:
     AccessToken:
       type: apiKey
       in: header
-      name: X-EXECD-ACCESS-TOKEN
+      name: OpenSandbox-Execd-Token
       description: |
         Access token for API authentication. All requests must include this header
         with a valid token. The token is configured during server initialization.
+        The legacy header X-EXECD-ACCESS-TOKEN is also accepted with the same
+        token value.
 
   schemas:
     CreateSessionRequest:


### PR DESCRIPTION
# Summary
- accept both `OpenSandbox-Execd-Token` and `X-EXECD-ACCESS-TOKEN` headers

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered