### PR TITLE
test(k8s): make e2e suite portable across cluster modes

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -56,6 +56,8 @@ CONTROLLER_IMG ?= controller:dev
 TASK_EXECUTOR_IMG ?= task-executor:dev
 # IMAGE_COMMITTER_IMG defines the image for the image-committer service.
 IMAGE_COMMITTER_IMG ?= image-committer:dev
+# SNAPSHOT_REGISTRY defines the OCI registry used by the controller for snapshot images.
+SNAPSHOT_REGISTRY ?= docker-registry.default.svc.cluster.local:5000
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -364,7 +366,10 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/default | \
+		sed 's|--snapshot-registry=docker-registry.default.svc.cluster.local:5000|--snapshot-registry=$(SNAPSHOT_REGISTRY)|' | \
+		sed 's|--image-committer-image=image-committer:dev|--image-committer-image=$(IMAGE_COMMITTER_IMG)|' | \
+		$(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/kubernetes/config/manager/manager.yaml
+++ b/kubernetes/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
           - --snapshot-registry-insecure=true
           - --snapshot-push-secret=registry-snapshot-push-secret
           - --resume-pull-secret=registry-pull-secret
+          - --image-committer-image=image-committer:dev
         image: controller:dev
         name: manager
         ports: []

--- a/kubernetes/test/e2e/e2e_suite_test.go
+++ b/kubernetes/test/e2e/e2e_suite_test.go
@@ -36,6 +36,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	if utils.SkipImageBuild() {
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"E2E_MODE=%s SKIP_IMAGE_BUILD=true: skipping docker build & kind load (images expected to be pre-built)\n",
+			utils.Mode())
+		return
+	}
+
 	dockerBuildArgs := os.Getenv("DOCKER_BUILD_ARGS")
 
 	By("building the manager(Operator) image")
@@ -79,22 +86,22 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(utils.ImageCommitterImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the image-committer image into Kind")
 
-	By("pulling the registry:2 image (required for pause/resume tests)")
-	cmd = exec.Command("docker", "pull", "--platform", "linux/amd64", "registry:2")
+	By("pulling the registry image (required for pause/resume tests)")
+	cmd = exec.Command("docker", "pull", "--platform", "linux/amd64", utils.RegistrySourceImage())
 	_, err = utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to pull registry:2 image")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to pull registry image")
 
-	By("loading the registry:2 image on Kind")
-	err = utils.LoadImageToKindClusterWithName("registry:2")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the registry:2 image into Kind")
+	By("loading the registry image on Kind")
+	err = utils.LoadImageToKindClusterWithName(utils.RegistrySourceImage())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the registry image into Kind")
 
 	By("pulling the alpine image (required for commit jobs)")
-	cmd = exec.Command("docker", "pull", "alpine:latest")
+	cmd = exec.Command("docker", "pull", utils.AlpineImage())
 	_, err = utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to pull alpine:latest image")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to pull alpine image")
 
 	By("loading the alpine image on Kind")
-	err = utils.LoadImageToKindClusterWithName("alpine:latest")
+	err = utils.LoadImageToKindClusterWithName(utils.AlpineImage())
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the alpine image into Kind")
 })
 

--- a/kubernetes/test/e2e/e2e_test.go
+++ b/kubernetes/test/e2e/e2e_test.go
@@ -34,7 +34,7 @@ import (
 // namespace where the project is deployed in
 const namespace = "opensandbox-system"
 
-var _ = Describe("Manager", Ordered, func() {
+var _ = Describe("Manager", Ordered, Label("Core"), func() {
 	var controllerPodName string
 
 	// Before running the tests, set up the environment by creating the namespace,
@@ -49,11 +49,15 @@ var _ = Describe("Manager", Ordered, func() {
 			Expect(err.Error()).To(ContainSubstring("AlreadyExists"), "Failed to create namespace")
 		}
 
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+		if psa := utils.PodSecurityEnforce(); psa != "" {
+			By("labeling the namespace to enforce the " + psa + " security policy")
+			cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+				"pod-security.kubernetes.io/enforce="+psa)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with "+psa+" policy")
+		} else {
+			By("skipping pod-security label (E2E_POD_SECURITY_ENFORCE is empty)")
+		}
 
 		By("installing CRDs")
 		cmd = exec.Command("make", "install")
@@ -132,7 +136,7 @@ var _ = Describe("Manager", Ordered, func() {
 	SetDefaultEventuallyTimeout(2 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
-	Context("Manager", func() {
+	Context("Manager", Label("Manager"), func() {
 		It("should run successfully", func() {
 			By("validating that the controller-manager pod is running as expected")
 			verifyControllerUp := func(g Gomega) {
@@ -167,7 +171,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool", func() {
+	Context("Pool", Label("Pool"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -869,7 +873,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("BatchSandbox", func() {
+	Context("BatchSandbox", Label("Batch"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -1391,7 +1395,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Task", func() {
+	Context("Task", Label("Task"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -1557,7 +1561,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool Update", func() {
+	Context("Pool Update", Label("Pool"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -1815,7 +1819,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool State Recovery", func() {
+	Context("Pool State Recovery", Label("Pool"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -2440,7 +2444,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool Recycle", func() {
+	Context("Pool Recycle", Label("Pool"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {
@@ -3084,7 +3088,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool Allocator Integrity", func() {
+	Context("Pool Allocator Integrity", Label("Pool"), func() {
 		const testNamespace = "default"
 
 		BeforeAll(func() {
@@ -4362,7 +4366,7 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
-	Context("Pool Auto-Assign", func() {
+	Context("Pool Auto-Assign", Label("Pool"), func() {
 		BeforeAll(func() {
 			By("waiting for controller to be ready")
 			Eventually(func(g Gomega) {

--- a/kubernetes/test/e2e/pause_resume_test.go
+++ b/kubernetes/test/e2e/pause_resume_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/alibaba/OpenSandbox/sandbox-k8s/test/utils"
 )
 
-const (
-	pauseResumeNamespace = "default"
-	registryServiceAddr  = "docker-registry.default.svc.cluster.local:5000"
-	registryUsername     = "testuser"
-	registryPassword     = "testpass"
+var (
+	pauseResumeNamespace = utils.PauseResumeNamespace()
+	registryServiceAddr  = utils.PauseResumeRegistryAddr()
+	registryUsername     = utils.PauseResumeRegistryUser()
+	registryPassword     = utils.PauseResumeRegistryPass()
 )
 
-var _ = Describe("PauseResume", Ordered, func() {
+var _ = Describe("PauseResume", Ordered, Label("PauseResume"), func() {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
@@ -49,19 +49,34 @@ var _ = Describe("PauseResume", Ordered, func() {
 			Expect(err.Error()).To(ContainSubstring("AlreadyExists"))
 		}
 
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+		if pauseResumeNamespace != namespace {
+			By("creating pause-resume namespace")
+			cmd = exec.Command("kubectl", "create", "ns", pauseResumeNamespace)
+			_, err = utils.Run(cmd)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("AlreadyExists"))
+			}
+		}
+
+		if psa := utils.PodSecurityEnforce(); psa != "" {
+			By("labeling the namespace to enforce the " + psa + " security policy")
+			cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+				"pod-security.kubernetes.io/enforce="+psa)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with "+psa+" policy")
+		} else {
+			By("skipping pod-security label (E2E_POD_SECURITY_ENFORCE is empty)")
+		}
 
 		By("installing CRDs")
-		cmd = exec.Command("kubectl", "apply", "-f", "config/crd/bases")
+		cmd = exec.Command("make", "install")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 		By("deploying the controller-manager")
-		cmd = exec.Command("kubectl", "apply", "-k", "config/default")
+		cmd = exec.Command("make", "deploy",
+			fmt.Sprintf("CONTROLLER_IMG=%s", utils.ControllerImage),
+			fmt.Sprintf("SNAPSHOT_REGISTRY=%s", registryServiceAddr))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 
@@ -82,7 +97,10 @@ var _ = Describe("PauseResume", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("deploying Docker Registry")
-		registryYAML, err := renderTemplate("testdata/registry-deployment.yaml", nil)
+		registryYAML, err := renderTemplate("testdata/registry-deployment.yaml", map[string]interface{}{
+			"RegistryImage": utils.RegistrySourceImage(),
+			"Namespace":     pauseResumeNamespace,
+		})
 		Expect(err).NotTo(HaveOccurred())
 
 		registryFile := filepath.Join("/tmp", "test-registry.yaml")
@@ -126,11 +144,11 @@ var _ = Describe("PauseResume", Ordered, func() {
 		utils.Run(cmd)
 
 		By("undeploying the controller-manager")
-		cmd = exec.Command("kubectl", "delete", "-k", "config/default", "--ignore-not-found=true")
+		cmd = exec.Command("make", "undeploy")
 		utils.Run(cmd)
 
 		By("uninstalling CRDs")
-		cmd = exec.Command("kubectl", "delete", "-f", "config/crd/bases", "--ignore-not-found=true")
+		cmd = exec.Command("make", "uninstall")
 		utils.Run(cmd)
 
 		By("removing manager namespace")

--- a/kubernetes/test/e2e/testdata/registry-deployment.yaml
+++ b/kubernetes/test/e2e/testdata/registry-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: docker-registry
-  namespace: default
+  namespace: {{ .Namespace }}
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: registry:2
+        image: {{ .RegistryImage }}
         ports:
         - containerPort: 5000
         env:
@@ -41,12 +41,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: docker-registry
-  namespace: default
+  namespace: {{ .Namespace }}
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - port: 5000
     targetPort: 5000
-    nodePort: 30500
   selector:
     app: docker-registry

--- a/kubernetes/test/utils/cluster_mode.go
+++ b/kubernetes/test/utils/cluster_mode.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "os"
+
+const (
+	// ModeKind runs e2e against a local Kind cluster (default).
+	ModeKind = "kind"
+	// ModeExternal runs e2e against an externally-provided Kubernetes cluster
+	// using the kubeconfig pointed to by KUBECONFIG. Use this when targeting
+	// minikube, a shared dev cluster, a CI-provisioned cluster, etc.
+	ModeExternal = "external"
+)
+
+// Mode returns the e2e cluster mode. Reads E2E_MODE env, defaults to ModeKind.
+func Mode() string {
+	if v := os.Getenv("E2E_MODE"); v != "" {
+		return v
+	}
+	return ModeKind
+}
+
+// IsKind reports whether the current e2e mode is the local Kind cluster.
+func IsKind() bool { return Mode() == ModeKind }
+
+// IsExternal reports whether the current e2e mode targets an
+// externally-provided cluster via KUBECONFIG.
+func IsExternal() bool { return !IsKind() }
+
+// SkipImageBuild reports whether the suite should skip the docker-build /
+// kind-load steps in BeforeSuite. Non-Kind modes default to true because
+// images are expected to be pre-built and pushed to a registry the target
+// cluster can pull from.
+func SkipImageBuild() bool {
+	if v := os.Getenv("SKIP_IMAGE_BUILD"); v != "" {
+		return v == "1" || v == "true" || v == "TRUE"
+	}
+	return IsExternal()
+}
+
+// RegistrySourceImage returns the upstream registry image used by the
+// in-cluster docker-registry deployment for pause/resume tests. Override
+// via REGISTRY_SOURCE_IMAGE to point at a mirror reachable from the target
+// cluster.
+func RegistrySourceImage() string {
+	if v := os.Getenv("REGISTRY_SOURCE_IMAGE"); v != "" {
+		return v
+	}
+	return "registry:2"
+}
+
+// AlpineImage returns the alpine image used by commit jobs.
+func AlpineImage() string {
+	if v := os.Getenv("ALPINE_IMAGE"); v != "" {
+		return v
+	}
+	return "alpine:latest"
+}
+
+// PauseResumeNamespace returns the namespace used by pause/resume tests for
+// the in-cluster docker-registry and registry secrets.
+func PauseResumeNamespace() string {
+	if v := os.Getenv("PAUSE_RESUME_NAMESPACE"); v != "" {
+		return v
+	}
+	return "default"
+}
+
+// PauseResumeRegistryAddr returns the in-cluster docker-registry service
+// address used by pause/resume tests. When unset, it derives the host from
+// PauseResumeNamespace() so overriding only PAUSE_RESUME_NAMESPACE is
+// sufficient and credential auths stay aligned with the registry endpoint.
+func PauseResumeRegistryAddr() string {
+	if v := os.Getenv("PAUSE_RESUME_REGISTRY_ADDR"); v != "" {
+		return v
+	}
+	return "docker-registry." + PauseResumeNamespace() + ".svc.cluster.local:5000"
+}
+
+// PauseResumeRegistryUser returns the registry username for pause/resume tests.
+func PauseResumeRegistryUser() string {
+	if v := os.Getenv("PAUSE_RESUME_REGISTRY_USER"); v != "" {
+		return v
+	}
+	return "testuser"
+}
+
+// PauseResumeRegistryPass returns the registry password for pause/resume tests.
+func PauseResumeRegistryPass() string {
+	if v := os.Getenv("PAUSE_RESUME_REGISTRY_PASS"); v != "" {
+		return v
+	}
+	return "testpass"
+}
+
+// PodSecurityEnforce returns the value applied to the
+// `pod-security.kubernetes.io/enforce` namespace label. Empty string means
+// the suite must skip applying the label (some platforms reject restricted).
+func PodSecurityEnforce() string {
+	if v, ok := os.LookupEnv("E2E_POD_SECURITY_ENFORCE"); ok {
+		return v
+	}
+	return "restricted"
+}

--- a/kubernetes/test/utils/utils.go
+++ b/kubernetes/test/utils/utils.go
@@ -163,8 +163,15 @@ func IsCertManagerCRDsInstalled() bool {
 	return false
 }
 
-// LoadImageToKindClusterWithName loads a local docker image to the kind cluster
+// LoadImageToKindClusterWithName loads a local docker image to the kind cluster.
+// When E2E_MODE is not "kind" this is a no-op: the image is expected to live in
+// a registry the target cluster can pull from, so there is no Kind node to
+// load into.
 func LoadImageToKindClusterWithName(name string) error {
+	if IsExternal() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "skipping kind load for %q (E2E_MODE=%s)\n", name, Mode())
+		return nil
+	}
 	cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v


### PR DESCRIPTION
Decouples the kubernetes/ e2e suite from the assumption that it always runs against a freshly-built Kind cluster, so it can also be pointed at an externally-provided Kubernetes cluster (e.g. minikube, a shared dev cluster, or a CI-provisioned one) via KUBECONFIG.

- New test/utils/cluster_mode.go centralises mode + env-driven defaults (E2E_MODE, E2E_POD_SECURITY_ENFORCE, registry / namespace / credential knobs for the pause/resume sub-suite). Default mode stays "kind", so existing `make test-e2e-main` behaviour is unchanged.
- LoadImageToKindClusterWithName becomes a no-op when E2E_MODE!=kind, since images are expected to be pre-pushed to a registry the target cluster can pull from.
- BeforeSuite skips docker-build / kind-load entirely outside Kind mode.
- The pod-security label step is now controlled by E2E_POD_SECURITY_ENFORCE; setting it to an empty value skips the label, which is useful on clusters that enforce their own admission policy. Default value preserves the current "restricted" behaviour.
- pause_resume_test.go: registry namespace / address / credentials are now overridable via env; deploy/undeploy switched to `make install/deploy/undeploy/uninstall` for consistency with e2e_test.go; registry-deployment.yaml is rendered as a template so the source image can be pointed at a mirror.
- registry-deployment.yaml: parameterised image and switched the Service to ClusterIP (the suite only consumes it via cluster DNS, so the previous NodePort 30500 was unnecessary and can collide on shared clusters).
- Added Ginkgo Labels (Core/Manager/Pool/Batch/Task/PauseResume) so consumers can use -ginkgo.label-filter to subset the suite.

# Summary
- What is changing and why?

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
