### PR TITLE
fix(code-interpreter): skip repeated tslab install on startup

### DIFF
--- a/sandboxes/code-interpreter/scripts/code-interpreter.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter.sh
@@ -112,11 +112,27 @@ setup_java() {
 	}
 }
 
+tslab_kernels_installed() {
+	local kernels
+	kernels=$(jupyter kernelspec list 2>/dev/null)
+	grep -Eq '^[[:space:]]+tslab[[:space:]]' <<<"$kernels" && grep -Eq '^[[:space:]]+jslab[[:space:]]' <<<"$kernels"
+}
+
+ensure_tslab_command() {
+	if command -v tslab >/dev/null 2>&1; then
+		return
+	fi
+
+	npm install -g tslab
+}
+
 # setup node
 setup_node() {
 	time {
-		npm install -g tslab
-		tslab install
+		ensure_tslab_command
+		if ! tslab_kernels_installed; then
+			tslab install
+		fi
 	}
 }
 

--- a/sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh
+++ b/sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+script="$repo_root/sandboxes/code-interpreter/scripts/code-interpreter.sh"
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+
+write_tslab_stub() {
+	cat >"$sandbox/tslab" <<'STUB'
+#!/usr/bin/env bash
+echo "tslab $*" >>"$CALL_LOG"
+STUB
+	chmod +x "$sandbox/tslab"
+}
+
+cat >"$sandbox/npm" <<'STUB'
+#!/usr/bin/env bash
+echo "npm $*" >>"$CALL_LOG"
+if [ "$1 $2 $3" = "install -g tslab" ]; then
+	cat >"$TEST_BIN_DIR/tslab" <<'TSLAB'
+#!/usr/bin/env bash
+echo "tslab $*" >>"$CALL_LOG"
+TSLAB
+	chmod +x "$TEST_BIN_DIR/tslab"
+fi
+STUB
+write_tslab_stub
+cat >"$sandbox/jupyter" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "kernelspec" ] && [ "$2" = "list" ]; then
+	cat "$JUPYTER_KERNELS"
+fi
+STUB
+chmod +x "$sandbox/npm" "$sandbox/jupyter"
+
+extract_node_setup() {
+	awk '
+		/^tslab_kernels_installed\(\)/ {emit=1}
+		emit {print}
+		/^setup_node\(\)/ {in_setup=1}
+		in_setup && /^}/ {exit}
+	' "$script"
+}
+
+run_setup_node() {
+	CALL_LOG=$1 JUPYTER_KERNELS=$2 TEST_BIN_DIR="$sandbox" PATH="$sandbox:$PATH" bash -c "$(extract_node_setup); setup_node"
+}
+
+call_log="$sandbox/calls-installed.log"
+kernels="$sandbox/kernels-installed.txt"
+cat >"$kernels" <<'KERNELS'
+Available kernels:
+  python    /usr/local/share/jupyter/kernels/python
+  tslab     /usr/local/share/jupyter/kernels/tslab
+  jslab     /usr/local/share/jupyter/kernels/jslab
+KERNELS
+run_setup_node "$call_log" "$kernels"
+if [ -s "$call_log" ]; then
+	echo "expected no npm or tslab calls when kernels are already installed" >&2
+	cat "$call_log" >&2
+	exit 1
+fi
+
+call_log="$sandbox/calls-missing-kernels.log"
+kernels="$sandbox/kernels-missing.txt"
+cat >"$kernels" <<'KERNELS'
+Available kernels:
+  python    /usr/local/share/jupyter/kernels/python
+KERNELS
+run_setup_node "$call_log" "$kernels"
+if grep -q '^npm install -g tslab$' "$call_log"; then
+	echo "did not expect npm install when tslab command exists" >&2
+	cat "$call_log" >&2
+	exit 1
+fi
+if ! grep -q '^tslab install$' "$call_log"; then
+	echo "expected tslab install when kernels are missing" >&2
+	cat "$call_log" >&2
+	exit 1
+fi
+
+call_log="$sandbox/calls-partial-kernels.log"
+kernels="$sandbox/kernels-partial.txt"
+cat >"$kernels" <<'KERNELS'
+Available kernels:
+  python    /usr/local/share/jupyter/kernels/python
+  tslab     /usr/local/share/jupyter/kernels/tslab
+KERNELS
+run_setup_node "$call_log" "$kernels"
+if grep -q '^npm install -g tslab$' "$call_log"; then
+	echo "did not expect npm install when tslab command exists" >&2
+	cat "$call_log" >&2
+	exit 1
+fi
+if ! grep -q '^tslab install$' "$call_log"; then
+	echo "expected tslab install when one kernel is missing" >&2
+	cat "$call_log" >&2
+	exit 1
+fi
+
+rm "$sandbox/tslab"
+call_log="$sandbox/calls-missing-command.log"
+run_setup_node "$call_log" "$kernels"
+if ! grep -q '^npm install -g tslab$' "$call_log"; then
+	echo "expected npm install when tslab command is missing" >&2
+	cat "$call_log" >&2
+	exit 1
+fi


### PR DESCRIPTION
# Summary
- Skip `npm install -g tslab` during Code Interpreter startup when the image already has the `tslab` command available.
- Skip `tslab install` when both `tslab` and `jslab` Jupyter kernelspecs are already registered.
- Keep the existing repair path: if `tslab` is missing, startup still installs it, and if either kernelspec is missing, startup registers the kernels.

Fixes #946

# Testing
- [x] Unit tests
  - `bash -n sandboxes/code-interpreter/scripts/code-interpreter.sh sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh`
  - `sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh`
  - `git diff --check`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
