### PR TITLE
fix(egress): retry mitmdump restart with backoff instead of giving up

### DIFF
--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
@@ -29,13 +30,24 @@ import (
 	"github.com/alibaba/opensandbox/internal/safego"
 )
 
+// exitEvent carries an OnExit notification tagged with the generation of the
+// mitmdump process that produced it. Generation tagging lets the watcher tell
+// "the currently-running mitmdump just died" apart from "a half-launched
+// attempt we already killed during a retry storm just finished reaping".
+type exitEvent struct {
+	gen uint64
+	err error
+}
+
 type mitmTransparent struct {
-	mu        sync.Mutex
-	running   *mitmproxy.Running
-	port      int
-	uid       uint32
-	cfg       mitmproxy.Config
-	restartCh chan error
+	mu         sync.Mutex
+	running    *mitmproxy.Running
+	currentGen uint64 // generation of the mitmdump currently considered live
+	port       int
+	uid        uint32
+	cfg        mitmproxy.Config // OnExit must NOT be set here; built per-Launch
+	nextGen    uint64           // atomic; monotonic gen counter handed to each Launch
+	restartCh  chan exitEvent
 }
 
 func (m *mitmTransparent) getRunning() *mitmproxy.Running {
@@ -44,10 +56,29 @@ func (m *mitmTransparent) getRunning() *mitmproxy.Running {
 	return m.running
 }
 
-func (m *mitmTransparent) setRunning(r *mitmproxy.Running) {
+func (m *mitmTransparent) setRunning(r *mitmproxy.Running, gen uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.running = r
+	m.currentGen = gen
+}
+
+func (m *mitmTransparent) getCurrentGen() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentGen
+}
+
+// launchTagged starts mitmdump with an OnExit closure that publishes the death
+// of this specific process (identified by gen) into restartCh.
+func launchTagged(cfg mitmproxy.Config, restartCh chan<- exitEvent, gen uint64) (*mitmproxy.Running, error) {
+	cfg.OnExit = func(err error) {
+		select {
+		case restartCh <- exitEvent{gen: gen, err: err}:
+		default:
+		}
+	}
+	return mitmproxy.Launch(cfg)
 }
 
 // startMitmproxyTransparentIfEnabled starts mitmdump in transparent mode, waits for the listener, and installs OUTPUT REDIRECT, then syncs the CA.
@@ -68,14 +99,9 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 		ConfDir:    strings.TrimSpace(os.Getenv(constants.EnvMitmproxyConfDir)),
 		ScriptPath: strings.TrimSpace(os.Getenv(constants.EnvMitmproxyScript)),
 	}
-	restartCh := make(chan error, 1)
-	cfg.OnExit = func(err error) {
-		select {
-		case restartCh <- err:
-		default:
-		}
-	}
-	running, err := mitmproxy.Launch(cfg)
+	restartCh := make(chan exitEvent, 1)
+	const initialGen uint64 = 1
+	running, err := launchTagged(cfg, restartCh, initialGen)
 	if err != nil {
 		return nil, fmt.Errorf("start mitmdump: %w", err)
 	}
@@ -93,7 +119,15 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 	if err := mitmproxy.SyncRootCA(confDir, mpHome); err != nil {
 		return nil, fmt.Errorf("mitm CA export: %w", err)
 	}
-	return &mitmTransparent{running: running, port: mpPort, uid: mpUID, cfg: cfg, restartCh: restartCh}, nil
+	return &mitmTransparent{
+		running:    running,
+		currentGen: initialGen,
+		port:       mpPort,
+		uid:        mpUID,
+		cfg:        cfg,
+		nextGen:    initialGen,
+		restartCh:  restartCh,
+	}, nil
 }
 
 // watchMitmproxy monitors mitmdump for unexpected exits, logs the error, and restarts it.
@@ -102,14 +136,22 @@ func (m *mitmTransparent) watchMitmproxy(ctx context.Context, gate *mitmproxy.He
 	safego.Go(func() {
 		for {
 			select {
-			case err := <-m.restartCh:
+			case ev := <-m.restartCh:
 				select {
 				case <-ctx.Done():
 					return
 				default:
 				}
+				cur := m.getCurrentGen()
+				if ev.gen != cur {
+					// Stale event: a previous half-launched attempt that we
+					// killed is just now being reaped. The currently-live
+					// mitmdump is unaffected; ignore and keep watching.
+					log.Infof("[mitmproxy] ignoring stale exit event (gen=%d, current=%d): %v", ev.gen, cur, ev.err)
+					continue
+				}
 
-				log.Errorf("[mitmproxy] mitmdump exited: %v; restarting...", err)
+				log.Errorf("[mitmproxy] mitmdump exited (gen=%d): %v; restarting...", ev.gen, ev.err)
 				gate.SetReady(false)
 				m.restartWithBackoff(ctx, gate)
 
@@ -123,6 +165,11 @@ func (m *mitmTransparent) watchMitmproxy(ctx context.Context, gate *mitmproxy.He
 // restartWithBackoff retries mitmdump launch indefinitely with exponential backoff
 // (1s, 2s, 4s, ..., capped at 30s) until it succeeds or ctx is cancelled.
 // Transient OOM / resource pressure must not leave egress in a permanent dead state.
+//
+// Each attempt is tagged with a fresh generation; setRunning publishes that
+// generation as the "live" one. Exit events for older (killed) generations are
+// filtered out by watchMitmproxy, so we do NOT drain restartCh here -- doing
+// so could swallow a real death of the freshly-restarted mitmdump.
 func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmproxy.HealthGate) {
 	const (
 		initialBackoff = time.Second
@@ -138,26 +185,22 @@ func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmprox
 		default:
 		}
 
-		newRunning, launchErr := mitmproxy.Launch(m.cfg)
+		gen := atomic.AddUint64(&m.nextGen, 1)
+		newRunning, launchErr := launchTagged(m.cfg, m.restartCh, gen)
 		if launchErr == nil {
 			if waitErr := mitmproxy.WaitListenPort(waitAddr, 15*time.Second); waitErr == nil {
-				m.setRunning(newRunning)
+				m.setRunning(newRunning, gen)
 				gate.SetReady(true)
-				log.Infof("[mitmproxy] mitmdump restarted (pid %d, attempt %d)", newRunning.Cmd.Process.Pid, attempt)
-				// Drain any stale exit signal queued by killed half-launched attempts.
-				select {
-				case <-m.restartCh:
-				default:
-				}
+				log.Infof("[mitmproxy] mitmdump restarted (pid %d, gen %d, attempt %d)", newRunning.Cmd.Process.Pid, gen, attempt)
 				return
 			} else {
-				log.Errorf("[mitmproxy] restart attempt %d: wait listen %s: %v", attempt, waitAddr, waitErr)
+				log.Errorf("[mitmproxy] restart attempt %d (gen %d): wait listen %s: %v", attempt, gen, waitAddr, waitErr)
 				if newRunning.Cmd != nil && newRunning.Cmd.Process != nil {
 					_ = newRunning.Cmd.Process.Kill()
 				}
 			}
 		} else {
-			log.Errorf("[mitmproxy] restart attempt %d: launch failed: %v", attempt, launchErr)
+			log.Errorf("[mitmproxy] restart attempt %d (gen %d): launch failed: %v", attempt, gen, launchErr)
 		}
 
 		log.Warnf("[mitmproxy] restart attempt %d failed; retrying in %s", attempt, backoff)

--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -111,26 +111,66 @@ func (m *mitmTransparent) watchMitmproxy(ctx context.Context, gate *mitmproxy.He
 
 				log.Errorf("[mitmproxy] mitmdump exited: %v; restarting...", err)
 				gate.SetReady(false)
-
-				newRunning, launchErr := mitmproxy.Launch(m.cfg)
-				if launchErr != nil {
-					log.Errorf("[mitmproxy] failed to restart mitmdump: %v; giving up", launchErr)
-					return
-				}
-
-				waitAddr := fmt.Sprintf("127.0.0.1:%d", m.cfg.ListenPort)
-				if waitErr := mitmproxy.WaitListenPort(waitAddr, 15*time.Second); waitErr != nil {
-					log.Errorf("[mitmproxy] restart: wait listen %s: %v; giving up", waitAddr, waitErr)
-					return
-				}
-
-				m.setRunning(newRunning)
-				gate.SetReady(true)
-				log.Infof("[mitmproxy] mitmdump restarted (pid %d)", newRunning.Cmd.Process.Pid)
+				m.restartWithBackoff(ctx, gate)
 
 			case <-ctx.Done():
 				return
 			}
 		}
 	})
+}
+
+// restartWithBackoff retries mitmdump launch indefinitely with exponential backoff
+// (1s, 2s, 4s, ..., capped at 30s) until it succeeds or ctx is cancelled.
+// Transient OOM / resource pressure must not leave egress in a permanent dead state.
+func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmproxy.HealthGate) {
+	const (
+		initialBackoff = time.Second
+		maxBackoff     = 30 * time.Second
+	)
+	backoff := initialBackoff
+	waitAddr := fmt.Sprintf("127.0.0.1:%d", m.cfg.ListenPort)
+
+	for attempt := 1; ; attempt++ {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		newRunning, launchErr := mitmproxy.Launch(m.cfg)
+		if launchErr == nil {
+			if waitErr := mitmproxy.WaitListenPort(waitAddr, 15*time.Second); waitErr == nil {
+				m.setRunning(newRunning)
+				gate.SetReady(true)
+				log.Infof("[mitmproxy] mitmdump restarted (pid %d, attempt %d)", newRunning.Cmd.Process.Pid, attempt)
+				// Drain any stale exit signal queued by killed half-launched attempts.
+				select {
+				case <-m.restartCh:
+				default:
+				}
+				return
+			} else {
+				log.Errorf("[mitmproxy] restart attempt %d: wait listen %s: %v", attempt, waitAddr, waitErr)
+				if newRunning.Cmd != nil && newRunning.Cmd.Process != nil {
+					_ = newRunning.Cmd.Process.Kill()
+				}
+			}
+		} else {
+			log.Errorf("[mitmproxy] restart attempt %d: launch failed: %v", attempt, launchErr)
+		}
+
+		log.Warnf("[mitmproxy] restart attempt %d failed; retrying in %s", attempt, backoff)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
 }

--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -48,6 +48,7 @@ type mitmTransparent struct {
 	cfg        mitmproxy.Config // OnExit must NOT be set here; built per-Launch
 	nextGen    uint64           // atomic; monotonic gen counter handed to each Launch
 	restartCh  chan exitEvent
+	shutdownCh chan struct{} // closed by watchMitmproxy on ctx cancel; lets OnExit unblock during shutdown
 }
 
 func (m *mitmTransparent) getRunning() *mitmproxy.Running {
@@ -71,11 +72,20 @@ func (m *mitmTransparent) getCurrentGen() uint64 {
 
 // launchTagged starts mitmdump with an OnExit closure that publishes the death
 // of this specific process (identified by gen) into restartCh.
-func launchTagged(cfg mitmproxy.Config, restartCh chan<- exitEvent, gen uint64) (*mitmproxy.Running, error) {
+//
+// The send is blocking with shutdownCh as the only escape: dropping an exit
+// event while the watcher is still running can leave egress in a silent dead
+// state (the watcher would never see the death and never trigger a restart).
+// Stale events from killed half-launched attempts are still cheap to discard
+// downstream via the gen check in watchMitmproxy; we just must not lose them
+// in transit. Shutdown is the only legitimate reason to give up on a send,
+// and we log a warning when that happens so the drop is observable.
+func launchTagged(cfg mitmproxy.Config, restartCh chan<- exitEvent, shutdownCh <-chan struct{}, gen uint64) (*mitmproxy.Running, error) {
 	cfg.OnExit = func(err error) {
 		select {
 		case restartCh <- exitEvent{gen: gen, err: err}:
-		default:
+		case <-shutdownCh:
+			log.Warnf("[mitmproxy] dropping exit event during shutdown (gen=%d): %v", gen, err)
 		}
 	}
 	return mitmproxy.Launch(cfg)
@@ -99,17 +109,15 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 		ConfDir:    strings.TrimSpace(os.Getenv(constants.EnvMitmproxyConfDir)),
 		ScriptPath: strings.TrimSpace(os.Getenv(constants.EnvMitmproxyScript)),
 	}
-	// Buffered enough to absorb stale exit events from a retry storm without
-	// dropping the death event of the currently-live mitmdump. With buffer 1,
-	// a single half-launched attempt's OnExit can occupy the slot, causing the
-	// fresh process's real death event to be dropped via the default branch in
-	// launchTagged -- watcher would then read the stale event, ignore it on
-	// gen mismatch, and block forever (the same silent-dead-state this watchdog
-	// is meant to prevent). Stale events are still cheap to discard via the
-	// gen check; we just need room to store them.
+	// Buffer absorbs OnExit events from a retry storm so OnExit goroutines
+	// don't all park waiting for the watcher to drain. Correctness does not
+	// depend on the size: launchTagged uses a blocking send with shutdownCh
+	// as the only escape, so events cannot be silently dropped while the
+	// watcher is alive.
 	restartCh := make(chan exitEvent, 64)
+	shutdownCh := make(chan struct{})
 	const initialGen uint64 = 1
-	running, err := launchTagged(cfg, restartCh, initialGen)
+	running, err := launchTagged(cfg, restartCh, shutdownCh, initialGen)
 	if err != nil {
 		return nil, fmt.Errorf("start mitmdump: %w", err)
 	}
@@ -135,12 +143,20 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 		cfg:        cfg,
 		nextGen:    initialGen,
 		restartCh:  restartCh,
+		shutdownCh: shutdownCh,
 	}, nil
 }
 
 // watchMitmproxy monitors mitmdump for unexpected exits, logs the error, and restarts it.
 // Must be called after startMitmproxyTransparentIfEnabled.
 func (m *mitmTransparent) watchMitmproxy(ctx context.Context, gate *mitmproxy.HealthGate) {
+	// Closing shutdownCh on ctx cancel unblocks any OnExit closures that are
+	// parked on the (now-unread) restartCh send so they don't leak past
+	// shutdown.
+	safego.Go(func() {
+		<-ctx.Done()
+		close(m.shutdownCh)
+	})
 	safego.Go(func() {
 		for {
 			select {
@@ -194,7 +210,7 @@ func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmprox
 		}
 
 		gen := atomic.AddUint64(&m.nextGen, 1)
-		newRunning, launchErr := launchTagged(m.cfg, m.restartCh, gen)
+		newRunning, launchErr := launchTagged(m.cfg, m.restartCh, m.shutdownCh, gen)
 		if launchErr == nil {
 			if waitErr := mitmproxy.WaitListenPort(waitAddr, 15*time.Second); waitErr == nil {
 				m.setRunning(newRunning, gen)

--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -99,7 +99,15 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 		ConfDir:    strings.TrimSpace(os.Getenv(constants.EnvMitmproxyConfDir)),
 		ScriptPath: strings.TrimSpace(os.Getenv(constants.EnvMitmproxyScript)),
 	}
-	restartCh := make(chan exitEvent, 1)
+	// Buffered enough to absorb stale exit events from a retry storm without
+	// dropping the death event of the currently-live mitmdump. With buffer 1,
+	// a single half-launched attempt's OnExit can occupy the slot, causing the
+	// fresh process's real death event to be dropped via the default branch in
+	// launchTagged -- watcher would then read the stale event, ignore it on
+	// gen mismatch, and block forever (the same silent-dead-state this watchdog
+	// is meant to prevent). Stale events are still cheap to discard via the
+	// gen check; we just need room to store them.
+	restartCh := make(chan exitEvent, 64)
 	const initialGen uint64 = 1
 	running, err := launchTagged(cfg, restartCh, initialGen)
 	if err != nil {
@@ -195,9 +203,11 @@ func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmprox
 				return
 			} else {
 				log.Errorf("[mitmproxy] restart attempt %d (gen %d): wait listen %s: %v", attempt, gen, waitAddr, waitErr)
-				if newRunning.Cmd != nil && newRunning.Cmd.Process != nil {
-					_ = newRunning.Cmd.Process.Kill()
-				}
+				// GracefulShutdown SIGTERMs then SIGKILLs and waits for reap, so
+				// the listen port is released before the next attempt's Launch
+				// races to bind it. Direct Process.Kill returns immediately and
+				// can cause spurious WaitListenPort failures on port contention.
+				mitmproxy.GracefulShutdown(newRunning, time.Second)
 			}
 		} else {
 			log.Errorf("[mitmproxy] restart attempt %d (gen %d): launch failed: %v", attempt, gen, launchErr)


### PR DESCRIPTION
# Summary
- Previously, if Launch or WaitListenPort failed during a restart (e.g. under node memory pressure that just OOM-killed mitmdump), the watchdog goroutine would log "giving up" and return, leaving egress in a silent dead state with no future restarts.
- Replace the one-shot restart with restartWithBackoff: retry forever with exponential backoff (1s -> 30s), kill half-launched processes, drain stale exit signals on success, and respect ctx cancellation. Readiness gate stays false across the retry window so k8s drains traffic.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered