### PR TITLE
feat(sdks): support diagonostic

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,115 @@
+# CLI AGENTS
+
+You are working on the OpenSandbox CLI. Keep commands as thin, predictable wrappers over the Python SDK, and keep help text, README examples, bundled skills, and tests aligned whenever user-visible CLI behavior changes.
+
+## Scope
+
+- `src/opensandbox_cli/**`
+- `tests/**`
+- `README.md`
+- `pyproject.toml` and `uv.lock` when CLI dependencies or release metadata change
+- `assets/**` only when screenshots or visual CLI documentation are intentionally refreshed
+
+If the task changes SDK-facing behavior, also read `../sdks/AGENTS.md`. If the task is driven by public API contracts, also read `../specs/AGENTS.md`.
+
+## Key Areas
+
+- `src/opensandbox_cli/main.py`: root command registration, global options, version/banner behavior
+- `src/opensandbox_cli/client.py`: resolved config, SDK manager/client construction, output formatter wiring
+- `src/opensandbox_cli/commands/`: command groups and command-scoped options
+- `src/opensandbox_cli/output.py`: table, JSON, YAML, and raw rendering behavior
+- `src/opensandbox_cli/skills/`: bundled skills installed into external agent tools
+- `src/opensandbox_cli/skill_registry.py`: skill metadata shown by `osb skills list/show`
+- `tests/test_cli_help.py`: root and command help coverage
+- `tests/test_commands.py`: SDK-backed command behavior with mocked SDK calls
+- `tests/test_skills.py`: bundled skill quality and CLI alignment checks
+
+## Command Design
+
+Prefer clear command groups whose names match stable product concepts. Commands should call Python SDK facades such as `SandboxManager`, `Sandbox`, or service objects instead of rebuilding HTTP paths locally. Raw HTTP or private client access is acceptable only for explicitly experimental or legacy commands.
+
+For new stable commands:
+
+- expose concise flags with names that match SDK/API concepts
+- support `-o/--output` consistently with nearby commands
+- use `raw` only for payload text or streaming-style output
+- use `json` / `yaml` for structured descriptors or SDK models
+- register the command in `main.py`
+- add help tests and mocked SDK command tests
+- update README examples when the command is user-facing
+- update bundled skills when agents should use the command
+
+For deprecated commands:
+
+- preserve old option meanings, especially short flags
+- do not silently reuse an old flag for a new concept
+- print or return explicit migration guidance
+- keep compatibility wrappers small and route to the stable implementation when practical
+
+## Skills
+
+Bundled skills are operational guidance for real agents, not long-form documentation. Keep them concise, command-first, and aligned with actual CLI behavior.
+
+When changing commands that appear in skills:
+
+- update the relevant skill examples
+- explain only the semantics agents need to make decisions
+- keep examples executable and include explicit `-o` output formats
+- avoid relying on deprecated CLI APIs unless the skill clearly marks them as fallback
+- update `skill_registry.py` summaries when the skill's advertised behavior changes
+- update `tests/test_skills.py` so command examples and option names stay aligned with the CLI
+
+## Commands
+
+Common CLI checks:
+
+```bash
+cd cli
+uv run --frozen ruff check
+uv run --frozen pyright
+uv run --frozen pytest tests/ -q
+```
+
+Focused checks:
+
+```bash
+cd cli
+uv run --frozen pytest tests/test_cli_help.py -q
+uv run --frozen pytest tests/test_commands.py -q
+uv run --frozen pytest tests/test_skills.py -q
+```
+
+Use `--frozen` for validation when you do not intend to update `uv.lock`. If `uv run` changes `uv.lock` unexpectedly, inspect the diff and keep it only when the dependency graph intentionally changed.
+
+## Guardrails
+
+Always:
+
+- Keep CLI behavior aligned with the Python SDK surface it wraps.
+- Keep help text accurate for supported options and output formats.
+- Add or update tests for new commands, changed flags, changed rendering, and skill examples.
+- Preserve command output compatibility unless the migration is explicit and documented.
+- Treat bundled skills as part of the user-facing CLI surface.
+- Keep command implementations small; put reusable rendering, validation, and error handling in local helpers when that matches existing style.
+- Mention verification that was not run in the final handoff.
+
+Ask first:
+
+- Removing a command or flag.
+- Changing the meaning of an existing option or short flag.
+- Making a legacy or experimental command the preferred path without a migration story.
+- Changing installed skill formats or target layouts.
+
+Never:
+
+- Reimplement stable SDK APIs with ad hoc HTTP calls in a new stable CLI command.
+- Update generated or lock files as incidental noise.
+- Leave README, help text, or bundled skills pointing at deprecated commands after adding a stable replacement.
+- Mix unrelated CLI feature work into a command behavior change.
+
+## Good Patterns
+
+- Stable command wraps SDK manager/service method and shares rendering helpers.
+- Legacy command delegates to the stable implementation and emits migration guidance.
+- Tests mock `ClientContext` and assert exact SDK calls.
+- Skill tests assert that examples use existing commands and explicit output formats.

--- a/cli/README.md
+++ b/cli/README.md
@@ -223,14 +223,31 @@ osb command run <sandbox-id> -o raw -- curl -I https://pypi.org
 
 ### Collect diagnostics
 
-These commands are experimental and return plain text.
+Use the stable diagnostics commands for API-backed log and event descriptors.
 
 ```bash
-osb devops summary <sandbox-id> -o raw
+osb diagnostics events <sandbox-id> --scope lifecycle -o raw
+osb diagnostics events <sandbox-id> --scope runtime -o raw
+osb diagnostics logs <sandbox-id> --scope container -o raw
+osb diagnostics logs <sandbox-id> --scope lifecycle -o json
+osb diagnostics events <sandbox-id> --scope runtime -o json
+osb diagnostics logs <sandbox-id> --scope container -o yaml
+```
+
+`--scope` is required for stable diagnostics. Common scopes are `lifecycle` and
+`container` for logs, and `lifecycle` and `runtime` for events. Raw output
+prints inline diagnostic text, or the content URL when diagnostics are
+delivered as a temporary URL. Structured CLI output follows the SDK/Python field
+style, for example `content_url`, `content_length`, and `expires_at`.
+Some server builds may return `DIAGNOSTICS_NOT_IMPLEMENTED` for scoped
+diagnostics until the stable backend implementation is enabled.
+
+Legacy DevOps diagnostics remain experimental. Prefer `osb diagnostics logs/events`
+for stable API-backed log and event collection.
+
+```bash
 osb devops inspect <sandbox-id> -o raw
-osb devops events <sandbox-id> --limit 100 -o raw
-osb devops logs <sandbox-id> --tail 500 -o raw
-osb devops logs <sandbox-id> --since 30m -o raw
+osb devops summary <sandbox-id> -o raw
 ```
 
 ## Output Formats
@@ -260,7 +277,8 @@ The main command groups are:
 - `osb command`: command execution and persistent sessions
 - `osb file`: file and directory operations
 - `osb egress`: runtime egress policy
-- `osb devops`: experimental diagnostics
+- `osb diagnostics`: stable diagnostics logs and events
+- `osb devops`: experimental legacy diagnostics
 - `osb config`: local CLI configuration
 - `osb skills`: bundled skills for AI tools
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "opensandbox>=0.1.7,<0.2.0",
+    "opensandbox>=0.1.9,<0.2.0",
     "click>=8.1.0,<9.0",
     "rich>=13.0.0,<14.0",
     "pyyaml>=6.0,<7.0",
@@ -66,7 +66,7 @@ source = "vcs"
 root = ".."
 tag_regex = "^cli/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "cli/v*"'
-fallback_version = "0.1.0"
+fallback_version = "0.1.1"
 
 [tool.hatch.build]
 include = [

--- a/cli/src/opensandbox_cli/commands/devops.py
+++ b/cli/src/opensandbox_cli/commands/devops.py
@@ -57,7 +57,8 @@ def devops_logs(
     since: str | None,
     output_format: str | None,
 ) -> None:
-    """Retrieve container logs for a sandbox."""
+    """Deprecated: use `osb diagnostics logs` instead."""
+    click.echo("Warning: `osb devops logs` is deprecated. Use `osb diagnostics logs`.", err=True)
     prepare_output(obj, output_format, allowed=("raw",), fallback="raw")
     params: dict = {"tail": tail}
     if since:
@@ -93,7 +94,8 @@ def devops_inspect(
 def devops_events(
     obj: ClientContext, sandbox_id: str, limit: int, output_format: str | None
 ) -> None:
-    """Retrieve events related to a sandbox."""
+    """Deprecated: use `osb diagnostics events` instead."""
+    click.echo("Warning: `osb devops events` is deprecated. Use `osb diagnostics events`.", err=True)
     prepare_output(obj, output_format, allowed=("raw",), fallback="raw")
     params: dict = {"limit": limit}
     text = _fetch_plain_text(obj, sandbox_id, "events", params=params)

--- a/cli/src/opensandbox_cli/commands/diagnostics.py
+++ b/cli/src/opensandbox_cli/commands/diagnostics.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable sandbox diagnostics commands backed by the Python SDK."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+from opensandbox.models.diagnostics import DiagnosticContent
+
+from opensandbox_cli.client import ClientContext
+from opensandbox_cli.utils import handle_errors, output_option, prepare_output
+
+
+def _diagnostic_to_dict(content: DiagnosticContent) -> dict[str, Any]:
+    """Convert SDK diagnostics content to a CLI-friendly dict."""
+    return content.model_dump(mode="json")
+
+
+def render_diagnostic_content(
+    obj: ClientContext,
+    content: DiagnosticContent,
+    output_format: str | None,
+    *,
+    title: str,
+) -> None:
+    """Render diagnostics descriptor or raw diagnostic payload."""
+    output = prepare_output(
+        obj,
+        output_format,
+        allowed=("table", "json", "yaml", "raw"),
+        fallback="raw",
+    )
+
+    if output.fmt == "raw":
+        if content.delivery == "inline":
+            click.echo(content.content or "")
+            return
+        if content.content_url:
+            click.echo(content.content_url)
+            return
+        raise click.ClickException("Diagnostic response did not include inline content or a content URL.")
+
+    output.print_dict(_diagnostic_to_dict(content), title=title)
+
+
+@click.group("diagnostics", invoke_without_command=True)
+@click.pass_context
+def diagnostics_group(ctx: click.Context) -> None:
+    """Stable sandbox diagnostics backed by the OpenSandbox SDK."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@diagnostics_group.command("logs")
+@click.argument("sandbox_id")
+@click.option(
+    "--scope",
+    "-s",
+    required=True,
+    help=(
+        "Diagnostic log scope. Common scopes: lifecycle for manager logs, "
+        "container for sandbox stdout; other scopes are server-defined."
+    ),
+)
+@output_option(
+    "table",
+    "json",
+    "yaml",
+    "raw",
+    help_text="Output format. raw prints inline text, or the content URL for URL-delivered diagnostics.",
+)
+@click.pass_obj
+@handle_errors
+def diagnostics_logs(
+    obj: ClientContext,
+    sandbox_id: str,
+    scope: str,
+    output_format: str | None,
+) -> None:
+    """Retrieve diagnostic logs for a sandbox."""
+    sandbox_id = obj.resolve_sandbox_id(sandbox_id)
+    content = obj.get_manager().get_diagnostic_logs(sandbox_id, scope=scope)
+    render_diagnostic_content(obj, content, output_format, title="Diagnostic Logs")
+
+
+@diagnostics_group.command("events")
+@click.argument("sandbox_id")
+@click.option(
+    "--scope",
+    "-s",
+    required=True,
+    help=(
+        "Diagnostic event scope. Common scopes: lifecycle for audit events, "
+        "runtime for scheduler/container events; other scopes are server-defined."
+    ),
+)
+@output_option(
+    "table",
+    "json",
+    "yaml",
+    "raw",
+    help_text="Output format. raw prints inline text, or the content URL for URL-delivered diagnostics.",
+)
+@click.pass_obj
+@handle_errors
+def diagnostics_events(
+    obj: ClientContext,
+    sandbox_id: str,
+    scope: str,
+    output_format: str | None,
+) -> None:
+    """Retrieve diagnostic events for a sandbox."""
+    sandbox_id = obj.resolve_sandbox_id(sandbox_id)
+    content = obj.get_manager().get_diagnostic_events(sandbox_id, scope=scope)
+    render_diagnostic_content(obj, content, output_format, title="Diagnostic Events")

--- a/cli/src/opensandbox_cli/main.py
+++ b/cli/src/opensandbox_cli/main.py
@@ -26,6 +26,7 @@ from opensandbox_cli.client import ClientContext
 from opensandbox_cli.commands.command import command_group
 from opensandbox_cli.commands.config_cmd import config_group
 from opensandbox_cli.commands.devops import devops_group
+from opensandbox_cli.commands.diagnostics import diagnostics_group
 from opensandbox_cli.commands.egress import egress_group
 from opensandbox_cli.commands.file import file_group
 from opensandbox_cli.commands.sandbox import sandbox_group
@@ -134,5 +135,6 @@ cli.add_command(command_group)
 cli.add_command(file_group)
 cli.add_command(egress_group)
 cli.add_command(config_group)
+cli.add_command(diagnostics_group)
 cli.add_command(devops_group)
 cli.add_command(skills_group)

--- a/cli/src/opensandbox_cli/skill_registry.py
+++ b/cli/src/opensandbox_cli/skill_registry.py
@@ -25,8 +25,8 @@ BUILTIN_SKILLS: dict[str, SkillSpec] = {
         package_file="opensandbox-sandbox-troubleshooting.md",
         title="OpenSandbox Sandbox Troubleshooting",
         summary=(
-            "Triage failed or unhealthy sandboxes with state, health, summary, "
-            "inspect, events, logs, and concrete remediation steps."
+            "Triage failed or unhealthy sandboxes with state, health, stable "
+            "diagnostic logs/events, and concrete remediation steps."
         ),
         trigger_hint=(
             "Use when the user reports sandbox startup failures, crashes, OOM, "

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
@@ -1,11 +1,11 @@
 ---
 name: sandbox-troubleshooting
-description: Use OpenSandbox CLI state, health, summary, inspect, events, and logs to investigate failed, unhealthy, or unreachable sandboxes. Trigger when users report startup failures, crashes, OOM, image pull problems, pending sandboxes, network issues, or an unresponsive sandbox and want root cause plus next actions.
+description: Use OpenSandbox CLI state, health, and stable diagnostics logs/events to investigate failed, unhealthy, or unreachable sandboxes. Trigger when users report startup failures, crashes, OOM, image pull problems, pending sandboxes, network issues, or an unresponsive sandbox and want root cause plus next actions.
 ---
 
 # OpenSandbox Sandbox Troubleshooting
 
-Investigate the reported sandbox before proposing a fix. Prefer evidence from OpenSandbox state, health checks, summary output, and diagnostics streams over speculation.
+Investigate the reported sandbox before proposing a fix. Prefer evidence from OpenSandbox state, health checks, and stable diagnostics streams over speculation.
 
 ## Inputs To Collect
 
@@ -52,7 +52,7 @@ Use raw HTTP only after domain, protocol, and API key expectations are explicit.
 
 ## Operating Rules
 
-- start with the highest-signal commands first: sandbox state, sandbox health, then diagnostics summary
+- start with the highest-signal commands first: sandbox state, sandbox health, then stable diagnostics events/logs
 - use CLI commands when `osb` is available because they are shorter and usually already authenticated
 - use HTTP only when the CLI is unavailable or the user is clearly working from raw API access
 - distinguish observed facts from inference and quote the field, event, or log line that supports the diagnosis
@@ -67,32 +67,57 @@ Use this order by default:
 ```bash
 osb sandbox get <sandbox-id> -o json
 osb sandbox health <sandbox-id> -o json
-osb devops summary <sandbox-id> -o raw
+osb diagnostics events <sandbox-id> --scope lifecycle -o raw
+osb diagnostics events <sandbox-id> --scope runtime -o raw
+osb diagnostics logs <sandbox-id> --scope container -o raw
 ```
 
-Then drill down only where the summary points:
+Then drill down only where the stable diagnostics point:
 
 ```bash
-osb devops inspect <sandbox-id> -o raw
-osb devops events <sandbox-id> --limit 100 -o raw
-osb devops logs <sandbox-id> --tail 500 -o raw
-osb devops logs <sandbox-id> --since 30m -o raw
+osb diagnostics logs <sandbox-id> --scope lifecycle -o raw
+osb diagnostics events <sandbox-id> --scope all -o raw
+osb diagnostics logs <sandbox-id> --scope all -o raw
 ```
 
 ## Diagnostics Streams
 
 Important properties of the diagnostics commands:
 
-- `summary` is the broadest starting point because it combines inspect output, event history, and recent logs
-- `inspect`, `events`, and `logs` are detailed streams used after the broad summary
-- diagnostics commands return plain-text output, not structured SDK model objects
+- `diagnostics events` and `diagnostics logs` are stable API-backed commands
+- `--scope` is required for stable diagnostics; requests without scope use deprecated plain-text DevOps behavior
+- if the server returns `DIAGNOSTICS_NOT_IMPLEMENTED`, state that stable diagnostics are unavailable on this server and stop diagnostics collection
+- use known supported scopes first: `events:lifecycle`, `events:runtime`, `logs:lifecycle`, and `logs:container`
+- `--scope all` is useful when the server supports aggregate diagnostics; if it is empty, retry concrete supported scopes
+- other scopes such as `network` or `process` are server-defined and may be empty on some deployments
+- `-o raw` prints inline diagnostic text directly, or a content URL when the server returns URL delivery
+- `-o json` / `-o yaml` prints the CLI descriptor including `delivery`, `content_url`, `expires_at`, `truncated`, and `warnings`
 - quote concrete lines from diagnostics output instead of summarizing vaguely
 
 Use:
 
-- `inspect` for container state, exit code, restart count, resources, ports, and runtime metadata
-- `events` for scheduling failures, image pull issues, restarts, OOM kills, and probe transitions
-- `logs` for application errors, missing binaries, bad entrypoints, startup hangs, and health-check failures
+- `osb diagnostics events <sandbox-id> --scope lifecycle -o raw` for sandbox actions such as `CREATE`, `RENEW`, `DELETE`, `PAUSE`, `RESUME`, and `FORK`
+- `osb diagnostics events <sandbox-id> --scope runtime -o raw` for scheduler and container events such as `Scheduled`, `Pulling`, `Pulled`, `Created`, `Started`, and `ContainerDied`
+- `osb diagnostics logs <sandbox-id> --scope lifecycle -o raw` for manager server logs related to create, renew, delete, callbacks, request IDs, and server-side failures
+- `osb diagnostics logs <sandbox-id> --scope container -o raw` for sandbox main-process stdout, including application errors, missing binaries, bad entrypoints, startup hangs, and health-check failures
+
+## Evidence Semantics
+
+- `sandbox get` shows control-plane state; it does not prove the workload is healthy
+- `sandbox health` shows readiness or endpoint health; it can fail even when the sandbox is running
+- lifecycle diagnostics explain OpenSandbox manager behavior; container logs explain the user workload
+- runtime events are platform facts and usually outrank application logs for scheduling, image pull, restart, and kill reasons
+- empty diagnostics do not prove there is no issue; the scope may be unsupported, expired, or outside retention
+- `truncated: true` means the evidence is incomplete; lower confidence and mention the truncation
+- always read `warnings`; they may explain missing, partial, unsupported, or expired diagnostic content
+
+## URL Delivery
+
+- with `delivery: inline`, use `content` as the diagnostic text
+- with `delivery: url`, `-o raw` prints the diagnostic content URL; fetch it only if you need the diagnostic body
+- `content_url` in structured CLI output is a diagnostic artifact URL, not a sandbox service endpoint
+- check `expires_at`; container log URLs may expire quickly, so request diagnostics again if the URL is stale
+- do not forward diagnostic URLs or lifecycle logs to unrelated people because they may contain sensitive troubleshooting data
 
 ## Symptom To Command Mapping
 
@@ -100,11 +125,11 @@ Use the first command that best matches the reported symptom:
 
 | Symptom | First command | What to confirm next |
 | --- | --- | --- |
-| pending forever or stuck creating | `osb devops events <sandbox-id> --limit 100 -o raw` | image pull errors, scheduling failures, admission errors |
-| image pull failure | `osb devops events <sandbox-id> --limit 100 -o raw` | image name, tag, registry auth |
-| crash loop or repeated restarts | `osb devops logs <sandbox-id> --tail 200 -o raw` | `osb devops inspect <sandbox-id> -o raw` for exit code and restart count |
-| suspected OOM or exit code issue | `osb devops inspect <sandbox-id> -o raw` | `OOMKilled`, exit code, resource limits |
-| endpoint unreachable or connection refused | `osb sandbox health <sandbox-id> -o json` | `osb sandbox endpoint <sandbox-id> --port <port> -o json` and then `osb devops logs <sandbox-id> --tail 200 -o raw` |
+| pending forever or stuck creating | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | image pull errors, scheduling failures, admission errors, then lifecycle logs |
+| image pull failure | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | image name, tag, registry auth |
+| crash loop or repeated restarts | `osb diagnostics logs <sandbox-id> --scope container -o raw` | `osb diagnostics events <sandbox-id> --scope runtime -o raw` for restarts or kill signals |
+| suspected OOM or exit code issue | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | kill signals, restart events, resource pressure messages |
+| endpoint unreachable or connection refused | `osb sandbox health <sandbox-id> -o json` | `osb sandbox endpoint <sandbox-id> --port <port> -o json` and then `osb diagnostics logs <sandbox-id> --scope container -o raw` |
 | outbound network access failure | `osb sandbox health <sandbox-id> -o json` | check service behavior, then switch to `network-egress` if the issue is egress policy related |
 
 ## Diagnosis Playbooks
@@ -118,15 +143,15 @@ Use the first command that best matches the reported symptom:
 
 ### OOM Kill
 
-- first evidence: `inspect` shows `OOMKilled: True` or exit code `137`
-- confirming evidence: events mention container killed due to out-of-memory
+- first evidence: runtime events mention container killed due to out-of-memory or resource pressure
+- confirming evidence: sandbox becomes unhealthy, restarts, or exits after memory-intensive work
 - likely cause: memory limit too low for the workload
 - next actions: increase memory, rerun the workload, compare peak workload memory with the configured limit
 
 ### Crash Loop Or Bad Entrypoint
 
 - first evidence: `logs` show startup exceptions, missing binaries, or permission errors
-- confirming evidence: `inspect` shows repeated restarts, exit code `126`, or exit code `127`
+- confirming evidence: runtime events show repeated restarts, failed starts, or container exit reasons
 - likely cause: bad entrypoint, missing executable, or application crash on boot
 - next actions: fix the command or image contents, correct file permissions, redeploy or recreate
 
@@ -144,16 +169,16 @@ CLI-first troubleshooting:
 ```bash
 osb sandbox get <sandbox-id> -o json
 osb sandbox health <sandbox-id> -o json
-osb devops summary <sandbox-id> -o raw
-osb devops events <sandbox-id> --limit 100 -o raw
+osb diagnostics events <sandbox-id> --scope lifecycle -o raw
+osb diagnostics events <sandbox-id> --scope runtime -o raw
+osb diagnostics logs <sandbox-id> --scope container -o raw
 ```
 
 Crash-focused investigation:
 
 ```bash
-osb devops summary <sandbox-id> -o raw
-osb devops logs <sandbox-id> --tail 500 -o raw
-osb devops inspect <sandbox-id> -o raw
+osb diagnostics logs <sandbox-id> --scope container -o raw
+osb diagnostics events <sandbox-id> --scope runtime -o raw
 ```
 
 Endpoint troubleshooting:
@@ -162,7 +187,7 @@ Endpoint troubleshooting:
 osb sandbox get <sandbox-id> -o json
 osb sandbox health <sandbox-id> -o json
 osb sandbox endpoint <sandbox-id> --port <port> -o json
-osb devops logs <sandbox-id> --tail 200 -o raw
+osb diagnostics logs <sandbox-id> --scope container -o raw
 ```
 
 ## Response Format

--- a/cli/tests/test_cli_help.py
+++ b/cli/tests/test_cli_help.py
@@ -47,7 +47,7 @@ class TestRootCLI:
 
     def test_root_lists_commands(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["--help"])
-        for cmd in ("sandbox", "command", "file", "egress", "config", "devops", "skills"):
+        for cmd in ("sandbox", "command", "file", "egress", "config", "diagnostics", "devops", "skills"):
             assert cmd in result.output
 
 
@@ -160,6 +160,38 @@ class TestDevopsHelp:
         assert result.exit_code == 0
         for subcmd in ("logs", "inspect", "events", "summary"):
             assert subcmd in result.output
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics sub-commands
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsHelp:
+    def test_diagnostics_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["diagnostics", "--help"])
+        assert result.exit_code == 0
+        for subcmd in ("logs", "events"):
+            assert subcmd in result.output
+
+    @pytest.mark.parametrize("subcmd", ["logs", "events"])
+    def test_diagnostics_subcommand_help(self, runner: CliRunner, subcmd: str) -> None:
+        result = runner.invoke(cli, ["diagnostics", subcmd, "--help"])
+        assert result.exit_code == 0
+        assert "--scope" in result.output
+        assert "content URL" in result.output
+
+    def test_diagnostics_logs_help_describes_common_scopes(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["diagnostics", "logs", "--help"])
+        assert result.exit_code == 0
+        assert "lifecycle" in result.output
+        assert "container" in result.output
+
+    def test_diagnostics_events_help_describes_common_scopes(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["diagnostics", "events", "--help"])
+        assert result.exit_code == 0
+        assert "lifecycle" in result.output
+        assert "runtime" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import SandboxImageSpec
 
 from opensandbox_cli.main import cli
@@ -1049,27 +1050,139 @@ class TestCommandSession:
 
 
 class TestDevopsCommands:
-    def test_logs_fetches_plain_text(self, runner: CliRunner) -> None:
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = "sandbox logs"
-        mock_client.get.return_value = mock_response
+    def test_logs_preserves_legacy_plain_text_filters_with_warning(self, runner: CliRunner) -> None:
         mock_ctx = _build_mock_client_context()
-        mock_ctx.get_devops_client.return_value = mock_client
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "sandbox logs"
+        response.raise_for_status = MagicMock()
+        devops_client = MagicMock()
+        devops_client.get.return_value = response
+        mock_ctx.get_devops_client.return_value = devops_client
 
         with patch("opensandbox_cli.main.resolve_config") as mock_resolve, \
              patch("opensandbox_cli.main.ClientContext", return_value=mock_ctx):
             mock_resolve.return_value = mock_ctx.resolved_config
-            mock_ctx.output = OutputFormatter("table", color=False)
-            result = runner.invoke(cli, ["devops", "logs", "sb-1"], catch_exceptions=False)
+            result = runner.invoke(
+                cli,
+                ["devops", "logs", "sb-1", "--tail", "100", "--since", "30m"],
+                catch_exceptions=False,
+            )
 
         assert result.exit_code == 0
+        assert "deprecated" in result.output
         assert "sandbox logs" in result.output
-        mock_client.get.assert_called_once()
-        assert mock_client.get.call_args.args[0] == "sandboxes/sb-1/diagnostics/logs"
+        devops_client.get.assert_called_once_with(
+            "sandboxes/sb-1/diagnostics/logs",
+            params={"tail": 100, "since": "30m"},
+        )
 
-    def test_logs_reject_json_output(self, runner: CliRunner) -> None:
-        result = _invoke(runner, ["devops", "logs", "sb-1", "-o", "json"])
+    def test_events_preserves_legacy_limit_with_warning(self, runner: CliRunner) -> None:
+        mock_ctx = _build_mock_client_context()
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "sandbox events"
+        response.raise_for_status = MagicMock()
+        devops_client = MagicMock()
+        devops_client.get.return_value = response
+        mock_ctx.get_devops_client.return_value = devops_client
+
+        with patch("opensandbox_cli.main.resolve_config") as mock_resolve, \
+             patch("opensandbox_cli.main.ClientContext", return_value=mock_ctx):
+            mock_resolve.return_value = mock_ctx.resolved_config
+            result = runner.invoke(
+                cli,
+                ["devops", "events", "sb-1", "--limit", "25"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert "deprecated" in result.output
+        assert "sandbox events" in result.output
+        devops_client.get.assert_called_once_with(
+            "sandboxes/sb-1/diagnostics/events",
+            params={"limit": 25},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stable diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsCommands:
+    def test_logs_requires_scope(self, runner: CliRunner) -> None:
+        result = _invoke(runner, ["diagnostics", "logs", "sb-1", "-o", "raw"])
         assert result.exit_code != 0
-        assert "Invalid value for '-o' / '--output'" in result.output
+        assert "Missing option '--scope'" in result.output
+
+    def test_logs_raw_prints_inline_content(self, runner: CliRunner) -> None:
+        manager = MagicMock()
+        manager.get_diagnostic_logs.return_value = DiagnosticContent(
+            sandboxId="sb-1",
+            kind="logs",
+            scope="container",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="line 1\nline 2",
+            truncated=False,
+        )
+
+        result = _invoke(
+            runner,
+            ["diagnostics", "logs", "sb-1", "--scope", "container", "-o", "raw"],
+            manager=manager,
+        )
+
+        assert result.exit_code == 0
+        assert "line 1\nline 2" in result.output
+        manager.get_diagnostic_logs.assert_called_once_with("sb-1", scope="container")
+
+    def test_events_json_prints_descriptor(self, runner: CliRunner) -> None:
+        manager = MagicMock()
+        manager.get_diagnostic_events.return_value = DiagnosticContent(
+            sandboxId="sb-1",
+            kind="events",
+            scope="runtime",
+            delivery="url",
+            contentType="text/plain; charset=utf-8",
+            contentUrl="https://example.com/events.txt",
+            contentLength=12,
+            truncated=False,
+        )
+
+        result = _invoke(
+            runner,
+            ["diagnostics", "events", "sb-1", "--scope", "runtime", "-o", "json"],
+            manager=manager,
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["kind"] == "events"
+        assert data["scope"] == "runtime"
+        assert data["delivery"] == "url"
+        assert data["content_url"] == "https://example.com/events.txt"
+        assert data["content_length"] == 12
+        manager.get_diagnostic_events.assert_called_once_with("sb-1", scope="runtime")
+
+    def test_raw_url_delivery_prints_content_url(self, runner: CliRunner) -> None:
+        manager = MagicMock()
+        manager.get_diagnostic_logs.return_value = DiagnosticContent(
+            sandboxId="sb-1",
+            kind="logs",
+            scope="container",
+            delivery="url",
+            contentType="text/plain; charset=utf-8",
+            contentUrl="https://example.com/logs.txt",
+            truncated=False,
+        )
+
+        result = _invoke(
+            runner,
+            ["diagnostics", "logs", "sb-1", "--scope", "container", "-o", "raw"],
+            manager=manager,
+        )
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "https://example.com/logs.txt"

--- a/cli/tests/test_skills.py
+++ b/cli/tests/test_skills.py
@@ -516,9 +516,33 @@ class TestSkillContentQuality:
 
         assert "## Triage Order" in content
         assert "osb sandbox get <sandbox-id> -o json" in content
-        assert "osb devops summary <sandbox-id> -o raw" in content
+        assert "osb diagnostics events <sandbox-id> --scope lifecycle -o raw" in content
+        assert "osb diagnostics events <sandbox-id> --scope runtime -o raw" in content
+        assert "osb diagnostics logs <sandbox-id> --scope container -o raw" in content
         assert "## Diagnostics Streams" in content
+        assert "## Evidence Semantics" in content
+        assert "## URL Delivery" in content
+        assert "truncated: true" in content
+        assert "osb devops" not in content
         assert "## Symptom To Command Mapping" in content
+
+    def test_builtin_skills_do_not_reference_legacy_devops_diagnostics(self) -> None:
+        skills_dir = Path("src/opensandbox_cli/skills")
+        forbidden = (
+            "osb devops inspect",
+            "osb devops summary",
+            "devops inspect",
+            "devops summary",
+        )
+
+        violations: list[str] = []
+        for skill_path in sorted(skills_dir.glob("*.md")):
+            content = skill_path.read_text(encoding="utf-8")
+            for term in forbidden:
+                if term in content:
+                    violations.append(f"{skill_path.name}: {term}")
+
+        assert violations == []
 
     def test_lifecycle_skill_keeps_json_shapes_and_health_guidance(self) -> None:
         content = _read_builtin_skill("opensandbox-sandbox-lifecycle.md")
@@ -580,13 +604,17 @@ class TestSkillCliAlignment:
         assert {"--mode", "--owner", "--group", "-o", "--output"} <= _option_names(_command(["file", "chmod"]))
         assert {"--old", "--new", "-o", "--output"} <= _option_names(_command(["file", "replace"]))
 
-    def test_network_egress_and_devops_skills_match_cli(self) -> None:
+    def test_network_egress_diagnostics_and_devops_skills_match_cli(self) -> None:
         patch_cmd = _command(["egress", "patch"])
+        diag_logs_cmd = _command(["diagnostics", "logs"])
+        diag_events_cmd = _command(["diagnostics", "events"])
         logs_cmd = _command(["devops", "logs"])
         events_cmd = _command(["devops", "events"])
         summary_cmd = _command(["devops", "summary"])
 
         assert {"--rule", "-o", "--output"} <= _option_names(patch_cmd)
+        assert {"--scope", "-s", "-o", "--output"} <= _option_names(diag_logs_cmd)
+        assert {"--scope", "-s", "-o", "--output"} <= _option_names(diag_events_cmd)
         assert {"--tail", "-n", "--since", "-s", "-o", "--output"} <= _option_names(logs_cmd)
         assert {"--limit", "-l", "-o", "--output"} <= _option_names(events_cmd)
         assert {"--tail", "-n", "--event-limit", "-o", "--output"} <= _option_names(summary_cmd)

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.10
+project.version=1.0.11
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
+++ b/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
@@ -109,11 +109,23 @@ val generateEgressApi =
         modelPackage.set("com.alibaba.opensandbox.sandbox.api.models.egress")
     }
 
+val generateDiagnosticApi =
+    tasks.register<GenerateTask>("generateDiagnosticApi") {
+        configureCommonOptions()
+
+        inputSpec.set(rootProject.projectDir.parentFile.parentFile.parentFile.resolve("specs/diagnostic-api.yml").absolutePath)
+        outputDir.set(layout.buildDirectory.dir("generated/api/diagnostic").get().asFile.absolutePath)
+        packageName.set("com.alibaba.opensandbox.sandbox.api.diagnostic")
+        apiPackage.set("com.alibaba.opensandbox.sandbox.api.diagnostic")
+        modelPackage.set("com.alibaba.opensandbox.sandbox.api.models.diagnostic")
+    }
+
 val lifecycleSrc = generateSandboxLifecycleApi.map { file(it.outputDir).resolve("src/main/kotlin") }
 val execdSrc = generateExecdApi.map { file(it.outputDir).resolve("src/main/kotlin") }
 val egressSrc = generateEgressApi.map { file(it.outputDir).resolve("src/main/kotlin") }
+val diagnosticSrc = generateDiagnosticApi.map { file(it.outputDir).resolve("src/main/kotlin") }
 sourceSets {
     main {
-        java.srcDirs(lifecycleSrc, execdSrc, egressSrc)
+        java.srcDirs(lifecycleSrc, execdSrc, egressSrc, diagnosticSrc)
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -21,6 +21,7 @@ import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentExceptio
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxInternalException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxReadyTimeoutException
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
 import com.alibaba.opensandbox.sandbox.domain.models.execd.DEFAULT_EGRESS_PORT
 import com.alibaba.opensandbox.sandbox.domain.models.execd.DEFAULT_EXECD_PORT
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
@@ -34,6 +35,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxRenewRespo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SnapshotInfo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 import com.alibaba.opensandbox.sandbox.domain.services.Commands
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
 import com.alibaba.opensandbox.sandbox.domain.services.Egress
 import com.alibaba.opensandbox.sandbox.domain.services.Filesystem
 import com.alibaba.opensandbox.sandbox.domain.services.Health
@@ -91,6 +93,7 @@ class Sandbox internal constructor(
     private val egressService: Egress,
     private val customHealthCheck: ((sandbox: Sandbox) -> Boolean)? = null,
     private val httpClientProvider: HttpClientProvider,
+    private val diagnosticsService: Diagnostics,
 ) : AutoCloseable {
     private val logger = LoggerFactory.getLogger(Sandbox::class.java)
 
@@ -120,6 +123,13 @@ class Sandbox internal constructor(
      * @return Service for metrics retrieval
      */
     fun metrics() = metricsService
+
+    /**
+     * Provides access to sandbox diagnostic log and event descriptors.
+     *
+     * @return Service for sandbox diagnostics retrieval
+     */
+    fun diagnostics() = diagnosticsService
 
     /**
      * Provides access to shared httpclient provider
@@ -213,6 +223,7 @@ class Sandbox internal constructor(
                         connectionConfig.useServerProxy,
                     )
                 val egressService = factory.createEgress(egressEndpoint)
+                val diagnosticsService = factory.createDiagnostics()
 
                 val sandbox =
                     Sandbox(
@@ -225,6 +236,7 @@ class Sandbox internal constructor(
                         egressService = egressService,
                         customHealthCheck = healthCheck,
                         httpClientProvider = httpClientProvider,
+                        diagnosticsService = diagnosticsService,
                     )
 
                 if (!skipHealthCheck) {
@@ -446,6 +458,28 @@ class Sandbox internal constructor(
      */
     fun getMetrics(): SandboxMetrics {
         return metricsService.getMetrics(id)
+    }
+
+    /**
+     * Gets diagnostic log content for this sandbox.
+     *
+     * @param scope Required diagnostic scope such as "container", "lifecycle", or "all"
+     * @return Diagnostic log content descriptor
+     * @throws SandboxException if the operation fails
+     */
+    fun getDiagnosticLogs(scope: String): DiagnosticContent {
+        return diagnosticsService.getLogs(id, scope)
+    }
+
+    /**
+     * Gets diagnostic event content for this sandbox.
+     *
+     * @param scope Required diagnostic scope such as "runtime", "lifecycle", or "all"
+     * @return Diagnostic event content descriptor
+     * @throws SandboxException if the operation fails
+     */
+    fun getDiagnosticEvents(scope: String): DiagnosticContent {
+        return diagnosticsService.getEvents(id, scope)
     }
 
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/SandboxManager.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/SandboxManager.kt
@@ -19,6 +19,7 @@ package com.alibaba.opensandbox.sandbox
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxException
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSnapshotInfos
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter
@@ -26,6 +27,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxInfo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxRenewResponse
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SnapshotFilter
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SnapshotInfo
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
 import com.alibaba.opensandbox.sandbox.domain.services.Sandboxes
 import com.alibaba.opensandbox.sandbox.infrastructure.factory.AdapterFactory
 import org.slf4j.LoggerFactory
@@ -74,6 +76,7 @@ import java.time.OffsetDateTime
 class SandboxManager internal constructor(
     private val sandboxService: Sandboxes,
     private val httpClientProvider: HttpClientProvider,
+    private val diagnosticsService: Diagnostics,
 ) : AutoCloseable {
     private val logger = LoggerFactory.getLogger(SandboxManager::class.java)
 
@@ -92,7 +95,8 @@ class SandboxManager internal constructor(
             val httpClientProvider = HttpClientProvider(connectionConfig)
             val factory = AdapterFactory(httpClientProvider)
             val sandboxService = factory.createSandboxes()
-            return SandboxManager(sandboxService, httpClientProvider)
+            val diagnosticsService = factory.createDiagnostics()
+            return SandboxManager(sandboxService, httpClientProvider, diagnosticsService)
         }
     }
 
@@ -110,6 +114,36 @@ class SandboxManager internal constructor(
     fun getSandboxInfo(sandboxId: String): SandboxInfo {
         logger.debug("Getting info for sandbox: {}", sandboxId)
         return sandboxService.getSandboxInfo(sandboxId)
+    }
+
+    /**
+     * Gets diagnostic log content for a sandbox by ID.
+     *
+     * @param sandboxId Sandbox ID to retrieve diagnostics for
+     * @param scope Required diagnostic scope such as "container", "lifecycle", or "all"
+     * @return Diagnostic log content descriptor
+     * @throws SandboxException if the operation fails
+     */
+    fun getDiagnosticLogs(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent {
+        return diagnosticsService.getLogs(sandboxId, scope)
+    }
+
+    /**
+     * Gets diagnostic event content for a sandbox by ID.
+     *
+     * @param sandboxId Sandbox ID to retrieve diagnostics for
+     * @param scope Required diagnostic scope such as "runtime", "lifecycle", or "all"
+     * @return Diagnostic event content descriptor
+     * @throws SandboxException if the operation fails
+     */
+    fun getDiagnosticEvents(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent {
+        return diagnosticsService.getEvents(sandboxId, scope)
     }
 
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -71,7 +71,7 @@ class ConnectionConfig private constructor(
         private const val ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.10"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.11"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/diagnostics/DiagnosticContent.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/diagnostics/DiagnosticContent.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.domain.models.diagnostics
+
+import java.net.URI
+import java.time.OffsetDateTime
+
+/**
+ * Descriptor for best-effort plain-text diagnostic content.
+ *
+ * @property sandboxId Unique identifier of the sandbox
+ * @property kind Diagnostic payload kind, such as "logs" or "events"
+ * @property scope Diagnostic scope used for this response
+ * @property delivery How the diagnostic text payload is delivered, such as "inline" or "url"
+ * @property contentType Media type of the diagnostic payload
+ * @property truncated Whether the diagnostic payload was intentionally truncated
+ * @property content Inline diagnostic text payload when delivery is "inline"
+ * @property contentUrl URL where the diagnostic text payload can be downloaded when delivery is "url"
+ * @property contentLength Payload size in bytes when known
+ * @property expiresAt Expiration time for the download URL when delivery is "url"
+ * @property warnings Non-fatal warnings about payload completeness or availability
+ */
+class DiagnosticContent(
+    val sandboxId: String,
+    val kind: String,
+    val scope: String,
+    val delivery: String,
+    val contentType: String,
+    val truncated: Boolean,
+    val content: String? = null,
+    val contentUrl: URI? = null,
+    val contentLength: Int? = null,
+    val expiresAt: OffsetDateTime? = null,
+    val warnings: List<String>? = null,
+)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Diagnostics.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Diagnostics.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.domain.services
+
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
+
+/**
+ * Sandbox diagnostics service.
+ */
+interface Diagnostics {
+    /**
+     * Gets diagnostic log content for a sandbox by ID.
+     *
+     * @param sandboxId Unique identifier of the sandbox
+     * @param scope Required diagnostic scope such as "container", "lifecycle", or "all"
+     */
+    fun getLogs(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent
+
+    /**
+     * Gets diagnostic event content for a sandbox by ID.
+     *
+     * @param sandboxId Unique identifier of the sandbox
+     * @param scope Required diagnostic scope such as "runtime", "lifecycle", or "all"
+     */
+    fun getEvents(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/DiagnosticModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/DiagnosticModelConverter.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter
+
+import com.alibaba.opensandbox.sandbox.api.models.diagnostic.DiagnosticContentResponse
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
+
+internal object DiagnosticModelConverter {
+    fun DiagnosticContentResponse.toDiagnosticContent(): DiagnosticContent {
+        return DiagnosticContent(
+            sandboxId = sandboxId,
+            kind = kind.value,
+            scope = scope,
+            delivery = delivery.value,
+            contentType = contentType,
+            truncated = truncated,
+            content = content,
+            contentUrl = contentUrl,
+            contentLength = contentLength,
+            expiresAt = expiresAt,
+            warnings = warnings,
+        )
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -30,6 +30,10 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 import java.io.IOException
+import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientError as DiagnosticClientError
+import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientException as DiagnosticClientException
+import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ServerError as DiagnosticServerError
+import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ServerException as DiagnosticServerException
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ClientError as ExecdClientError
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ClientException as ExecdClientException
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ServerError as ExecdServerError
@@ -40,6 +44,7 @@ fun Exception.toSandboxException(): SandboxException {
         is SandboxException -> this
         is ClientException, is ServerException,
         is ExecdClientException, is ExecdServerException,
+        is DiagnosticClientException, is DiagnosticServerException,
         -> this.toApiException()
         is IOException ->
             SandboxInternalException(
@@ -71,6 +76,8 @@ private fun Exception.toApiException(): SandboxApiException {
             is ServerException -> this.statusCode to this.response
             is ExecdClientException -> this.statusCode to this.response
             is ExecdServerException -> this.statusCode to this.response
+            is DiagnosticClientException -> this.statusCode to this.response
+            is DiagnosticServerException -> this.statusCode to this.response
             else -> 0 to null
         }
 
@@ -80,6 +87,8 @@ private fun Exception.toApiException(): SandboxApiException {
             is ServerError<*> -> rawResponse.headers.extractRequestId()
             is ExecdClientError<*> -> rawResponse.headers.extractRequestId()
             is ExecdServerError<*> -> rawResponse.headers.extractRequestId()
+            is DiagnosticClientError<*> -> rawResponse.headers.extractRequestId()
+            is DiagnosticServerError<*> -> rawResponse.headers.extractRequestId()
             else -> null
         }
 
@@ -89,6 +98,8 @@ private fun Exception.toApiException(): SandboxApiException {
             is ExecdServerError<*> -> rawResponse.body
             is ServerError<*> -> rawResponse.body
             is ExecdClientError<*> -> rawResponse.body
+            is DiagnosticClientError<*> -> rawResponse.body
+            is DiagnosticServerError<*> -> rawResponse.body
             else -> null
         }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/DiagnosticsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/DiagnosticsAdapter.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
+
+import com.alibaba.opensandbox.sandbox.HttpClientProvider
+import com.alibaba.opensandbox.sandbox.api.diagnostic.DiagnosticsApi
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.DiagnosticModelConverter.toDiagnosticContent
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
+import okhttp3.Interceptor
+import org.slf4j.LoggerFactory
+
+internal class DiagnosticsAdapter(
+    private val provider: HttpClientProvider,
+) : Diagnostics {
+    private val logger = LoggerFactory.getLogger(DiagnosticsAdapter::class.java)
+    private val diagnosticsClient =
+        provider.authenticatedClient.newBuilder()
+            .addInterceptor(
+                Interceptor { chain ->
+                    chain.proceed(
+                        chain.request().newBuilder()
+                            .header("Accept", "application/json")
+                            .build(),
+                    )
+                },
+            )
+            .build()
+    private val api = DiagnosticsApi(provider.config.getBaseUrl(), diagnosticsClient)
+
+    override fun getLogs(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent {
+        return try {
+            api.sandboxesSandboxIdDiagnosticsLogsGet(sandboxId, scope).toDiagnosticContent()
+        } catch (e: Exception) {
+            logger.error("Failed to get diagnostic logs for sandbox {}", sandboxId, e)
+            throw e.toSandboxException()
+        }
+    }
+
+    override fun getEvents(
+        sandboxId: String,
+        scope: String,
+    ): DiagnosticContent {
+        return try {
+            api.sandboxesSandboxIdDiagnosticsEventsGet(sandboxId, scope).toDiagnosticContent()
+        } catch (e: Exception) {
+            logger.error("Failed to get diagnostic events for sandbox {}", sandboxId, e)
+            throw e.toSandboxException()
+        }
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/factory/AdapterFactory.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/factory/AdapterFactory.kt
@@ -19,12 +19,14 @@ package com.alibaba.opensandbox.sandbox.infrastructure.factory
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
 import com.alibaba.opensandbox.sandbox.domain.services.Commands
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
 import com.alibaba.opensandbox.sandbox.domain.services.Egress
 import com.alibaba.opensandbox.sandbox.domain.services.Filesystem
 import com.alibaba.opensandbox.sandbox.domain.services.Health
 import com.alibaba.opensandbox.sandbox.domain.services.Metrics
 import com.alibaba.opensandbox.sandbox.domain.services.Sandboxes
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.service.CommandsAdapter
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.service.DiagnosticsAdapter
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.service.EgressAdapter
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.service.FilesystemAdapter
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.service.HealthAdapter
@@ -42,6 +44,10 @@ internal class AdapterFactory(
 ) {
     fun createSandboxes(): Sandboxes {
         return SandboxesAdapter(httpClientProvider)
+    }
+
+    fun createDiagnostics(): Diagnostics {
+        return DiagnosticsAdapter(httpClientProvider)
     }
 
     fun createFilesystem(endpoint: SandboxEndpoint): Filesystem {

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxManagerTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxManagerTest.kt
@@ -16,6 +16,7 @@
 
 package com.alibaba.opensandbox.sandbox
 
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PaginationInfo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter
@@ -24,6 +25,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxInfo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxRenewResponse
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxState
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxStatus
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
 import com.alibaba.opensandbox.sandbox.domain.services.Sandboxes
 import io.mockk.Runs
 import io.mockk.every
@@ -46,13 +48,16 @@ class SandboxManagerTest {
     lateinit var sandboxService: Sandboxes
 
     @MockK
+    lateinit var diagnosticsService: Diagnostics
+
+    @MockK
     lateinit var httpClientProvider: HttpClientProvider
 
     private lateinit var sandboxManager: SandboxManager
 
     @BeforeEach
     fun setUp() {
-        sandboxManager = SandboxManager(sandboxService, httpClientProvider)
+        sandboxManager = SandboxManager(sandboxService, httpClientProvider, diagnosticsService)
     }
 
     @Test
@@ -108,6 +113,30 @@ class SandboxManagerTest {
 
         assertEquals(expectedInfo, result)
         verify { sandboxService.getSandboxInfo(sandboxId) }
+    }
+
+    @Test
+    fun `getDiagnosticLogs should return logs from diagnostics service`() {
+        val sandboxId = "sandbox-id"
+        val expected = mockk<DiagnosticContent>()
+        every { diagnosticsService.getLogs(sandboxId, "container") } returns expected
+
+        val result = sandboxManager.getDiagnosticLogs(sandboxId, "container")
+
+        assertSame(expected, result)
+        verify { diagnosticsService.getLogs(sandboxId, "container") }
+    }
+
+    @Test
+    fun `getDiagnosticEvents should return events from diagnostics service`() {
+        val sandboxId = "sandbox-id"
+        val expected = mockk<DiagnosticContent>()
+        every { diagnosticsService.getEvents(sandboxId, "runtime") } returns expected
+
+        val result = sandboxManager.getDiagnosticEvents(sandboxId, "runtime")
+
+        assertSame(expected, result)
+        verify { diagnosticsService.getEvents(sandboxId, "runtime") }
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
@@ -18,6 +18,7 @@ package com.alibaba.opensandbox.sandbox
 
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxReadyTimeoutException
+import com.alibaba.opensandbox.sandbox.domain.models.diagnostics.DiagnosticContent
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkRule
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
@@ -25,6 +26,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxInfo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxMetrics
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxRenewResponse
 import com.alibaba.opensandbox.sandbox.domain.services.Commands
+import com.alibaba.opensandbox.sandbox.domain.services.Diagnostics
 import com.alibaba.opensandbox.sandbox.domain.services.Egress
 import com.alibaba.opensandbox.sandbox.domain.services.Filesystem
 import com.alibaba.opensandbox.sandbox.domain.services.Health
@@ -68,6 +70,9 @@ class SandboxTest {
     lateinit var egressService: Egress
 
     @MockK
+    lateinit var diagnosticsService: Diagnostics
+
+    @MockK
     lateinit var httpClientProvider: HttpClientProvider
 
     private lateinit var sandbox: Sandbox
@@ -94,6 +99,7 @@ class SandboxTest {
                 egressService = egressService,
                 customHealthCheck = null,
                 httpClientProvider = httpClientProvider,
+                diagnosticsService = diagnosticsService,
             )
     }
 
@@ -110,6 +116,11 @@ class SandboxTest {
     @Test
     fun `metrics should return metrics service`() {
         assertSame(metricsService, sandbox.metrics())
+    }
+
+    @Test
+    fun `diagnostics should return diagnostics service`() {
+        assertSame(diagnosticsService, sandbox.diagnostics())
     }
 
     @Test
@@ -151,6 +162,28 @@ class SandboxTest {
 
         assertSame(expectedMetrics, result)
         verify { metricsService.getMetrics(sandboxId) }
+    }
+
+    @Test
+    fun `getDiagnosticLogs should delegate to diagnosticsService`() {
+        val expected = mockk<DiagnosticContent>()
+        every { diagnosticsService.getLogs(sandboxId, "container") } returns expected
+
+        val result = sandbox.getDiagnosticLogs("container")
+
+        assertSame(expected, result)
+        verify { diagnosticsService.getLogs(sandboxId, "container") }
+    }
+
+    @Test
+    fun `getDiagnosticEvents should delegate to diagnosticsService`() {
+        val expected = mockk<DiagnosticContent>()
+        every { diagnosticsService.getEvents(sandboxId, "runtime") } returns expected
+
+        val result = sandbox.getDiagnosticEvents("runtime")
+
+        assertSame(expected, result)
+        verify { diagnosticsService.getEvents(sandboxId, "runtime") }
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/DiagnosticsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/DiagnosticsAdapterTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
+
+import com.alibaba.opensandbox.sandbox.HttpClientProvider
+import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DiagnosticsAdapterTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var diagnosticsAdapter: DiagnosticsAdapter
+    private lateinit var httpClientProvider: HttpClientProvider
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val config =
+            ConnectionConfig.builder()
+                .domain("${mockWebServer.hostName}:${mockWebServer.port}")
+                .protocol("http")
+                .apiKey("test-api-key")
+                .build()
+
+        httpClientProvider = HttpClientProvider(config)
+        diagnosticsAdapter = DiagnosticsAdapter(httpClientProvider)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+        httpClientProvider.close()
+    }
+
+    @Test
+    fun `getLogs should send scoped request and parse response`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "sandboxId": "sbx-1",
+                      "kind": "logs",
+                      "scope": "container",
+                      "delivery": "inline",
+                      "contentType": "text/plain; charset=utf-8",
+                      "content": "log line",
+                      "truncated": false,
+                      "warnings": ["partial"]
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val result = diagnosticsAdapter.getLogs("sbx-1", "container")
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/v1/sandboxes/sbx-1/diagnostics/logs?scope=container", request.path)
+        assertEquals("test-api-key", request.getHeader("OPEN-SANDBOX-API-KEY"))
+        assertEquals("application/json", request.getHeader("Accept"))
+        assertEquals("logs", result.kind)
+        assertEquals("container", result.scope)
+        assertEquals("inline", result.delivery)
+        assertEquals("log line", result.content)
+        assertEquals(listOf("partial"), result.warnings)
+    }
+
+    @Test
+    fun `getEvents should send scoped request and parse response`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    {
+                      "sandboxId": "sbx-1",
+                      "kind": "events",
+                      "scope": "runtime",
+                      "delivery": "url",
+                      "contentType": "text/plain; charset=utf-8",
+                      "contentUrl": "https://example.com/events.txt",
+                      "contentLength": 12,
+                      "expiresAt": "2026-04-14T10:30:00Z",
+                      "truncated": false
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val result = diagnosticsAdapter.getEvents("sbx-1", "runtime")
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/v1/sandboxes/sbx-1/diagnostics/events?scope=runtime", request.path)
+        assertEquals("application/json", request.getHeader("Accept"))
+        assertEquals("events", result.kind)
+        assertEquals("runtime", result.scope)
+        assertEquals("url", result.delivery)
+        assertEquals("https://example.com/events.txt", result.contentUrl.toString())
+        assertEquals(12, result.contentLength)
+    }
+}

--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -67,7 +67,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.8"
+fallback_version = "0.1.9"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/scripts/generate_api.py
+++ b/sdks/sandbox/python/scripts/generate_api.py
@@ -165,6 +165,60 @@ def generate_egress_api_client() -> None:
                 break
 
 
+def generate_diagnostic_api_client() -> None:
+    """Generate the diagnostics API client from OpenAPI spec."""
+    print("\n🔧 Generating diagnostics API client...")
+
+    spec_path = Path("../../../specs/diagnostic-api.yml").resolve()
+    output_path = Path("src/opensandbox/api/diagnostic")
+    config_path = Path("scripts/openapi_diagnostic_config.yaml")
+    temp_output = Path("temp_diagnostic_client")
+
+    if not spec_path.exists():
+        print(f"❌ OpenAPI spec not found at {spec_path}")
+        print("Please ensure the specs directory is available")
+        return
+
+    if output_path.exists():
+        shutil.rmtree(output_path)
+
+    if temp_output.exists():
+        shutil.rmtree(temp_output)
+
+    cmd = [
+        "openapi-python-client",
+        "generate",
+        "--path",
+        str(spec_path),
+        "--output-path",
+        str(temp_output),
+        "--config",
+        str(config_path),
+        "--overwrite",
+    ]
+
+    try:
+        run_command(cmd, "Generating diagnostics API client")
+    except subprocess.CalledProcessError:
+        print("❌ Failed to generate diagnostics API client")
+        return
+
+    generated_package = temp_output / "opensandbox_api_diagnostic"
+    if generated_package.exists():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(generated_package), str(output_path))
+        shutil.rmtree(temp_output)
+        print(f"✅ Moved generated code to {output_path}")
+    else:
+        for item in temp_output.iterdir():
+            if item.is_dir() and not item.name.startswith("."):
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(item), str(output_path))
+                shutil.rmtree(temp_output)
+                print(f"✅ Moved generated code from {item} to {output_path}")
+                break
+
+
 def generate_sandbox_lifecycle_api() -> None:
     """Generate the sandbox lifecycle API client."""
     print("\n🔧 Generating sandbox lifecycle API client...")
@@ -267,6 +321,7 @@ def post_process_generated_code() -> None:
     # Ensure all generated python files have a license header.
     add_license_headers(Path("src/opensandbox/api/execd"))
     add_license_headers(Path("src/opensandbox/api/egress"))
+    add_license_headers(Path("src/opensandbox/api/diagnostic"))
     add_license_headers(Path("src/opensandbox/api/lifecycle"))
     add_license_headers(Path("src/opensandbox/api"))
 
@@ -297,6 +352,7 @@ def main() -> None:
     # Generate API clients
     generate_execd_api_client()
     generate_egress_api_client()
+    generate_diagnostic_api_client()
     generate_sandbox_lifecycle_api()
 
     # Post-process
@@ -306,6 +362,7 @@ def main() -> None:
     print("Generated clients:")
     print("  - src/opensandbox/api/execd/")
     print("  - src/opensandbox/api/egress/")
+    print("  - src/opensandbox/api/diagnostic/")
     print("  - src/opensandbox/api/lifecycle/")
     print("\nThe generated clients support custom httpx.AsyncClient injection:")
     print("  from opensandbox.api.execd import Client, AuthenticatedClient")

--- a/sdks/sandbox/python/scripts/openapi_diagnostic_config.yaml
+++ b/sdks/sandbox/python/scripts/openapi_diagnostic_config.yaml
@@ -1,0 +1,6 @@
+# openapi-python-client configuration for diagnostics API
+
+project_name_override: opensandbox_api_diagnostic
+package_name_override: opensandbox_api_diagnostic
+
+use_path_prefix_for_title_model_names: true

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/diagnostic_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/diagnostic_model_converter.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Converters for diagnostics API models."""
+
+from opensandbox.api.diagnostic.models import (
+    DiagnosticContentResponse as ApiDiagnosticContentResponse,
+)
+from opensandbox.models.diagnostics import DiagnosticContent
+
+
+class DiagnosticModelConverter:
+    """Convert generated diagnostics API models to public SDK models."""
+
+    @staticmethod
+    def to_diagnostic_content(
+        response: ApiDiagnosticContentResponse,
+    ) -> DiagnosticContent:
+        return DiagnosticContent.model_validate(response.to_dict())

--- a/sdks/sandbox/python/src/opensandbox/adapters/diagnostics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/diagnostics_adapter.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Diagnostics service adapter implementation."""
+
+import logging
+
+import httpx  # type: ignore[reportMissingImports]
+
+from opensandbox.adapters.converter.diagnostic_model_converter import (
+    DiagnosticModelConverter,
+)
+from opensandbox.adapters.converter.exception_converter import ExceptionConverter
+from opensandbox.adapters.converter.response_handler import (
+    handle_api_error,
+    require_parsed,
+)
+from opensandbox.config import ConnectionConfig
+from opensandbox.models.diagnostics import DiagnosticContent
+from opensandbox.services.diagnostics import Diagnostics
+
+logger = logging.getLogger(__name__)
+
+
+class DiagnosticsAdapter(Diagnostics):
+    """Adapter for sandbox diagnostics management API operations."""
+
+    def __init__(self, connection_config: ConnectionConfig) -> None:
+        self.connection_config = connection_config
+        from opensandbox.api.diagnostic import AuthenticatedClient
+
+        api_key = self.connection_config.get_api_key()
+        timeout_seconds = self.connection_config.request_timeout.total_seconds()
+        timeout = httpx.Timeout(timeout_seconds)
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": self.connection_config.user_agent,
+            **self.connection_config.headers,
+        }
+        if api_key:
+            headers["OPEN-SANDBOX-API-KEY"] = api_key
+
+        self._client = AuthenticatedClient(
+            base_url=self.connection_config.get_base_url(),
+            token=api_key or "",
+            prefix="",
+            auth_header_name="OPEN-SANDBOX-API-KEY",
+            timeout=timeout,
+        )
+        self._httpx_client = httpx.AsyncClient(
+            base_url=self.connection_config.get_base_url(),
+            headers=headers,
+            timeout=timeout,
+            transport=self.connection_config.transport,
+        )
+        self._client.set_async_httpx_client(self._httpx_client)
+
+    async def _get_client(self):
+        return self._client
+
+    async def get_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        try:
+            from opensandbox.api.diagnostic.api.diagnostics import (
+                get_sandboxes_sandbox_id_diagnostics_logs,
+            )
+            from opensandbox.api.diagnostic.models import DiagnosticContentResponse
+
+            response_obj = await get_sandboxes_sandbox_id_diagnostics_logs.asyncio_detailed(
+                sandbox_id=sandbox_id,
+                client=await self._get_client(),
+                scope=scope,
+            )
+            handle_api_error(response_obj, f"Get diagnostic logs for sandbox {sandbox_id}")
+            parsed = require_parsed(
+                response_obj,
+                DiagnosticContentResponse,
+                f"Get diagnostic logs for sandbox {sandbox_id}",
+            )
+            return DiagnosticModelConverter.to_diagnostic_content(parsed)
+        except Exception as e:
+            logger.error("Failed to get diagnostic logs for sandbox %s", sandbox_id, exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def get_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        try:
+            from opensandbox.api.diagnostic.api.diagnostics import (
+                get_sandboxes_sandbox_id_diagnostics_events,
+            )
+            from opensandbox.api.diagnostic.models import DiagnosticContentResponse
+
+            response_obj = await get_sandboxes_sandbox_id_diagnostics_events.asyncio_detailed(
+                sandbox_id=sandbox_id,
+                client=await self._get_client(),
+                scope=scope,
+            )
+            handle_api_error(response_obj, f"Get diagnostic events for sandbox {sandbox_id}")
+            parsed = require_parsed(
+                response_obj,
+                DiagnosticContentResponse,
+                f"Get diagnostic events for sandbox {sandbox_id}",
+            )
+            return DiagnosticModelConverter.to_diagnostic_content(parsed)
+        except Exception as e:
+            logger.error("Failed to get diagnostic events for sandbox %s", sandbox_id, exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/adapters/factory.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/factory.py
@@ -25,6 +25,7 @@ to ensure consistent pooling/proxy/retry behavior across services.
 """
 
 from opensandbox.adapters.command_adapter import CommandsAdapter
+from opensandbox.adapters.diagnostics_adapter import DiagnosticsAdapter
 from opensandbox.adapters.egress_adapter import EgressAdapter
 from opensandbox.adapters.filesystem_adapter import FilesystemAdapter
 from opensandbox.adapters.health_adapter import HealthAdapter
@@ -33,6 +34,7 @@ from opensandbox.adapters.sandboxes_adapter import SandboxesAdapter
 from opensandbox.config import ConnectionConfig
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.services.command import Commands
+from opensandbox.services.diagnostics import Diagnostics
 from opensandbox.services.egress import Egress
 from opensandbox.services.filesystem import Filesystem
 from opensandbox.services.health import Health
@@ -69,6 +71,10 @@ class AdapterFactory:
             Service for creating, managing, and monitoring sandbox instances
         """
         return SandboxesAdapter(self.connection_config)
+
+    def create_diagnostics_service(self) -> Diagnostics:
+        """Create a diagnostics service for sandbox troubleshooting operations."""
+        return DiagnosticsAdapter(self.connection_config)
 
     def create_filesystem_service(self, endpoint: SandboxEndpoint) -> Filesystem:
         """Create a filesystem service for file and directory operations.

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A client library for accessing OpenSandbox Diagnostics API"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains methods for accessing the API"""

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains endpoint functions for accessing the API"""

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_events.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_events.py
@@ -1,0 +1,282 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.diagnostic_content_response import DiagnosticContentResponse
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    sandbox_id: str,
+    *,
+    scope: str,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["scope"] = scope
+
+    params = {k: v for k, v in params.items() if v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/sandboxes/{sandbox_id}/diagnostics/events".format(
+            sandbox_id=quote(str(sandbox_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    if response.status_code == 200:
+        response_200 = DiagnosticContentResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorResponse.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 500:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = ErrorResponse.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    """Get diagnostic events
+
+     Retrieve a best-effort descriptor for sandbox diagnostic event text.
+
+    Events are rendered as diagnostic text rather than exposed as a stable
+    structured event model. Depending on the selected `scope` and runtime, event
+    text may include lifecycle transitions, runtime or platform events such as
+    Kubernetes Events, network diagnostic events, process activity events, or
+    other implementation-defined event material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic event text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DiagnosticContentResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        scope=scope,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    """Get diagnostic events
+
+     Retrieve a best-effort descriptor for sandbox diagnostic event text.
+
+    Events are rendered as diagnostic text rather than exposed as a stable
+    structured event model. Depending on the selected `scope` and runtime, event
+    text may include lifecycle transitions, runtime or platform events such as
+    Kubernetes Events, network diagnostic events, process activity events, or
+    other implementation-defined event material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic event text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DiagnosticContentResponse | ErrorResponse
+    """
+
+    return sync_detailed(
+        sandbox_id=sandbox_id,
+        client=client,
+        scope=scope,
+    ).parsed
+
+
+async def asyncio_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    """Get diagnostic events
+
+     Retrieve a best-effort descriptor for sandbox diagnostic event text.
+
+    Events are rendered as diagnostic text rather than exposed as a stable
+    structured event model. Depending on the selected `scope` and runtime, event
+    text may include lifecycle transitions, runtime or platform events such as
+    Kubernetes Events, network diagnostic events, process activity events, or
+    other implementation-defined event material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic event text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DiagnosticContentResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        scope=scope,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    """Get diagnostic events
+
+     Retrieve a best-effort descriptor for sandbox diagnostic event text.
+
+    Events are rendered as diagnostic text rather than exposed as a stable
+    structured event model. Depending on the selected `scope` and runtime, event
+    text may include lifecycle transitions, runtime or platform events such as
+    Kubernetes Events, network diagnostic events, process activity events, or
+    other implementation-defined event material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic event text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DiagnosticContentResponse | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            sandbox_id=sandbox_id,
+            client=client,
+            scope=scope,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_logs.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_logs.py
@@ -1,0 +1,278 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.diagnostic_content_response import DiagnosticContentResponse
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    sandbox_id: str,
+    *,
+    scope: str,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["scope"] = scope
+
+    params = {k: v for k, v in params.items() if v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/sandboxes/{sandbox_id}/diagnostics/logs".format(
+            sandbox_id=quote(str(sandbox_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    if response.status_code == 200:
+        response_200 = DiagnosticContentResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorResponse.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 500:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = ErrorResponse.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    """Get diagnostic logs
+
+     Retrieve a best-effort descriptor for sandbox diagnostic log text.
+
+    Logs are not limited to a structured observability model. Depending on the
+    selected `scope` and server configuration, log text may include sandbox
+    container stdout/stderr, lifecycle diagnostic text, network diagnostic text,
+    or other implementation-defined diagnostic material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DiagnosticContentResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        scope=scope,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    """Get diagnostic logs
+
+     Retrieve a best-effort descriptor for sandbox diagnostic log text.
+
+    Logs are not limited to a structured observability model. Depending on the
+    selected `scope` and server configuration, log text may include sandbox
+    container stdout/stderr, lifecycle diagnostic text, network diagnostic text,
+    or other implementation-defined diagnostic material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DiagnosticContentResponse | ErrorResponse
+    """
+
+    return sync_detailed(
+        sandbox_id=sandbox_id,
+        client=client,
+        scope=scope,
+    ).parsed
+
+
+async def asyncio_detailed(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> Response[DiagnosticContentResponse | ErrorResponse]:
+    """Get diagnostic logs
+
+     Retrieve a best-effort descriptor for sandbox diagnostic log text.
+
+    Logs are not limited to a structured observability model. Depending on the
+    selected `scope` and server configuration, log text may include sandbox
+    container stdout/stderr, lifecycle diagnostic text, network diagnostic text,
+    or other implementation-defined diagnostic material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DiagnosticContentResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        sandbox_id=sandbox_id,
+        scope=scope,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    sandbox_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    scope: str,
+) -> DiagnosticContentResponse | ErrorResponse | None:
+    """Get diagnostic logs
+
+     Retrieve a best-effort descriptor for sandbox diagnostic log text.
+
+    Logs are not limited to a structured observability model. Depending on the
+    selected `scope` and server configuration, log text may include sandbox
+    container stdout/stderr, lifecycle diagnostic text, network diagnostic text,
+    or other implementation-defined diagnostic material.
+
+    This endpoint does not provide streaming, pagination, or a stable line-level
+    schema in this version. The server returns a JSON descriptor for currently
+    available diagnostic text for the requested scope, subject to
+    implementation-defined retention and response size limits. The descriptor
+    either embeds the text as `content` or returns a `contentUrl` where the
+    text can be downloaded.
+
+    Args:
+        sandbox_id (str):
+        scope (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DiagnosticContentResponse | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            sandbox_id=sandbox_id,
+            client=client,
+            scope=scope,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/client.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/client.py
@@ -1,0 +1,284 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/errors.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/errors.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains all the data models used in inputs/outputs"""
+
+from .diagnostic_content_response import DiagnosticContentResponse
+from .diagnostic_content_response_delivery import DiagnosticContentResponseDelivery
+from .diagnostic_content_response_kind import DiagnosticContentResponseKind
+from .error_response import ErrorResponse
+
+__all__ = (
+    "DiagnosticContentResponse",
+    "DiagnosticContentResponseDelivery",
+    "DiagnosticContentResponseKind",
+    "ErrorResponse",
+)

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response.py
@@ -1,0 +1,170 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from dateutil.parser import isoparse
+
+from ..models.diagnostic_content_response_delivery import DiagnosticContentResponseDelivery
+from ..models.diagnostic_content_response_kind import DiagnosticContentResponseKind
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DiagnosticContentResponse")
+
+
+@_attrs_define
+class DiagnosticContentResponse:
+    """Descriptor for diagnostic text content.
+
+    When `delivery` is `inline`, servers MUST include `content` with the
+    diagnostic text and MUST omit `contentUrl` / `expiresAt`.
+
+    When `delivery` is `url`, servers MUST include `contentUrl` and `expiresAt`
+    to identify where the diagnostic text can be downloaded and MUST omit
+    `content`.
+
+        Attributes:
+            sandbox_id (str): Unique sandbox identifier.
+            kind (DiagnosticContentResponseKind): Diagnostic payload kind.
+            scope (str): Diagnostic scope used for this response.
+            delivery (DiagnosticContentResponseDelivery): How the diagnostic text payload is delivered.
+            content_type (str): Media type of the diagnostic payload.
+            truncated (bool): Whether the diagnostic payload returned inline or by URL was
+                intentionally truncated by the server. This does not indicate backend
+                retention gaps such as expired Kubernetes Events; those should be
+                reported through `warnings` when available.
+            content (str | Unset): Inline diagnostic text payload. Present when `delivery` is `inline`.
+            content_url (str | Unset): URL where the diagnostic text payload can be downloaded. Present when `delivery` is
+                `url`.
+            content_length (int | Unset): Payload size in bytes when known.
+            expires_at (datetime.datetime | Unset): Expiration time for the download URL. Present when `delivery` is `url`.
+            warnings (list[str] | Unset): Non-fatal warnings about payload completeness or availability.
+    """
+
+    sandbox_id: str
+    kind: DiagnosticContentResponseKind
+    scope: str
+    delivery: DiagnosticContentResponseDelivery
+    content_type: str
+    truncated: bool
+    content: str | Unset = UNSET
+    content_url: str | Unset = UNSET
+    content_length: int | Unset = UNSET
+    expires_at: datetime.datetime | Unset = UNSET
+    warnings: list[str] | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        sandbox_id = self.sandbox_id
+
+        kind = self.kind.value
+
+        scope = self.scope
+
+        delivery = self.delivery.value
+
+        content_type = self.content_type
+
+        truncated = self.truncated
+
+        content = self.content
+
+        content_url = self.content_url
+
+        content_length = self.content_length
+
+        expires_at: str | Unset = UNSET
+        if not isinstance(self.expires_at, Unset):
+            expires_at = self.expires_at.isoformat()
+
+        warnings: list[str] | Unset = UNSET
+        if not isinstance(self.warnings, Unset):
+            warnings = self.warnings
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "sandboxId": sandbox_id,
+                "kind": kind,
+                "scope": scope,
+                "delivery": delivery,
+                "contentType": content_type,
+                "truncated": truncated,
+            }
+        )
+        if content is not UNSET:
+            field_dict["content"] = content
+        if content_url is not UNSET:
+            field_dict["contentUrl"] = content_url
+        if content_length is not UNSET:
+            field_dict["contentLength"] = content_length
+        if expires_at is not UNSET:
+            field_dict["expiresAt"] = expires_at
+        if warnings is not UNSET:
+            field_dict["warnings"] = warnings
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        sandbox_id = d.pop("sandboxId")
+
+        kind = DiagnosticContentResponseKind(d.pop("kind"))
+
+        scope = d.pop("scope")
+
+        delivery = DiagnosticContentResponseDelivery(d.pop("delivery"))
+
+        content_type = d.pop("contentType")
+
+        truncated = d.pop("truncated")
+
+        content = d.pop("content", UNSET)
+
+        content_url = d.pop("contentUrl", UNSET)
+
+        content_length = d.pop("contentLength", UNSET)
+
+        _expires_at = d.pop("expiresAt", UNSET)
+        expires_at: datetime.datetime | Unset
+        if isinstance(_expires_at, Unset):
+            expires_at = UNSET
+        else:
+            expires_at = isoparse(_expires_at)
+
+        warnings = cast(list[str], d.pop("warnings", UNSET))
+
+        diagnostic_content_response = cls(
+            sandbox_id=sandbox_id,
+            kind=kind,
+            scope=scope,
+            delivery=delivery,
+            content_type=content_type,
+            truncated=truncated,
+            content=content,
+            content_url=content_url,
+            content_length=content_length,
+            expires_at=expires_at,
+            warnings=warnings,
+        )
+
+        return diagnostic_content_response

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response_delivery.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response_delivery.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class DiagnosticContentResponseDelivery(str, Enum):
+    INLINE = "inline"
+    URL = "url"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response_kind.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/diagnostic_content_response_kind.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class DiagnosticContentResponseKind(str, Enum):
+    EVENTS = "events"
+    LOGS = "logs"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/error_response.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/models/error_response.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="ErrorResponse")
+
+
+@_attrs_define
+class ErrorResponse:
+    """Standard error response for all non-2xx HTTP responses.
+    HTTP status code indicates the error category; code and message provide details.
+
+        Attributes:
+            code (str): Machine-readable error code.
+            message (str): Human-readable error message describing what went wrong.
+    """
+
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        message = self.message
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "code": code,
+                "message": message,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code")
+
+        message = d.pop("message")
+
+        error_response = cls(
+            code=code,
+            message=message,
+        )
+
+        return error_response

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/py.typed
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/types.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/types.py
@@ -1,0 +1,70 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -65,7 +65,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.8", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.9", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -53,7 +53,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.8", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.9", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 

--- a/sdks/sandbox/python/src/opensandbox/manager.py
+++ b/sdks/sandbox/python/src/opensandbox/manager.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta, timezone
 
 from opensandbox.adapters.factory import AdapterFactory
 from opensandbox.config import ConnectionConfig
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
     PagedSandboxInfos,
@@ -35,6 +36,7 @@ from opensandbox.models.sandboxes import (
     SnapshotFilter,
     SnapshotInfo,
 )
+from opensandbox.services.diagnostics import Diagnostics
 from opensandbox.services.sandbox import Sandboxes
 
 logger = logging.getLogger(__name__)
@@ -84,6 +86,7 @@ class SandboxManager:
         self,
         sandbox_service: Sandboxes,
         connection_config: ConnectionConfig,
+        diagnostics_service: Diagnostics | None = None,
     ) -> None:
         """
         Internal constructor for SandboxManager.
@@ -93,9 +96,13 @@ class SandboxManager:
         Args:
             sandbox_service: Service for sandbox operations
             connection_config: Connection configuration (shared transport, headers, timeouts)
+            diagnostics_service: Optional service for sandbox diagnostics
         """
         self._sandbox_service = sandbox_service
         self._connection_config = connection_config
+        self._diagnostics_service = diagnostics_service or AdapterFactory(
+            connection_config
+        ).create_diagnostics_service()
 
     @property
     def connection_config(self) -> ConnectionConfig:
@@ -119,7 +126,8 @@ class SandboxManager:
         config = (connection_config or ConnectionConfig()).with_transport_if_missing()
         factory = AdapterFactory(config)
         sandbox_service = factory.create_sandbox_service()
-        return cls(sandbox_service, config)
+        diagnostics_service = factory.create_diagnostics_service()
+        return cls(sandbox_service, config, diagnostics_service)
 
     async def list_sandbox_infos(self, filter: SandboxFilter) -> PagedSandboxInfos:
         """
@@ -151,6 +159,34 @@ class SandboxManager:
         """
         logger.debug(f"Getting info for sandbox: {sandbox_id}")
         return await self._sandbox_service.get_sandbox_info(sandbox_id)
+
+    async def get_diagnostic_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """
+        Get diagnostic log content for a sandbox by ID.
+
+        Args:
+            sandbox_id: Sandbox ID to retrieve diagnostics for
+            scope: Required diagnostic scope such as "container", "lifecycle", or "all".
+        """
+        return await self._diagnostics_service.get_logs(sandbox_id, scope)
+
+    async def get_diagnostic_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """
+        Get diagnostic event content for a sandbox by ID.
+
+        Args:
+            sandbox_id: Sandbox ID to retrieve diagnostics for
+            scope: Required diagnostic scope such as "runtime", "lifecycle", or "all".
+        """
+        return await self._diagnostics_service.get_events(sandbox_id, scope)
 
     async def patch_sandbox_metadata(
         self, sandbox_id: str, patch: dict[str, str | None]

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -19,6 +19,7 @@ OpenSandbox data models.
 Core Pydantic models for sandbox operations.
 """
 
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.execd import (
     CommandLogs,
     CommandStatus,
@@ -60,6 +61,7 @@ from opensandbox.models.sandboxes import (
 
 __all__ = [
     # Execution models
+    "DiagnosticContent",
     "Execution",
     "ExecutionLogs",
     "OutputMessage",

--- a/sdks/sandbox/python/src/opensandbox/models/diagnostics.py
+++ b/sdks/sandbox/python/src/opensandbox/models/diagnostics.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Diagnostic payload models."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DiagnosticContent(BaseModel):
+    """Descriptor for best-effort plain-text diagnostic content."""
+
+    sandbox_id: str = Field(alias="sandboxId")
+    kind: Literal["logs", "events"]
+    scope: str
+    delivery: Literal["inline", "url"]
+    content_type: str = Field(alias="contentType")
+    truncated: bool
+    content: str | None = None
+    content_url: str | None = Field(default=None, alias="contentUrl")
+    content_length: int | None = Field(default=None, alias="contentLength")
+    expires_at: datetime | None = Field(default=None, alias="expiresAt")
+    warnings: list[str] | None = None
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -33,6 +33,7 @@ from opensandbox.exceptions import (
     SandboxInternalException,
     SandboxReadyTimeoutException,
 )
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
     NetworkPolicy,
@@ -48,6 +49,7 @@ from opensandbox.models.sandboxes import (
 )
 from opensandbox.services import (
     Commands,
+    Diagnostics,
     Egress,
     Filesystem,
     Health,
@@ -118,6 +120,7 @@ class Sandbox:
         metrics_service: Metrics,
         egress_service: Egress,
         connection_config: ConnectionConfig,
+        diagnostics_service: Diagnostics | None = None,
         custom_health_check: Callable[["Sandbox"], Awaitable[bool]] | None = None,
     ) -> None:
         """
@@ -131,6 +134,9 @@ class Sandbox:
         self._metrics_service = metrics_service
         self._egress_service = egress_service
         self._connection_config = connection_config
+        self._diagnostics_service = diagnostics_service or AdapterFactory(
+            connection_config
+        ).create_diagnostics_service()
         self._custom_health_check = custom_health_check
 
     @property
@@ -159,6 +165,13 @@ class Sandbox:
         Allows retrieving resource usage statistics (CPU, memory) and other performance metrics.
         """
         return self._metrics_service
+
+    @property
+    def diagnostics(self) -> Diagnostics:
+        """
+        Provides access to sandbox diagnostic log and event descriptors.
+        """
+        return self._diagnostics_service
 
     @property
     def connection_config(self) -> ConnectionConfig:
@@ -223,6 +236,24 @@ class Sandbox:
             SandboxException: if metrics cannot be retrieved
         """
         return await self._metrics_service.get_metrics(self.id)
+
+    async def get_diagnostic_logs(self, scope: str) -> DiagnosticContent:
+        """
+        Get diagnostic log content for this sandbox.
+
+        Args:
+            scope: Required diagnostic scope such as "container", "lifecycle", or "all".
+        """
+        return await self._diagnostics_service.get_logs(self.id, scope)
+
+    async def get_diagnostic_events(self, scope: str) -> DiagnosticContent:
+        """
+        Get diagnostic event content for this sandbox.
+
+        Args:
+            scope: Required diagnostic scope such as "runtime", "lifecycle", or "all".
+        """
+        return await self._diagnostics_service.get_events(self.id, scope)
 
     async def renew(self, timeout: timedelta) -> SandboxRenewResponse:
         """
@@ -533,6 +564,7 @@ class Sandbox:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -629,6 +661,7 @@ class Sandbox:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -704,6 +737,7 @@ class Sandbox:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )

--- a/sdks/sandbox/python/src/opensandbox/services/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/services/__init__.py
@@ -20,6 +20,7 @@ Protocol definitions for sandbox services.
 """
 
 from opensandbox.services.command import Commands
+from opensandbox.services.diagnostics import Diagnostics
 from opensandbox.services.egress import Egress
 from opensandbox.services.filesystem import Filesystem
 from opensandbox.services.health import Health
@@ -28,6 +29,7 @@ from opensandbox.services.sandbox import Sandboxes
 
 __all__ = [
     "Commands",
+    "Diagnostics",
     "Egress",
     "Filesystem",
     "Health",

--- a/sdks/sandbox/python/src/opensandbox/services/diagnostics.py
+++ b/sdks/sandbox/python/src/opensandbox/services/diagnostics.py
@@ -1,0 +1,40 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Diagnostics service interface."""
+
+from typing import Protocol
+
+from opensandbox.models.diagnostics import DiagnosticContent
+
+
+class Diagnostics(Protocol):
+    """Sandbox diagnostics service."""
+
+    async def get_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """Get diagnostic log content descriptor."""
+        ...
+
+    async def get_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """Get diagnostic event content descriptor."""
+        ...

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/diagnostics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/diagnostics_adapter.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Synchronous diagnostics service adapter implementation."""
+
+import logging
+
+import httpx
+
+from opensandbox.adapters.converter.diagnostic_model_converter import (
+    DiagnosticModelConverter,
+)
+from opensandbox.adapters.converter.exception_converter import ExceptionConverter
+from opensandbox.adapters.converter.response_handler import (
+    handle_api_error,
+    require_parsed,
+)
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.models.diagnostics import DiagnosticContent
+from opensandbox.sync.services.diagnostics import DiagnosticsSync
+
+logger = logging.getLogger(__name__)
+
+
+class DiagnosticsAdapterSync(DiagnosticsSync):
+    """Synchronous adapter for sandbox diagnostics management API operations."""
+
+    def __init__(self, connection_config: ConnectionConfigSync) -> None:
+        self.connection_config = connection_config
+        from opensandbox.api.diagnostic import AuthenticatedClient
+
+        api_key = self.connection_config.get_api_key()
+        timeout_seconds = self.connection_config.request_timeout.total_seconds()
+        timeout = httpx.Timeout(timeout_seconds)
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": self.connection_config.user_agent,
+            **self.connection_config.headers,
+        }
+        if api_key:
+            headers["OPEN-SANDBOX-API-KEY"] = api_key
+
+        self._client = AuthenticatedClient(
+            base_url=self.connection_config.get_base_url(),
+            token=api_key or "",
+            prefix="",
+            auth_header_name="OPEN-SANDBOX-API-KEY",
+            timeout=timeout,
+        )
+        self._httpx_client = httpx.Client(
+            base_url=self.connection_config.get_base_url(),
+            headers=headers,
+            timeout=timeout,
+            transport=self.connection_config.transport,
+        )
+        self._client.set_httpx_client(self._httpx_client)
+
+    def _get_client(self):
+        return self._client
+
+    def get_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        try:
+            from opensandbox.api.diagnostic.api.diagnostics import (
+                get_sandboxes_sandbox_id_diagnostics_logs,
+            )
+            from opensandbox.api.diagnostic.models import DiagnosticContentResponse
+
+            response_obj = get_sandboxes_sandbox_id_diagnostics_logs.sync_detailed(
+                sandbox_id=sandbox_id,
+                client=self._get_client(),
+                scope=scope,
+            )
+            handle_api_error(response_obj, f"Get diagnostic logs for sandbox {sandbox_id}")
+            parsed = require_parsed(
+                response_obj,
+                DiagnosticContentResponse,
+                f"Get diagnostic logs for sandbox {sandbox_id}",
+            )
+            return DiagnosticModelConverter.to_diagnostic_content(parsed)
+        except Exception as e:
+            logger.error("Failed to get diagnostic logs for sandbox %s", sandbox_id, exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def get_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        try:
+            from opensandbox.api.diagnostic.api.diagnostics import (
+                get_sandboxes_sandbox_id_diagnostics_events,
+            )
+            from opensandbox.api.diagnostic.models import DiagnosticContentResponse
+
+            response_obj = get_sandboxes_sandbox_id_diagnostics_events.sync_detailed(
+                sandbox_id=sandbox_id,
+                client=self._get_client(),
+                scope=scope,
+            )
+            handle_api_error(response_obj, f"Get diagnostic events for sandbox {sandbox_id}")
+            parsed = require_parsed(
+                response_obj,
+                DiagnosticContentResponse,
+                f"Get diagnostic events for sandbox {sandbox_id}",
+            )
+            return DiagnosticModelConverter.to_diagnostic_content(parsed)
+        except Exception as e:
+            logger.error("Failed to get diagnostic events for sandbox %s", sandbox_id, exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/factory.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/factory.py
@@ -20,6 +20,7 @@ Synchronous service factory for creating sync adapter instances.
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
+from opensandbox.sync.adapters.diagnostics_adapter import DiagnosticsAdapterSync
 from opensandbox.sync.adapters.egress_adapter import EgressAdapterSync
 from opensandbox.sync.adapters.filesystem_adapter import FilesystemAdapterSync
 from opensandbox.sync.adapters.health_adapter import HealthAdapterSync
@@ -27,6 +28,7 @@ from opensandbox.sync.adapters.metrics_adapter import MetricsAdapterSync
 from opensandbox.sync.adapters.sandboxes_adapter import SandboxesAdapterSync
 from opensandbox.sync.services import (
     CommandsSync,
+    DiagnosticsSync,
     EgressSync,
     FilesystemSync,
     HealthSync,
@@ -41,6 +43,9 @@ class AdapterFactorySync:
 
     def create_sandbox_service(self) -> SandboxesSync:
         return SandboxesAdapterSync(self.connection_config)
+
+    def create_diagnostics_service(self) -> DiagnosticsSync:
+        return DiagnosticsAdapterSync(self.connection_config)
 
     def create_filesystem_service(self, endpoint: SandboxEndpoint) -> FilesystemSync:
         return FilesystemAdapterSync(self.connection_config, endpoint)

--- a/sdks/sandbox/python/src/opensandbox/sync/manager.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/manager.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
     PagedSandboxInfos,
@@ -33,6 +34,7 @@ from opensandbox.models.sandboxes import (
     SnapshotInfo,
 )
 from opensandbox.sync.adapters.factory import AdapterFactorySync
+from opensandbox.sync.services.diagnostics import DiagnosticsSync
 from opensandbox.sync.services.sandbox import SandboxesSync
 
 logger = logging.getLogger(__name__)
@@ -62,7 +64,10 @@ class SandboxManagerSync:
     """
 
     def __init__(
-        self, sandbox_service: SandboxesSync, connection_config: ConnectionConfigSync
+        self,
+        sandbox_service: SandboxesSync,
+        connection_config: ConnectionConfigSync,
+        diagnostics_service: DiagnosticsSync | None = None,
     ) -> None:
         """
         Internal constructor for SandboxManagerSync.
@@ -72,9 +77,13 @@ class SandboxManagerSync:
         Args:
             sandbox_service: Service for sandbox operations
             connection_config: Connection configuration (shared transport, headers, timeouts)
+            diagnostics_service: Optional service for sandbox diagnostics
         """
         self._sandbox_service = sandbox_service
         self._connection_config = connection_config
+        self._diagnostics_service = diagnostics_service or AdapterFactorySync(
+            connection_config
+        ).create_diagnostics_service()
 
     @property
     def connection_config(self) -> ConnectionConfigSync:
@@ -96,7 +105,8 @@ class SandboxManagerSync:
         config = (connection_config or ConnectionConfigSync()).with_transport_if_missing()
         factory = AdapterFactorySync(config)
         sandbox_service = factory.create_sandbox_service()
-        return cls(sandbox_service, config)
+        diagnostics_service = factory.create_diagnostics_service()
+        return cls(sandbox_service, config, diagnostics_service)
 
     def list_sandbox_infos(self, filter: SandboxFilter) -> PagedSandboxInfos:
         """
@@ -128,6 +138,34 @@ class SandboxManagerSync:
         """
         logger.debug("Getting info for sandbox: %s", sandbox_id)
         return self._sandbox_service.get_sandbox_info(sandbox_id)
+
+    def get_diagnostic_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """
+        Get diagnostic log content for a sandbox by ID.
+
+        Args:
+            sandbox_id: Sandbox ID to retrieve diagnostics for
+            scope: Required diagnostic scope such as "container", "lifecycle", or "all".
+        """
+        return self._diagnostics_service.get_logs(sandbox_id, scope)
+
+    def get_diagnostic_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """
+        Get diagnostic event content for a sandbox by ID.
+
+        Args:
+            sandbox_id: Sandbox ID to retrieve diagnostics for
+            scope: Required diagnostic scope such as "runtime", "lifecycle", or "all".
+        """
+        return self._diagnostics_service.get_events(sandbox_id, scope)
 
     def patch_sandbox_metadata(
         self, sandbox_id: str, patch: dict[str, str | None]

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -31,6 +31,7 @@ from opensandbox.exceptions import (
     SandboxInternalException,
     SandboxReadyTimeoutException,
 )
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
     NetworkPolicy,
@@ -47,6 +48,7 @@ from opensandbox.models.sandboxes import (
 from opensandbox.sync.adapters.factory import AdapterFactorySync
 from opensandbox.sync.services import (
     CommandsSync,
+    DiagnosticsSync,
     EgressSync,
     FilesystemSync,
     HealthSync,
@@ -124,6 +126,7 @@ class SandboxSync:
         metrics_service: MetricsSync,
         egress_service: EgressSync,
         connection_config: ConnectionConfigSync,
+        diagnostics_service: DiagnosticsSync | None = None,
         custom_health_check: Callable[["SandboxSync"], bool] | None = None,
     ) -> None:
         """
@@ -137,6 +140,9 @@ class SandboxSync:
         self._metrics_service = metrics_service
         self._egress_service = egress_service
         self._connection_config = connection_config
+        self._diagnostics_service = diagnostics_service or AdapterFactorySync(
+            connection_config
+        ).create_diagnostics_service()
         self._custom_health_check = custom_health_check
 
     @property
@@ -165,6 +171,13 @@ class SandboxSync:
         Allows retrieving resource usage statistics (CPU, memory) and other performance metrics.
         """
         return self._metrics_service
+
+    @property
+    def diagnostics(self) -> DiagnosticsSync:
+        """
+        Provides access to sandbox diagnostic log and event descriptors.
+        """
+        return self._diagnostics_service
 
     @property
     def connection_config(self) -> ConnectionConfigSync:
@@ -229,6 +242,24 @@ class SandboxSync:
             SandboxException: if metrics cannot be retrieved
         """
         return self._metrics_service.get_metrics(self.id)
+
+    def get_diagnostic_logs(self, scope: str) -> DiagnosticContent:
+        """
+        Get diagnostic log content for this sandbox.
+
+        Args:
+            scope: Required diagnostic scope such as "container", "lifecycle", or "all".
+        """
+        return self._diagnostics_service.get_logs(self.id, scope)
+
+    def get_diagnostic_events(self, scope: str) -> DiagnosticContent:
+        """
+        Get diagnostic event content for this sandbox.
+
+        Args:
+            scope: Required diagnostic scope such as "runtime", "lifecycle", or "all".
+        """
+        return self._diagnostics_service.get_events(self.id, scope)
 
     def renew(self, timeout: timedelta) -> SandboxRenewResponse:
         """
@@ -521,6 +552,7 @@ class SandboxSync:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -604,6 +636,7 @@ class SandboxSync:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -679,6 +712,7 @@ class SandboxSync:
                 health_service=factory.create_health_service(execd_endpoint),
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
+                diagnostics_service=factory.create_diagnostics_service(),
                 connection_config=config,
                 custom_health_check=health_check,
             )

--- a/sdks/sandbox/python/src/opensandbox/sync/services/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/__init__.py
@@ -18,6 +18,7 @@ Synchronous service interfaces (Protocols) for the sync SDK.
 """
 
 from opensandbox.sync.services.command import CommandsSync
+from opensandbox.sync.services.diagnostics import DiagnosticsSync
 from opensandbox.sync.services.egress import EgressSync
 from opensandbox.sync.services.filesystem import FilesystemSync
 from opensandbox.sync.services.health import HealthSync
@@ -26,6 +27,7 @@ from opensandbox.sync.services.sandbox import SandboxesSync
 
 __all__ = [
     "CommandsSync",
+    "DiagnosticsSync",
     "EgressSync",
     "FilesystemSync",
     "HealthSync",

--- a/sdks/sandbox/python/src/opensandbox/sync/services/diagnostics.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/diagnostics.py
@@ -1,0 +1,40 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Synchronous diagnostics service interface."""
+
+from typing import Protocol
+
+from opensandbox.models.diagnostics import DiagnosticContent
+
+
+class DiagnosticsSync(Protocol):
+    """Synchronous sandbox diagnostics service."""
+
+    def get_logs(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """Get diagnostic log content descriptor."""
+        ...
+
+    def get_events(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticContent:
+        """Get diagnostic event content descriptor."""
+        ...

--- a/sdks/sandbox/python/tests/test_diagnostics_service_adapter.py
+++ b/sdks/sandbox/python/tests/test_diagnostics_service_adapter.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from opensandbox.adapters.diagnostics_adapter import DiagnosticsAdapter
+from opensandbox.api.diagnostic.models import (
+    DiagnosticContentResponse,
+    DiagnosticContentResponseDelivery,
+    DiagnosticContentResponseKind,
+)
+from opensandbox.config import ConnectionConfig
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.sync.adapters.diagnostics_adapter import DiagnosticsAdapterSync
+
+
+class _Resp:
+    def __init__(self, *, status_code: int, parsed) -> None:
+        self.status_code = status_code
+        self.parsed = parsed
+        self.headers = {}
+
+
+def _api_diagnostic_content(kind: DiagnosticContentResponseKind) -> DiagnosticContentResponse:
+    return DiagnosticContentResponse(
+        sandbox_id="sbx-123",
+        kind=kind,
+        scope="runtime",
+        delivery=DiagnosticContentResponseDelivery.INLINE,
+        content_type="text/plain; charset=utf-8",
+        truncated=False,
+        content="diagnostic line",
+        expires_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        warnings=["partial"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_diagnostics_adapter_maps_logs_request_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {}
+
+    async def _fake_asyncio_detailed(*, sandbox_id, client, scope):
+        called["sandbox_id"] = sandbox_id
+        called["client"] = client
+        called["scope"] = scope
+        return _Resp(
+            status_code=200,
+            parsed=_api_diagnostic_content(DiagnosticContentResponseKind.LOGS),
+        )
+
+    monkeypatch.setattr(
+        "opensandbox.api.diagnostic.api.diagnostics."
+        "get_sandboxes_sandbox_id_diagnostics_logs.asyncio_detailed",
+        _fake_asyncio_detailed,
+    )
+
+    adapter = DiagnosticsAdapter(ConnectionConfig(domain="example.com:8080", api_key="k"))
+    out = await adapter.get_logs("sbx-123", scope="runtime")
+
+    assert called["sandbox_id"] == "sbx-123"
+    assert called["scope"] == "runtime"
+    assert out.kind == "logs"
+    assert out.scope == "runtime"
+    assert out.content == "diagnostic line"
+    assert out.warnings == ["partial"]
+
+
+def test_sync_diagnostics_adapter_maps_events_request_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {}
+
+    def _fake_sync_detailed(*, sandbox_id, client, scope):
+        called["sandbox_id"] = sandbox_id
+        called["client"] = client
+        called["scope"] = scope
+        return _Resp(
+            status_code=200,
+            parsed=_api_diagnostic_content(DiagnosticContentResponseKind.EVENTS),
+        )
+
+    monkeypatch.setattr(
+        "opensandbox.api.diagnostic.api.diagnostics."
+        "get_sandboxes_sandbox_id_diagnostics_events.sync_detailed",
+        _fake_sync_detailed,
+    )
+
+    adapter = DiagnosticsAdapterSync(
+        ConnectionConfigSync(domain="example.com:8080", api_key="k")
+    )
+    out = adapter.get_events("sbx-123", scope="runtime")
+
+    assert called["sandbox_id"] == "sbx-123"
+    assert called["scope"] == "runtime"
+    assert out.kind == "events"
+    assert out.scope == "runtime"
+    assert out.content == "diagnostic line"

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -24,6 +24,7 @@ import pytest
 from opensandbox.config import ConnectionConfig
 from opensandbox.constants import DEFAULT_EGRESS_PORT, DEFAULT_EXECD_PORT
 from opensandbox.exceptions import SandboxReadyTimeoutException
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import NetworkPolicy, NetworkRule, SandboxEndpoint
 from opensandbox.sandbox import Sandbox
 
@@ -71,10 +72,40 @@ class _EgressServiceStub:
         self.patch_calls.append(rules)
 
 
+class _DiagnosticsServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, str | None]] = []
+
+    async def get_logs(self, sandbox_id: str, scope: str) -> DiagnosticContent:
+        self.calls.append(("logs", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="logs",
+            scope=scope or "container",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="log line",
+            truncated=False,
+        )
+
+    async def get_events(self, sandbox_id: str, scope: str) -> DiagnosticContent:
+        self.calls.append(("events", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="events",
+            scope=scope or "runtime",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="event line",
+            truncated=False,
+        )
+
+
 def _make_sandbox(
     *,
     health_service,
     sandbox_service,
+    diagnostics_service=None,
     custom_health_check=None,
     connection_config: ConnectionConfig | None = None,
 ) -> Sandbox:
@@ -86,6 +117,7 @@ def _make_sandbox(
         health_service=health_service,
         metrics_service=_Noop(),
         egress_service=_EgressServiceStub(),
+        diagnostics_service=diagnostics_service or _DiagnosticsServiceStub(),
         connection_config=connection_config or ConnectionConfig(),
         custom_health_check=custom_health_check,
     )
@@ -207,6 +239,7 @@ async def test_patch_egress_rules_uses_injected_egress_service(
         health_service=_HealthServiceStub(),
         metrics_service=_Noop(),
         egress_service=egress_service,
+        diagnostics_service=_DiagnosticsServiceStub(),
         connection_config=ConnectionConfig(use_server_proxy=False),
     )
     rules = [NetworkRule(action="allow", target="www.github.com")]
@@ -215,6 +248,26 @@ async def test_patch_egress_rules_uses_injected_egress_service(
 
     assert svc.endpoint_calls == []
     assert egress_service.patch_calls == [rules]
+
+
+@pytest.mark.asyncio
+async def test_get_diagnostics_uses_injected_diagnostics_service() -> None:
+    diagnostics_service = _DiagnosticsServiceStub()
+    sbx = _make_sandbox(
+        health_service=_HealthServiceStub(),
+        sandbox_service=_SandboxServiceStub(),
+        diagnostics_service=diagnostics_service,
+    )
+
+    logs = await sbx.get_diagnostic_logs(scope="container")
+    events = await sbx.diagnostics.get_events(sbx.id, scope="runtime")
+
+    assert logs.kind == "logs"
+    assert events.kind == "events"
+    assert diagnostics_service.calls == [
+        ("logs", sbx.id, "container"),
+        ("events", sbx.id, "runtime"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -263,6 +316,9 @@ async def test_create_resolves_egress_endpoint_and_builds_service(
         def create_egress_service(self, endpoint: SandboxEndpoint) -> _EgressServiceStub:
             factory_calls.append(endpoint)
             return egress_service
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
 
     sandbox_service = _SandboxServiceCreateStub()
     monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
@@ -385,6 +441,9 @@ async def test_create_preserves_manual_cleanup_timeout(
         def create_egress_service(self, _endpoint: SandboxEndpoint):
             return _EgressServiceStub()
 
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
     sandbox_service = _SandboxServiceCreateStub()
     monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
 
@@ -467,6 +526,9 @@ async def test_create_passes_new_signature_keywords_even_when_unused(
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
 
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
     monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
     await Sandbox.create(
         "python:3.11",
@@ -547,6 +609,9 @@ async def test_create_restore_from_snapshot_passes_snapshot_id(
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
 
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
     monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
     await Sandbox.create(snapshot_id="snap-123", skip_health_check=True)
 
@@ -615,6 +680,9 @@ async def test_create_restore_from_snapshot_preserves_custom_entrypoint(
 
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
 
     monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
     await Sandbox.create(

--- a/sdks/sandbox/python/tests/test_sandbox_close_and_connect_validation.py
+++ b/sdks/sandbox/python/tests/test_sandbox_close_and_connect_validation.py
@@ -60,6 +60,7 @@ async def test_sandbox_close_does_not_close_user_transport() -> None:
         health_service=_NoopService(),
         metrics_service=_NoopService(),
         egress_service=_NoopEgressService(),
+        diagnostics_service=_NoopService(),
         connection_config=cfg,
         custom_health_check=None,
     )

--- a/sdks/sandbox/python/tests/test_sandbox_manager_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_manager_business_logic.py
@@ -23,6 +23,7 @@ import pytest
 
 from opensandbox.config import ConnectionConfig
 from opensandbox.manager import SandboxManager
+from opensandbox.models.diagnostics import DiagnosticContent
 
 
 class _SandboxServiceStub:
@@ -63,6 +64,35 @@ class _SandboxServiceStub:
 
     async def delete_snapshot(self, snapshot_id):
         self.snapshot_calls.append(("delete", snapshot_id))
+
+
+class _DiagnosticsServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, str | None]] = []
+
+    async def get_logs(self, sandbox_id, scope) -> DiagnosticContent:
+        self.calls.append(("logs", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="logs",
+            scope=scope or "container",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="log line",
+            truncated=False,
+        )
+
+    async def get_events(self, sandbox_id, scope) -> DiagnosticContent:
+        self.calls.append(("events", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="events",
+            scope=scope or "runtime",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="event line",
+            truncated=False,
+        )
 
 
 @pytest.mark.asyncio
@@ -114,3 +144,23 @@ async def test_manager_snapshot_methods_delegate() -> None:
     assert svc.snapshot_calls[0] == ("create", ("sbx-1", "before-upgrade"))
     assert svc.snapshot_calls[1] == ("get", "snap-1")
     assert svc.snapshot_calls[3] == ("delete", "snap-1")
+
+
+@pytest.mark.asyncio
+async def test_manager_diagnostic_methods_delegate_by_sandbox_id() -> None:
+    diagnostics_service = _DiagnosticsServiceStub()
+    mgr = SandboxManager(
+        _SandboxServiceStub(),
+        ConnectionConfig(),
+        diagnostics_service=diagnostics_service,
+    )
+
+    logs = await mgr.get_diagnostic_logs("sbx-1", scope="container")
+    events = await mgr.get_diagnostic_events("sbx-1", scope="runtime")
+
+    assert logs.kind == "logs"
+    assert events.kind == "events"
+    assert diagnostics_service.calls == [
+        ("logs", "sbx-1", "container"),
+        ("events", "sbx-1", "runtime"),
+    ]

--- a/sdks/sandbox/python/tests/test_sandbox_manager_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_manager_sync_business_logic.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 import httpx
 
 from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.sync.manager import SandboxManagerSync
 
 
@@ -61,6 +62,35 @@ class _SandboxServiceStub:
 
     def delete_snapshot(self, snapshot_id):
         self.snapshot_calls.append(("delete", snapshot_id))
+
+
+class _DiagnosticsServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, str | None]] = []
+
+    def get_logs(self, sandbox_id, scope) -> DiagnosticContent:
+        self.calls.append(("logs", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="logs",
+            scope=scope or "container",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="log line",
+            truncated=False,
+        )
+
+    def get_events(self, sandbox_id, scope) -> DiagnosticContent:
+        self.calls.append(("events", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="events",
+            scope=scope or "runtime",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="event line",
+            truncated=False,
+        )
 
 
 def test_sync_manager_renew_uses_utc_datetime() -> None:
@@ -109,3 +139,22 @@ def test_sync_manager_snapshot_methods_delegate() -> None:
     assert svc.snapshot_calls[0] == ("create", ("sbx-1", "before-upgrade"))
     assert svc.snapshot_calls[1] == ("get", "snap-1")
     assert svc.snapshot_calls[3] == ("delete", "snap-1")
+
+
+def test_sync_manager_diagnostic_methods_delegate_by_sandbox_id() -> None:
+    diagnostics_service = _DiagnosticsServiceStub()
+    mgr = SandboxManagerSync(
+        _SandboxServiceStub(),
+        ConnectionConfigSync(),
+        diagnostics_service=diagnostics_service,
+    )
+
+    logs = mgr.get_diagnostic_logs("sbx-1", scope="container")
+    events = mgr.get_diagnostic_events("sbx-1", scope="runtime")
+
+    assert logs.kind == "logs"
+    assert events.kind == "events"
+    assert diagnostics_service.calls == [
+        ("logs", "sbx-1", "container"),
+        ("events", "sbx-1", "runtime"),
+    ]

--- a/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
@@ -23,6 +23,7 @@ import pytest
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.constants import DEFAULT_EGRESS_PORT, DEFAULT_EXECD_PORT
 from opensandbox.exceptions import SandboxReadyTimeoutException
+from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import NetworkPolicy, NetworkRule, SandboxEndpoint
 from opensandbox.sync.sandbox import SandboxSync
 
@@ -54,6 +55,35 @@ class _EgressServiceStub:
         self.patch_calls.append(rules)
 
 
+class _DiagnosticsServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, str | None]] = []
+
+    def get_logs(self, sandbox_id: str, scope: str) -> DiagnosticContent:
+        self.calls.append(("logs", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="logs",
+            scope=scope or "container",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="log line",
+            truncated=False,
+        )
+
+    def get_events(self, sandbox_id: str, scope: str) -> DiagnosticContent:
+        self.calls.append(("events", sandbox_id, scope))
+        return DiagnosticContent(
+            sandboxId=sandbox_id,
+            kind="events",
+            scope=scope or "runtime",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="event line",
+            truncated=False,
+        )
+
+
 def test_sync_check_ready_timeout_message_includes_troubleshooting_hints() -> None:
     def _always_false(_: SandboxSync) -> bool:
         return False
@@ -66,6 +96,7 @@ def test_sync_check_ready_timeout_message_includes_troubleshooting_hints() -> No
         health_service=_Noop(),
         metrics_service=_Noop(),
         egress_service=_EgressServiceStub(),
+        diagnostics_service=_DiagnosticsServiceStub(),
         connection_config=ConnectionConfigSync(
             domain="10.0.0.2:8080",
             use_server_proxy=False,
@@ -90,6 +121,7 @@ def test_sync_get_egress_policy_uses_injected_egress_service() -> None:
         health_service=_Noop(),
         metrics_service=_Noop(),
         egress_service=_EgressServiceStub(),
+        diagnostics_service=_DiagnosticsServiceStub(),
         connection_config=ConnectionConfigSync(use_server_proxy=True),
     )
 
@@ -112,6 +144,7 @@ def test_sync_patch_egress_rules_uses_injected_egress_service() -> None:
         health_service=_Noop(),
         metrics_service=_Noop(),
         egress_service=egress_service,
+        diagnostics_service=_DiagnosticsServiceStub(),
         connection_config=ConnectionConfigSync(use_server_proxy=False),
     )
     rules = [NetworkRule(action="allow", target="www.github.com")]
@@ -120,6 +153,31 @@ def test_sync_patch_egress_rules_uses_injected_egress_service() -> None:
 
     assert svc.endpoint_calls == []
     assert egress_service.patch_calls == [rules]
+
+
+def test_sync_get_diagnostics_uses_injected_diagnostics_service() -> None:
+    diagnostics_service = _DiagnosticsServiceStub()
+    sbx = SandboxSync(
+        sandbox_id=str(uuid4()),
+        sandbox_service=_SandboxServiceStub(),
+        filesystem_service=_Noop(),
+        command_service=_Noop(),
+        health_service=_Noop(),
+        metrics_service=_Noop(),
+        egress_service=_EgressServiceStub(),
+        diagnostics_service=diagnostics_service,
+        connection_config=ConnectionConfigSync(use_server_proxy=True),
+    )
+
+    logs = sbx.get_diagnostic_logs(scope="container")
+    events = sbx.diagnostics.get_events(sbx.id, scope="runtime")
+
+    assert logs.kind == "logs"
+    assert events.kind == "events"
+    assert diagnostics_service.calls == [
+        ("logs", sbx.id, "container"),
+        ("events", sbx.id, "runtime"),
+    ]
 
 
 def test_sync_create_resolves_egress_endpoint_and_builds_service(
@@ -167,6 +225,9 @@ def test_sync_create_resolves_egress_endpoint_and_builds_service(
         def create_egress_service(self, endpoint: SandboxEndpoint) -> _EgressServiceStub:
             factory_calls.append(endpoint)
             return egress_service
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
 
     sandbox_service = _SandboxServiceCreateStub()
     monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
@@ -254,6 +315,9 @@ def test_sync_create_passes_new_signature_keywords_even_when_unused(
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
 
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
     monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
     SandboxSync.create(
         "python:3.11",
@@ -308,6 +372,9 @@ def test_sync_create_preserves_manual_cleanup_timeout(
 
         def create_egress_service(self, _endpoint: SandboxEndpoint):
             return _EgressServiceStub()
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
 
     sandbox_service = _SandboxServiceCreateStub()
     monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
@@ -390,6 +457,9 @@ def test_sync_create_restore_from_snapshot_passes_snapshot_id(
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
 
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
     monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
     SandboxSync.create(snapshot_id="snap-123", skip_health_check=True)
 
@@ -457,6 +527,9 @@ def test_sync_create_restore_from_snapshot_preserves_custom_entrypoint(
 
         def create_egress_service(self, _endpoint):
             return _EgressServiceStub()
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
 
     monkeypatch.setattr("opensandbox.sync.sandbox.AdapterFactorySync", _FactoryStub)
     SandboxSync.create(

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -15,14 +15,17 @@
 """
 API routes for OpenSandbox DevOps diagnostics.
 
-All endpoints return plain text for easy consumption by humans and AI agents.
+Requests that include `scope` target the stable Diagnostics API. The open-source
+server has not implemented that API yet, so these requests return a uniform
+not-implemented error. Requests without `scope` preserve the deprecated DevOps
+plain-text behavior for legacy humans, agents, and CLI clients.
 """
 
 import logging
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query, status
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from opensandbox_server.api.lifecycle import sandbox_service
 
@@ -30,29 +33,70 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["DevOps"])
 
 
+def _diagnostics_not_implemented_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={
+            "code": "DIAGNOSTICS_NOT_IMPLEMENTED",
+            "message": "The stable Diagnostics API is not implemented by this OpenSandbox server.",
+        },
+    )
+
+
+def _deprecated_plain_text_response(content: str) -> PlainTextResponse:
+    return PlainTextResponse(
+        content=content,
+        headers={"Deprecation": "true"},
+    )
+
+
 @router.get(
     "/sandboxes/{sandbox_id}/diagnostics/logs",
-    response_class=PlainTextResponse,
+    response_model=None,
     status_code=status.HTTP_200_OK,
     responses={
-        200: {"description": "Container logs as plain text", "content": {"text/plain": {}}},
+        200: {
+            "description": "Deprecated plain-text logs when scope is omitted",
+            "content": {"text/plain": {}},
+        },
+        501: {
+            "description": "Stable Diagnostics API is not implemented by this server",
+            "content": {"application/json": {}},
+        },
         404: {"description": "Sandbox not found"},
     },
 )
 def get_sandbox_logs(
     sandbox_id: str,
-    tail: int = Query(100, ge=1, le=10000, description="Number of trailing log lines"),
-    since: Optional[str] = Query(None, description="Only return logs newer than this duration (e.g. 10m, 1h)"),
-) -> PlainTextResponse:
-    """Retrieve container logs for a sandbox."""
+    scope: Optional[str] = Query(
+        None,
+        description="Required for stable Diagnostics JSON responses. Omit only for deprecated plain-text logs.",
+    ),
+    tail: int = Query(
+        100,
+        ge=1,
+        le=10000,
+        deprecated=True,
+        description="Deprecated plain-text logs only. Number of trailing log lines.",
+    ),
+    since: Optional[str] = Query(
+        None,
+        deprecated=True,
+        description="Deprecated plain-text logs only. Only return logs newer than this duration (e.g. 10m, 1h).",
+    ),
+) -> JSONResponse | PlainTextResponse:
+    """Retrieve diagnostic logs for a sandbox."""
+    if scope is not None:
+        return _diagnostics_not_implemented_response()
     text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since)
-    return PlainTextResponse(content=text)
+    return _deprecated_plain_text_response(text)
 
 
 @router.get(
     "/sandboxes/{sandbox_id}/diagnostics/inspect",
     response_class=PlainTextResponse,
     status_code=status.HTTP_200_OK,
+    deprecated=True,
     responses={
         200: {"description": "Container inspection as plain text", "content": {"text/plain": {}}},
         404: {"description": "Sandbox not found"},
@@ -66,26 +110,46 @@ def get_sandbox_inspect(sandbox_id: str) -> PlainTextResponse:
 
 @router.get(
     "/sandboxes/{sandbox_id}/diagnostics/events",
-    response_class=PlainTextResponse,
+    response_model=None,
     status_code=status.HTTP_200_OK,
     responses={
-        200: {"description": "Sandbox events as plain text", "content": {"text/plain": {}}},
+        200: {
+            "description": "Deprecated plain-text events when scope is omitted",
+            "content": {"text/plain": {}},
+        },
+        501: {
+            "description": "Stable Diagnostics API is not implemented by this server",
+            "content": {"application/json": {}},
+        },
         404: {"description": "Sandbox not found"},
     },
 )
 def get_sandbox_events(
     sandbox_id: str,
-    limit: int = Query(50, ge=1, le=500, description="Maximum number of events to return"),
-) -> PlainTextResponse:
-    """Retrieve events related to a sandbox."""
+    scope: Optional[str] = Query(
+        None,
+        description="Required for stable Diagnostics JSON responses. Omit only for deprecated plain-text events.",
+    ),
+    limit: int = Query(
+        50,
+        ge=1,
+        le=500,
+        deprecated=True,
+        description="Deprecated plain-text events only. Maximum number of events to return.",
+    ),
+) -> JSONResponse | PlainTextResponse:
+    """Retrieve diagnostic events for a sandbox."""
+    if scope is not None:
+        return _diagnostics_not_implemented_response()
     text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)
-    return PlainTextResponse(content=text)
+    return _deprecated_plain_text_response(text)
 
 
 @router.get(
     "/sandboxes/{sandbox_id}/diagnostics/summary",
     response_class=PlainTextResponse,
     status_code=status.HTTP_200_OK,
+    deprecated=True,
     responses={
         200: {"description": "Combined diagnostics summary as plain text", "content": {"text/plain": {}}},
         404: {"description": "Sandbox not found"},

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -17,6 +17,76 @@ from fastapi.testclient import TestClient
 from opensandbox_server.api import devops
 
 
+def test_diagnostics_logs_with_scope_returns_not_implemented(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(sandbox_id: str, tail: int, since: str | None = None) -> str:
+            raise AssertionError("stable diagnostics requests must not call legacy logs")
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/logs?scope=container",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 501
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["code"] == "DIAGNOSTICS_NOT_IMPLEMENTED"
+
+
+def test_diagnostics_logs_without_scope_preserves_deprecated_plain_text(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(sandbox_id: str, tail: int, since: str | None = None) -> str:
+            assert sandbox_id == "sbx-001"
+            assert tail == 25
+            assert since == "5m"
+            return "legacy logs"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/logs?tail=25&since=5m",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.headers["deprecation"] == "true"
+    assert response.text == "legacy logs"
+
+
+def test_diagnostics_events_with_scope_returns_not_implemented(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            raise AssertionError("stable diagnostics requests must not call legacy events")
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=runtime",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 501
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["code"] == "DIAGNOSTICS_NOT_IMPLEMENTED"
+
+
 def test_diagnostics_summary_redacts_unexpected_exception_details(
     client: TestClient,
     auth_headers: dict,

--- a/specs/diagnostic-api.yml
+++ b/specs/diagnostic-api.yml
@@ -108,6 +108,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
   /sandboxes/{sandboxId}/diagnostics/events:
     get:
       tags: [Diagnostics]
@@ -175,6 +177,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 components:
   securitySchemes:
     apiKeyAuth:
@@ -196,12 +200,15 @@ components:
     DiagnosticScope:
       name: scope
       in: query
-      required: false
+      required: true
       description: |
-        Optional diagnostic scope selector. Known scopes may include `container`,
+        Required diagnostic scope selector. Known scopes may include `container`,
         `lifecycle`, `runtime`, `network`, `process`, and `all`. Supported scopes
-        and defaults are implementation-defined; servers may add new scopes over
-        time.
+        are implementation-defined; servers may add new scopes over time.
+
+        On deployments that still expose the legacy DevOps plain-text behavior on
+        this path, requests without `scope` are treated as deprecated legacy
+        requests and may return `text/plain` instead of this JSON descriptor.
       schema:
         type: string
       examples:
@@ -259,6 +266,15 @@ components:
           $ref: '#/components/headers/XRequestId'
     InternalServerError:
       description: An unexpected server error occurred
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/XRequestId'
+    NotImplemented:
+      description: The stable Diagnostics API is not implemented by this server
       content:
         application/json:
           schema:


### PR DESCRIPTION
# Summary
- Add stable Diagnostics API support to the sandbox Python SDK, including generated diagnostic client bindings, handwritten adapters/converters, async and sync services, and `Sandbox` / `SandboxManager` convenience methods for diagnostic logs and events.
- Add matching Diagnostics support to the Kotlin sandbox SDK, including domain models, service adapter, converter, factory wiring, and `Sandbox` / `SandboxManager` APIs.
- Expose stable CLI commands: `osb diagnostics logs` and `osb diagnostics events`, implemented as thin wrappers over the Python SDK manager diagnostics methods.
- Make `scope` required for the stable Diagnostics API. In the current open-source server, requests with `scope` return a uniform `DIAGNOSTICS_NOT_IMPLEMENTED` error until the stable backend implementation is added; requests without `scope` preserve the deprecated legacy DevOps plain-text behavior.
- Keep legacy `osb devops logs/events` as deprecated compatibility wrappers over the old plain-text flow, preserving `--tail`, `--since`, and `--limit` behavior with migration warnings.
- Update the bundled troubleshooting skill and CLI docs to prefer the new diagnostics API, explain supported diagnostic scopes, evidence semantics, URL delivery, truncation, warnings, and the current not-implemented server response.
- Remove legacy `devops inspect` / `devops summary` guidance from bundled skills so agent troubleshooting flows use the stable diagnostics API only.
- Bump release metadata: Python sandbox SDK `0.1.9`, Kotlin sandbox SDK `1.0.11`, CLI `0.1.1`.

# API / CLI Notes
- Python SDK adds `get_diagnostic_logs` and `get_diagnostic_events` on both `Sandbox` and `SandboxManager`, with async and sync variants. `scope` is required.
- Kotlin SDK adds `getDiagnosticLogs` and `getDiagnosticEvents` on both `Sandbox` and `SandboxManager`. `scope` is required.
- Server diagnostics currently distinguishes new vs legacy behavior by query shape: `scope=...` returns `501 DIAGNOSTICS_NOT_IMPLEMENTED`; no `scope` returns deprecated `text/plain` for existing DevOps clients.
- CLI supports `table`, `json`, `yaml`, and `raw` output for stable diagnostics once a server implements the JSON descriptor response. `raw` prints inline diagnostic text, or `contentUrl` for URL-delivered diagnostics.
- `devops inspect/summary` remain experimental legacy commands for direct CLI compatibility, but bundled skills no longer reference them. Agent-facing troubleshooting should stop diagnostics collection on `DIAGNOSTICS_NOT_IMPLEMENTED` instead of falling back to legacy DevOps APIs.
- `devops logs/events` remain available but deprecated in favor of `diagnostics logs/events`.

# Testing
- [x] CLI lint/type checks: `uv run --frozen ruff check`, `uv run --frozen pyright`
- [x] Focused CLI tests for diagnostics help, commands, and skill alignment
- [x] Server lint and focused DevOps/diagnostics route tests
- [x] Python SDK lint/type checks and focused diagnostics tests
- [x] Kotlin SDK focused diagnostics, sandbox, and manager tests
- [ ] Full cross-language e2e not run locally

# Breaking Changes
- [x] None for existing legacy DevOps clients. Requests without `scope` keep the old plain-text behavior and legacy filter parameters.
- Stable Diagnostics SDK/CLI calls require `scope`; the current open-source server returns a clear not-implemented error until the stable backend implementation exists.

# Checklist
- [x] Added/updated docs and bundled troubleshooting skill
- [x] Added/updated tests for server, SDK, and CLI behavior
- [x] Backward compatibility considered for legacy DevOps commands
- [x] Security impact considered for diagnostic URL delivery and sensitive troubleshooting output
