### PR TITLE
feat(k8s): add containerd-socket-path to controller

### DIFF
--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         {{- if .Values.controller.snapshot.imageCommitterImage }}
         - --image-committer-image={{ .Values.controller.snapshot.imageCommitterImage }}
         {{- end }}
+        {{- if .Values.controller.snapshot.containerdSocketPath }}
+        - --containerd-socket-path={{ .Values.controller.snapshot.containerdSocketPath }}
+        {{- end }}
         {{- if .Values.controller.snapshot.commitJobTimeout }}
         - --commit-job-timeout={{ .Values.controller.snapshot.commitJobTimeout }}
         {{- end }}

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -48,6 +48,8 @@ controller:
   snapshot:
     # -- Image used for commit operations (must contain nerdctl tool)
     imageCommitterImage: "image-committer:dev"
+    # -- Containerd socket path of host
+    containerdSocketPath: "/var/run/containerd/containerd.sock"
     # -- Timeout duration for commit jobs
     commitJobTimeout: "10m"
     # -- OCI registry prefix used for snapshot images.

--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -198,6 +198,9 @@ func main() {
 	var imageCommitterImage string
 	flag.StringVar(&imageCommitterImage, "image-committer-image", "image-committer:dev", "The image used for commit operations (contains nerdctl tool).")
 
+	var containerdSocketPath string
+	flag.StringVar(&containerdSocketPath, "containerd-socket-path", controller.ContainerdSocketPath, "Containerd socket path")
+
 	// Commit job timeout
 	var commitJobTimeout time.Duration
 	flag.DurationVar(&commitJobTimeout, "commit-job-timeout", 10*time.Minute, "The timeout duration for commit jobs.")
@@ -443,6 +446,7 @@ func main() {
 		Scheme:                   mgr.GetScheme(),
 		Recorder:                 mgr.GetEventRecorderFor("sandboxsnapshot-controller"),
 		ImageCommitterImage:      imageCommitterImage,
+		ContainerdSocketPath:     containerdSocketPath,
 		CommitJobTimeout:         commitJobTimeout,
 		SnapshotRegistry:         snapshotRegistry,
 		SnapshotRegistryInsecure: snapshotRegistryInsecure,

--- a/kubernetes/internal/controller/sandboxsnapshot_controller.go
+++ b/kubernetes/internal/controller/sandboxsnapshot_controller.go
@@ -67,6 +67,9 @@ type SandboxSnapshotReconciler struct {
 	// ImageCommitterImage is the image for image-committer (uses nerdctl to commit/push container images)
 	ImageCommitterImage string
 
+	// ContainerdSocketPath is containerd socket path for image-committer (nerdctl --address)
+	ContainerdSocketPath string
+
 	// CommitJobTimeout is the timeout for commit jobs (default: 10 minutes)
 	CommitJobTimeout time.Duration
 

--- a/kubernetes/internal/controller/sandboxsnapshot_lifecycle.go
+++ b/kubernetes/internal/controller/sandboxsnapshot_lifecycle.go
@@ -305,6 +305,13 @@ func (r *SandboxSnapshotReconciler) imageCommitterImage() string {
 	return "image-committer:dev"
 }
 
+func (r *SandboxSnapshotReconciler) containerdSocketPath() string {
+	if r.ContainerdSocketPath != "" {
+		return r.ContainerdSocketPath
+	}
+	return ContainerdSocketPath
+}
+
 func commitJobSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsUser:                ptrToInt64(0),
@@ -326,7 +333,7 @@ func (r *SandboxSnapshotReconciler) buildCommitJob(snapshot *sandboxv1alpha1.San
 		{
 			Name: "containerd-sock",
 			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{Path: ContainerdSocketPath},
+				HostPath: &corev1.HostPathVolumeSource{Path: r.containerdSocketPath()},
 			},
 		},
 	}
@@ -462,7 +469,7 @@ func (r *SandboxSnapshotReconciler) buildUnpauseJob(snapshot *sandboxv1alpha1.Sa
 						{
 							Name: "containerd-sock",
 							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{Path: ContainerdSocketPath},
+								HostPath: &corev1.HostPathVolumeSource{Path: r.containerdSocketPath()},
 							},
 						},
 					},


### PR DESCRIPTION
# Summary
- add containerd-socket-path to controller(example in k3s: containerd-socket-path=/run/k3s/containerd/containerd.sock)

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
