### PR TITLE
feat(sdk): add skipAccumulation to prevent OutputMessage OOM

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Internal/ExecutionEventDispatcher.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Internal/ExecutionEventDispatcher.cs
@@ -95,7 +95,10 @@ internal sealed class ExecutionEventDispatcher
             IsError = false
         };
 
-        _execution.Logs.Stdout.Add(msg);
+        if (_handlers is not { SkipAccumulation: true })
+        {
+            _execution.Logs.Stdout.Add(msg);
+        }
 
         if (_handlers?.OnStdout != null)
         {
@@ -112,7 +115,10 @@ internal sealed class ExecutionEventDispatcher
             IsError = true
         };
 
-        _execution.Logs.Stderr.Add(msg);
+        if (_handlers is not { SkipAccumulation: true })
+        {
+            _execution.Logs.Stderr.Add(msg);
+        }
 
         if (_handlers?.OnStderr != null)
         {

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Execution.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Execution.cs
@@ -207,4 +207,11 @@ public class ExecutionHandlers
     /// Gets or sets the handler for execution initialization.
     /// </summary>
     public Func<ExecutionInit, Task>? OnInit { get; set; }
+
+    /// <summary>
+    /// When true, stdout/stderr messages are only delivered to handlers without
+    /// being accumulated in <see cref="ExecutionLogs"/>. Use for long-running
+    /// executions to prevent unbounded memory growth.
+    /// </summary>
+    public bool SkipAccumulation { get; set; }
 }

--- a/sdks/sandbox/go/execution.go
+++ b/sdks/sandbox/go/execution.go
@@ -104,6 +104,11 @@ type ExecutionHandlers struct {
 	OnResult   func(ExecutionResult) error
 	OnComplete func(ExecutionComplete) error
 	OnError    func(ExecutionError) error
+
+	// SkipAccumulation, when true, prevents stdout/stderr messages from being
+	// accumulated in the Execution struct. Messages are still delivered to handlers.
+	// Use for long-running executions to prevent unbounded memory growth.
+	SkipAccumulation bool
 }
 
 // sseErrorPayload is the nested error object in a ServerStreamEvent.
@@ -146,7 +151,9 @@ func processStreamEvent(exec *Execution, event StreamEvent, handlers *ExecutionH
 	if err := json.Unmarshal([]byte(data), &ev); err != nil {
 		// Not JSON — treat as raw stdout
 		msg := OutputMessage{Text: data}
-		exec.Stdout = append(exec.Stdout, msg)
+		if handlers == nil || !handlers.SkipAccumulation {
+			exec.Stdout = append(exec.Stdout, msg)
+		}
 		if handlers != nil && handlers.OnStdout != nil {
 			return handlers.OnStdout(msg)
 		}
@@ -163,14 +170,18 @@ func processStreamEvent(exec *Execution, event StreamEvent, handlers *ExecutionH
 
 	case "stdout":
 		msg := OutputMessage{Text: ev.Text, Timestamp: ev.Timestamp}
-		exec.Stdout = append(exec.Stdout, msg)
+		if handlers == nil || !handlers.SkipAccumulation {
+			exec.Stdout = append(exec.Stdout, msg)
+		}
 		if handlers != nil && handlers.OnStdout != nil {
 			return handlers.OnStdout(msg)
 		}
 
 	case "stderr":
 		msg := OutputMessage{Text: ev.Text, Timestamp: ev.Timestamp}
-		exec.Stderr = append(exec.Stderr, msg)
+		if handlers == nil || !handlers.SkipAccumulation {
+			exec.Stderr = append(exec.Stderr, msg)
+		}
 		if handlers != nil && handlers.OnStderr != nil {
 			return handlers.OnStderr(msg)
 		}
@@ -239,7 +250,9 @@ func processStreamEvent(exec *Execution, event StreamEvent, handlers *ExecutionH
 		// Unknown event type — treat as stdout
 		if ev.Text != "" {
 			msg := OutputMessage{Text: ev.Text, Timestamp: ev.Timestamp}
-			exec.Stdout = append(exec.Stdout, msg)
+			if handlers == nil || !handlers.SkipAccumulation {
+				exec.Stdout = append(exec.Stdout, msg)
+			}
 			if handlers != nil && handlers.OnStdout != nil {
 				return handlers.OnStdout(msg)
 			}

--- a/sdks/sandbox/javascript/src/models/execution.ts
+++ b/sdks/sandbox/javascript/src/models/execution.ts
@@ -69,4 +69,10 @@ export interface ExecutionHandlers {
   onExecutionComplete?: (c: ExecutionComplete) => void | Promise<void>;
   onError?: (err: ExecutionError) => void | Promise<void>;
   onInit?: (init: ExecutionInit) => void | Promise<void>;
+  /**
+   * When true, stdout/stderr messages are only delivered to handlers without
+   * being accumulated in the execution logs. Use for long-running executions
+   * to prevent unbounded memory growth.
+   */
+  skipAccumulation?: boolean;
 }

--- a/sdks/sandbox/javascript/src/models/executionEventDispatcher.ts
+++ b/sdks/sandbox/javascript/src/models/executionEventDispatcher.ts
@@ -48,13 +48,17 @@ export class ExecutionEventDispatcher {
       }
       case "stdout": {
         const msg: OutputMessage = { text: ev.text ?? "", timestamp: ts, isError: false };
-        this.execution.logs.stdout.push(msg);
+        if (!this.handlers?.skipAccumulation) {
+          this.execution.logs.stdout.push(msg);
+        }
         await this.handlers?.onStdout?.(msg);
         return;
       }
       case "stderr": {
         const msg: OutputMessage = { text: ev.text ?? "", timestamp: ts, isError: true };
-        this.execution.logs.stderr.push(msg);
+        if (!this.handlers?.skipAccumulation) {
+          this.execution.logs.stderr.push(msg);
+        }
         await this.handlers?.onStderr?.(msg);
         return;
       }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/ExecutionModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/executions/ExecutionModels.kt
@@ -216,6 +216,12 @@ class ExecutionHandlers private constructor(
      * Called when code execution starts.
      */
     val onInit: OutputHandler<ExecutionInit>? = null,
+    /**
+     * When true, stdout/stderr messages are only delivered to handlers without
+     * being accumulated in [ExecutionLogs]. Use this for long-running executions
+     * to prevent unbounded memory growth.
+     */
+    val skipAccumulation: Boolean = false,
 ) {
     companion object {
         @JvmStatic
@@ -229,6 +235,7 @@ class ExecutionHandlers private constructor(
         private var onExecutionComplete: OutputHandler<ExecutionComplete>? = null
         private var onError: OutputHandler<ExecutionError>? = null
         private var onInit: OutputHandler<ExecutionInit>? = null
+        private var skipAccumulation: Boolean = false
 
         fun onStdout(handler: OutputHandler<OutputMessage>): Builder {
             this.onStdout = handler
@@ -260,6 +267,11 @@ class ExecutionHandlers private constructor(
             return this
         }
 
+        fun skipAccumulation(skip: Boolean): Builder {
+            this.skipAccumulation = skip
+            return this
+        }
+
         fun build(): ExecutionHandlers {
             return ExecutionHandlers(
                 onStdout = onStdout,
@@ -268,6 +280,7 @@ class ExecutionHandlers private constructor(
                 onExecutionComplete = onExecutionComplete,
                 onError = onError,
                 onInit = onInit,
+                skipAccumulation = skipAccumulation,
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExecutionEventDispatcher.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExecutionEventDispatcher.kt
@@ -62,7 +62,9 @@ class ExecutionEventDispatcher(
     ) {
         val stdoutText = eventNode.text ?: ""
         val stdoutMessage = OutputMessage(stdoutText, timestamp, false)
-        execution.logs.addStdout(stdoutMessage)
+        if (handlers?.skipAccumulation != true) {
+            execution.logs.addStdout(stdoutMessage)
+        }
         handlers?.onStdout?.handle(stdoutMessage)
     }
 
@@ -72,7 +74,9 @@ class ExecutionEventDispatcher(
     ) {
         val stderrText = eventNode.text ?: ""
         val stderrMessage = OutputMessage(stderrText, timestamp, true)
-        execution.logs.addStderr(stderrMessage)
+        if (handlers?.skipAccumulation != true) {
+            execution.logs.addStderr(stderrMessage)
+        }
         handlers?.onStderr?.handle(stderrMessage)
     }
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/execution_event_dispatcher.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/execution_event_dispatcher.py
@@ -80,7 +80,8 @@ class ExecutionEventDispatcher:
             timestamp=timestamp,
             is_error=False,
         )
-        self.execution.logs.add_stdout(message)
+        if not (self.handlers and self.handlers.skip_accumulation):
+            self.execution.logs.add_stdout(message)
         if self.handlers and self.handlers.on_stdout:
             await self.handlers.on_stdout(message)
 
@@ -91,7 +92,8 @@ class ExecutionEventDispatcher:
             timestamp=timestamp,
             is_error=True,
         )
-        self.execution.logs.add_stderr(message)
+        if not (self.handlers and self.handlers.skip_accumulation):
+            self.execution.logs.add_stderr(message)
         if self.handlers and self.handlers.on_stderr:
             await self.handlers.on_stderr(message)
 

--- a/sdks/sandbox/python/src/opensandbox/models/execd.py
+++ b/sdks/sandbox/python/src/opensandbox/models/execd.py
@@ -260,6 +260,12 @@ class ExecutionHandlers(BaseModel):
     on_init: AsyncOutputHandler | None = Field(
         default=None, description="Async handler for execution init"
     )
+    skip_accumulation: bool = Field(
+        default=False,
+        description="When True, stdout/stderr messages are only delivered to handlers "
+        "without being accumulated in ExecutionLogs. Use for long-running "
+        "executions to prevent unbounded memory growth.",
+    )
 
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
 

--- a/sdks/sandbox/python/src/opensandbox/models/execd_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/models/execd_sync.py
@@ -39,5 +39,10 @@ class ExecutionHandlersSync(BaseModel):
     on_execution_complete: SyncOutputHandler | None = Field(default=None, alias="on_execution_complete")
     on_error: SyncOutputHandler | None = Field(default=None)
     on_init: SyncOutputHandler | None = Field(default=None)
+    skip_accumulation: bool = Field(
+        default=False,
+        description="When True, stdout/stderr messages are only delivered to handlers "
+        "without being accumulated in ExecutionLogs.",
+    )
 
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/converter/execution_event_dispatcher.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/converter/execution_event_dispatcher.py
@@ -67,13 +67,15 @@ class ExecutionEventDispatcherSync:
 
     def _handle_stdout(self, event_node: EventNode, timestamp: int) -> None:
         message = OutputMessage(text=event_node.text or "", timestamp=timestamp, is_error=False)
-        self.execution.logs.add_stdout(message)
+        if not (self.handlers and self.handlers.skip_accumulation):
+            self.execution.logs.add_stdout(message)
         if self.handlers and self.handlers.on_stdout:
             self.handlers.on_stdout(message)
 
     def _handle_stderr(self, event_node: EventNode, timestamp: int) -> None:
         message = OutputMessage(text=event_node.text or "", timestamp=timestamp, is_error=True)
-        self.execution.logs.add_stderr(message)
+        if not (self.handlers and self.handlers.skip_accumulation):
+            self.execution.logs.add_stderr(message)
         if self.handlers and self.handlers.on_stderr:
             self.handlers.on_stderr(message)
 


### PR DESCRIPTION
## Summary

- Add `skipAccumulation` option to `ExecutionHandlers` across all SDK languages (Kotlin, Python async/sync, TypeScript, Go, C#)
- When enabled, stdout/stderr messages are delivered to handler callbacks without being appended to `ExecutionLogs`, enabling constant-memory streaming for long-running executions
- Default `false` — fully backward compatible, no breaking changes

## Motivation

Production OOM caused by unbounded `OutputMessage` accumulation when streaming handlers are provided (41M objects observed in Java heap dump). Users who provide streaming handlers have no way to opt out of message buffering.

## Changes

| SDK | Files |
|-----|-------|
| Kotlin | `ExecutionModels.kt`, `ExecutionEventDispatcher.kt` |
| Python (async) | `execd.py`, `execution_event_dispatcher.py` |
| Python (sync) | `execd_sync.py`, sync `execution_event_dispatcher.py` |
| TypeScript | `execution.ts`, `executionEventDispatcher.ts` |
| Go | `execution.go` |
| C# | `Execution.cs`, `ExecutionEventDispatcher.cs` |

## Test plan

- [x] Go: `go test ./...` passes
- [x] TypeScript: `npx tsc --noEmit` + `npm test` passes
- [x] Python: `pytest` passes + manual import verification
- [ ] Kotlin: needs JVM 17+ (not available in local env, CI will verify)
- [ ] C#: CI will verify

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)