### PR TITLE
chore(chart): bump opensandbox-controller chart version to 0.2.0

### DIFF
--- a/kubernetes/charts/opensandbox-controller/Chart.yaml
+++ b/kubernetes/charts/opensandbox-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opensandbox-controller
 description: A Kubernetes operator for managing sandbox environments with resource pooling and batch delivery
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 keywords:
   - sandbox

--- a/kubernetes/charts/opensandbox/Chart.lock
+++ b/kubernetes/charts/opensandbox/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opensandbox-controller
   repository: file://../opensandbox-controller
-  version: 0.1.0
+  version: 0.2.0
 - name: opensandbox-server
   repository: file://../opensandbox-server
   version: 0.1.0
-digest: sha256:c66976fab3f4eea75ec3004c1842079d754387ea430c56cce5514e4f457ee40c
-generated: "2026-03-04T17:56:49.467373+08:00"
+digest: sha256:b88aa0bfffb5e30aa46163794cb74aa25157ee4b4a437c22867df19633b2a89f
+generated: "2026-05-15T14:39:18.571067+08:00"

--- a/kubernetes/charts/opensandbox/Chart.yaml
+++ b/kubernetes/charts/opensandbox/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: opensandbox
 description: All-in-one Helm chart for deploying OpenSandbox controller and server
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 keywords:
   - sandbox
@@ -40,7 +40,7 @@ kubeVersion: ">=1.21.1-0"
 
 dependencies:
   - name: opensandbox-controller
-    version: "0.1.0"
+    version: "0.2.0"
     repository: "file://../opensandbox-controller"
   - name: opensandbox-server
     version: "0.1.0"


### PR DESCRIPTION
# Summary
- Bump opensandbox-controller Helm chart version from 0.1.0 to 0.2.0
- Update opensandbox all-in-one chart dependency to match new controller chart version
- Required because new CRD (sandboxsnapshots) and CRD schema changes were added since 0.1.0

# Testing
- [x] Not run (explain why)
  - Chart version bump only, no logic change. CI Helm lint will validate.

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered