### PR TITLE
fix(egress): switch mitmproxy to connection_strategy=eager

### DIFF
--- a/components/egress/Dockerfile
+++ b/components/egress/Dockerfile
@@ -122,7 +122,8 @@ COPY --from=builder /out/opensandbox-supervisor /opt/opensandbox-egress/supervis
 COPY components/egress/scripts/cleanup.sh /opt/opensandbox-egress/cleanup.sh
 RUN chmod 0755 /opt/opensandbox-egress/cleanup.sh \
             /opt/opensandbox-egress/egress \
-            /opt/opensandbox-egress/supervisor
+            /opt/opensandbox-egress/supervisor \
+    && ln -s /opt/opensandbox-egress/egress /egress
 
 COPY components/egress/mitmscripts /var/egress/mitmscripts
 

--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -107,9 +107,18 @@ func Launch(cfg Config) (*Running, error) {
 	// Stream large bodies instead of buffering them in memory (OOM prevention).
 	args = append(args, "--set", "stream_large_bodies=1m")
 
-	// Lazy connection strategy: defer upstream connection until the request is fully received,
-	// which avoids unnecessary connections for blocked/filtered requests.
-	args = append(args, "--set", "connection_strategy=lazy")
+	// Eager connection strategy: open the upstream connection alongside the client
+	// connection so mitm's IO loop continuously observes upstream FIN/RST. Lazy
+	// defers the upstream open until the full request is buffered and checks the
+	// upstream pool per-request; on h1 keepalive sessions this exposes a stale-
+	// connection race where the second request (e.g. POST /git-upload-pack right
+	// after GET /info/refs) picks an upstream conn the peer has already closed,
+	// surfacing as a silent transport error with no fatal output on the client.
+	// Eager trades a wasted TCP/TLS handshake for the small fraction of requests
+	// denied by the egress addon — acceptable because a denied flow already short-
+	// circuits with `flow.response = ...` before any HTTP write reaches upstream,
+	// so the upstream still sees no path/method/headers from the denied request.
+	args = append(args, "--set", "connection_strategy=eager")
 
 	// Transparent mode redirects TCP to IP addresses. Clients connecting to IPs
 	// do not send SNI, so upstream TLS cert hostname verification fails with


### PR DESCRIPTION
# Summary
Lazy was originally chosen so denied requests could short-circuit before touching upstream, but in practice the egress policy defaults to allow and denies only a small minority of requests. The savings on the deny path do not justify the cost on the allow path: lazy checks the upstream connection pool per-request, and on h1 keepalive sessions this exposes a stale-conn race where the second request (e.g. POST /git-upload-pack right after GET /info/refs) picks an upstream conn the peer has already closed, surfacing as a silent transport error with no fatal output on the client.

Eager opens the upstream connection alongside the client connection, so mitm's IO loop continuously observes upstream FIN/RST and a stale conn is detected before the client's next request arrives. The cost is a wasted TCP/TLS handshake for the small fraction of denied requests — acceptable because a denied flow still short-circuits with `flow.response = ...` before any HTTP write reaches upstream, so upstream sees no path / method / headers, only an unfinished handshake.

Audited the bundled addons (system.py, custom.py): no hook depends on lazy-only behavior (no server_connect routing, no flow.request.host modification, no client-SNI-based upstream decisions).

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered