### PR TITLE
feat(ci): publish image-committer image via release workflow

### DIFF
--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -22,6 +22,7 @@ on:
           - egress
           - controller
           - task-executor
+          - image-committer
         default: 'execd'
       image_tag:
         description: 'Docker image tag'
@@ -35,6 +36,7 @@ on:
       - 'docker/egress/**'
       - 'k8s/controller/**'
       - 'k8s/task-executor/**'
+      - 'k8s/image-committer/**'
 
 jobs:
   publish:
@@ -116,6 +118,8 @@ jobs:
           elif [ "$COMPONENT" == "controller" ]; then
             cd kubernetes
           elif [ "$COMPONENT" == "task-executor" ]; then
+            cd kubernetes
+          elif [ "$COMPONENT" == "image-committer" ]; then
             cd kubernetes
           else
             cd sandboxes/$COMPONENT

--- a/kubernetes/build.sh
+++ b/kubernetes/build.sh
@@ -37,15 +37,20 @@ DOCKERHUB_REPO="opensandbox"
 ACR_REPO="sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox"
 
 # Component specific settings
+DOCKERFILE="Dockerfile"
 if [ "$COMPONENT" == "controller" ]; then
     IMAGE_NAME="controller"
     BUILD_ARG="--build-arg PACKAGE=./cmd/controller"
 elif [ "$COMPONENT" == "task-executor" ]; then
     IMAGE_NAME="task-executor"
     BUILD_ARG="--build-arg PACKAGE=cmd/task-executor/main.go --build-arg USERID=0"
+elif [ "$COMPONENT" == "image-committer" ]; then
+    IMAGE_NAME="image-committer"
+    BUILD_ARG=""
+    DOCKERFILE="Dockerfile.image-committer"
 else
     echo "Error: Unknown component: $COMPONENT"
-    echo "Available components: controller, task-executor"
+    echo "Available components: controller, task-executor, image-committer"
     exit 1
 fi
 
@@ -69,7 +74,7 @@ if [ "$PUSH" == "true" ]; then
         -t "${ACR_REPO}/${IMAGE_NAME}:${TAG}" \
         --metadata-file "${BUILD_METADATA_FILE}" \
         --push \
-        -f Dockerfile \
+        -f "$DOCKERFILE" \
         .
     
     echo "========================================="
@@ -84,7 +89,7 @@ else
         $BUILD_ARG \
         "${BUILD_ARGS[@]}" \
         -t ${IMAGE_NAME}:${TAG} \
-        -f Dockerfile \
+        -f "$DOCKERFILE" \
         --load \
         .
     

--- a/scripts/bump-component-version.sh
+++ b/scripts/bump-component-version.sh
@@ -36,16 +36,17 @@ elif [ $# -eq 2 ]; then
   COMPONENT="$1"
   NEW_VERSION="$2"
 else
-  echo "Usage: $0 [egress|execd|ingress|code-interpreter] NEW_VERSION" >&2
+  echo "Usage: $0 [egress|execd|ingress|code-interpreter|image-committer] NEW_VERSION" >&2
   echo "       $0 NEW_VERSION   # bumps egress" >&2
   echo "Example: $0 egress v1.0.2" >&2
   echo "Example: $0 execd 1.0.7" >&2
   echo "Example: $0 ingress v1.0.6" >&2
+  echo "Example: $0 image-committer v0.1.0" >&2
   exit 1
 fi
 
 case "$COMPONENT" in
-  egress|execd|ingress|code-interpreter) ;;
+  egress|execd|ingress|code-interpreter|image-committer) ;;
   *)
     echo "Error: unsupported component: $COMPONENT" >&2
     exit 0


### PR DESCRIPTION
# Summary
Add image-committer as a selectable component in publish-components.yml, wire the kubernetes/build.sh to use Dockerfile.image-committer, and allow the bump script to update image-committer references after release.

refs #917