### PR TITLE
fix(sdks): fix backoff

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -28,7 +28,7 @@ import java.time.Instant
 internal class ReconcileState(
     private val degradedThreshold: Int,
     private val backoffBase: Duration = Duration.ofSeconds(1),
-    private val backoffMax: Duration = Duration.ofSeconds(60),
+    private val backoffMax: Duration = Duration.ofDays(1),
 ) {
     @Volatile
     var failureCount: Int = 0
@@ -63,7 +63,7 @@ internal class ReconcileState(
         if (failureCount >= degradedThreshold) {
             state = PoolState.DEGRADED
             backoffAttempts++
-            val exponent = backoffAttempts.coerceAtMost(10)
+            val exponent = backoffAttempts.coerceAtMost(30)
             val delaySeconds = backoffBase.seconds * (1L shl exponent)
             val delayMs =
                 minOf(

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -45,6 +45,18 @@ class PoolReconcilerStateTest {
     }
 
     @Test
+    fun `default degraded backoff caps at one day`() {
+        val state = ReconcileState(degradedThreshold = 1)
+
+        repeat(20) { state.recordFailure("boom") }
+
+        assertEquals(PoolState.DEGRADED, state.state)
+        assertEquals(20, state.failureCount)
+        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofHours(23))))
+        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofHours(25))))
+    }
+
+    @Test
     fun `reconcile create exception increments failure count once per task`() {
         val stateStore = InMemoryPoolStateStore()
         val config =

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class ReconcileState:
     degraded_threshold: int
     backoff_base: timedelta = timedelta(seconds=1)
-    backoff_max: timedelta = timedelta(seconds=60)
+    backoff_max: timedelta = timedelta(days=1)
     failure_count: int = 0
     state: PoolState = PoolState.HEALTHY
     last_error: str | None = None
@@ -53,7 +53,7 @@ class ReconcileState:
         if self.failure_count >= self.degraded_threshold:
             self.state = PoolState.DEGRADED
             self.backoff_attempts += 1
-            exponent = min(self.backoff_attempts, 10)
+            exponent = min(self.backoff_attempts, 30)
             delay = min(
                 self.backoff_base.total_seconds() * (1 << exponent),
                 self.backoff_max.total_seconds(),

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import threading
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import httpx
 import pytest
 
+from opensandbox._pool_reconciler import ReconcileState
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import (
     PoolAcquireFailedException,
@@ -17,6 +18,17 @@ from opensandbox.exceptions import (
 from opensandbox.models.sandboxes import PlatformSpec
 from opensandbox.pool import AcquirePolicy, InMemoryPoolStateStore, PoolCreationSpec
 from opensandbox.sync.pool import SandboxPoolSync
+
+
+def test_degraded_backoff_caps_at_one_day() -> None:
+    state = ReconcileState(degraded_threshold=1)
+
+    for _ in range(20):
+        state.record_failure("boom")
+
+    assert state.failure_count == 20
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=23))
+    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=25))
 
 
 def test_acquire_fail_fast_empty_raises_pool_empty() -> None:


### PR DESCRIPTION
# Summary
- Increase the sandbox pool degraded reconcile backoff cap from 60 seconds to 1 day for Kotlin and Python SDKs.
- Raise the internal exponential backoff exponent cap so the default 1-second base can actually grow up to the 1-day maximum.
- Add regression coverage for the new cap behavior.

# Background
The previous degraded backoff ceiling was too low. When sandbox warmup keeps failing, the pool can still retry frequently enough to continue consuming create attempts and risk exhausting quota. Capping the degraded retry window at 1 day reduces pressure on the backend and quota during prolonged failures while still allowing automatic recovery once a later retry succeeds.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
  - `uv run pytest tests/test_pool_sync.py -q`
  - `./gradlew :sandbox:test --tests com.alibaba.opensandbox.sandbox.infrastructure.pool.PoolReconcilerStateTest`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
