### PR TITLE
docs: fix server example config links

### DIFF
--- a/examples/host-volume-mount/README.md
+++ b/examples/host-volume-mount/README.md
@@ -224,4 +224,4 @@ Sandbox sandbox = Sandbox.builder()
 
 - [OSEP-0003: Volume and VolumeBinding Support](../../oseps/0003-volume-and-volumebinding-support.md) — Design proposal
 - [Sandbox Lifecycle API Spec](../../specs/sandbox-lifecycle.yml) — OpenAPI schema for volume definitions
-- [Server Configuration](../../server/example.config.toml) — `[storage]` section for `allowed_host_paths`
+- [Server Configuration](../../server/opensandbox_server/examples/example.config.toml) — `[storage]` section for `allowed_host_paths`

--- a/examples/host-volume-mount/README_zh.md
+++ b/examples/host-volume-mount/README_zh.md
@@ -233,4 +233,4 @@ Sandbox sandbox = Sandbox.builder()
 
 - [OSEP-0003: Volume 与 VolumeBinding 支持](../../oseps/0003-volume-and-volumebinding-support.md) — 设计提案
 - [Sandbox Lifecycle API 规范](../../specs/sandbox-lifecycle.yml) — Volume 定义的 OpenAPI 规范
-- [服务端配置示例](../../server/example.config.zh.toml) — `[storage]` 段中的 `allowed_host_paths` 配置
+- [服务端配置示例](../../server/opensandbox_server/examples/example.config.zh.toml) — `[storage]` 段中的 `allowed_host_paths` 配置

--- a/server/README.md
+++ b/server/README.md
@@ -221,11 +221,11 @@ Single source of truth for TOML: **[configuration.md](configuration.md)** (inclu
 
 ## Experimental features
 
-Optional **🧪 experimental** behavior; **off by default** in [`example.config.toml`](example.config.toml) (and mirrored copies under `opensandbox_server/examples/`). See release notes before production.
+Optional **🧪 experimental** behavior; **off by default** in [`example.config.toml`](opensandbox_server/examples/example.config.toml). See release notes before production.
 
 ### Auto-renew on access
 
-Extends sandbox TTL when traffic is observed (lifecycle **proxy** and/or **ingress** + optional **Redis** queue). Design and operations: **[OSEP-0009](../oseps/0009-auto-renew-sandbox-on-ingress-access.md)**. TOML keys (`[renew_intent]`, including nested `redis.*`): see **[configuration.md](configuration.md)** and [`example.config.toml`](example.config.toml).
+Extends sandbox TTL when traffic is observed (lifecycle **proxy** and/or **ingress** + optional **Redis** queue). Design and operations: **[OSEP-0009](../oseps/0009-auto-renew-sandbox-on-ingress-access.md)**. TOML keys (`[renew_intent]`, including nested `redis.*`): see **[configuration.md](configuration.md)** and [`example.config.toml`](opensandbox_server/examples/example.config.toml).
 
 Per-sandbox: on **create**, set `extensions["access.renew.extend.seconds"]` (string integer **300**–**86400**). Clients using the server proxy: request endpoints with `use_server_proxy=true` (REST) or SDK `ConnectionConfig(..., use_server_proxy=True)` — details in OSEP-0009.
 

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -10,10 +10,10 @@ Example files in this repository:
 
 | File | Purpose |
 |------|---------|
-| [`example.config.toml`](example.config.toml) | Docker runtime (English) |
-| [`example.config.zh.toml`](example.config.zh.toml) | Docker runtime (中文) |
-| [`example.config.k8s.toml`](example.config.k8s.toml) | Kubernetes runtime (English) |
-| [`example.config.k8s.zh.toml`](example.config.k8s.zh.toml) | Kubernetes runtime (中文) |
+| [`example.config.toml`](opensandbox_server/examples/example.config.toml) | Docker runtime (English) |
+| [`example.config.zh.toml`](opensandbox_server/examples/example.config.zh.toml) | Docker runtime (中文) |
+| [`example.config.k8s.toml`](opensandbox_server/examples/example.config.k8s.toml) | Kubernetes runtime (English) |
+| [`example.config.k8s.zh.toml`](opensandbox_server/examples/example.config.k8s.zh.toml) | Kubernetes runtime (中文) |
 
 ---
 


### PR DESCRIPTION
# Summary
- Fix a tiny docs papercut: server config links pointed at `server/example.config*.toml`.
- The files actually live in `server/opensandbox_server/examples/` after #558, so the GitHub links were dead. not great lol.
- Related: #321, #558

# Repro
- Before this change, a relative Markdown link check reports missing targets like `server/README.md: missing example.config.toml` and `server/configuration.md: missing example.config.k8s.toml`.
- After this change, the same check on the touched docs says: `fixed docs: no missing relative markdown targets`.
- No cloud quotas/API limits involved here, this is just rendered Markdown links.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Ran:
- `cd server && uv run --frozen pytest tests/test_schema.py -q`
- `cd server && uv run --frozen ruff check`
- focused relative Markdown link check for touched files

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
