### PR TITLE
feat(telemetry): fall back to HOST_IP and /etc/hostinfo for OTLP endpoint

### DIFF
--- a/components/internal/telemetry/init.go
+++ b/components/internal/telemetry/init.go
@@ -18,6 +18,7 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"strings"
 
@@ -37,6 +38,14 @@ type Config struct {
 	ResourceAttributes []attribute.KeyValue
 	RegisterMetrics    func() error
 }
+
+const (
+	envOTLPMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	envOTLPEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envHostIP              = "HOST_IP"
+	otlpHTTPPort           = "4318"
+	hostInfoPath           = "/etc/hostinfo"
+)
 
 // Init sets a noop TracerProvider, optionally MeterProvider with OTLP HTTP exporter.
 // Shutdown must be called on exit.
@@ -58,7 +67,7 @@ func Init(ctx context.Context, cfg Config) (shutdown func(context.Context) error
 	)
 
 	if metricsEnabled() {
-		mexp, err := otlpmetrichttp.New(ctx)
+		mexp, err := otlpmetrichttp.New(ctx, metricsClientOptions()...)
 		if err != nil {
 			return nil, err
 		}
@@ -100,8 +109,55 @@ func buildResource(ctx context.Context, serviceName string, extra []attribute.Ke
 	return resource.New(ctx, opts...)
 }
 
+// Endpoint precedence: OTEL_EXPORTER_OTLP_*_ENDPOINT -> HOST_IP -> /etc/hostinfo.
 func metricsEnabled() bool {
-	return firstEndpoint(os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != ""
+	if otlpEndpointFromEnv() != "" {
+		return true
+	}
+	_, ok := resolveNodeIP()
+	return ok
+}
+
+func metricsClientOptions() []otlpmetrichttp.Option {
+	if otlpEndpointFromEnv() != "" {
+		return nil
+	}
+	ip, ok := resolveNodeIP()
+	if !ok {
+		return nil
+	}
+	return []otlpmetrichttp.Option{
+		otlpmetrichttp.WithEndpoint(net.JoinHostPort(ip, otlpHTTPPort)),
+		otlpmetrichttp.WithInsecure(),
+	}
+}
+
+func otlpEndpointFromEnv() string {
+	return firstEndpoint(os.Getenv(envOTLPMetricsEndpoint), os.Getenv(envOTLPEndpoint))
+}
+
+func resolveNodeIP() (string, bool) {
+	if ip := strings.TrimSpace(os.Getenv(envHostIP)); ip != "" && net.ParseIP(ip) != nil {
+		return ip, true
+	}
+	return readHostInfoIP(hostInfoPath)
+}
+
+func readHostInfoIP(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if net.ParseIP(line) != nil {
+			return line, true
+		}
+	}
+	return "", false
 }
 
 func firstEndpoint(primary, fallback string) string {


### PR DESCRIPTION
# Summary
When neither `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` nor `OTEL_EXPORTER_OTLP_ENDPOINT` is set, resolve the node IP from the `HOST_IP` env var, then from `/etc/hostinfo`, and point the OTLP/HTTP exporter at `<node-ip>:4318` over plaintext. Lets execd and egress emit metrics in environments where only a node IP is available, without requiring callers to template the full endpoint URL.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered