### PR TITLE
fix(server): handle null spec.template in pool-mode BatchSandbox

### DIFF
--- a/server/opensandbox_server/services/k8s/workload_mapper.py
+++ b/server/opensandbox_server/services/k8s/workload_mapper.py
@@ -84,10 +84,12 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
 
 def _extract_platform_from_workload(workload: Any) -> Optional[PlatformSpec]:
     if isinstance(workload, dict):
-        spec = workload.get("spec", {})
+        spec = workload.get("spec") or {}
+        template = spec.get("template") or {}
+        pod_template = spec.get("podTemplate") or {}
         pod_spec = (
-            spec.get("template", {}).get("spec")
-            or spec.get("podTemplate", {}).get("spec")
+            (template.get("spec") if isinstance(template, dict) else None)
+            or (pod_template.get("spec") if isinstance(pod_template, dict) else None)
             or {}
         )
     else:

--- a/server/tests/k8s/test_workload_mapper.py
+++ b/server/tests/k8s/test_workload_mapper.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opensandbox_server.services.k8s.workload_mapper import (
+    _extract_platform_from_workload,
+)
+
+
+class TestExtractPlatformFromWorkload:
+    """Regression tests for _extract_platform_from_workload.
+
+    The BatchSandbox CRD declares spec.template as an optional preserve-unknown-fields
+    object. In pool mode, the BatchSandbox CR is created with only ``poolRef`` and
+    ``taskTemplate`` under spec; the Kubernetes API server may then return the object
+    with ``spec.template`` explicitly set to ``None`` (because the field is part of the
+    schema but unset). Earlier code did ``spec.get("template", {}).get("spec")`` which
+    crashed in that case because the default ``{}`` is only returned when the key is
+    absent, not when its value is ``None``.
+    """
+
+    def test_pool_mode_workload_with_null_template_returns_none(self):
+        """Pool-mode BatchSandbox CR has spec.template == None; must not crash."""
+        workload = {
+            "metadata": {"name": "sb-1", "namespace": "opensandbox-system"},
+            "spec": {
+                "replicas": 1,
+                "poolRef": "pool-runc",
+                "template": None,  # <-- this used to crash
+                "taskTemplate": {},
+            },
+            "status": {"replicas": 1, "ready": 1, "allocated": 1},
+        }
+        # Should return None (no platform info), not raise.
+        assert _extract_platform_from_workload(workload) is None
+
+    def test_pool_mode_workload_without_template_key_returns_none(self):
+        """Pool-mode BatchSandbox CR may also omit spec.template entirely."""
+        workload = {
+            "metadata": {"name": "sb-1"},
+            "spec": {
+                "replicas": 1,
+                "poolRef": "pool-runc",
+            },
+        }
+        assert _extract_platform_from_workload(workload) is None
+
+    def test_template_mode_with_full_platform_returns_platform(self):
+        """Template-mode workload with nodeSelector returns the declared platform."""
+        workload = {
+            "metadata": {"name": "sb-1"},
+            "spec": {
+                "replicas": 1,
+                "template": {
+                    "spec": {
+                        "nodeSelector": {
+                            "kubernetes.io/os": "linux",
+                            "kubernetes.io/arch": "amd64",
+                        },
+                    },
+                },
+            },
+        }
+        platform = _extract_platform_from_workload(workload)
+        assert platform is not None
+        assert platform.os == "linux"
+        assert platform.arch == "amd64"
+
+    def test_pod_template_alias_still_works(self):
+        """Some workload types use ``podTemplate`` instead of ``template``."""
+        workload = {
+            "spec": {
+                "podTemplate": {
+                    "spec": {
+                        "nodeSelector": {
+                            "kubernetes.io/os": "linux",
+                            "kubernetes.io/arch": "arm64",
+                        },
+                    },
+                },
+            },
+        }
+        platform = _extract_platform_from_workload(workload)
+        assert platform is not None
+        assert platform.os == "linux"
+        assert platform.arch == "arm64"
+
+    def test_null_spec_returns_none(self):
+        """spec itself being None must not crash."""
+        workload = {"metadata": {"name": "sb-1"}, "spec": None}
+        assert _extract_platform_from_workload(workload) is None
+
+    def test_empty_workload_returns_none(self):
+        workload = {}
+        assert _extract_platform_from_workload(workload) is None


### PR DESCRIPTION
## Problem

Creating a sandbox via pool mode (`extensions.poolRef`) returns HTTP 500 with `{"code":"KUBERNETES::API_ERROR","message":"Failed to create sandbox: 'NoneType' object has no attribute 'get'"}`, even though the underlying sandbox is created successfully and reaches Running state.

Pool-mode `BatchSandbox` CRs have `spec.poolRef` and `spec.taskTemplate` but no `spec.template`. Because the CRD declares `template` as an optional `preserve-unknown-fields` object, the Kubernetes API server returns the CR with `spec.template: null` (key present, value None).

In `server/opensandbox_server/services/k8s/workload_mapper.py:85`:
```python
spec = workload.get("spec", {})
pod_spec = (
    spec.get("template", {}).get("spec")  # crashes when template is None
    or spec.get("podTemplate", {}).get("spec")
    or {}
)
```
The default `{}` is only returned when the key is absent — not when its value is `None`. So `spec.get("template", {})` returns `None` and the next `.get("spec")` crashes.

## Impact

- All pool-mode sandbox creations fail with HTTP 500 at the API layer.
- The K8s-layer `BatchSandbox` is created and the Pod reaches Running, but clients see an error and have no `sandbox_id` returned. Resources leak unless cleaned up out-of-band.
- Affects every caller of `POST /sandboxes` that uses `extensions.poolRef` (the documented way to use pools).

Reproduction:
1. Create a Pool CR and wait for `AVAILABLE >= 1`.
2. `POST /sandboxes` with `extensions.poolRef=<pool-name>`.
3. Server returns HTTP 500; `kubectl get batchsandbox` shows the sandbox is actually `ALLOCATED=1 READY=1`.

## Fix

Treat null and missing the same when reading `template` / `podTemplate`. The same `or {}` pattern is already used correctly in the sibling function `_build_sandbox_from_workload` (`workload_mapper.py:50`).

```python
spec = workload.get("spec") or {}
template = spec.get("template") or {}
pod_template = spec.get("podTemplate") or {}
pod_spec = (
    (template.get("spec") if isinstance(template, dict) else None)
    or (pod_template.get("spec") if isinstance(pod_template, dict) else None)
    or {}
)
```

Added `server/tests/k8s/test_workload_mapper.py` with 6 cases:
- pool-mode (null template) — the original bug
- pool-mode (template key absent)
- template-mode with full platform — happy path
- `podTemplate` alias still works
- null `spec`
- empty workload

# Testing
- [x] Unit tests
- [x] Manual verification — `POST /sandboxes` with `extensions.poolRef` now returns the expected `CreateSandboxResponse` with `state: Running`

# Breaking Changes
- [x] None — purely defensive, only changes behavior in cases that previously crashed

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs — N/A, bug fix only
- [x] Added/updated tests
- [x] Security impact considered — none
- [x] Backward compatibility considered — fully backwards compatible