### PR TITLE
fix(execd): extend mitm CA wait to 300s and log wait duration

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -129,7 +129,7 @@ trust_mitm_ca_nss() {
 MITM_CA="/opt/opensandbox/mitmproxy-ca-cert.pem"
 if is_truthy "${OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT:-}"; then
 	i=0
-	while [ "$i" -lt 30 ]; do
+	while [ "$i" -lt 300 ]; do
 		if [ -f "$MITM_CA" ] && [ -s "$MITM_CA" ]; then
 			break
 		fi
@@ -137,9 +137,12 @@ if is_truthy "${OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT:-}"; then
 		i=$((i + 1))
 	done
 	if [ ! -f "$MITM_CA" ] || [ ! -s "$MITM_CA" ]; then
-		echo "warning: timed out after 30s waiting for $MITM_CA (egress mitm CA export); continuing without system CA trust" >&2
-	elif ! trust_mitm_ca "$MITM_CA"; then
-		echo "warning: failed to install mitm CA into system trust store; TLS interception may not work for system libraries" >&2
+		echo "warning: timed out after 300s waiting for $MITM_CA (egress mitm CA export); continuing without system CA trust" >&2
+	else
+		echo "mitm CA ready at $MITM_CA after ${i}s"
+		if ! trust_mitm_ca "$MITM_CA"; then
+			echo "warning: failed to install mitm CA into system trust store; TLS interception may not work for system libraries" >&2
+		fi
 	fi
 
 	if [ -f "$MITM_CA" ] && [ -s "$MITM_CA" ]; then


### PR DESCRIPTION
# Summary
The bootstrap script waited at most 30s for /opt/opensandbox/mitmproxy-ca-cert.pem before skipping system CA trust setup. When the egress sidecar is recovering from a transient failure (e.g. mitmproxy OOM-killed and being restarted with backoff), 30s is not enough and the sandbox starts without TLS interception support, silently breaking HTTPS for system libraries.

Extend the wait to 300s and log the actual wait duration on success so the boot timeline is visible in execd logs.

# Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered