### PR TITLE
fix(build): align Go ELF segments to 64KB for aarch64 64K-page kernels

### DIFF
--- a/components/egress/Dockerfile
+++ b/components/egress/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
            CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
            CGO_LDFLAGS="${CGO_LDFLAGS}"; \
     go build ${GOFLAGS} -trimpath -buildvcs=false \
-    -ldflags "${LDFLAGS} -buildid= -B none \
+    -ldflags "${LDFLAGS} -buildid= -B none -R 0x10000 \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -51,14 +51,14 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
            CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
            CGO_LDFLAGS="${CGO_LDFLAGS}"; \
     go build ${GOFLAGS} -trimpath -buildvcs=false \
-    -ldflags "${LDFLAGS} -buildid= -B none \
+    -ldflags "${LDFLAGS} -buildid= -B none -R 0x10000 \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/execd ./main.go
 
 RUN CGO_ENABLED=0 GOOS=windows go build ${GOFLAGS} -trimpath -buildvcs=false \
-    -ldflags "${LDFLAGS} -buildid= -B none \
+    -ldflags "${LDFLAGS} -buildid= -B none -R 0x10000 \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \

--- a/components/execd/Makefile
+++ b/components/execd/Makefile
@@ -30,7 +30,11 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || git rev-p
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME ?= $(shell if [ -n "$$SOURCE_DATE_EPOCH" ]; then date -u -d "@$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; else date -u +"%Y-%m-%dT%H:%M:%SZ"; fi)
 PROJECT_GOFLAGS := -trimpath -buildvcs=false
-PROJECT_LDFLAGS := -buildid= -B none -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
+# -R 0x10000 pins ELF PT_LOAD segment alignment to 64KB so binaries load on
+# aarch64 kernels built with CONFIG_ARM64_64K_PAGES=y (e.g. NVIDIA Grace,
+# RHEL aarch64+64k). Go's internal linker honours this for ELF/PE; on Mach-O
+# the value just affects layout. See issue #853.
+PROJECT_LDFLAGS := -buildid= -B none -R 0x10000 -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.BuildTime=$(BUILD_TIME)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.GitCommit=$(GIT_COMMIT)'
 GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))

--- a/components/ingress/Dockerfile
+++ b/components/ingress/Dockerfile
@@ -53,7 +53,7 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
            CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
            CGO_LDFLAGS="${CGO_LDFLAGS}"; \
     go build ${GOFLAGS} -trimpath -buildvcs=false \
-    -ldflags "${LDFLAGS} -buildid= -B none \
+    -ldflags "${LDFLAGS} -buildid= -B none -R 0x10000 \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
               -X 'github.com/alibaba/opensandbox/internal/version.BuildTime=${BUILD_TIME}' \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \

--- a/components/ingress/Makefile
+++ b/components/ingress/Makefile
@@ -30,7 +30,11 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME ?= $(shell if [ -n "$$SOURCE_DATE_EPOCH" ]; then date -u -d "@$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; else date -u +"%Y-%m-%dT%H:%M:%SZ"; fi)
 PROJECT_GOFLAGS := -trimpath -buildvcs=false
-PROJECT_LDFLAGS := -buildid= -B none -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
+# -R 0x10000 pins ELF PT_LOAD segment alignment to 64KB so binaries load on
+# aarch64 kernels built with CONFIG_ARM64_64K_PAGES=y (e.g. NVIDIA Grace,
+# RHEL aarch64+64k). Go's internal linker honours this for ELF/PE; on Mach-O
+# the value just affects layout. See issue #853.
+PROJECT_LDFLAGS := -buildid= -B none -R 0x10000 -X 'github.com/alibaba/opensandbox/internal/version.Version=$(VERSION)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.BuildTime=$(BUILD_TIME)' \
 	-X 'github.com/alibaba/opensandbox/internal/version.GitCommit=$(GIT_COMMIT)'
 GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -55,7 +55,7 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
            CGO_CXXFLAGS="${CGO_CXXFLAGS:-${CXXFLAGS}}" \
            CGO_LDFLAGS="${CGO_LDFLAGS}"; \
     go build ${GOFLAGS} -trimpath -buildvcs=false \
-    -ldflags "${LDFLAGS} -buildid= -B none" \
+    -ldflags "${LDFLAGS} -buildid= -B none -R 0x10000" \
     -o server ${PACKAGE}
 
 # Use golang image as base to ensure nsenter (util-linux) is available

--- a/kubernetes/Dockerfile.image-committer
+++ b/kubernetes/Dockerfile.image-committer
@@ -28,7 +28,9 @@ RUN  GOPROXY=https://goproxy.cn,direct go mod download
 COPY cmd/image-committer/ cmd/image-committer/
 
 # Build binary
-RUN CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/image-committer ./cmd/image-committer/
+# -R 0x10000 pins ELF PT_LOAD segment alignment to 64KB for aarch64 64K-page
+# kernel compatibility. See issue #853.
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-R 0x10000" -o /usr/local/bin/image-committer ./cmd/image-committer/
 
 # Runtime stage
 FROM alpine:3.19

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -255,8 +255,11 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 ##@ Build
 
 PROJECT_GOFLAGS := -trimpath -buildvcs=false
+# -R 0x10000 pins ELF PT_LOAD segment alignment to 64KB so binaries load on
+# aarch64 kernels built with CONFIG_ARM64_64K_PAGES=y (e.g. NVIDIA Grace,
+# RHEL aarch64+64k). See issue #853.
 GO_BUILD_FLAGS := $(strip $(GOFLAGS) $(PROJECT_GOFLAGS))
-GO_LDFLAGS := $(strip $(LDFLAGS) -buildid= -B none)
+GO_LDFLAGS := $(strip $(LDFLAGS) -buildid= -B none -R 0x10000)
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.


### PR DESCRIPTION
# Summary
Pass `-R 0x10000` to Go's linker so PT_LOAD segments are aligned to 64KB in every Go binary build (execd, ingress, egress, controller, task-executor, image-committer). Without this, ELF binaries built for amd64 use 4KB segment alignment by default and fail to load on aarch64 kernels configured with CONFIG_ARM64_64K_PAGES=y (NVIDIA Grace Hopper, ARM Neoverse-V2 HPC, RHEL/CentOS aarch64+64k variants). The flag is also applied to arm64 builds to lock the alignment in case Go's default ever regresses.

Closes #853.

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered