### PR TITLE
Potential fix for code scanning alert no. 159: Clear-text logging of sensitive information

### DIFF
--- a/examples/openclaw/main.py
+++ b/examples/openclaw/main.py
@@ -72,8 +72,8 @@ def main() -> None:
     port = DEFAULT_PORT
 
     print(f"Creating openclaw sandbox with image={image} on OpenSandbox server {server}...")
-    print(f"  API Key: {api_key[:16]}..." if len(api_key) > 16 else f"  API Key: {api_key}")
-    print(f"  Token: {token[:16]}..." if len(token) > 16 else f"  Token: {token}")
+    print(f"  API Key: {'[REDACTED] (set)' if api_key else '[NOT SET]'}")
+    print(f"  Token: {'[REDACTED] (set)' if token else '[NOT SET]'}")
     print(f"  Port: {port}")
     print(f"  Timeout: {timeout_seconds}s")
     


### PR DESCRIPTION
Potential fix for [https://github.com/alibaba/OpenSandbox/security/code-scanning/159](https://github.com/alibaba/OpenSandbox/security/code-scanning/159)

The best fix is to stop logging secret values entirely and replace them with non-sensitive status information (for example, whether the API key/token is set). This preserves functionality (sandbox creation still uses the real `api_key` and `token`) while removing sensitive data exposure.

In `examples/openclaw/main.py`, update the startup logging lines around 75–76:
- Replace API key print with a redacted/set-not-set message.
- Replace token print similarly (same class of issue, and prevents similar future alerts).

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
