### PR TITLE
fix(java-sdk): Add Java timeout overload

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunCommandRequest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunCommandRequest.kt
@@ -17,6 +17,8 @@
 package com.alibaba.opensandbox.sandbox.domain.models.execd.executions
 
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 /**
  * Parameters for command execution.
@@ -77,6 +79,14 @@ class RunCommandRequest private constructor(
          */
         fun timeout(timeout: Duration?): Builder {
             this.timeout = timeout
+            return this
+        }
+
+        /**
+         * Java-friendly timeout overload using java.time.Duration.
+         */
+        fun timeout(timeout: java.time.Duration?): Builder {
+            this.timeout = timeout?.toMillis()?.toDuration(DurationUnit.MILLISECONDS)
             return this
         }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunCommandRequestTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/RunCommandRequestTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.domain.models.execd.executions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class RunCommandRequestTest {
+    @Test
+    fun `builder accepts java duration overload for timeout`() {
+        val request =
+            RunCommandRequest.builder()
+                .command("echo hi")
+                .timeout(Duration.ofSeconds(5))
+                .build()
+
+        assertEquals(5.seconds, request.timeout)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `java.time.Duration` overload for `RunCommandRequest.Builder.timeout(...)`
- Convert the Java duration to Kotlin duration in milliseconds before building the request
- Add a focused regression test for the Java-friendly overload

Fixes #849.

## Verification

- `./gradlew :sandbox:test --tests com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequestTest`
- `git diff --check`