### PR TITLE
fix(server): preserve encoded proxy response bodies

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -136,13 +136,14 @@ def _schedule_proxy_renew(request: Request | WebSocket, sandbox_id: str) -> None
 
 async def _stream_backend_response(resp: httpx.Response) -> AsyncIterator[bytes]:
     """
-    Yield backend body chunks and always close the httpx streaming response.
+    Yield backend body chunks without httpx content decoding and always close the response.
 
     httpx requires ``await resp.aclose()`` for ``stream=True`` responses so connections
     return to the pool; Starlette's StreamingResponse does not do this automatically.
+    Use ``aiter_raw`` so forwarded ``content-encoding`` headers still match the body bytes.
     """
     try:
-        async for chunk in resp.aiter_bytes():
+        async for chunk in resp.aiter_raw():
             yield chunk
     finally:
         await resp.aclose()

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import gzip
 from typing import Any, cast
 
 import httpx
@@ -29,15 +30,28 @@ from opensandbox_server.services.constants import OPEN_SANDBOX_SECURE_ACCESS_HEA
 
 class _FakeStreamingResponse:
     def __init__(
-        self, status_code: int = 200, headers: dict | None = None, chunks: list[bytes] | None = None
+        self,
+        status_code: int = 200,
+        headers: dict | None = None,
+        chunks: list[bytes] | None = None,
+        raw_chunks: list[bytes] | None = None,
     ):
         self.status_code = status_code
         self.headers = httpx.Headers(headers or {})
         self._chunks = chunks or []
+        self._raw_chunks = raw_chunks if raw_chunks is not None else self._chunks
         self.aclose_called = False
+        self.aiter_bytes_called = False
+        self.aiter_raw_called = False
 
     async def aiter_bytes(self):
+        self.aiter_bytes_called = True
         for chunk in self._chunks:
+            yield chunk
+
+    async def aiter_raw(self):
+        self.aiter_raw_called = True
+        for chunk in self._raw_chunks:
             yield chunk
 
     async def aclose(self):
@@ -423,6 +437,46 @@ def test_proxy_filters_response_hop_by_hop_headers(
     assert response.headers.get("keep-alive") is None
     assert response.headers.get("trailer") is None
     assert response.headers.get("x-hop-temp") is None
+
+
+def test_proxy_preserves_compressed_response_body(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    decoded_body = b"<html>vnc</html>"
+    encoded_body = gzip.compress(decoded_body)
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(
+        status_code=200,
+        headers={
+            "content-type": "text/html",
+            "content-encoding": "gzip",
+        },
+        chunks=[decoded_body],
+        raw_chunks=[encoded_body],
+    )
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/8080/vnc/index.html",
+        headers={**auth_headers, "Accept-Encoding": "gzip"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"
+    assert response.content == decoded_body
+    assert fake_client.response.aiter_raw_called is True
+    assert fake_client.response.aiter_bytes_called is False
+    assert fake_client.response.aclose_called is True
 
 
 def test_proxy_rejects_websocket_upgrade(

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -439,7 +439,7 @@ def test_proxy_filters_response_hop_by_hop_headers(
     assert response.headers.get("x-hop-temp") is None
 
 
-def test_proxy_preserves_compressed_response_body(
+def test_proxy_streams_raw_body_for_content_encoded_response(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -450,7 +450,7 @@ def test_proxy_preserves_compressed_response_body(
             assert resolve_internal is True
             return Endpoint(endpoint="10.57.1.91:40109")
 
-    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService)
 
     decoded_body = b"<html>vnc</html>"
     encoded_body = gzip.compress(decoded_body)


### PR DESCRIPTION
## Summary
- stream sandbox proxy responses with raw backend bytes so preserved Content-Encoding headers stay correct
- add a regression test for gzip-encoded backend responses through the server proxy

## Root cause
The proxy forwarded backend content-encoding headers while streaming with httpx aiter_bytes(), which decodes compressed bodies. Clients then saw a gzip header on already-decoded bytes and failed to render gzip responses such as noVNC pages.

## Testing
- /tmp/opensandbox-server-py311-env/bin/python -m pytest tests/test_routes_proxy.py
- /tmp/opensandbox-server-py311-env/bin/python -m ruff check opensandbox_server/api/proxy.py tests/test_routes_proxy.py

Closes #965