### PR TITLE
fix(js-sdk): Accept empty ping responses

### DIFF
--- a/sdks/sandbox/javascript/src/adapters/healthAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/healthAdapter.ts
@@ -20,7 +20,7 @@ export class HealthAdapter implements ExecdHealth {
   constructor(private readonly client: ExecdClient) {}
 
   async ping(): Promise<boolean> {
-    const { error, response } = await this.client.GET("/ping");
+    const { error, response } = await this.client.GET("/ping", { parseAs: "text" });
     throwOnOpenApiFetchError({ error, response }, "Execd ping failed");
     return true;
   }

--- a/sdks/sandbox/javascript/tests/health.test.mjs
+++ b/sdks/sandbox/javascript/tests/health.test.mjs
@@ -1,0 +1,42 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { HealthAdapter, createExecdClient } from "../dist/internal.js";
+import { SandboxApiException } from "../dist/index.js";
+
+test("HealthAdapter treats empty 200 ping responses as healthy", async () => {
+  const health = new HealthAdapter(createExecdClient({
+    baseUrl: "http://execd.test",
+    async fetch(request) {
+      assert.equal(new URL(request.url).pathname, "/ping");
+      return new Response("", { status: 200 });
+    },
+  }));
+
+  assert.equal(await health.ping(), true);
+});
+
+test("HealthAdapter still maps ping API errors", async () => {
+  const health = new HealthAdapter(createExecdClient({
+    baseUrl: "http://execd.test",
+    async fetch() {
+      return Response.json({ code: "UNAVAILABLE", message: "not ready" }, { status: 503 });
+    },
+  }));
+
+  await assert.rejects(() => health.ping(), SandboxApiException);
+});


### PR DESCRIPTION
## Summary

- Read the JS SDK `/ping` health check response as text so an empty HTTP 200 body is treated as healthy.
- Preserve existing API error mapping for non-2xx ping responses.
- Add a focused Node test for empty 200 ping responses and API errors.

Fixes #891

## Tests

- `cd sdks && pnpm install --frozen-lockfile`
- `cd sdks/sandbox/javascript && pnpm run build`
- `cd sdks/sandbox/javascript && pnpm run typecheck`
- `cd sdks/sandbox/javascript && pnpm run lint`
- `cd sdks/sandbox/javascript && node --test tests/health.test.mjs`
- `git diff --check`