### PR TITLE
fix(deps): pin fast-uri to 3.1.2 to close GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc

### DIFF
--- a/sdks/package.json
+++ b/sdks/package.json
@@ -17,7 +17,8 @@
       "picomatch@^4.0.0": "4.0.4",
       "brace-expansion@^1.0.0": "1.1.13",
       "brace-expansion@^2.0.0": "2.0.3",
-      "flatted@^3.0.0": "3.4.2"
+      "flatted@^3.0.0": "3.4.2",
+      "fast-uri@^3.0.0": "3.1.2"
     }
   },
   "devDependencies": {

--- a/sdks/pnpm-lock.yaml
+++ b/sdks/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   brace-expansion@^1.0.0: 1.1.13
   brace-expansion@^2.0.0: 2.0.3
   flatted@^3.0.0: 3.4.2
+  fast-uri@^3.0.0: 3.1.2
 
 importers:
 
@@ -695,8 +696,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1263,7 +1264,7 @@ snapshots:
   '@redocly/ajv@8.17.1':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1650,7 +1651,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
# Summary
Add a pnpm override so the transitive `fast-uri` (pulled in via `openapi-typescript > @redocly/openapi-core > @redocly/ajv`) resolves to 3.1.2. The previously locked 3.1.0 is affected by two high-severity advisories:

- CVE-2026-6321 (GHSA-q3j6-qgpj-74h6): path traversal via percent-encoded dot segments in `normalize()` / `equal()`.
- CVE-2026-6322 (GHSA-v39h-62p7-jpjc): host confusion via percent-encoded authority delimiters.

`pnpm audit` now reports 0 vulnerabilities for the sdks workspace. `docs/` and `tests/javascript/` audits are already clean.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered