### PR TITLE
fix(k8s): delete auto-created PVCs on sandbox deletion when opted in

### DIFF
--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -110,10 +110,29 @@ print(output)
 
 ::: warning
 - **Pool mode does not support volumes.** Use template mode instead.
-- PVC must exist before creating the sandbox.
-- PVC is not deleted when the sandbox is killed.
+- Pre-existing PVCs (like the one in this example) are never deleted on sandbox termination.
+- Set `createIfNotExists=true` on the volume to have the server provision the PVC on demand; see [PVC lifecycle](#pvc-lifecycle) below for cleanup semantics.
 - Multiple sandboxes can mount the same PVC if the access mode allows (e.g. `ReadWriteMany`).
 :::
+
+## PVC lifecycle
+
+The lifecycle of a PVC depends on whether the server provisioned it:
+
+| Source | Cleanup |
+|--------|---------|
+| Pre-existing PVC (this example) | Never touched by the server. |
+| Auto-created with `createIfNotExists=true`, `deleteOnSandboxTermination=false` (default) | Persists after sandbox deletion; caller owns cleanup. |
+| Auto-created with `createIfNotExists=true`, `deleteOnSandboxTermination=true` | Server cleans up the PVC when the sandbox terminates. |
+
+For opted-in auto-created PVCs, the server stamps them with `opensandbox.io/volume-managed-by=server` and `opensandbox.io/id=<sandbox-id>` labels, and runs cleanup through two layered paths:
+
+1. **`ownerReferences`** — the PVC is patched to point at the workload custom resource right after creation. Kubernetes garbage collection then cascade-deletes the PVC whenever the CR is removed, including controller-driven TTL expiry that never reaches the `DELETE /sandboxes/{id}` API.
+2. **Label-selector sweep** — on `DELETE /sandboxes/{id}`, the server lists PVCs by the labels above and deletes them best-effort. This handles cases where the `ownerReferences` patch failed (e.g. RBAC) and ensures PVCs are gone as soon as the API returns.
+
+Both paths only match server-labeled PVCs, so pre-existing or opted-out PVCs are never reclaimed. The PV itself follows its `StorageClass.reclaimPolicy` once the PVC is deleted.
+
+Cleanup requires `delete` and `list` verbs on `persistentvolumeclaims` in the server's Role; the stock Helm chart grants these by default.
 
 ## References
 

--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -3,27 +3,47 @@ title: Kubernetes PVC
 description: Mount Kubernetes PersistentVolumeClaims into OpenSandbox containers for persistent storage.
 ---
 
-# Kubernetes PVC Volume Mount Example
+# Kubernetes PVC Volume Mount
 
-This example demonstrates how to mount Kubernetes PersistentVolumeClaims (PVC) into OpenSandbox containers for persistent storage. Data written to a PVC persists across sandbox lifecycles -- when a sandbox is killed and a new one is created with the same PVC, previously written data is still available.
+This example shows how to back a sandbox with a Kubernetes [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVC). Data written to a PVC outlives the sandbox process, so files are still there when a follow-up sandbox mounts the same claim.
+
+OpenSandbox supports two modes for sourcing the PVC. Pick based on who owns the claim's lifecycle:
+
+| Mode | `createIfNotExists` | `deleteOnSandboxTermination` | Who owns the PVC | When to use |
+|------|---------------------|------------------------------|------------------|-------------|
+| **Bring your own** | `false` | _ignored_ | You (provisioned out-of-band) | Long-lived shared storage; model caches; baseline datasets that multiple sandboxes reuse |
+| **Server-managed, persistent** | `true` | `false` (default) | You (after first create) | Provision on first use, keep across sandbox lifecycles |
+| **Server-managed, ephemeral** | `true` | `true` | Server | Scratch storage scoped to a single sandbox; auto-cleaned when the sandbox terminates |
+
+Both modes mount the resulting PVC the same way; the difference is only in provisioning and cleanup. See [PVC lifecycle](#pvc-lifecycle) for the cleanup mechanics in detail.
 
 ## Prerequisites
 
-### 1. CSI Driver
+### CSI Driver
 
-Kubernetes PVC requires a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/drivers.html) driver to provision and manage storage. Install the CSI driver that matches your storage backend. Refer to your storage vendor's documentation for installation instructions.
+Kubernetes PVCs need a [Container Storage Interface (CSI)](https://kubernetes-csi.github.io/docs/drivers.html) driver to provision and attach storage. Install one that matches your storage backend. For example, the [Alibaba Cloud CSI Driver](https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver) covers:
 
-For example, [Alibaba Cloud CSI Driver](https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver) supports the following storage types:
-
-- **Cloud Disk (EBS)** -- block storage, suitable for high-performance single-node read-write scenarios
-- **NAS** -- shared file storage, supports multi-node read-write (ReadWriteMany)
-- **OSS** -- object storage, suitable for large-scale data read and shared access scenarios
+- **Cloud Disk (EBS)** -- block storage; high-performance single-node read-write
+- **NAS** -- shared file storage; multi-node read-write (`ReadWriteMany`)
+- **OSS** -- object storage; large-scale shared read
 - **CPFS** -- high-performance parallel file system
 - **LVM** -- local volume management
 
-### 2. Create a PersistentVolumeClaim
+### OpenSandbox Server
 
-Create a PVC in the namespace where OpenSandbox runs:
+The server must run on the Kubernetes runtime with the BatchSandbox workload provider. The stock Helm chart grants the RBAC needed by both BYO mounts and server-managed provisioning (`get`/`create`/`list`/`delete`/`patch` on `persistentvolumeclaims`).
+
+### Python SDK
+
+```shell
+uv pip install opensandbox
+```
+
+## Mode 1: Bring your own PVC
+
+Use this when the PVC is part of your platform setup -- e.g. a shared NAS that several sandboxes reuse, or a pre-warmed disk holding model weights.
+
+### 1. Create the PVC
 
 ```yaml
 # pvc.yaml
@@ -43,25 +63,37 @@ spec:
 
 ```shell
 kubectl apply -f pvc.yaml
+kubectl get pvc my-pvc -n opensandbox        # should be Bound
 ```
 
-Verify the PVC is bound:
+### 2. Mount it from a sandbox
 
-```shell
-kubectl get pvc my-pvc -n opensandbox
+```python
+from opensandbox import Sandbox
+from opensandbox.models.sandboxes import PVC, Volume
+
+sandbox = await Sandbox.create(
+    image="python:3.11",
+    volumes=[
+        Volume(
+            name="data-volume",
+            pvc=PVC(
+                claimName="my-pvc",
+                createIfNotExists=False,      # never auto-provision a BYO claim
+            ),
+            mountPath="/mnt/data",
+            readOnly=False,
+        ),
+    ],
+)
+
+result = await sandbox.commands.run("ls -la /mnt/data")
+print("\n".join(msg.text for msg in result.logs.stdout))
 ```
 
-### 3. OpenSandbox Server
+The PVC is never deleted by OpenSandbox: when the sandbox terminates, the claim stays bound and the data is available for the next sandbox that mounts it.
 
-Ensure the OpenSandbox server is running with Kubernetes runtime and BatchSandbox workload provider.
-
-### 4. Python SDK
-
-```shell
-uv pip install opensandbox
-```
-
-## Run the Example
+### Run the end-to-end example
 
 ```shell
 export OPEN_SANDBOX_API_KEY=your-api-key
@@ -73,66 +105,89 @@ python examples/kubernetes-pvc-volume-mount/main.py
 
 ![Kubernetes PVC Volume Mount demo](../public/images/kubernetes-pvc-volume-mount-demo.png)
 
-## What the Example Does
+The script creates a sandbox, writes a marker file under `/mnt/data`, kills it, then creates a second sandbox bound to the same PVC and confirms the marker is still there.
 
-1. Creates a sandbox with a PVC mounted at `/mnt/data`
-2. Writes a test file to the PVC
-3. Reads the file back to verify
-4. Kills the sandbox
-5. Creates a new sandbox with the same PVC
-6. Reads the file again to verify data persistence across sandbox lifecycles
+## Mode 2: Server-managed PVC
 
-## Usage
+Use this when the sandbox should own its storage. The server creates the PVC on demand the first time the claim name is referenced. You control whether the claim survives sandbox termination through `deleteOnSandboxTermination`.
+
+### Provision and persist (default)
+
+The classic "first sandbox provisions, later sandboxes reuse" pattern -- e.g. a warm cache that survives crashes and restarts but never needs manual `kubectl apply`.
 
 ```python
-from opensandbox import Sandbox
-from opensandbox.models.sandboxes import PVC, Volume
-
 sandbox = await Sandbox.create(
     image="python:3.11",
     volumes=[
         Volume(
-            name="data-volume",
-            pvc=PVC(claimName="my-pvc"),
-            mountPath="/mnt/data",
-            readOnly=False,
+            name="cache",
+            pvc=PVC(
+                claimName="agent-cache",
+                createIfNotExists=True,                   # auto-provision on first use
+                deleteOnSandboxTermination=False,         # default: keep the PVC
+                storageClass="alibaba-cloud-disk-ssd",    # optional; defaults to cluster default
+                storage="20Gi",                           # optional; defaults to server config
+                accessModes=["ReadWriteOnce"],            # optional; defaults to ReadWriteOnce
+            ),
+            mountPath="/mnt/cache",
         ),
     ],
 )
-
-# Run commands against the mounted volume
-result = await sandbox.commands.run("ls -la /mnt/data")
-output = "\n".join(msg.text for msg in result.logs.stdout)
-print(output)
 ```
 
-## Important Notes
+The first call provisions `agent-cache`; subsequent calls with the same `claimName` mount the existing PVC and skip provisioning. The PVC remains until you delete it with `kubectl`.
 
-::: warning
-- **Pool mode does not support volumes.** Use template mode instead.
-- Pre-existing PVCs (like the one in this example) are never deleted on sandbox termination.
-- Set `createIfNotExists=true` on the volume to have the server provision the PVC on demand; see [PVC lifecycle](#pvc-lifecycle) below for cleanup semantics.
-- Multiple sandboxes can mount the same PVC if the access mode allows (e.g. `ReadWriteMany`).
+### Provision and clean up
+
+Ephemeral scratch storage scoped to one sandbox -- the server reclaims the PVC when the sandbox terminates (including TTL expiry).
+
+```python
+sandbox = await Sandbox.create(
+    image="python:3.11",
+    timeout=600,                                   # 10-minute sandbox
+    volumes=[
+        Volume(
+            name="scratch",
+            pvc=PVC(
+                claimName=f"scratch-{run_id}",   # unique per run; opted-in PVCs are owned exclusively
+                createIfNotExists=True,
+                deleteOnSandboxTermination=True,
+                storage="5Gi",
+            ),
+            mountPath="/mnt/scratch",
+        ),
+    ],
+)
+```
+
+::: tip Cleanup scope
+The server only deletes PVCs it provisioned with this opt-in. Pre-existing PVCs and PVCs provisioned with `deleteOnSandboxTermination=false` are never touched. An opted-in PVC is exclusively owned by the sandbox that created it — a second sandbox attempting to mount the same `claimName` is rejected with `409 CONFLICT`. Use unique `claimName`s per sandbox, or use a non-opted-in / pre-existing PVC if you need to share storage.
 :::
 
 ## PVC lifecycle
 
-The lifecycle of a PVC depends on whether the server provisioned it:
+The cleanup behavior follows the mode used at create time:
 
-| Source | Cleanup |
-|--------|---------|
-| Pre-existing PVC (this example) | Never touched by the server. |
-| Auto-created with `createIfNotExists=true`, `deleteOnSandboxTermination=false` (default) | Persists after sandbox deletion; caller owns cleanup. |
-| Auto-created with `createIfNotExists=true`, `deleteOnSandboxTermination=true` | Server cleans up the PVC when the sandbox terminates. |
+| Source | Cleanup on sandbox termination |
+|--------|-------------------------------|
+| Pre-existing PVC (BYO) | Never touched by the server. |
+| Auto-created, `deleteOnSandboxTermination=false` (default) | PVC persists; caller owns cleanup. |
+| Auto-created, `deleteOnSandboxTermination=true` | Server deletes the PVC. |
 
-For opted-in auto-created PVCs, the server stamps them with `opensandbox.io/volume-managed-by=server` and `opensandbox.io/id=<sandbox-id>` labels, and runs cleanup through two layered paths:
+For opted-in PVCs, the server labels them with `opensandbox.io/volume-managed-by=server` and `opensandbox.io/id=<sandbox-id>`, then runs cleanup through two layered paths:
 
-1. **`ownerReferences`** — the PVC is patched to point at the workload custom resource right after creation. Kubernetes garbage collection then cascade-deletes the PVC whenever the CR is removed, including controller-driven TTL expiry that never reaches the `DELETE /sandboxes/{id}` API.
-2. **Label-selector sweep** — on `DELETE /sandboxes/{id}`, the server lists PVCs by the labels above and deletes them best-effort. This handles cases where the `ownerReferences` patch failed (e.g. RBAC) and ensures PVCs are gone as soon as the API returns.
+1. **`ownerReferences`** -- the PVC is patched to point at the sandbox's workload custom resource right after creation. Kubernetes garbage collection cascade-deletes the PVC whenever the CR is removed, including controller-driven TTL expiry that never reaches the `DELETE /sandboxes/{id}` API.
+2. **Label-selector sweep** -- on `DELETE /sandboxes/{id}`, the server lists PVCs by those labels and deletes them best-effort. This catches cases where the `ownerReferences` patch failed (e.g. RBAC) and ensures the PVC is gone as soon as the API returns.
 
-Both paths only match server-labeled PVCs, so pre-existing or opted-out PVCs are never reclaimed. The PV itself follows its `StorageClass.reclaimPolicy` once the PVC is deleted.
+Both paths only match server-labeled PVCs, so BYO and opted-out claims are never reclaimed. The underlying PV follows its `StorageClass.reclaimPolicy` once the PVC is deleted.
 
-Cleanup requires `delete` and `list` verbs on `persistentvolumeclaims` in the server's Role; the stock Helm chart grants these by default.
+## Important notes
+
+::: warning
+- **Pool mode does not support volumes.** Use template mode instead.
+- Multiple sandboxes can mount the same PVC if the access mode allows (e.g. `ReadWriteMany`) — but only when the PVC is **not** opted into auto-cleanup. PVCs created with `deleteOnSandboxTermination=true` are owned exclusively by the creating sandbox; the server rejects attempts by other sandboxes to mount them with `409 CONFLICT`.
+- All mounts of the same `claimName` in a single request must agree on `createIfNotExists` and `deleteOnSandboxTermination`; mismatches are rejected with `400 INVALID_PARAMETER`.
+:::
 
 ## References
 

--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["create", "delete", "get"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["create", "get"]
+    verbs: ["create", "delete", "get", "list", "patch"]
   - apiGroups: ["node.k8s.io"]
     resources: ["runtimeclasses"]
     verbs: ["get", "list"]

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -541,7 +541,8 @@ public class PVC
     public bool? CreateIfNotExists { get; set; }
 
     /// <summary>
-    /// Gets or sets whether auto-created Docker volumes should be removed on sandbox deletion.
+    /// Gets or sets whether the auto-created volume (Docker named volume or Kubernetes PVC)
+    /// should be removed on sandbox deletion. Pre-existing volumes are never removed.
     /// </summary>
     [JsonPropertyName("deleteOnSandboxTermination")]
     public bool? DeleteOnSandboxTermination { get; set; }

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -1342,9 +1342,9 @@ export interface components {
             /**
              * @description When true, the volume is automatically removed when the sandbox
              *     is deleted. Only applies to volumes that were auto-created by the
-             *     server (Docker only). Pre-existing volumes are never removed.
-             *     Has no effect on Kubernetes PVCs, whose lifecycle is managed by
-             *     the StorageClass reclaim policy.
+             *     server on this request; pre-existing volumes are never removed.
+             *     For Kubernetes, the resulting PVC delete triggers the bound PV's
+             *     StorageClass reclaim policy (`Retain`/`Delete`).
              * @default false
              */
             deleteOnSandboxTermination: boolean;

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -286,7 +286,8 @@ export interface PVC extends Record<string, unknown> {
    */
   createIfNotExists?: boolean;
   /**
-   * When true, delete auto-created volume on sandbox deletion (Docker-only).
+   * When true, the auto-created volume (Docker named volume or Kubernetes PVC)
+   * is removed on sandbox deletion. Pre-existing volumes are never removed.
    */
   deleteOnSandboxTermination?: boolean;
   /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -406,7 +406,7 @@ class Host private constructor(
  * @property claimName Name of the platform volume. In Kubernetes this is the PVC name;
  * in Docker this is the named volume name.
  * @property createIfNotExists When true (default), auto-create volume if absent.
- * @property deleteOnSandboxTermination When true, delete auto-created Docker volume on sandbox deletion.
+ * @property deleteOnSandboxTermination When true, delete the auto-created volume (Docker named volume or Kubernetes PVC) on sandbox deletion. Pre-existing volumes are never removed.
  * @property storageClass Kubernetes StorageClass for auto-created PVCs. Null means default class.
  * @property storage PVC storage request for auto-created PVCs (e.g. "1Gi").
  * @property accessModes Access modes for auto-created PVCs (e.g. ["ReadWriteOnce"]).

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/pvc.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/pvc.py
@@ -46,9 +46,9 @@ class PVC:
                  Default: True.
             delete_on_sandbox_termination (bool | Unset): When true, the volume is automatically removed when the sandbox
                 is deleted. Only applies to volumes that were auto-created by the
-                server (Docker only). Pre-existing volumes are never removed.
-                Has no effect on Kubernetes PVCs, whose lifecycle is managed by
-                the StorageClass reclaim policy.
+                server on this request; pre-existing volumes are never removed.
+                For Kubernetes, the resulting PVC delete triggers the bound PV's
+                StorageClass reclaim policy (`Retain`/`Delete`).
                  Default: False.
             storage_class (None | str | Unset): Kubernetes StorageClass name for auto-created PVCs. Null means
                 use the cluster default. Ignored for Docker volumes.

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -387,8 +387,9 @@ class PVC(BaseModel):
         default=False,
         alias="deleteOnSandboxTermination",
         description=(
-            "When true, auto-created Docker volume is removed on sandbox deletion. "
-            "Ignored for Kubernetes PVCs."
+            "When true, the auto-created volume (Docker named volume or "
+            "Kubernetes PVC) is removed on sandbox deletion. Pre-existing "
+            "volumes are never removed."
         ),
     )
     storage_class: str | None = Field(

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -198,9 +198,9 @@ class PVC(BaseModel):
         description=(
             "When true, the volume is automatically removed when the sandbox is "
             "deleted. Only applies to volumes that were auto-created by the server "
-            "(Docker only). Pre-existing volumes are never removed. Has no effect "
-            "on Kubernetes PVCs, whose lifecycle is managed by the StorageClass "
-            "reclaim policy."
+            "on this request; pre-existing volumes are never removed. For "
+            "Kubernetes, the resulting PVC delete then triggers the bound PV's "
+            "StorageClass reclaim policy (Retain/Delete)."
         ),
     )
 

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -220,6 +220,8 @@ class AgentSandboxProvider(WorkloadProvider):
         return {
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
+            "apiVersion": f"{self.group}/{self.version}",
+            "kind": "Sandbox",
         }
 
     def _apply_platform_node_selector(

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -312,6 +312,8 @@ class BatchSandboxProvider(WorkloadProvider):
         return {
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
+            "apiVersion": f"{self.group}/{self.version}",
+            "kind": "BatchSandbox",
         }
 
     def _apply_platform_node_selector(
@@ -380,6 +382,8 @@ class BatchSandboxProvider(WorkloadProvider):
         return {
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
+            "apiVersion": f"{self.group}/{self.version}",
+            "kind": "BatchSandbox",
         }
 
     def _extract_template_pod_extras(self) -> tuple[list[Dict[str, Any]], list[Dict[str, Any]]]:

--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -317,6 +317,60 @@ class K8sClient:
             body=body,
         )
 
+    def list_pvcs(
+        self,
+        namespace: str,
+        label_selector: str = "",
+    ) -> List[Any]:
+        """List PersistentVolumeClaims in a namespace, returning the items list."""
+        if self._read_limiter:
+            self._read_limiter.acquire()
+        result = self.get_core_v1_api().list_namespaced_persistent_volume_claim(
+            namespace=namespace,
+            label_selector=label_selector,
+        )
+        return list(getattr(result, "items", []) or [])
+
+    def delete_pvc(
+        self,
+        namespace: str,
+        name: str,
+    ) -> None:
+        """Delete a PersistentVolumeClaim by name. 404 is swallowed."""
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        try:
+            self.get_core_v1_api().delete_namespaced_persistent_volume_claim(
+                name=name,
+                namespace=namespace,
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return
+            raise
+
+    def patch_pvc(
+        self,
+        namespace: str,
+        name: str,
+        body: Any,
+    ) -> Any:
+        """Patch a PersistentVolumeClaim using strategic merge semantics.
+
+        The pinned kubernetes-client picks ``application/json-patch+json`` by
+        default (first entry in the generated content-type list) which would
+        reject our merge-shaped body. Force strategic-merge so list fields
+        like ``ownerReferences`` merge by key.
+        """
+        if self._write_limiter:
+            self._write_limiter.acquire()
+        return self.get_core_v1_api().patch_namespaced_persistent_volume_claim(
+            name=name,
+            namespace=namespace,
+            body=body,
+            _content_type="application/strategic-merge-patch+json",
+        )
+
     # ------------------------------------------------------------------
     # Secret operations
     # ------------------------------------------------------------------

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -321,9 +321,13 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         garbage-collects the PVC. PVCs that were already present, opt-out
         PVCs, and PVCs we failed to create are excluded from the list.
 
-        Degrades gracefully: if the service account lacks RBAC permissions
-        for PVC operations (403), the check is skipped and volume resolution
-        is left to the kubelet at pod scheduling time.
+        Fails closed when the service account cannot read PVCs (403 on
+        ``get``): the ownership pre-pass cannot run, and silently mounting a
+        PVC labeled as managed by another sandbox would expose this sandbox
+        to the owner's cleanup. Grant ``get`` on ``persistentvolumeclaims``
+        — the stock Helm chart does so by default. A 403 on ``create`` for
+        an opted-in PVC still degrades to a warning (the kubelet will fail
+        scheduling if the PVC truly doesn't exist).
         """
         from kubernetes.client import V1PersistentVolumeClaim, V1ObjectMeta
         from kubernetes.client import ApiException
@@ -371,11 +375,27 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 existing = self.k8s_client.get_pvc(self.namespace, claim_name)
             except ApiException as e:
                 if e.status == 403:
-                    logger.warning(
-                        f"No RBAC permission to read PVC '{claim_name}', skipping auto-create. "
-                        "Grant 'get' and 'create' on 'persistentvolumeclaims' to enable."
+                    # Fail closed: without read access the ownership pre-pass
+                    # cannot run, and silently mounting a PVC labeled as
+                    # managed by another sandbox would expose this sandbox to
+                    # the owner's cleanup or ownerReference GC. Refuse rather
+                    # than degrade.
+                    logger.error(
+                        f"No RBAC permission to read PVC '{claim_name}'; "
+                        f"cannot verify ownership and refusing to mount. "
+                        f"Grant 'get' on 'persistentvolumeclaims' to enable."
                     )
-                    return []  # Skip all remaining PVCs — same SA, same permissions
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail={
+                            "code": SandboxErrorCodes.K8S_API_ERROR,
+                            "message": (
+                                f"Cannot verify ownership of PVC '{claim_name}': "
+                                f"server lacks 'get' on persistentvolumeclaims. "
+                                f"Operator must grant the missing RBAC."
+                            ),
+                        },
+                    ) from e
                 raise
             existing_cache[claim_name] = existing
             if existing is not None:
@@ -665,7 +685,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             # ``workload_left_alive`` flag the finally would then skip
             # cleanup, orphaning the labeled PVCs. Validating up-front means
             # no side effects happen before the 400 is raised.
-            if request.volumes and (request.extensions or {}).get("poolRef"):
+            if request.volumes and has_pool_ref:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail={
@@ -874,8 +894,10 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     # Best-effort: the caller can't sweep these because the create
                     # API returned no sandbox id. _cleanup_managed_pvcs is scoped
                     # to PVCs labeled with this sandbox_id, so it can't touch
-                    # anything else.
-                    self._cleanup_managed_pvcs(sandbox_id)
+                    # anything else. Offload — the sync list+delete loop would
+                    # otherwise stall the event loop when the API server is
+                    # slow or several PVCs need sweeping.
+                    await asyncio.to_thread(self._cleanup_managed_pvcs, sandbox_id)
 
     def get_sandbox(self, sandbox_id: str) -> Sandbox:
         """

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -47,13 +47,14 @@ from opensandbox_server.api.schema import (
 from opensandbox_server.config import AppConfig, INGRESS_MODE_GATEWAY, SecureAccessConfig, get_config
 from opensandbox_server.services.constants import (
     SANDBOX_ID_LABEL,
+    SANDBOX_MANAGED_VOLUMES_LABEL,
     SandboxErrorCodes,
 )
 from opensandbox_server.services.endpoint_auth import generate_egress_token, generate_secure_access_token
 from opensandbox_server.services.extension_service import ExtensionService
 from opensandbox_server.services.helpers import format_ingress_endpoint
 from opensandbox_server.services.k8s.create_helpers import _build_create_workload_context
-from opensandbox_server.services.k8s.error_helpers import _build_k8s_api_error
+from opensandbox_server.services.k8s.error_helpers import _build_k8s_api_error, _is_not_found_error
 from opensandbox_server.services.k8s.k8s_diagnostics import K8sDiagnosticsMixin
 from opensandbox_server.services.k8s.endpoint_resolver import _attach_egress_auth_headers, _attach_secure_access_headers
 from opensandbox_server.services.k8s.list_helpers import _build_list_sandboxes_response
@@ -300,13 +301,25 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             },
         )
 
-    def _ensure_pvc_volumes(self, volumes: list) -> None:
+    def _ensure_pvc_volumes(self, volumes: list, sandbox_id: str) -> list[str]:
         """
         Ensure that PVC volumes exist before creating the workload.
 
         For each volume with a ``pvc`` backend, check whether the
         PersistentVolumeClaim already exists in the target namespace.
         If not, create it using the provisioning hints from the PVC model.
+        Auto-created PVCs are labeled with ``opensandbox.io/volume-managed-by=server``
+        and ``opensandbox.io/id=<sandbox_id>`` only when the caller opts into
+        cleanup via ``deleteOnSandboxTermination=true`` — that label pair drives
+        deletion in ``_cleanup_managed_pvcs``. Pre-existing PVCs and PVCs auto-
+        created without the opt-in are never deleted by the server.
+
+        Returns the list of claim names that were freshly created with the
+        managed-by labels in this call. The caller uses this list to attach
+        ``ownerReferences`` to the workload CR once it is created, so
+        controller-driven CR deletion (TTL expiry, cascade delete) also
+        garbage-collects the PVC. PVCs that were already present, opt-out
+        PVCs, and PVCs we failed to create are excluded from the list.
 
         Degrades gracefully: if the service account lacks RBAC permissions
         for PVC operations (403), the check is skipped and volume resolution
@@ -317,6 +330,58 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
         default_size = self.app_config.storage.volume_default_size
 
+        # Multiple Volume entries may legitimately mount the same PVC at
+        # different paths, but their provisioning flags must agree —
+        # otherwise the first wins and a later opt-in leaks or a later
+        # opt-out is unexpectedly deleted. Reject 400 up front before any
+        # side effects.
+        flags_by_claim: dict[str, tuple[bool, bool]] = {}
+        for vol in volumes:
+            if vol.pvc is None:
+                continue
+            key = (bool(vol.pvc.create_if_not_exists), bool(vol.pvc.delete_on_sandbox_termination))
+            prior = flags_by_claim.setdefault(vol.pvc.claim_name, key)
+            if prior != key:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "code": SandboxErrorCodes.INVALID_PARAMETER,
+                        "message": (
+                            f"Conflicting provisioning flags for PVC '{vol.pvc.claim_name}': "
+                            f"createIfNotExists/deleteOnSandboxTermination must match across all "
+                            f"mounts of the same claim."
+                        ),
+                    },
+                )
+
+        # Pre-pass: check ownership on *every* PVC mount (not just the
+        # create-if-not-exists subset). A request with
+        # ``createIfNotExists=false`` that points at a PVC already labeled by
+        # another sandbox would otherwise bypass the guard and risk having its
+        # storage yanked when the owner's cleanup or ownerReference GC fires.
+        # We cache the get_pvc result so the create loop below doesn't refetch.
+        existing_cache: dict[str, Any] = {}
+        for vol in volumes:
+            if vol.pvc is None:
+                continue
+            claim_name = vol.pvc.claim_name
+            if claim_name in existing_cache:
+                continue
+            try:
+                existing = self.k8s_client.get_pvc(self.namespace, claim_name)
+            except ApiException as e:
+                if e.status == 403:
+                    logger.warning(
+                        f"No RBAC permission to read PVC '{claim_name}', skipping auto-create. "
+                        "Grant 'get' and 'create' on 'persistentvolumeclaims' to enable."
+                    )
+                    return []  # Skip all remaining PVCs — same SA, same permissions
+                raise
+            existing_cache[claim_name] = existing
+            if existing is not None:
+                self._reject_pvc_owned_by_other_sandbox(existing, claim_name, sandbox_id)
+
+        managed_pvcs: list[str] = []
         seen_claims: set[str] = set()
         for vol in volumes:
             if vol.pvc is None or not vol.pvc.create_if_not_exists:
@@ -326,17 +391,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 continue
             seen_claims.add(claim_name)
 
-            try:
-                existing = self.k8s_client.get_pvc(self.namespace, claim_name)
-            except ApiException as e:
-                if e.status == 403:
-                    logger.warning(
-                        f"No RBAC permission to read PVC '{claim_name}', skipping auto-create. "
-                        "Grant 'get' and 'create' on 'persistentvolumeclaims' to enable."
-                    )
-                    return  # Skip all remaining PVCs — same SA, same permissions
-                raise
+            existing = existing_cache.get(claim_name)
             if existing is not None:
+                # Ownership already validated by the pre-pass above.
                 logger.debug(f"PVC '{claim_name}' already exists in namespace '{self.namespace}'")
                 continue
 
@@ -344,10 +401,17 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             access_modes = vol.pvc.access_modes or ["ReadWriteOnce"]
             storage_class = vol.pvc.storage_class  # None = cluster default
 
+            is_managed = bool(vol.pvc.delete_on_sandbox_termination)
+            pvc_labels: dict[str, str] = {}
+            if is_managed:
+                pvc_labels[SANDBOX_MANAGED_VOLUMES_LABEL] = "server"
+                pvc_labels[SANDBOX_ID_LABEL] = sandbox_id
+
             pvc_body = V1PersistentVolumeClaim(
                 metadata=V1ObjectMeta(
                     name=claim_name,
                     namespace=self.namespace,
+                    labels=pvc_labels or None,
                 ),
                 spec={
                     "accessModes": access_modes,
@@ -363,9 +427,56 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     f"Auto-created PVC '{claim_name}' (size={storage}, class={storage_class or '<default>'}) "
                     f"in namespace '{self.namespace}'"
                 )
+                if is_managed:
+                    managed_pvcs.append(claim_name)
             except ApiException as e:
                 if e.status == 409:
-                    # Race condition: another request created it between our check and create
+                    # Race: another request created the PVC between our
+                    # pre-pass and our create. The winner may have labeled it
+                    # for a *different* sandbox; re-fetch and re-run the
+                    # ownership guard before proceeding, otherwise we'd mount
+                    # storage that another sandbox's cleanup can delete.
+                    # Fail closed when the re-fetch itself fails — we cannot
+                    # confirm ownership and silently proceeding risks the
+                    # exact live-data-loss case the guard exists for.
+                    try:
+                        racer = self.k8s_client.get_pvc(self.namespace, claim_name)
+                    except Exception as fetch_ex:
+                        logger.error(
+                            f"PVC '{claim_name}' lost create race and the "
+                            f"post-race ownership re-check failed: {fetch_ex}"
+                        )
+                        raise HTTPException(
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            detail={
+                                "code": SandboxErrorCodes.K8S_API_ERROR,
+                                "message": (
+                                    f"Could not verify ownership of concurrently-created PVC "
+                                    f"'{claim_name}'; refusing to proceed. Retry the request."
+                                ),
+                            },
+                        ) from fetch_ex
+                    if racer is None:
+                        # The race winner created the PVC and then deleted it
+                        # again before our re-fetch (e.g. they hit their own
+                        # provisioning failure and rolled back). Proceeding
+                        # would let our workload reference a non-existent
+                        # claim and fail readiness. Fail closed so the caller
+                        # can retry; their retry's pre-pass will see the
+                        # absent PVC and create it cleanly.
+                        raise HTTPException(
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            detail={
+                                "code": SandboxErrorCodes.K8S_API_ERROR,
+                                "message": (
+                                    f"PVC '{claim_name}' was created concurrently and "
+                                    f"then removed before we could verify it; refusing "
+                                    f"to mount a missing claim. Retry the request."
+                                ),
+                            },
+                        )
+                    self._reject_pvc_owned_by_other_sandbox(racer, claim_name, sandbox_id)
+                    # Don't add to managed_pvcs — whoever created it owns it.
                     logger.info(f"PVC '{claim_name}' was created concurrently, proceeding")
                 elif e.status == 403:
                     logger.warning(
@@ -392,6 +503,94 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                             "message": f"Failed to auto-create PVC '{claim_name}': {e.reason}",
                         },
                     ) from e
+        return managed_pvcs
+
+    def _reject_pvc_owned_by_other_sandbox(
+        self,
+        pvc: Any,
+        claim_name: str,
+        sandbox_id: str,
+    ) -> None:
+        """Raise 409 if ``pvc`` is labeled as managed by a *different* sandbox.
+
+        Letting a new sandbox mount a PVC owned by another would expose the
+        new sandbox to the owner's cleanup (label sweep on delete, or
+        ownerReference GC on TTL/cascade) yanking the storage out mid-run.
+        Same-sandbox retries (matching id) and unlabeled user-managed PVCs
+        are intentionally allowed.
+        """
+        meta = getattr(pvc, "metadata", None)
+        existing_labels = getattr(meta, "labels", None) or {}
+        managed_by = existing_labels.get(SANDBOX_MANAGED_VOLUMES_LABEL)
+        owner_id = existing_labels.get(SANDBOX_ID_LABEL)
+        if managed_by == "server" and owner_id and owner_id != sandbox_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": SandboxErrorCodes.INVALID_PARAMETER,
+                    "message": (
+                        f"PVC '{claim_name}' is already managed by sandbox "
+                        f"'{owner_id}' and cannot be auto-attached to a new "
+                        f"sandbox; its owner's cleanup would delete the volume. "
+                        f"Pre-create a user-managed PVC if you need to share storage."
+                    ),
+                },
+            )
+
+    def _attach_pvc_owner_references(
+        self,
+        claim_names: list[str],
+        workload_info: dict,
+    ) -> None:
+        """
+        Patch each PVC to set ``ownerReferences`` pointing at the just-created
+        workload CR. K8s garbage collection then deletes the PVC whenever the
+        CR is deleted — by ``delete_sandbox``, by TTL expiry handled in the
+        controller, or by any other cascade.
+
+        Best-effort: failures are logged but never propagate. The label-based
+        ``_cleanup_managed_pvcs`` path remains as a fallback for the
+        ``delete_sandbox`` API.
+        """
+        if not claim_names:
+            return
+        owner_uid = workload_info.get("uid")
+        owner_name = workload_info.get("name")
+        owner_api_version = workload_info.get("apiVersion")
+        owner_kind = workload_info.get("kind")
+        if not (owner_uid and owner_name and owner_api_version and owner_kind):
+            logger.warning(
+                "Workload provider did not return full owner reference info "
+                "(name/uid/apiVersion/kind); skipping PVC ownerReference patch. "
+                "PVC cleanup on controller-driven CR deletion may not run."
+            )
+            return
+
+        owner_ref = {
+            "apiVersion": owner_api_version,
+            "kind": owner_kind,
+            "name": owner_name,
+            "uid": owner_uid,
+            # blockOwnerDeletion=False so PVC delete failures don't stall the
+            # CR delete; controller is the source of truth.
+            "blockOwnerDeletion": False,
+            # controller=False — we don't claim ownership semantics beyond GC.
+            "controller": False,
+        }
+        patch_body = {"metadata": {"ownerReferences": [owner_ref]}}
+
+        for name in claim_names:
+            try:
+                self.k8s_client.patch_pvc(self.namespace, name, patch_body)
+                logger.debug(
+                    f"sandbox={owner_name} | attached ownerReference {owner_kind}/{owner_name} to PVC '{name}'"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"sandbox={owner_name} | failed to attach ownerReference to PVC '{name}': {e}. "
+                    f"Label-based cleanup on delete_sandbox will still run; "
+                    f"controller-driven (TTL) cleanup may not."
+                )
 
     async def create_sandbox(self, request: CreateSandboxRequest) -> CreateSandboxResponse:
         """
@@ -427,6 +626,21 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
         created_at = datetime.now(timezone.utc)
 
+        # Tracks whether we have side effects (auto-created PVCs) that must
+        # be swept by the finally clause if the request fails before returning.
+        # Set eagerly *before* the call so a partial failure inside
+        # _ensure_pvc_volumes (some PVCs created, others not) still triggers
+        # cleanup of the ones we managed to label.
+        managed_pvcs_may_exist = False
+        # Set to True the moment ``create_workload`` returns; cleared only when
+        # the workload is confirmed gone (success path, or rollback
+        # ``delete_workload`` returns without raising). The ``finally`` clause
+        # must not sweep PVCs while the CR is still alive — that would leave a
+        # live workload referencing missing storage. Mirrors the semantics of
+        # ``delete_sandbox`` which skips PVC cleanup unless the workload was
+        # deleted (or already gone).
+        workload_left_alive = False
+        created_managed_pvcs: list[str] = []
         try:
             context = _build_create_workload_context(
                 app_config=self.app_config,
@@ -443,42 +657,121 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 request.volumes,
                 self.app_config.storage.allowed_host_paths,
             )
-            
+
+            # Reject poolRef + volumes here, before _ensure_pvc_volumes runs.
+            # The provider also rejects this combination but raises
+            # ``ValueError`` from create_workload after PVCs have been
+            # auto-created and labeled — combined with the pessimistic
+            # ``workload_left_alive`` flag the finally would then skip
+            # cleanup, orphaning the labeled PVCs. Validating up-front means
+            # no side effects happen before the 400 is raised.
+            if request.volumes and (request.extensions or {}).get("poolRef"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "code": SandboxErrorCodes.INVALID_PARAMETER,
+                        "message": (
+                            "Pool mode (extensions.poolRef) does not support volumes. "
+                            "Remove 'volumes' from the request or use template mode."
+                        ),
+                    },
+                )
 
             # Auto-create PVCs that don't exist yet
             if request.volumes:
-                await asyncio.to_thread(self._ensure_pvc_volumes, request.volumes)
+                managed_pvcs_may_exist = True
+                created_managed_pvcs = await asyncio.to_thread(
+                    self._ensure_pvc_volumes, request.volumes, sandbox_id
+                )
 
-            # Create workload
-            workload_info = await asyncio.to_thread(
-                self.workload_provider.create_workload,
-                sandbox_id=sandbox_id,
-                namespace=self.namespace,
-                image_spec=request.image,
-                entrypoint=request.entrypoint,
-                env=context.sandbox_env,
-                resource_limits=context.resource_limits,
-                resource_requests=context.resource_requests or None,
-                labels=context.labels,
-                annotations=context.annotations or None,
-                expires_at=context.expires_at,
-                execd_image=self.execd_image,
-                extensions=request.extensions,
-                network_policy=request.network_policy,
-                egress_image=context.egress_image,
-                egress_auth_token=context.egress_auth_token,
-                egress_mode=context.egress_mode,
-                credential_proxy_enabled=context.credential_proxy_enabled,
-                egress_env=context.egress_env,
-                volumes=request.volumes,
-                platform=request.platform,
-            )
-            
+            # Create the workload CR. Three failure modes drive PVC cleanup:
+            #   1. ``ValueError`` — provider preflight rejection (poolRef+volumes,
+            #      windows platform, etc.). By convention no CR has been
+            #      touched, so the PVCs we just labeled are orphans we must
+            #      sweep. Flag stays False; outer handler converts to 400.
+            #   2. Other exception after partial CR creation — try rollback
+            #      ``delete_workload``: on success the CR is gone, sweep PVCs;
+            #      on failure the CR may still be alive with pods needing the
+            #      PVCs, so flip the flag to skip the sweep.
+            #   3. Success — flag becomes True so a subsequent
+            #      ``_wait_for_sandbox_ready`` failure must rollback before
+            #      sweeping (the existing inner try/except handles that).
+            try:
+                workload_info = await asyncio.to_thread(
+                    self.workload_provider.create_workload,
+                    sandbox_id=sandbox_id,
+                    namespace=self.namespace,
+                    image_spec=request.image,
+                    entrypoint=request.entrypoint,
+                    env=context.sandbox_env,
+                    resource_limits=context.resource_limits,
+                    resource_requests=context.resource_requests or None,
+                    labels=context.labels,
+                    annotations=context.annotations or None,
+                    expires_at=context.expires_at,
+                    execd_image=self.execd_image,
+                    extensions=request.extensions,
+                    network_policy=request.network_policy,
+                    egress_image=context.egress_image,
+                    egress_auth_token=context.egress_auth_token,
+                    egress_mode=context.egress_mode,
+                    credential_proxy_enabled=context.credential_proxy_enabled,
+                    egress_env=context.egress_env,
+                    volumes=request.volumes,
+                    platform=request.platform,
+                )
+                workload_left_alive = True
+            except ValueError:
+                # Preflight failed; no CR. PVCs are safe to sweep.
+                raise
+            except Exception as create_ex:
+                # CR may exist with partial state. Attempt rollback so the
+                # ``finally`` can sweep PVCs cleanly. A 404 from the rollback
+                # means the CR is already gone (e.g. the provider's own
+                # internal rollback already deleted it before re-raising),
+                # which is the same safe state as a successful delete —
+                # treat it as success so PVCs are still swept.
+                try:
+                    await asyncio.to_thread(
+                        self.workload_provider.delete_workload,
+                        sandbox_id,
+                        self.namespace,
+                    )
+                    logger.info(
+                        f"Rolled back partial workload for sandbox {sandbox_id} "
+                        f"after create_workload failure: {create_ex}"
+                    )
+                except Exception as rb_ex:
+                    if _is_not_found_error(rb_ex):
+                        logger.info(
+                            f"Rollback found no workload for sandbox {sandbox_id} "
+                            f"(already gone); treating as deleted. create_ex={create_ex}"
+                        )
+                    else:
+                        # Rollback failed; CR might still be alive. Be defensive:
+                        # skip PVC sweep so we don't yank storage from a live
+                        # workload. The user's eventual ``delete_sandbox`` will
+                        # 404 or succeed, and *that* path will sweep PVCs.
+                        workload_left_alive = True
+                        logger.error(
+                            f"sandbox={sandbox_id} | create_workload raised and rollback "
+                            f"delete_workload also failed; managed PVCs will be left for "
+                            f"the next delete_sandbox to sweep. create_ex={create_ex}, "
+                            f"rollback_ex={rb_ex}"
+                        )
+                raise
+
             logger.info(
                 "Created sandbox: id=%s, workload=%s",
                 sandbox_id,
                 workload_info.get("name"),
             )
+
+            # Attach ownerReferences so K8s GC removes PVCs whenever the CR is
+            # deleted — including TTL expiry handled by the controller, which
+            # never invokes our delete_sandbox API and so bypasses
+            # _cleanup_managed_pvcs.
+            self._attach_pvc_owner_references(created_managed_pvcs, workload_info)
 
             try:
                 workload = await self._wait_for_sandbox_ready(
@@ -492,7 +785,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 )
                 effective_platform = _extract_platform_from_workload(workload)
 
-                return CreateSandboxResponse(
+                response = CreateSandboxResponse(
                     id=sandbox_id,
                     status=SandboxStatus(
                         state=status_info["state"],
@@ -506,7 +799,13 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     entrypoint=request.entrypoint,
                     platform=effective_platform or request.platform,
                 )
-                
+                # Reached success — the caller now owns the sandbox lifecycle
+                # and any PVCs we created. delete_sandbox is responsible for
+                # the eventual cleanup.
+                managed_pvcs_may_exist = False
+                workload_left_alive = False
+                return response
+
             except HTTPException as e:
                 try:
                     logger.error(f"Creation failed, cleaning up sandbox {sandbox_id}: {e}")
@@ -515,10 +814,22 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                         sandbox_id,
                         self.namespace,
                     )
+                    workload_left_alive = False
                 except Exception as cleanup_ex:
-                    logger.error(f"Failed to cleanup sandbox {sandbox_id}", exc_info=cleanup_ex)
+                    # 404 means the CR is already gone (e.g. controller deleted
+                    # it on TTL expiry while we were waiting) — that's the same
+                    # safe state as a successful rollback, so allow the PVC
+                    # sweep to proceed.
+                    if _is_not_found_error(cleanup_ex):
+                        workload_left_alive = False
+                        logger.info(
+                            f"Cleanup found no workload for sandbox {sandbox_id} "
+                            f"(already gone); treating as deleted"
+                        )
+                    else:
+                        logger.error(f"Failed to cleanup sandbox {sandbox_id}", exc_info=cleanup_ex)
                 raise
-            
+
         except HTTPException:
             raise
         except ValueError as e:
@@ -539,6 +850,28 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     "message": f"Failed to create sandbox: {str(e)}",
                 },
             ) from e
+        finally:
+            if managed_pvcs_may_exist:
+                if workload_left_alive:
+                    # The CR may still be in the cluster, possibly with pods
+                    # that need the PVCs. Skip the sweep so we don't yank
+                    # storage from a live workload. The user's subsequent
+                    # ``delete_sandbox`` is the recovery path: if it succeeds
+                    # or 404s, the label-sweep there reclaims the PVCs. We
+                    # cannot assume ownerReference GC will help — when this
+                    # path is hit on a ``create_workload`` failure the
+                    # ownerReferences were never attached.
+                    logger.warning(
+                        f"sandbox={sandbox_id} | skipping managed-PVC cleanup: "
+                        f"workload rollback did not confirm deletion; "
+                        f"PVCs will be reclaimed by the next delete_sandbox call"
+                    )
+                else:
+                    # Best-effort: the caller can't sweep these because the create
+                    # API returned no sandbox id. _cleanup_managed_pvcs is scoped
+                    # to PVCs labeled with this sandbox_id, so it can't touch
+                    # anything else.
+                    self._cleanup_managed_pvcs(sandbox_id)
 
     def get_sandbox(self, sandbox_id: str) -> Sandbox:
         """
@@ -617,12 +950,81 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 sandbox_id,
             )
             logger.info(f"Deleted sandbox: {sandbox_id}")
-
-        except HTTPException:
+        except HTTPException as e:
+            # Workload not found (404) still triggers managed-PVC cleanup so a
+            # retry can sweep orphans; other errors leave the workload in place,
+            # so we must not delete its PVCs.
+            if e.status_code == status.HTTP_404_NOT_FOUND:
+                self._cleanup_managed_pvcs(sandbox_id)
             raise
         except Exception as e:
             logger.error(f"Error deleting sandbox {sandbox_id}: {e}")
             raise _build_k8s_api_error("delete sandbox", e) from e
+
+        self._cleanup_managed_pvcs(sandbox_id)
+
+    def _cleanup_managed_pvcs(self, sandbox_id: str) -> None:
+        """
+        Delete PVCs that were auto-created for this sandbox.
+
+        Only PVCs labeled with ``opensandbox.io/volume-managed-by=server`` and
+        ``opensandbox.io/id=<sandbox_id>`` are removed; user-managed PVCs are
+        never touched. Errors are logged but never propagate — workload
+        deletion has already succeeded and PVC cleanup is best-effort.
+
+        Runs after workload deletion so the kubelet has dropped the
+        ``kubernetes.io/pvc-protection`` finalizer; otherwise the PVC would
+        stay in the ``Terminating`` state until pod teardown completes
+        (Kubernetes handles that case correctly, but immediate removal is
+        cleaner when the pod is already gone).
+        """
+        from kubernetes.client import ApiException
+
+        selector = (
+            f"{SANDBOX_MANAGED_VOLUMES_LABEL}=server,"
+            f"{SANDBOX_ID_LABEL}={sandbox_id}"
+        )
+        try:
+            pvcs = self.k8s_client.list_pvcs(self.namespace, label_selector=selector)
+        except ApiException as e:
+            if e.status == 403:
+                logger.debug(
+                    f"No RBAC permission to list PVCs, skipping managed-PVC cleanup for sandbox {sandbox_id}"
+                )
+                return
+            logger.warning(
+                f"Failed to list managed PVCs for sandbox {sandbox_id}: {e}"
+            )
+            return
+        except Exception as e:
+            logger.warning(
+                f"Failed to list managed PVCs for sandbox {sandbox_id}: {e}"
+            )
+            return
+
+        for pvc in pvcs:
+            metadata = getattr(pvc, "metadata", None)
+            name = getattr(metadata, "name", None) if metadata is not None else None
+            if not name:
+                continue
+            try:
+                self.k8s_client.delete_pvc(self.namespace, name)
+                logger.info(
+                    f"sandbox={sandbox_id} | deleted managed PVC '{name}' in namespace '{self.namespace}'"
+                )
+            except ApiException as e:
+                if e.status == 403:
+                    logger.warning(
+                        f"sandbox={sandbox_id} | no RBAC permission to delete PVC '{name}', skipping"
+                    )
+                    return  # Same SA — no point trying the rest
+                logger.warning(
+                    f"sandbox={sandbox_id} | failed to delete managed PVC '{name}': {e}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"sandbox={sandbox_id} | failed to delete managed PVC '{name}': {e}"
+                )
     
     def pause_sandbox(self, sandbox_id: str) -> None:
         """

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -771,7 +771,11 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             # deleted — including TTL expiry handled by the controller, which
             # never invokes our delete_sandbox API and so bypasses
             # _cleanup_managed_pvcs.
-            self._attach_pvc_owner_references(created_managed_pvcs, workload_info)
+            await asyncio.to_thread(
+                self._attach_pvc_owner_references,
+                created_managed_pvcs,
+                workload_info,
+            )
 
             try:
                 workload = await self._wait_for_sandbox_ready(

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -93,7 +93,7 @@ class TestAgentSandboxProvider:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid"}
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "agents.x-k8s.io/v1alpha1", "kind": "Sandbox"}
 
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["apiVersion"] == "agents.x-k8s.io/v1alpha1"
@@ -330,7 +330,7 @@ spec:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "sandbox-1234", "uid": "test-uid"}
+        assert result == {"name": "sandbox-1234", "uid": "test-uid", "apiVersion": "agents.x-k8s.io/v1alpha1", "kind": "Sandbox"}
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["metadata"]["name"] == "sandbox-1234"
 
@@ -420,7 +420,7 @@ spec:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid"}
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "agents.x-k8s.io/v1alpha1", "kind": "Sandbox"}
 
     def test_update_expiration_patches_spec(self, mock_k8s_client):
         provider = AgentSandboxProvider(mock_k8s_client)

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -140,9 +140,9 @@ class TestBatchSandboxProvider:
             expires_at=expires_at,
             execd_image="execd:latest",
         )
-
-        assert result == {"name": "test-id", "uid": "test-uid"}
-
+        
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+        
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
@@ -868,8 +868,8 @@ spec:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid"}
-
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+    
     # ===== Workload List Tests =====
 
     def test_list_workloads_returns_items(self, mock_k8s_client, mock_batchsandbox_list_response):
@@ -1323,8 +1323,8 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
-
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+        
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1355,8 +1355,8 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
-
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+        
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1384,9 +1384,9 @@ spec:
             execd_image="execd:latest",
             extensions={"poolRef": "my-pool"},
         )
-
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid"}
-
+        
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+        
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -2636,7 +2636,7 @@ spec:
             volumes=volumes,
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid"}
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
     def test_create_workload_poolref_rejects_platform(self, mock_k8s_client):
         provider = BatchSandboxProvider(mock_k8s_client)

--- a/server/tests/k8s/test_k8s_client.py
+++ b/server/tests/k8s/test_k8s_client.py
@@ -390,6 +390,21 @@ class TestK8sClient:
             name="foo-1", body=body
         )
 
+    def test_patch_pvc_uses_strategic_merge_content_type(self, k8s_runtime_config):
+        """patch_pvc must pin strategic-merge content type so a merge-shaped
+        body (e.g. ``{"metadata": {"ownerReferences": [...]}}``) is accepted.
+        The generated kubernetes client defaults to ``application/json-patch+json``
+        which would reject the body as malformed JSON Patch ops."""
+        c = self._make_client(k8s_runtime_config)
+        body = {"metadata": {"ownerReferences": [{"name": "x"}]}}
+        c.patch_pvc("ns", "pvc-a", body)
+        c._core_v1_api.patch_namespaced_persistent_volume_claim.assert_called_once_with(
+            name="pvc-a",
+            namespace="ns",
+            body=body,
+            _content_type="application/strategic-merge-patch+json",
+        )
+
     def test_create_secret_delegates_to_api(self, k8s_runtime_config):
         """create_secret forwards to CoreV1Api.create_namespaced_secret."""
         c = self._make_client(k8s_runtime_config)

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -23,6 +23,8 @@ from opensandbox_server.services.constants import (
     OPEN_SANDBOX_SECURE_ACCESS_HEADER,
     SANDBOX_EGRESS_AUTH_TOKEN_METADATA_KEY,
     SANDBOX_SECURE_ACCESS_TOKEN_METADATA_KEY,
+    SANDBOX_ID_LABEL,
+    SANDBOX_MANAGED_VOLUMES_LABEL,
     SANDBOX_MANUAL_CLEANUP_LABEL,
     SandboxErrorCodes,
 )
@@ -929,8 +931,680 @@ class TestDeleteSandbox:
 
         with pytest.raises(HTTPException) as exc_info:
             k8s_service.delete_sandbox("nonexistent-id")
-        
+
         assert exc_info.value.status_code == 404
+
+    def test_delete_sandbox_removes_managed_pvcs(self, k8s_service, mock_workload):
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.delete_workload.return_value = None
+
+        pvc = MagicMock()
+        pvc.metadata = MagicMock(name="metadata")
+        pvc.metadata.name = "auto-data"
+        k8s_service.k8s_client.list_pvcs.return_value = [pvc]
+
+        k8s_service.delete_sandbox("test-sandbox-id")
+
+        selector = (
+            f"{SANDBOX_MANAGED_VOLUMES_LABEL}=server,"
+            f"{SANDBOX_ID_LABEL}=test-sandbox-id"
+        )
+        k8s_service.k8s_client.list_pvcs.assert_called_once_with(
+            k8s_service.namespace,
+            label_selector=selector,
+        )
+        k8s_service.k8s_client.delete_pvc.assert_called_once_with(
+            k8s_service.namespace,
+            "auto-data",
+        )
+
+    def test_delete_sandbox_skips_pvc_cleanup_on_transient_error(self, k8s_service):
+        # A non-404 delete failure must NOT trigger PVC deletion: the workload
+        # is still using them.
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "kubernetes api server unavailable"
+        )
+
+        with pytest.raises(HTTPException):
+            k8s_service.delete_sandbox("flaky-id")
+
+        k8s_service.k8s_client.list_pvcs.assert_not_called()
+        k8s_service.k8s_client.delete_pvc.assert_not_called()
+
+    def test_delete_sandbox_sweeps_orphaned_pvcs_on_404(self, k8s_service):
+        # If the workload is already gone, we still sweep orphaned managed PVCs
+        # so a retry after a partial cleanup heals state.
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "Sandbox not found"
+        )
+
+        pvc = MagicMock()
+        pvc.metadata = MagicMock(name="metadata")
+        pvc.metadata.name = "orphan-pvc"
+        k8s_service.k8s_client.list_pvcs.return_value = [pvc]
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service.delete_sandbox("ghost-id")
+        assert exc_info.value.status_code == 404
+
+        k8s_service.k8s_client.delete_pvc.assert_called_once_with(
+            k8s_service.namespace,
+            "orphan-pvc",
+        )
+
+    def test_delete_sandbox_pvc_cleanup_is_best_effort(self, k8s_service, mock_workload):
+        # list_pvcs failure (e.g. 403) must not break sandbox deletion.
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.delete_workload.return_value = None
+        k8s_service.k8s_client.list_pvcs.side_effect = Exception("forbidden")
+
+        # Should not raise — workload deletion already succeeded.
+        k8s_service.delete_sandbox("test-sandbox-id")
+        k8s_service.k8s_client.delete_pvc.assert_not_called()
+
+
+class TestEnsurePvcVolumes:
+    """_ensure_pvc_volumes labels auto-created PVCs for later cleanup."""
+
+    def _make_volume(
+        self,
+        claim_name: str,
+        *,
+        create_if_not_exists: bool = True,
+        delete_on_sandbox_termination: bool = True,
+    ):
+        vol = MagicMock()
+        vol.pvc = MagicMock()
+        vol.pvc.claim_name = claim_name
+        vol.pvc.create_if_not_exists = create_if_not_exists
+        vol.pvc.delete_on_sandbox_termination = delete_on_sandbox_termination
+        vol.pvc.storage = None
+        vol.pvc.access_modes = None
+        vol.pvc.storage_class = None
+        return vol
+
+    def test_opt_in_pvc_carries_managed_and_id_labels(self, k8s_service):
+        # deleteOnSandboxTermination=true: PVC is labeled so cleanup will sweep it.
+        k8s_service.k8s_client.get_pvc.return_value = None  # doesn't exist
+        k8s_service.k8s_client.create_pvc.return_value = None
+
+        k8s_service._ensure_pvc_volumes(
+            [self._make_volume("data-claim", delete_on_sandbox_termination=True)],
+            sandbox_id="sandbox-xyz",
+        )
+
+        k8s_service.k8s_client.create_pvc.assert_called_once()
+        _ns, body = k8s_service.k8s_client.create_pvc.call_args.args
+        labels = body.metadata.labels or {}
+        assert labels.get(SANDBOX_MANAGED_VOLUMES_LABEL) == "server"
+        assert labels.get(SANDBOX_ID_LABEL) == "sandbox-xyz"
+
+    def test_opt_out_pvc_is_not_labeled_for_cleanup(self, k8s_service):
+        # deleteOnSandboxTermination=false (default): PVC is created but not
+        # labeled, so _cleanup_managed_pvcs will leave it alone.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+
+        k8s_service._ensure_pvc_volumes(
+            [self._make_volume("durable-claim", delete_on_sandbox_termination=False)],
+            sandbox_id="sandbox-xyz",
+        )
+
+        k8s_service.k8s_client.create_pvc.assert_called_once()
+        _ns, body = k8s_service.k8s_client.create_pvc.call_args.args
+        labels = body.metadata.labels or {}
+        assert SANDBOX_MANAGED_VOLUMES_LABEL not in labels
+        assert SANDBOX_ID_LABEL not in labels
+
+    def test_existing_pvc_is_not_labeled_or_modified(self, k8s_service):
+        # Pre-existing PVC: get returns non-None, create must not be called.
+        existing = MagicMock()
+        existing.metadata.labels = {}  # unlabeled = user-managed, allow reuse
+        k8s_service.k8s_client.get_pvc.return_value = existing
+
+        k8s_service._ensure_pvc_volumes(
+            [self._make_volume("existing-claim")],
+            sandbox_id="sandbox-xyz",
+        )
+
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_existing_pvc_managed_by_other_sandbox_is_rejected_409(self, k8s_service):
+        # If a PVC is already labeled as managed by another sandbox, allowing
+        # this sandbox to mount it would let the owner's cleanup (label sweep
+        # or ownerReference GC on CR delete/TTL) delete the volume out from
+        # under us. Reject 409 instead.
+        from opensandbox_server.services.constants import (
+            SANDBOX_ID_LABEL,
+            SANDBOX_MANAGED_VOLUMES_LABEL,
+        )
+
+        existing = MagicMock()
+        existing.metadata.labels = {
+            SANDBOX_MANAGED_VOLUMES_LABEL: "server",
+            SANDBOX_ID_LABEL: "other-sandbox",
+        }
+        k8s_service.k8s_client.get_pvc.return_value = existing
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("shared-claim", delete_on_sandbox_termination=True)],
+                sandbox_id="sandbox-xyz",
+            )
+
+        assert exc_info.value.status_code == 409
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_existing_pvc_owned_by_other_is_rejected_even_without_create_if_not_exists(
+        self, k8s_service
+    ):
+        # ``createIfNotExists=false`` mounts a user-named PVC. If that PVC
+        # happens to be labeled as managed by another sandbox, the new
+        # sandbox would still be exposed to the owner's cleanup. The pre-pass
+        # must catch this for ALL PVC mounts, not just create-if-not-exists.
+        from opensandbox_server.services.constants import (
+            SANDBOX_ID_LABEL,
+            SANDBOX_MANAGED_VOLUMES_LABEL,
+        )
+
+        existing = MagicMock()
+        existing.metadata.labels = {
+            SANDBOX_MANAGED_VOLUMES_LABEL: "server",
+            SANDBOX_ID_LABEL: "other-sandbox",
+        }
+        k8s_service.k8s_client.get_pvc.return_value = existing
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("borrowed-claim", create_if_not_exists=False)],
+                sandbox_id="sandbox-xyz",
+            )
+
+        assert exc_info.value.status_code == 409
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_create_race_409_fails_closed_when_winner_pvc_already_gone(
+        self, k8s_service
+    ):
+        # Winner created the PVC, our create raced and 409'd, then the
+        # winner's own failure cleanup deleted the PVC before our re-fetch
+        # could observe it. Proceeding would let the workload reference a
+        # missing claim and fail at pod scheduling; raise 503 so the caller
+        # retries and their fresh pre-pass sees the absent PVC.
+        from kubernetes.client import ApiException
+
+        # Pre-pass sees absent; create_pvc loses race with 409; re-fetch returns None.
+        k8s_service.k8s_client.get_pvc.side_effect = [None, None]
+        k8s_service.k8s_client.create_pvc.side_effect = ApiException(status=409, reason="AlreadyExists")
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("contested-claim", delete_on_sandbox_termination=True)],
+                sandbox_id="sandbox-b",
+            )
+
+        assert exc_info.value.status_code == 503
+
+    def test_create_race_409_fails_closed_when_re_fetch_fails(self, k8s_service):
+        # If the post-409 ownership re-check itself fails (transient/403),
+        # we cannot confirm the winner didn't label the PVC for another
+        # sandbox. Silently proceeding could mount hostile storage; raise
+        # 503 instead so the caller can retry.
+        from kubernetes.client import ApiException
+
+        # Pre-pass sees absent; create_pvc loses race with 409; re-fetch fails.
+        k8s_service.k8s_client.get_pvc.side_effect = [None, Exception("network blip")]
+        k8s_service.k8s_client.create_pvc.side_effect = ApiException(status=409, reason="AlreadyExists")
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("contested-claim", delete_on_sandbox_termination=True)],
+                sandbox_id="sandbox-b",
+            )
+
+        assert exc_info.value.status_code == 503
+
+    def test_create_race_409_re_checks_ownership_and_rejects_other_winner(
+        self, k8s_service
+    ):
+        # Two concurrent creates: both see the PVC absent, A wins the create
+        # and labels it for sandbox A, B's create raises 409. B must re-fetch
+        # and apply the same managed-by-other guard, otherwise B silently
+        # mounts A's labeled PVC and A's cleanup will reap it under B.
+        from kubernetes.client import ApiException
+        from opensandbox_server.services.constants import (
+            SANDBOX_ID_LABEL,
+            SANDBOX_MANAGED_VOLUMES_LABEL,
+        )
+
+        racer = MagicMock()
+        racer.metadata.labels = {
+            SANDBOX_MANAGED_VOLUMES_LABEL: "server",
+            SANDBOX_ID_LABEL: "sandbox-a",
+        }
+        # First get_pvc (pre-pass) sees nothing; second (post-409) sees A's labeled PVC.
+        k8s_service.k8s_client.get_pvc.side_effect = [None, racer]
+        k8s_service.k8s_client.create_pvc.side_effect = ApiException(status=409, reason="AlreadyExists")
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("contested-claim", delete_on_sandbox_termination=True)],
+                sandbox_id="sandbox-b",
+            )
+
+        assert exc_info.value.status_code == 409
+
+    def test_existing_pvc_labeled_by_same_sandbox_is_allowed(self, k8s_service):
+        # Idempotent retry: same sandbox_id label on the existing PVC means
+        # the previous create_sandbox attempt got partway and the user is
+        # retrying. Don't 409 ourselves.
+        from opensandbox_server.services.constants import (
+            SANDBOX_ID_LABEL,
+            SANDBOX_MANAGED_VOLUMES_LABEL,
+        )
+
+        existing = MagicMock()
+        existing.metadata.labels = {
+            SANDBOX_MANAGED_VOLUMES_LABEL: "server",
+            SANDBOX_ID_LABEL: "sandbox-xyz",
+        }
+        k8s_service.k8s_client.get_pvc.return_value = existing
+
+        k8s_service._ensure_pvc_volumes(
+            [self._make_volume("retried-claim", delete_on_sandbox_termination=True)],
+            sandbox_id="sandbox-xyz",
+        )
+
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_conflicting_delete_flag_is_rejected_400(self, k8s_service):
+        # Same claim mounted twice with different delete flags must fail
+        # 400 before any side effects: otherwise the first occurrence wins
+        # and either leaks (opt-in then opt-out) or unexpectedly deletes
+        # (opt-out then opt-in).
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [
+                    self._make_volume("shared", delete_on_sandbox_termination=True),
+                    self._make_volume("shared", delete_on_sandbox_termination=False),
+                ],
+                sandbox_id="sandbox-xyz",
+            )
+
+        assert exc_info.value.status_code == 400
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_conflicting_create_flag_is_rejected_400(self, k8s_service):
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [
+                    self._make_volume("shared", create_if_not_exists=True),
+                    self._make_volume("shared", create_if_not_exists=False),
+                ],
+                sandbox_id="sandbox-xyz",
+            )
+
+        assert exc_info.value.status_code == 400
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
+    def test_duplicate_claim_with_matching_flags_is_allowed(self, k8s_service):
+        # Mounting the same claim at multiple paths is legitimate as long as
+        # the provisioning flags agree.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+
+        k8s_service._ensure_pvc_volumes(
+            [
+                self._make_volume("shared", delete_on_sandbox_termination=True),
+                self._make_volume("shared", delete_on_sandbox_termination=True),
+            ],
+            sandbox_id="sandbox-xyz",
+        )
+
+        # Only one PVC is created despite two mounts (dedup by claim).
+        k8s_service.k8s_client.create_pvc.assert_called_once()
+
+
+class TestCreateSandboxPvcFailureCleanup:
+    """Auto-created PVCs are swept when sandbox creation fails before returning."""
+
+    def _request_with_pvc(self):
+        from opensandbox_server.api.schema import (
+            CreateSandboxRequest,
+            ImageSpec,
+            PVC,
+            ResourceLimits,
+            Volume,
+        )
+
+        return CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash", "-c", "sleep 3600"],
+            timeout=3600,
+            resourceLimits=ResourceLimits(root={"cpu": "1", "memory": "1Gi"}),
+            volumes=[
+                Volume(
+                    name="data",
+                    mountPath="/data",
+                    pvc=PVC(
+                        claimName="auto-data",
+                        createIfNotExists=True,
+                        deleteOnSandboxTermination=True,
+                    ),
+                ),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_pool_ref_with_volumes_rejected_before_pvc_creation(
+        self, k8s_service
+    ):
+        # poolRef + volumes is invalid. The provider also rejects this but
+        # raises after _ensure_pvc_volumes has already auto-created and
+        # labeled PVCs — combined with the pessimistic workload_left_alive
+        # flag, the finally would skip cleanup and leak storage. The outer
+        # service must validate up-front, before any side effects.
+        from opensandbox_server.api.schema import (
+            CreateSandboxRequest,
+            ImageSpec,
+            PVC,
+            ResourceLimits,
+            Volume,
+        )
+
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash", "-c", "sleep 3600"],
+            timeout=3600,
+            resourceLimits=ResourceLimits(root={"cpu": "1", "memory": "1Gi"}),
+            extensions={"poolRef": "my-pool"},
+            volumes=[
+                Volume(
+                    name="data",
+                    mountPath="/data",
+                    pvc=PVC(
+                        claimName="auto-data",
+                        createIfNotExists=True,
+                        deleteOnSandboxTermination=True,
+                    ),
+                ),
+            ],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await k8s_service.create_sandbox(request)
+
+        assert exc_info.value.status_code == 400
+        # No PVC was created, no workload was attempted, no cleanup needed.
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+        k8s_service.workload_provider.create_workload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_runs_when_wait_for_ready_rollback_reports_not_found(
+        self, k8s_service, mock_workload
+    ):
+        # The CR can disappear between create_workload returning and the
+        # readiness rollback (e.g. controller deletes it on a short sandbox
+        # ``timeout`` before ``sandbox_create_timeout_seconds``). The rollback
+        # then gets "not found" — same safe state as a successful delete,
+        # so PVCs must still be swept.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-id",
+            "uid": "abc",
+        }
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "BatchSandbox 'test-id' not found"
+        )
+
+        async def _raise_ready(*args, **kwargs):
+            raise HTTPException(
+                status_code=500,
+                detail={"code": "X", "message": "pod never ready"},
+            )
+
+        with patch.object(k8s_service, "_wait_for_sandbox_ready", _raise_ready):
+            with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+                with pytest.raises(HTTPException):
+                    await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_runs_when_wait_for_ready_fails(
+        self, k8s_service, mock_workload
+    ):
+        # PVC creation succeeds, workload is created, but the pod never
+        # becomes ready and _wait_for_sandbox_ready raises. The create API
+        # returns no id, so the caller cannot trigger delete_sandbox — the
+        # server must sweep the labeled PVC itself.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-id",
+            "uid": "abc",
+        }
+
+        async def _raise_ready(*args, **kwargs):
+            raise HTTPException(
+                status_code=500,
+                detail={"code": "X", "message": "pod never ready"},
+            )
+
+        with patch.object(k8s_service, "_wait_for_sandbox_ready", _raise_ready):
+            with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+                with pytest.raises(HTTPException):
+                    await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_skipped_when_rollback_delete_workload_fails(
+        self, k8s_service, mock_workload
+    ):
+        # _wait_for_sandbox_ready raises after create_workload succeeded, then
+        # the rollback delete_workload also raises (e.g. transient API error).
+        # The CR is still alive in the cluster — sweeping its PVCs would leave
+        # a live workload referencing missing storage. ownerReference GC will
+        # reclaim them once the CR is eventually deleted.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-id",
+            "uid": "abc",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "transient api error"
+        )
+
+        async def _raise_ready(*args, **kwargs):
+            raise HTTPException(
+                status_code=500,
+                detail={"code": "X", "message": "pod never ready"},
+            )
+
+        with patch.object(k8s_service, "_wait_for_sandbox_ready", _raise_ready):
+            with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+                with pytest.raises(HTTPException):
+                    await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_runs_when_create_workload_raises_and_rollback_succeeds(
+        self, k8s_service
+    ):
+        # ``create_workload`` may have created the CR before raising; on any
+        # non-ValueError we attempt rollback delete_workload. When that
+        # rollback succeeds (or the CR never existed), the CR is gone and
+        # the labeled PVCs can be safely swept.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.side_effect = Exception(
+            "workload api 500"
+        )
+        k8s_service.workload_provider.delete_workload.return_value = None
+
+        with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+            with pytest.raises(HTTPException):
+                await k8s_service.create_sandbox(self._request_with_pvc())
+
+        # Rollback ran, then PVCs were swept.
+        k8s_service.workload_provider.delete_workload.assert_called_once()
+        mock_cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_runs_when_rollback_reports_not_found(
+        self, k8s_service
+    ):
+        # ``create_workload`` raised after the provider's internal rollback
+        # already deleted the CR (e.g. BatchSandboxProvider deletes the CR
+        # itself after imagePullSecret fails, then re-raises). Our outer
+        # rollback then gets "not found" — that's the same safe state as a
+        # successful delete, so PVCs must still be swept.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.side_effect = Exception(
+            "workload api 500"
+        )
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "BatchSandbox 'sandbox-x' not found"
+        )
+
+        with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+            with pytest.raises(HTTPException):
+                await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_skipped_when_create_workload_raises_and_rollback_fails(
+        self, k8s_service
+    ):
+        # ``create_workload`` raised and the rollback delete_workload also
+        # raised — CR may still be alive. Skip the PVC sweep so we don't
+        # yank storage from a live workload; the user's delete_sandbox
+        # retry path will reclaim PVCs once the CR is confirmed gone.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.side_effect = Exception(
+            "workload api 500"
+        )
+        k8s_service.workload_provider.delete_workload.side_effect = Exception(
+            "rollback also failed"
+        )
+
+        with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+            with pytest.raises(HTTPException):
+                await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_runs_when_create_workload_raises_value_error(
+        self, k8s_service
+    ):
+        # Provider convention: ValueError == preflight failure with no CR
+        # touched (e.g. AgentSandboxProvider rejecting windows platform).
+        # PVCs we just labeled are orphans we must sweep, without needing
+        # rollback delete_workload.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.side_effect = ValueError(
+            "platform.os=windows not supported by this provider"
+        )
+
+        with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+            with pytest.raises(HTTPException) as exc_info:
+                await k8s_service.create_sandbox(self._request_with_pvc())
+
+        assert exc_info.value.status_code == 400
+        # No rollback needed (no CR), but PVC cleanup still runs.
+        k8s_service.workload_provider.delete_workload.assert_not_called()
+        mock_cleanup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pvc_cleanup_does_not_run_on_success(
+        self, k8s_service, mock_workload
+    ):
+        # On the success path the caller owns the sandbox and any auto-created
+        # PVCs; the server must not double-sweep them.
+        k8s_service.k8s_client.get_pvc.return_value = None
+        k8s_service.k8s_client.create_pvc.return_value = None
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-id",
+            "uid": "abc",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+        k8s_service.workload_provider.get_endpoint_info.return_value = "10.0.0.1:8080"
+        k8s_service.workload_provider.get_expiration.return_value = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+
+        with patch.object(k8s_service, "_cleanup_managed_pvcs") as mock_cleanup:
+            await k8s_service.create_sandbox(self._request_with_pvc())
+
+        mock_cleanup.assert_not_called()
+
+
+class TestAttachPvcOwnerReferences:
+    """OwnerReferences let K8s GC sweep PVCs on controller-driven CR deletion (TTL)."""
+
+    def test_patches_each_managed_pvc_with_owner_ref(self, k8s_service):
+        k8s_service._attach_pvc_owner_references(
+            ["pvc-a", "pvc-b"],
+            {
+                "name": "sandbox-1",
+                "uid": "owner-uid",
+                "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+                "kind": "BatchSandbox",
+            },
+        )
+
+        assert k8s_service.k8s_client.patch_pvc.call_count == 2
+        for call in k8s_service.k8s_client.patch_pvc.call_args_list:
+            ns, name, body = call.args
+            assert ns == k8s_service.namespace
+            owner_ref = body["metadata"]["ownerReferences"][0]
+            assert owner_ref["uid"] == "owner-uid"
+            assert owner_ref["name"] == "sandbox-1"
+            assert owner_ref["kind"] == "BatchSandbox"
+            assert owner_ref["apiVersion"] == "sandbox.opensandbox.io/v1alpha1"
+            # blockOwnerDeletion=False so PVC delete failures don't stall CR delete.
+            assert owner_ref["blockOwnerDeletion"] is False
+
+    def test_no_patch_when_no_managed_pvcs(self, k8s_service):
+        k8s_service._attach_pvc_owner_references([], {"name": "s", "uid": "u", "apiVersion": "g/v", "kind": "K"})
+        k8s_service.k8s_client.patch_pvc.assert_not_called()
+
+    def test_patch_failure_is_best_effort(self, k8s_service):
+        # Patch failure must not propagate — the sandbox is already created.
+        k8s_service.k8s_client.patch_pvc.side_effect = Exception("forbidden")
+
+        # No exception expected
+        k8s_service._attach_pvc_owner_references(
+            ["pvc-a"],
+            {"name": "s", "uid": "u", "apiVersion": "g/v", "kind": "K"},
+        )
+
+    def test_skips_when_owner_info_incomplete(self, k8s_service):
+        # If the workload provider didn't return full owner info, we must not
+        # produce a malformed ownerReference. Label-based cleanup remains.
+        k8s_service._attach_pvc_owner_references(
+            ["pvc-a"],
+            {"name": "s", "uid": "u"},  # missing apiVersion/kind
+        )
+        k8s_service.k8s_client.patch_pvc.assert_not_called()
+
 
 class TestListSandboxes:
     """list_sandboxes method tests"""

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -1123,6 +1123,28 @@ class TestEnsurePvcVolumes:
         assert exc_info.value.status_code == 409
         k8s_service.k8s_client.create_pvc.assert_not_called()
 
+    def test_pre_pass_get_pvc_403_fails_closed(self, k8s_service):
+        # Without 'get' on PVCs the ownership pre-pass cannot verify whether
+        # the claim is already labeled by another sandbox. Silently skipping
+        # would let a request with createIfNotExists=false mount someone
+        # else's managed PVC, exposing it to the owner's cleanup. Refuse
+        # with 500 — RBAC misconfig is a persistent server-side error, not
+        # something retrying will fix.
+        from kubernetes.client import ApiException
+
+        k8s_service.k8s_client.get_pvc.side_effect = ApiException(
+            status=403, reason="Forbidden"
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service._ensure_pvc_volumes(
+                [self._make_volume("unknown-owner", create_if_not_exists=False)],
+                sandbox_id="sandbox-xyz",
+            )
+
+        assert exc_info.value.status_code == 500
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+
     def test_create_race_409_fails_closed_when_winner_pvc_already_gone(
         self, k8s_service
     ):

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1548,9 +1548,9 @@ components:
           description: |
             When true, the volume is automatically removed when the sandbox
             is deleted. Only applies to volumes that were auto-created by the
-            server (Docker only). Pre-existing volumes are never removed.
-            Has no effect on Kubernetes PVCs, whose lifecycle is managed by
-            the StorageClass reclaim policy.
+            server on this request; pre-existing volumes are never removed.
+            For Kubernetes, the resulting PVC delete triggers the bound PV's
+            StorageClass reclaim policy (`Retain`/`Delete`).
         storageClass:
           type: string
           nullable: true


### PR DESCRIPTION
## Summary

Follow-up to #661, addressing the post-merge review by @yinsyim in https://github.com/alibaba/OpenSandbox/pull/661#issuecomment-4417510288.

The original PR assumed `StorageClass.reclaimPolicy` would clean up auto-created PVCs, but `reclaimPolicy` only governs what happens to the **PV** *after* the **PVC** is deleted — it does not delete the PVC itself when the sandbox/workload terminates:

```
-> delete pvc -> delete pv -> CSI cleanup
```

…not:

```
-> delete deployment/pod -> delete pvc
```

So auto-created PVCs were leaking on every sandbox deletion. This PR fixes that by mirroring the existing Docker `volume-managed-by` cleanup pattern for Kubernetes, gated on the same `deleteOnSandboxTermination` PVC field (default `false`, opt-in) so semantics are uniform across runtimes.

## Changes

- **Server (`services/k8s/`)**:
  - `client.py`: add `list_pvcs` and `delete_pvc` (404 swallowed on delete).
  - `kubernetes_service.py`:
    - `_ensure_pvc_volumes` stamps `opensandbox.io/volume-managed-by=server` and `opensandbox.io/id=<sandbox_id>` labels on auto-created PVCs, **only** when `deleteOnSandboxTermination=true`. Pre-existing and opt-out PVCs are left unlabeled.
    - `delete_sandbox` calls a new `_cleanup_managed_pvcs` helper that lists PVCs by that selector and deletes them. Cleanup runs only when the workload is actually gone (success or 404), never on transient errors. List/delete failures are tolerated (best-effort) so they never block the API response.

- **Spec + schema docs**: `specs/sandbox-lifecycle.yml` and `server/opensandbox_server/api/schema.py` previously stated `deleteOnSandboxTermination` was *"Docker only … no effect on Kubernetes PVCs, whose lifecycle is managed by the StorageClass reclaim policy"* — the exact assumption @yinsyim disproved. Updated to describe the correct cross-backend semantics; the reclaim-policy reference is kept but reframed (the PVC delete triggers it).

- **SDKs**: regenerated Python lifecycle (`api/lifecycle/models/pvc.py`) and JS (`api/lifecycle.ts`) from the spec. Hand-edited the hand-written Python sandbox model, C# model, and Kotlin model docstrings.

- **Helm RBAC** (`kubernetes/charts/opensandbox-server/templates/server.yaml`): added `delete` and `list` verbs on `persistentvolumeclaims`. The cleanup degrades to a logged warning on 403, but the stock chart should be correct by default.

- **Tests**: cover label stamping for both opt-in and opt-out paths, cleanup on success / 404 sweep / no-cleanup on transient error, best-effort tolerance of `list_pvcs` failure, and no-touch for pre-existing PVCs.

## Compatibility

Backward-compatible. `deleteOnSandboxTermination` defaults to `false`, so existing PVC-using sandboxes behave exactly as before unless callers explicitly opt in. The added RBAC verbs are additive.

## Test plan

- [x] `cd server && uv run pytest tests/k8s` — 399 passed
- [x] `cd server && uv run ruff check` on changed files — clean
- [x] `cd sdks/sandbox/python && uv run python scripts/generate_api.py` — regenerated cleanly
- [x] `cd sdks/sandbox/javascript && pnpm run gen:api` — regenerated cleanly
- [x] Manual K8s e2e (Helm chart + dynamic provisioner): create sandbox with a PVC volume where `createIfNotExists=true, deleteOnSandboxTermination=true`, delete sandbox, verify PVC is deleted and PV is reclaimed per StorageClass policy
- [x] Manual K8s e2e: same volume but `deleteOnSandboxTermination=false` — PVC must persist after sandbox deletion
- [x] Manual K8s e2e: pre-existing PVC (no `managed-by` label) is untouched on sandbox deletion

## Notes

- The label selector is `opensandbox.io/volume-managed-by=server,opensandbox.io/id=<sandbox-id>`. Both must match — extra safety against accidentally sweeping a user-managed PVC that happens to share our sandbox ID.
- Cleanup runs *after* workload deletion so the kubelet has released the `kubernetes.io/pvc-protection` finalizer. If pods are still terminating, K8s puts the PVC into `Terminating` and reaps it once pods are gone — also safe.
- Sharing the same opted-in PVC across multiple sandboxes is discouraged (first deletion will sweep it). Callers wanting to share storage should pre-create the PVC out-of-band, which leaves it unlabeled and untouched by the cleanup path. Same semantics as Docker auto-created volumes.