### PR TITLE
fix(egress): decouple DNS-resolved nft ops from signal context

### DIFF
--- a/components/egress/nft.go
+++ b/components/egress/nft.go
@@ -19,6 +19,7 @@ import (
 	"net/netip"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/dnsproxy"
@@ -51,7 +52,9 @@ func setupNft(ctx context.Context, nftMgr nftApplier, initialPolicy *policy.Netw
 	}
 	log.Infof("nftables static policy applied (table inet opensandbox); DNS-resolved IPs will be added to dynamic allow sets")
 	proxy.SetOnResolved(func(domain string, ips []nftables.ResolvedIP) {
-		if err := nftMgr.AddResolvedIPs(ctx, ips); err != nil {
+		addCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := nftMgr.AddResolvedIPs(addCtx, ips); err != nil {
 			log.Warnf("[dns] add resolved IPs to nft failed for domain %q: %v", domain, err)
 		}
 	})

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -280,7 +280,9 @@ func (s *policyServer) commitPolicy(ctx context.Context, w http.ResponseWriter, 
 	alwaysDeny, alwaysAllow := s.currentAlwaysRules()
 	merged := policy.MergeAlwaysOverlay(pol, alwaysDeny, alwaysAllow)
 	if s.nft != nil {
-		if err := s.nft.ApplyStatic(ctx, merged.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
+		nftCtx, nftCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer nftCancel()
+		if err := s.nft.ApplyStatic(nftCtx, merged.WithExtraAllowIPs(s.nameserverIPs)); err != nil {
 			logEgressUpdateFailedError(fmt.Sprintf("nftables apply (%s): %v", op, err))
 			log.Errorf("policy API: nftables apply failed (%s): %v", op, err)
 			http.Error(w, fmt.Sprintf("failed to apply nftables policy: %v", err), http.StatusInternalServerError)

--- a/components/egress/shutdown.go
+++ b/components/egress/shutdown.go
@@ -46,6 +46,9 @@ func waitForShutdown(ctx context.Context, proxy *dnsproxy.Proxy, policySrv *http
 			log.Errorf("policy server shutdown error: %v", err)
 		}
 	}
+
+	proxy.SetOnResolved(nil)
+
 	if err := proxy.Shutdown(); err != nil {
 		log.Errorf("dns proxy shutdown error: %v", err)
 	}
@@ -54,8 +57,6 @@ func waitForShutdown(ctx context.Context, proxy *dnsproxy.Proxy, policySrv *http
 		iptables.RemoveTransparentHTTP(mitm.port, mitm.uid)
 		mitmproxy.GracefulShutdown(mitm.getRunning(), defaultMitmShutdownTimeout)
 	}
-
-	proxy.SetOnResolved(nil)
 	iptables.RemoveRedirect(15353, exemptDst)
 
 	if applier != nil {


### PR DESCRIPTION
# Summary
`onResolved` closure captured the signal context, causing every DNS- triggered AddResolvedIPs call to fail with "context canceled" once SIGTERM arrived — even when shutdown hung and the process stayed alive.

- nft.go: use context.WithTimeout(Background, 5s) in onResolved instead of the captured signal context
- shutdown.go: clear onResolved callback before proxy.Shutdown() to close the race window with in-flight DNS handlers
- policy_server.go: use detached Background context (30s timeout) for ApplyStatic instead of r.Context(), so a disconnected HTTP client cannot kill nft mid-script and corrupt nftables state

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered