### PR TITLE
chore(helm): bump image-committer to v0.1.0

### DIFF
--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -47,7 +47,8 @@ controller:
   # -- Pause/Resume snapshot configuration
   snapshot:
     # -- Image used for commit operations (must contain nerdctl tool)
-    imageCommitterImage: "image-committer:dev"
+    # DockerHub: opensandbox/image-committer:v0.1.0
+    imageCommitterImage: "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/image-committer:v0.1.0"
     # -- Containerd socket path of host
     containerdSocketPath: "/var/run/containerd/containerd.sock"
     # -- Timeout duration for commit jobs

--- a/kubernetes/charts/opensandbox/values.yaml
+++ b/kubernetes/charts/opensandbox/values.yaml
@@ -9,7 +9,8 @@ opensandbox-controller:
     logLevel: info
     replicaCount: 1
     snapshot:
-      imageCommitterImage: image-committer:dev
+      # DockerHub: opensandbox/image-committer:v0.1.0
+      imageCommitterImage: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/image-committer:v0.1.0
       commitJobTimeout: 10m
       registry: ""
       registryInsecure: false


### PR DESCRIPTION
# Summary
- Sync helm values with image-committer v0.1.0 release. Use sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com mirror, note DockerHub location opensandbox/image-committer:v0.1.0 in comments.

# Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered