### PR TITLE
feat(sdk-go): add User-Agent header to HTTP requests

### DIFF
--- a/sdks/sandbox/go/constants.go
+++ b/sdks/sandbox/go/constants.go
@@ -38,6 +38,9 @@ const (
 	// DefaultCodeInterpreterTimeoutSeconds is the default TTL for code interpreter sandboxes.
 	DefaultCodeInterpreterTimeoutSeconds = 900
 
+	// Version is the SDK version reported in the User-Agent header.
+	Version = "1.0.1"
+
 	// APIVersion is the lifecycle API version prefix.
 	APIVersion = "v1"
 

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -161,6 +161,7 @@ func (e *ExecdClient) GetCommandLogs(ctx context.Context, commandID string, curs
 		if err != nil {
 			return fmt.Errorf("opensandbox: create request: %w", err)
 		}
+		req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/"+Version)
 		for k, v := range e.client.headers {
 			req.Header.Set(k, v)
 		}
@@ -274,6 +275,7 @@ func (e *ExecdClient) UploadFiles(ctx context.Context, entries []UploadFileEntry
 	}
 	defer bodyCloser.Close()
 
+	req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/"+Version)
 	for k, v := range e.client.headers {
 		req.Header.Set(k, v)
 	}
@@ -371,6 +373,7 @@ func (e *ExecdClient) DownloadFile(ctx context.Context, remotePath string, range
 		if err != nil {
 			return fmt.Errorf("opensandbox: create request: %w", err)
 		}
+		req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/"+Version)
 		for k, v := range e.client.headers {
 			req.Header.Set(k, v)
 		}

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -143,6 +143,7 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body an
 		return fmt.Errorf("opensandbox: create request: %w", err)
 	}
 
+	req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/"+Version)
 	for k, v := range c.headers {
 		req.Header.Set(k, v)
 	}
@@ -197,6 +198,7 @@ func (c *Client) doStreamRequest(ctx context.Context, method, path string, body 
 			return fmt.Errorf("opensandbox: create request: %w", err)
 		}
 
+		req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/"+Version)
 		for k, v := range c.headers {
 			req.Header.Set(k, v)
 		}


### PR DESCRIPTION
# Summary
- Set User-Agent: OpenSandbox-Go-SDK/1.0.1 on all outgoing requests (doRequestOnce, doStreamRequest, GetCommandLogs, UploadFiles, DownloadFile).

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered