### PR TITLE
fix(execd): use merged CA bundle for `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE`

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -42,27 +42,56 @@ _sudo() {
 	fi
 }
 
-# Install mitm egress CA into the system trust store (no extra env vars).
-# - Debian/Ubuntu/Alpine: update-ca-certificates + /usr/local/share/ca-certificates/
-# - RHEL/CentOS/Fedora/Alma/Rocky: update-ca-trust + /etc/pki/ca-trust/source/anchors/
+# Install mitm CA into the system trust store and set OPENSANDBOX_MERGED_CA
+# to a PEM bundle containing system roots + mitm CA (for env vars like
+# REQUESTS_CA_BUNDLE that replace rather than append to the default roots).
+OPENSANDBOX_MERGED_CA=""
 trust_mitm_ca() {
 	cert="$1"
+	merged="/opt/opensandbox/merged-ca-certificates.pem"
+	installed=false
+
 	if command -v update-ca-certificates >/dev/null 2>&1; then
-		_sudo mkdir -p /usr/local/share/ca-certificates
-		_sudo cp "$cert" /usr/local/share/ca-certificates/opensandbox-mitmproxy-ca.crt
-		_sudo update-ca-certificates
-		return 0
-	fi
-	if command -v update-ca-trust >/dev/null 2>&1; then
-		_sudo mkdir -p /etc/pki/ca-trust/source/anchors
-		_sudo cp "$cert" /etc/pki/ca-trust/source/anchors/opensandbox-mitmproxy-ca.pem
-		if ! _sudo update-ca-trust extract; then
-			_sudo update-ca-trust
+		if _sudo mkdir -p /usr/local/share/ca-certificates \
+			&& _sudo cp "$cert" /usr/local/share/ca-certificates/opensandbox-mitmproxy-ca.crt \
+			&& _sudo update-ca-certificates; then
+			installed=true
+			if [ -f /etc/ssl/certs/ca-certificates.crt ] && [ -s /etc/ssl/certs/ca-certificates.crt ]; then
+				OPENSANDBOX_MERGED_CA="/etc/ssl/certs/ca-certificates.crt"
+				return 0
+			fi
 		fi
-		return 0
+	elif command -v update-ca-trust >/dev/null 2>&1; then
+		if _sudo mkdir -p /etc/pki/ca-trust/source/anchors \
+			&& _sudo cp "$cert" /etc/pki/ca-trust/source/anchors/opensandbox-mitmproxy-ca.pem \
+			&& { _sudo update-ca-trust extract || _sudo update-ca-trust; }; then
+			installed=true
+			if [ -f /etc/pki/tls/certs/ca-bundle.crt ] && [ -s /etc/pki/tls/certs/ca-bundle.crt ]; then
+				OPENSANDBOX_MERGED_CA="/etc/pki/tls/certs/ca-bundle.crt"
+				return 0
+			fi
+		fi
 	fi
 
-	echo "warning: cannot install mitm CA (need update-ca-certificates or update-ca-trust)" >&2
+	# System trust-store update unavailable or failed — build merged bundle manually.
+	if [ "$installed" = false ]; then
+		echo "warning: cannot install mitm CA into system trust store; building merged bundle manually" >&2
+	else
+		echo "warning: system trust-store updated but consolidated bundle not found; building merged bundle manually" >&2
+	fi
+	for candidate in \
+		/etc/ssl/certs/ca-certificates.crt \
+		/etc/pki/tls/certs/ca-bundle.crt \
+		/etc/ssl/cert.pem \
+		/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do
+		if [ -f "$candidate" ] && [ -s "$candidate" ]; then
+			cat "$candidate" "$cert" > "$merged"
+			OPENSANDBOX_MERGED_CA="$merged"
+			return 0
+		fi
+	done
+
+	echo "warning: could not locate system CA bundle to merge with mitm CA" >&2
 	return 0
 }
 
@@ -117,8 +146,18 @@ if is_truthy "${OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT:-}"; then
 
 	if [ -f "$MITM_CA" ] && [ -s "$MITM_CA" ]; then
 		trust_mitm_ca_nss "$MITM_CA" || true
-		export NODE_EXTRA_CA_CERTS="$MITM_CA"
-		export REQUESTS_CA_BUNDLE="$MITM_CA"
+		export NODE_EXTRA_CA_CERTS="$MITM_CA"  # additive — Node appends to built-in roots
+
+		# REQUESTS_CA_BUNDLE and SSL_CERT_FILE replace the default bundle,
+		# so use merged roots (system CA + mitm CA).
+		if [ -n "$OPENSANDBOX_MERGED_CA" ] && [ -f "$OPENSANDBOX_MERGED_CA" ]; then
+			export REQUESTS_CA_BUNDLE="$OPENSANDBOX_MERGED_CA"
+			export SSL_CERT_FILE="$OPENSANDBOX_MERGED_CA"
+		else
+			echo "warning: merged CA bundle not available; REQUESTS_CA_BUNDLE/SSL_CERT_FILE will only contain the mitm CA" >&2
+			export REQUESTS_CA_BUNDLE="$MITM_CA"
+			export SSL_CERT_FILE="$MITM_CA"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
# Summary
- REQUESTS_CA_BUNDLE and SSL_CERT_FILE have replace semantics — setting them to the mitm CA alone caused Python requests and OpenSSL-based clients to lose trust in all system root certificates, breaking direct HTTPS connections.
- Update trust_mitm_ca() to track the merged bundle path (system roots + mitm CA) in OPENSANDBOX_MERGED_CA, either from the system-updated bundle (which already includes the mitm CA after update-ca-certificates / update-ca-trust) or by manually concatenating them as a fallback.
- NODE_EXTRA_CA_CERTS is unaffected as Node.js appends rather than replaces.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered