### PR TITLE
test(tests): run code-interpreter e2e manually

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -4,6 +4,13 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      run_code_interpreter_e2e:
+        description: 'Run code-interpreter E2E tests'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     branches: [ main ]
     paths:
@@ -25,6 +32,7 @@ jobs:
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
+      RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -116,6 +124,7 @@ jobs:
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
+      RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -228,6 +237,7 @@ jobs:
     env:
       UV_BIN: /home/admin/.local/bin
       NODE_VERSION: "20.19.0"
+      RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -321,6 +331,7 @@ jobs:
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
+      RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -407,6 +418,7 @@ jobs:
       HOME: /home/admin/actions-runner
       GOCACHE: /home/admin/actions-runner/_temp/go-build
       GOMODCACHE: /home/admin/actions-runner/_temp/go-mod-cache
+      RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/scripts/csharp-e2e.sh
+++ b/scripts/csharp-e2e.sh
@@ -16,6 +16,7 @@
 set -euxo pipefail
 
 TAG=${TAG:-latest}
+RUN_CODE_INTERPRETER_E2E=${RUN_CODE_INTERPRETER_E2E:-false}
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -60,8 +61,13 @@ export OPENSANDBOX_SANDBOX_DEFAULT_IMAGE="opensandbox/code-interpreter:${TAG}"
 
 mkdir -p tests/csharp/build/test-results
 dotnet restore "tests/csharp/OpenSandbox.E2ETests/OpenSandbox.E2ETests.csproj"
+DOTNET_TEST_FILTER=()
+if [ "${RUN_CODE_INTERPRETER_E2E}" != "true" ]; then
+  DOTNET_TEST_FILTER=(--filter "FullyQualifiedName!~CodeInterpreterE2ETests")
+fi
 dotnet test "tests/csharp/OpenSandbox.E2ETests/OpenSandbox.E2ETests.csproj" \
   --configuration Release \
   --no-restore \
   --results-directory "tests/csharp/build/test-results" \
-  --logger "trx;LogFileName=csharp-e2e.trx"
+  --logger "trx;LogFileName=csharp-e2e.trx" \
+  "${DOTNET_TEST_FILTER[@]}"

--- a/scripts/java-e2e.sh
+++ b/scripts/java-e2e.sh
@@ -16,6 +16,7 @@
 set -euxo pipefail
 
 TAG=${TAG:-latest}
+RUN_CODE_INTERPRETER_E2E=${RUN_CODE_INTERPRETER_E2E:-false}
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -62,4 +63,8 @@ cd ../../../
 
 # run Java e2e
 cd tests/java
-./gradlew test
+if [ "${RUN_CODE_INTERPRETER_E2E}" = "true" ]; then
+  ./gradlew test
+else
+  ./gradlew test -PskipCodeInterpreterE2E=true
+fi

--- a/scripts/javascript-e2e.sh
+++ b/scripts/javascript-e2e.sh
@@ -16,6 +16,7 @@
 set -euxo pipefail
 
 TAG=${TAG:-latest}
+RUN_CODE_INTERPRETER_E2E=${RUN_CODE_INTERPRETER_E2E:-false}
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -69,4 +70,13 @@ pnpm -C ../../sdks install --frozen-lockfile
 export OPENSANDBOX_TEST_API_KEY=""
 export OPENSANDBOX_SANDBOX_DEFAULT_IMAGE="opensandbox/code-interpreter:${TAG}"
 
-pnpm test:ci
+if [ "${RUN_CODE_INTERPRETER_E2E}" = "true" ]; then
+  pnpm test:ci
+else
+  pnpm run prep:sdk
+  test_files=$(find tests -name "*.test.ts" ! -name "test_code_interpreter_e2e.test.ts" -print | sort)
+  pnpm exec vitest run ${test_files} \
+    --reporter=default \
+    --reporter=junit \
+    --outputFile=build/test-results/junit.xml
+fi

--- a/scripts/python-e2e.sh
+++ b/scripts/python-e2e.sh
@@ -20,6 +20,7 @@
 set -euxo pipefail
 
 TAG=${TAG:-latest}
+RUN_CODE_INTERPRETER_E2E=${RUN_CODE_INTERPRETER_E2E:-false}
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -62,4 +63,11 @@ cd ../../..
 
 # run real python e2e
 cd tests/python
-uv sync --all-extras --refresh && make test
+uv sync --all-extras --refresh
+if [ "${RUN_CODE_INTERPRETER_E2E}" = "true" ]; then
+  make test
+else
+  uv run pytest \
+    --ignore=tests/test_code_interpreter_e2e.py \
+    --ignore=tests/test_code_interpreter_e2e_sync.py
+fi

--- a/tests/go/code_interpreter_e2e_test.go
+++ b/tests/go/code_interpreter_e2e_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -25,7 +26,9 @@ import (
 
 func createCodeInterpreter(t *testing.T) (context.Context, *opensandbox.CodeInterpreter) {
 	t.Helper()
-	t.Skip("skip code interpreter e2e tests")
+	if os.Getenv("RUN_CODE_INTERPRETER_E2E") != "true" {
+		t.Skip("Set RUN_CODE_INTERPRETER_E2E=true to run code interpreter e2e tests")
+	}
 	config := connectionConfigForStreaming(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)
@@ -104,6 +107,10 @@ func TestCodeInterpreter_ContextManagement(t *testing.T) {
 }
 
 func TestCodeInterpreter_ContextIsolation(t *testing.T) {
+	if os.Getenv("RUN_CODE_INTERPRETER_E2E") != "true" {
+		t.Skip("Set RUN_CODE_INTERPRETER_E2E=true to run code interpreter e2e tests")
+	}
+
 	config := connectionConfigForStreaming(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/tests/go/scenario_agent_e2e_test.go
+++ b/tests/go/scenario_agent_e2e_test.go
@@ -171,7 +171,9 @@ func TestScenario_SimpleAgentLoop(t *testing.T) {
 }
 
 func TestScenario_CodeInterpreterAgent(t *testing.T) {
-	t.Skip("skip code interpreter e2e tests")
+	if os.Getenv("RUN_CODE_INTERPRETER_E2E") != "true" {
+		t.Skip("Set RUN_CODE_INTERPRETER_E2E=true to run code interpreter e2e tests")
+	}
 
 	llmEndpoint := getLLMEndpoint()
 	if llmEndpoint == "" {

--- a/tests/java/build.gradle.kts
+++ b/tests/java/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    if (project.findProperty("skipCodeInterpreterE2E") == "true") {
+        exclude("**/CodeInterpreterE2ETest.class")
+    }
 }
 
 tasks.register<Test>("e2eTest") {


### PR DESCRIPTION
# Summary
- Default GitHub Actions E2E runs now skip code-interpreter E2E coverage for PR and push events.
- Added a manual `workflow_dispatch` switch, `run_code_interpreter_e2e`, so maintainers can opt in to the slower code-interpreter E2E suite when needed.
- Updated the Python, Java, JavaScript, C#, and Go E2E entry points so the same `RUN_CODE_INTERPRETER_E2E=true` signal controls whether code-interpreter tests are included.

# Why
- Code-interpreter E2E tests are comparatively expensive because they exercise full sandbox startup plus interpreter/runtime behavior across multiple SDK languages.
- The code-interpreter surface changes less frequently than the base sandbox/server lifecycle, so running it on every default E2E workflow adds CI time without proportional signal for most PRs.
- Keeping the suite manually runnable preserves coverage for targeted SDK/runtime changes, release validation, and suspected regressions while reducing the default feedback loop.

# How to run manually
- Open the `Real E2E Tests` workflow in GitHub Actions.
- Use `Run workflow` and enable `Run code-interpreter E2E tests`.
- The workflow sets `RUN_CODE_INTERPRETER_E2E=true`, which includes the code-interpreter tests in all affected language suites.

# Testing
- [x] `bash -n scripts/python-e2e.sh`
- [x] `bash -n scripts/java-e2e.sh`
- [x] `bash -n scripts/javascript-e2e.sh`
- [x] `bash -n scripts/csharp-e2e.sh`
- [x] `go test ./... -run TestCodeInterpreter_CreateAndPing -count=1` from `tests/go`
- [x] `git diff --check`
- [ ] Full E2E not run locally; requires Docker/self-hosted runner environment.
- [ ] Java Gradle dry-run was attempted, but local validation could not resolve `com.alibaba.opensandbox:code-interpreter:latest.integration` from Maven local. The failure was dependency availability, not the new skip flag wiring.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered