### PR TITLE
fix(k8s): batchsandboxe.status.conditions.type missing "Paused"

### DIFF
--- a/kubernetes/charts/opensandbox-controller/templates/crds/batchsandboxes.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/crds/batchsandboxes.yaml
@@ -182,6 +182,7 @@ spec:
                       enum:
                       - Ready
                       - Progressing
+                      - Paused
                       - PauseFailed
                       - ResumeFailed
                       - PodFailed


### PR DESCRIPTION
# Summary
- fix batchsandboxe.status.conditions.type missing "Paused"

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
