### PR TITLE
Feautre/minor updates 20260512

### DIFF
--- a/sdks/code-interpreter/kotlin/gradle.properties
+++ b/sdks/code-interpreter/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.9
+project.version=1.0.11
 project.description=A Kotlin SDK for Code Interpreter

--- a/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
+++ b/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 jackson = "2.18.2"
-sandbox = "1.0.9"
+sandbox = "1.0.11"
 junit-platform = "1.13.4"
 
 [libraries]

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconciler.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconciler.kt
@@ -122,13 +122,17 @@ internal object PoolReconciler {
             }
 
         val createdSandboxIds = mutableListOf<String>()
+        var failureCount = 0
+        var lastError: String? = null
         for ((newId, errorMessage) in results) {
             if (newId != null) {
                 createdSandboxIds += newId
             } else {
-                reconcileState.recordFailure(errorMessage)
+                failureCount++
+                lastError = errorMessage
             }
         }
+        reconcileState.recordFailures(failureCount, lastError)
 
         var created = 0
         for (index in createdSandboxIds.indices) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -58,7 +58,16 @@ internal class ReconcileState(
 
     @Synchronized
     fun recordFailure(errorMessage: String?) {
-        failureCount++
+        recordFailures(1, errorMessage)
+    }
+
+    @Synchronized
+    fun recordFailures(
+        count: Int,
+        errorMessage: String?,
+    ) {
+        if (count <= 0) return
+        failureCount += count
         lastError = errorMessage
         if (failureCount >= degradedThreshold) {
             state = PoolState.DEGRADED

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -27,7 +27,7 @@ import java.time.Instant
  */
 internal class ReconcileState(
     private val degradedThreshold: Int,
-    private val backoffBase: Duration = Duration.ofSeconds(1),
+    private val backoffBase: Duration = Duration.ofSeconds(30),
     private val backoffMax: Duration = Duration.ofDays(1),
 ) {
     @Volatile
@@ -63,7 +63,7 @@ internal class ReconcileState(
         if (failureCount >= degradedThreshold) {
             state = PoolState.DEGRADED
             backoffAttempts++
-            val exponent = backoffAttempts.coerceAtMost(30)
+            val exponent = (backoffAttempts - 1).coerceAtMost(30)
             val delaySeconds = backoffBase.seconds * (1L shl exponent)
             val delayMs =
                 minOf(

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -57,6 +57,16 @@ class PoolReconcilerStateTest {
     }
 
     @Test
+    fun `default degraded backoff starts at thirty seconds`() {
+        val state = ReconcileState(degradedThreshold = 1)
+
+        state.recordFailure("boom")
+
+        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(29))))
+        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(31))))
+    }
+
+    @Test
     fun `reconcile create exception increments failure count once per task`() {
         val stateStore = InMemoryPoolStateStore()
         val config =

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -67,6 +67,39 @@ class PoolReconcilerStateTest {
     }
 
     @Test
+    fun `reconcile batch failures only advance backoff once`() {
+        val stateStore = InMemoryPoolStateStore()
+        val config =
+            PoolConfig.builder()
+                .poolName("pool-batch-failure-test")
+                .ownerId("owner-1")
+                .maxIdle(10)
+                .warmupConcurrency(10)
+                .stateStore(stateStore)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .build()
+        val state = ReconcileState(degradedThreshold = 3)
+        val warmupExecutor = Executors.newFixedThreadPool(10)
+
+        try {
+            PoolReconciler.runReconcileTick(
+                config = config,
+                stateStore = stateStore,
+                createOne = { throw RuntimeException("boom") },
+                reconcileState = state,
+                warmupExecutor = warmupExecutor,
+            )
+        } finally {
+            warmupExecutor.shutdownNow()
+        }
+
+        assertEquals(10, state.failureCount)
+        assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(29))))
+        assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(31))))
+    }
+
+    @Test
     fun `reconcile create exception increments failure count once per task`() {
         val stateStore = InMemoryPoolStateStore()
         val config =

--- a/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
@@ -87,13 +87,18 @@ async def _run_primary_replenish_once(
         return_exceptions=True,
     )
     created_ids: list[str] = []
+    failure_count = 0
+    last_error: str | None = None
     for result in results:
         if isinstance(result, BaseException):
-            reconcile_state.record_failure(str(result))
+            failure_count += 1
+            last_error = str(result)
         elif result is not None:
             created_ids.append(result)
         else:
-            reconcile_state.record_failure(None)
+            failure_count += 1
+            last_error = None
+    reconcile_state.record_failures(failure_count, last_error)
 
     created = 0
     for index, sandbox_id in enumerate(created_ids):

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ReconcileState:
     degraded_threshold: int
-    backoff_base: timedelta = timedelta(seconds=1)
+    backoff_base: timedelta = timedelta(seconds=30)
     backoff_max: timedelta = timedelta(days=1)
     failure_count: int = 0
     state: PoolState = PoolState.HEALTHY
@@ -53,7 +53,7 @@ class ReconcileState:
         if self.failure_count >= self.degraded_threshold:
             self.state = PoolState.DEGRADED
             self.backoff_attempts += 1
-            exponent = min(self.backoff_attempts, 30)
+            exponent = min(self.backoff_attempts - 1, 30)
             delay = min(
                 self.backoff_base.total_seconds() * (1 << exponent),
                 self.backoff_max.total_seconds(),

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -48,7 +48,12 @@ class ReconcileState:
         self.last_error = None
 
     def record_failure(self, error_message: str | None) -> None:
-        self.failure_count += 1
+        self.record_failures(1, error_message)
+
+    def record_failures(self, count: int, error_message: str | None) -> None:
+        if count <= 0:
+            return
+        self.failure_count += count
         self.last_error = error_message
         if self.failure_count >= self.degraded_threshold:
             self.state = PoolState.DEGRADED
@@ -127,15 +132,20 @@ def _run_primary_replenish_once(
     futures = [warmup_executor.submit(create_one) for _ in range(to_create)]
     wait(futures)
     created_ids: list[str] = []
+    failure_count = 0
+    last_error: str | None = None
     for future in futures:
         try:
             sandbox_id = future.result()
             if sandbox_id is not None:
                 created_ids.append(sandbox_id)
             else:
-                reconcile_state.record_failure(None)
+                failure_count += 1
+                last_error = None
         except Exception as exc:
-            reconcile_state.record_failure(str(exc))
+            failure_count += 1
+            last_error = str(exc)
+    reconcile_state.record_failures(failure_count, last_error)
 
     created = 0
     for index, sandbox_id in enumerate(created_ids):

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_events.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_events.py
@@ -24,7 +24,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.diagnostic_content_response import DiagnosticContentResponse
 from ...models.error_response import ErrorResponse
-from ...types import Response
+from ...types import UNSET, Response
 
 
 def _get_kwargs(
@@ -36,7 +36,7 @@ def _get_kwargs(
 
     params["scope"] = scope
 
-    params = {k: v for k, v in params.items() if v is not None}
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -129,7 +129,7 @@ def sync_detailed(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -176,7 +176,7 @@ def sync(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -218,7 +218,7 @@ async def asyncio_detailed(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -263,7 +263,7 @@ async def asyncio(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_logs.py
+++ b/sdks/sandbox/python/src/opensandbox/api/diagnostic/api/diagnostics/get_sandboxes_sandbox_id_diagnostics_logs.py
@@ -24,7 +24,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.diagnostic_content_response import DiagnosticContentResponse
 from ...models.error_response import ErrorResponse
-from ...types import Response
+from ...types import UNSET, Response
 
 
 def _get_kwargs(
@@ -36,7 +36,7 @@ def _get_kwargs(
 
     params["scope"] = scope
 
-    params = {k: v for k, v in params.items() if v is not None}
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -128,7 +128,7 @@ def sync_detailed(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -174,7 +174,7 @@ def sync(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -215,7 +215,7 @@ async def asyncio_detailed(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -259,7 +259,7 @@ async def asyncio(
 
     Args:
         sandbox_id (str):
-        scope (str | Unset):
+        scope (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/sandbox/python/tests/test_pool_async.py
+++ b/sdks/sandbox/python/tests/test_pool_async.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import httpx
 import pytest
 
+from opensandbox._async_pool_reconciler import run_async_reconcile_tick
+from opensandbox._pool_reconciler import ReconcileState
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import (
     PoolAcquireFailedException,
@@ -17,6 +19,7 @@ from opensandbox.exceptions import (
 from opensandbox.models.sandboxes import PlatformSpec
 from opensandbox.pool import (
     AcquirePolicy,
+    AsyncPoolConfig,
     InMemoryAsyncPoolStateStore,
     PoolCreationSpec,
     SandboxPoolAsync,
@@ -33,6 +36,36 @@ async def test_async_acquire_fail_fast_empty_raises_pool_empty() -> None:
         assert exc.value.error.code == "POOL_EMPTY"
     finally:
         await pool.shutdown(False)
+
+
+@pytest.mark.asyncio
+async def test_async_reconcile_batch_failures_only_advance_backoff_once() -> None:
+    store = InMemoryAsyncPoolStateStore()
+    config = AsyncPoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=10,
+        warmup_concurrency=10,
+        state_store=store,
+        connection_config=ConnectionConfig(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    state = ReconcileState(degraded_threshold=3)
+
+    async def fail_create() -> str:
+        raise RuntimeError("boom")
+
+    await run_async_reconcile_tick(
+        config=config,
+        state_store=store,
+        create_one=fail_create,
+        on_discard_sandbox=_noop_discard,
+        reconcile_state=state,
+    )
+
+    assert state.failure_count == 10
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
+    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
 
 
 @pytest.mark.asyncio
@@ -318,6 +351,10 @@ def _create_pool(
 
 async def _manager_factory(manager: FakeAsyncManager) -> FakeAsyncManager:
     return manager
+
+
+async def _noop_discard(_sandbox_id: str) -> None:
+    return None
 
 
 async def _idle_count_equals(pool: SandboxPoolAsync, expected: int) -> bool:

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import httpx
 import pytest
 
-from opensandbox._pool_reconciler import ReconcileState
+from opensandbox._pool_reconciler import ReconcileState, run_reconcile_tick
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import (
     PoolAcquireFailedException,
@@ -16,7 +17,12 @@ from opensandbox.exceptions import (
     PoolNotRunningException,
 )
 from opensandbox.models.sandboxes import PlatformSpec
-from opensandbox.pool import AcquirePolicy, InMemoryPoolStateStore, PoolCreationSpec
+from opensandbox.pool import (
+    AcquirePolicy,
+    InMemoryPoolStateStore,
+    PoolConfig,
+    PoolCreationSpec,
+)
 from opensandbox.sync.pool import SandboxPoolSync
 
 
@@ -36,6 +42,37 @@ def test_degraded_backoff_starts_at_thirty_seconds() -> None:
 
     state.record_failure("boom")
 
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
+    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
+
+
+def test_reconcile_batch_failures_only_advance_backoff_once() -> None:
+    store = InMemoryPoolStateStore()
+    config = PoolConfig(
+        pool_name="pool",
+        owner_id="owner-1",
+        max_idle=10,
+        warmup_concurrency=10,
+        state_store=store,
+        connection_config=ConnectionConfigSync(),
+        creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    )
+    state = ReconcileState(degraded_threshold=3)
+
+    def fail_create() -> str:
+        raise RuntimeError("boom")
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        run_reconcile_tick(
+            config=config,
+            state_store=store,
+            create_one=fail_create,
+            on_discard_sandbox=lambda _sandbox_id: None,
+            reconcile_state=state,
+            warmup_executor=executor,
+        )
+
+    assert state.failure_count == 10
     assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
     assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
 

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -31,6 +31,15 @@ def test_degraded_backoff_caps_at_one_day() -> None:
     assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(hours=25))
 
 
+def test_degraded_backoff_starts_at_thirty_seconds() -> None:
+    state = ReconcileState(degraded_threshold=1)
+
+    state.record_failure("boom")
+
+    assert state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=29))
+    assert not state.is_backoff_active(datetime.now(timezone.utc) + timedelta(seconds=31))
+
+
 def test_acquire_fail_fast_empty_raises_pool_empty() -> None:
     pool = _create_pool(max_idle=0)
     pool.start()


### PR DESCRIPTION
# Summary
- Tune Python and Kotlin sandbox pool degraded backoff behavior.
- Change the default degraded backoff start from the old 1s base to an effective 30s first backoff window.
- Avoid compounding exponential backoff within a single warmup batch: multiple concurrent warmup failures in one reconcile cycle still increment `failureCount`, but advance `backoffAttempts` at most once.
- Bump Kotlin code-interpreter SDK version to `1.0.11` and align its OpenSandbox Kotlin dependency to `1.0.11`.

# Testing
- [x] Unit tests
  - `uv run pytest tests/test_pool_sync.py::test_reconcile_batch_failures_only_advance_backoff_once tests/test_pool_sync.py::test_degraded_backoff_starts_at_thirty_seconds tests/test_pool_sync.py::test_degraded_backoff_caps_at_one_day tests/test_pool_async.py::test_async_reconcile_batch_failures_only_advance_backoff_once -q`
  - `./gradlew :sandbox:test --tests com.alibaba.opensandbox.sandbox.infrastructure.pool.PoolReconcilerStateTest`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (not needed; no public config surface changed)
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
