### PR TITLE
feat(execd): add replacedCount feedback to Replace File Content API

### DIFF
--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -323,6 +323,8 @@ func (c *FilesystemController) ReplaceContent() {
 	rec := beginFilesystemMetric("replace")
 	defer rec.Finish(c.basicController)
 
+	verbose := c.ctx.Query("verbose") == "true"
+
 	var request map[string]model.ReplaceFileContentItem
 	if err := c.bindJSON(&request); err != nil {
 		c.RespondError(
@@ -333,7 +335,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
-	results := make(map[string]model.ReplaceFileContentResult)
+	var results map[string]model.ReplaceFileContentResult
+	if verbose {
+		results = make(map[string]model.ReplaceFileContentResult)
+	}
 
 	for file, item := range request {
 		origPath := file
@@ -367,7 +372,6 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 
 		contentStr := string(content)
-		count := strings.Count(contentStr, item.Old)
 		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
@@ -376,9 +380,17 @@ func (c *FilesystemController) ReplaceContent() {
 			return
 		}
 
-		results[origPath] = model.ReplaceFileContentResult{ReplacedCount: count}
+		if verbose {
+			results[origPath] = model.ReplaceFileContentResult{
+				ReplacedCount: strings.Count(contentStr, item.Old),
+			}
+		}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(results)
+	if verbose {
+		c.RespondSuccess(results)
+	} else {
+		c.RespondSuccess(nil)
+	}
 }

--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -361,6 +361,11 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
+		if item.Old == "" {
+			c.RespondError(http.StatusBadRequest, model.ErrorCodeInvalidRequest, "old content must not be empty")
+			return
+		}
+
 		contentStr := string(content)
 		count := strings.Count(contentStr, item.Old)
 		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)

--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -333,7 +333,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
+	results := make(map[string]model.ReplaceFileContentResult)
+
 	for file, item := range request {
+		origPath := file
 		file, err := pathutil.ExpandAbsPath(file)
 		if err != nil {
 			c.handleFileError(err)
@@ -358,15 +361,19 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
-		newContent := strings.ReplaceAll(string(content), item.Old, item.New)
+		contentStr := string(content)
+		count := strings.Count(contentStr, item.Old)
+		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
 		if err != nil {
 			c.handleFileError(err)
 			return
 		}
+
+		results[origPath] = model.ReplaceFileContentResult{ReplacedCount: count}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(nil)
+	c.RespondSuccess(results)
 }

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -309,6 +309,8 @@ func (c *FilesystemController) ReplaceContent() {
 	rec := beginFilesystemMetric("replace")
 	defer rec.Finish(c.basicController)
 
+	verbose := c.ctx.Query("verbose") == "true"
+
 	var request map[string]model.ReplaceFileContentItem
 	if err := c.bindJSON(&request); err != nil {
 		c.RespondError(
@@ -319,7 +321,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
-	results := make(map[string]model.ReplaceFileContentResult)
+	var results map[string]model.ReplaceFileContentResult
+	if verbose {
+		results = make(map[string]model.ReplaceFileContentResult)
+	}
 
 	for file, item := range request {
 		origPath := file
@@ -353,7 +358,6 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 
 		contentStr := string(content)
-		count := strings.Count(contentStr, item.Old)
 		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
@@ -362,9 +366,17 @@ func (c *FilesystemController) ReplaceContent() {
 			return
 		}
 
-		results[origPath] = model.ReplaceFileContentResult{ReplacedCount: count}
+		if verbose {
+			results[origPath] = model.ReplaceFileContentResult{
+				ReplacedCount: strings.Count(contentStr, item.Old),
+			}
+		}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(results)
+	if verbose {
+		c.RespondSuccess(results)
+	} else {
+		c.RespondSuccess(nil)
+	}
 }

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -347,6 +347,11 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
+		if item.Old == "" {
+			c.RespondError(http.StatusBadRequest, model.ErrorCodeInvalidRequest, "old content must not be empty")
+			return
+		}
+
 		contentStr := string(content)
 		count := strings.Count(contentStr, item.Old)
 		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -319,7 +319,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
+	results := make(map[string]model.ReplaceFileContentResult)
+
 	for file, item := range request {
+		origPath := file
 		file, err := pathutil.ExpandAbsPath(file)
 		if err != nil {
 			c.handleFileError(err)
@@ -344,15 +347,19 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
-		newContent := strings.ReplaceAll(string(content), item.Old, item.New)
+		contentStr := string(content)
+		count := strings.Count(contentStr, item.Old)
+		newContent := strings.ReplaceAll(contentStr, item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
 		if err != nil {
 			c.handleFileError(err)
 			return
 		}
+
+		results[origPath] = model.ReplaceFileContentResult{ReplacedCount: count}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(nil)
+	c.RespondSuccess(results)
 }

--- a/components/execd/pkg/web/model/filesystem.go
+++ b/components/execd/pkg/web/model/filesystem.go
@@ -48,3 +48,8 @@ type ReplaceFileContentItem struct {
 	Old string `json:"old,omitempty"`
 	New string `json:"new,omitempty"`
 }
+
+// ReplaceFileContentResult represents the result of a content replacement on a single file
+type ReplaceFileContentResult struct {
+	ReplacedCount int `json:"replacedCount"`
+}

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
@@ -700,7 +700,7 @@ def register_tools(
             ContentReplaceEntry(**entry.model_dump(exclude_none=True))
             for entry in entries
         ]
-        return await sandbox.files.replace_contents(replace_entries)
+        return await sandbox.files.replace_contents_detailed(replace_entries)
 
     @tool()
     async def sandbox_get_endpoint(

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/server.py
@@ -25,6 +25,7 @@ from opensandbox.config import ConnectionConfig
 from opensandbox.models.execd import Execution, RunCommandOpts
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -680,7 +681,7 @@ def register_tools(
         entries: list[ContentReplaceEntry],
         *,
         connect_if_missing: bool = False,
-    ) -> StatusResponse:
+    ) -> list[ContentReplaceResult]:
         """Replace content inside files.
 
         Parameters:
@@ -689,7 +690,7 @@ def register_tools(
             connect_if_missing: Connect if sandbox not in local registry.
 
         Returns:
-            {"status": "updated"} when successful.
+            List of replacement results with counts per file.
         """
         sandbox = await _get_or_connect_sandbox(
             sandbox_id,
@@ -699,8 +700,7 @@ def register_tools(
             ContentReplaceEntry(**entry.model_dump(exclude_none=True))
             for entry in entries
         ]
-        await sandbox.files.replace_contents(replace_entries)
-        return StatusResponse(status="updated")
+        return await sandbox.files.replace_contents(replace_entries)
 
     @tool()
     async def sandbox_get_endpoint(

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -255,7 +255,22 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         await _client.PostAsync("/files/mv", body, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(
+    public async Task ReplaceContentsAsync(
+        IEnumerable<ContentReplaceEntry> entries,
+        CancellationToken cancellationToken = default)
+    {
+        var body = entries.ToDictionary(
+            e => e.Path,
+            e => new ReplaceFileContentItem
+            {
+                Old = e.OldContent,
+                New = e.NewContent
+            });
+
+        await _client.PostAsync("/files/replace", body, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsDetailedAsync(
         IEnumerable<ContentReplaceEntry> entries,
         CancellationToken cancellationToken = default)
     {

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -267,16 +267,8 @@ internal sealed class FilesystemAdapter : ISandboxFiles
                 New = e.NewContent
             });
 
-        Dictionary<string, ReplaceFileContentResult> response;
-        try
-        {
-            response = await _client.PostAsync<Dictionary<string, ReplaceFileContentResult>>(
-                "/files/replace", body, cancellationToken).ConfigureAwait(false);
-        }
-        catch (JsonException)
-        {
-            return Array.Empty<ContentReplaceResult>();
-        }
+        var response = await _client.PostAsync<Dictionary<string, ReplaceFileContentResult>>(
+            "/files/replace?verbose=true", body, cancellationToken).ConfigureAwait(false);
 
         return response.Select(kv => new ContentReplaceResult
         {

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -267,8 +267,16 @@ internal sealed class FilesystemAdapter : ISandboxFiles
                 New = e.NewContent
             });
 
-        var response = await _client.PostAsync<Dictionary<string, ReplaceFileContentResult>>(
-            "/files/replace", body, cancellationToken).ConfigureAwait(false);
+        Dictionary<string, ReplaceFileContentResult> response;
+        try
+        {
+            response = await _client.PostAsync<Dictionary<string, ReplaceFileContentResult>>(
+                "/files/replace", body, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<ContentReplaceResult>();
+        }
 
         return response.Select(kv => new ContentReplaceResult
         {

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -255,7 +255,7 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         await _client.PostAsync("/files/mv", body, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task ReplaceContentsAsync(
+    public async Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(
         IEnumerable<ContentReplaceEntry> entries,
         CancellationToken cancellationToken = default)
     {
@@ -267,7 +267,14 @@ internal sealed class FilesystemAdapter : ISandboxFiles
                 New = e.NewContent
             });
 
-        await _client.PostAsync("/files/replace", body, cancellationToken).ConfigureAwait(false);
+        var response = await _client.PostAsync<Dictionary<string, ReplaceFileContentResult>>(
+            "/files/replace", body, cancellationToken).ConfigureAwait(false);
+
+        return response.Select(kv => new ContentReplaceResult
+        {
+            Path = kv.Key,
+            ReplacedCount = kv.Value.ReplacedCount,
+        }).ToList();
     }
 
     public async Task SetPermissionsAsync(

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
@@ -317,3 +317,31 @@ public class ReplaceFileContentItem
     [JsonPropertyName("new")]
     public required string New { get; set; }
 }
+
+/// <summary>
+/// Result of a content replacement operation on a single file.
+/// </summary>
+public class ContentReplaceResult
+{
+    /// <summary>
+    /// Gets or sets the file path.
+    /// </summary>
+    public required string Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of occurrences replaced. 0 means old content was not found.
+    /// </summary>
+    public int ReplacedCount { get; set; }
+}
+
+/// <summary>
+/// API response model for replace file content result.
+/// </summary>
+public class ReplaceFileContentResult
+{
+    /// <summary>
+    /// Gets or sets the number of occurrences replaced.
+    /// </summary>
+    [JsonPropertyName("replacedCount")]
+    public int ReplacedCount { get; set; }
+}

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
@@ -148,10 +148,21 @@ public interface ISandboxFiles
     /// </summary>
     /// <param name="entries">The content replace entries.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidArgumentException">Thrown when request values are invalid.</exception>
+    /// <exception cref="SandboxException">Thrown when the execd service request fails.</exception>
+    Task ReplaceContentsAsync(
+        IEnumerable<ContentReplaceEntry> entries,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces content in files and returns per-file replacement counts.
+    /// </summary>
+    /// <param name="entries">The content replace entries.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of replacement results with counts per file.</returns>
     /// <exception cref="InvalidArgumentException">Thrown when request values are invalid.</exception>
     /// <exception cref="SandboxException">Thrown when the execd service request fails.</exception>
-    Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(
+    Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsDetailedAsync(
         IEnumerable<ContentReplaceEntry> entries,
         CancellationToken cancellationToken = default);
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
@@ -148,9 +148,10 @@ public interface ISandboxFiles
     /// </summary>
     /// <param name="entries">The content replace entries.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of replacement results with counts per file.</returns>
     /// <exception cref="InvalidArgumentException">Thrown when request values are invalid.</exception>
     /// <exception cref="SandboxException">Thrown when the execd service request fails.</exception>
-    Task ReplaceContentsAsync(
+    Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(
         IEnumerable<ContentReplaceEntry> entries,
         CancellationToken cancellationToken = default);
 

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -367,7 +367,10 @@ public class SandboxEgressLifecycleTests
         public Task MoveFilesAsync(IEnumerable<MoveEntry> entries, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(IEnumerable<ContentReplaceEntry> entries, CancellationToken cancellationToken = default) =>
+        public Task ReplaceContentsAsync(IEnumerable<ContentReplaceEntry> entries, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsDetailedAsync(IEnumerable<ContentReplaceEntry> entries, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
         public Task SetPermissionsAsync(IEnumerable<SetPermissionEntry> entries, CancellationToken cancellationToken = default) =>

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -367,7 +367,7 @@ public class SandboxEgressLifecycleTests
         public Task MoveFilesAsync(IEnumerable<MoveEntry> entries, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
-        public Task ReplaceContentsAsync(IEnumerable<ContentReplaceEntry> entries, CancellationToken cancellationToken = default) =>
+        public Task<IReadOnlyList<ContentReplaceResult>> ReplaceContentsAsync(IEnumerable<ContentReplaceEntry> entries, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
         public Task SetPermissionsAsync(IEnumerable<SetPermissionEntry> entries, CancellationToken cancellationToken = default) =>

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -256,7 +256,12 @@ func (e *ExecdClient) SearchFiles(ctx context.Context, dir string, pattern strin
 }
 
 // ReplaceInFiles performs text replacement in the specified files.
-func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
+func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) error {
+	return e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, nil)
+}
+
+// ReplaceInFilesDetailed performs text replacement and returns per-file replacement counts.
+func (e *ExecdClient) ReplaceInFilesDetailed(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
 	var resp ReplaceResponse
 	err := e.client.doRequest(ctx, http.MethodPost, "/files/replace?verbose=true", req, &resp)
 	if err != nil {

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -17,7 +17,6 @@ package opensandbox
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -259,11 +258,8 @@ func (e *ExecdClient) SearchFiles(ctx context.Context, dir string, pattern strin
 // ReplaceInFiles performs text replacement in the specified files.
 func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
 	var resp ReplaceResponse
-	err := e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, &resp)
+	err := e.client.doRequest(ctx, http.MethodPost, "/files/replace?verbose=true", req, &resp)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return ReplaceResponse{}, nil
-		}
 		return nil, err
 	}
 	return resp, nil

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -256,8 +256,13 @@ func (e *ExecdClient) SearchFiles(ctx context.Context, dir string, pattern strin
 }
 
 // ReplaceInFiles performs text replacement in the specified files.
-func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) error {
-	return e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, nil)
+func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
+	var resp ReplaceResponse
+	err := e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // UploadFileOptions configures the destination path and multipart filename for an upload.

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -17,6 +17,7 @@ package opensandbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -260,6 +261,9 @@ func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (R
 	var resp ReplaceResponse
 	err := e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, &resp)
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return ReplaceResponse{}, nil
+		}
 		return nil, err
 	}
 	return resp, nil

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1570,9 +1570,6 @@ func TestReplaceInFiles(t *testing.T) {
 		if r.URL.Path != "/files/replace" {
 			assert.Fail(t, fmt.Sprintf("expected /files/replace, got %s", r.URL.Path))
 		}
-		if r.URL.Query().Get("verbose") != "true" {
-			assert.Fail(t, "expected verbose=true query param")
-		}
 
 		var req ReplaceRequest
 		json.NewDecoder(r.Body).Decode(&req)
@@ -1584,6 +1581,24 @@ func TestReplaceInFiles(t *testing.T) {
 			assert.Fail(t, fmt.Sprintf("replace item = %+v", item))
 		}
 
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.ReplaceInFiles(context.Background(), ReplaceRequest{
+		"/tmp/config.txt": {Old: "localhost", New: "production.example.com"},
+	})
+	require.NoErrorf(t, err, "ReplaceInFiles")
+}
+
+func TestReplaceInFilesDetailed(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/replace" {
+			assert.Fail(t, fmt.Sprintf("expected /files/replace, got %s", r.URL.Path))
+		}
+		if r.URL.Query().Get("verbose") != "true" {
+			assert.Fail(t, "expected verbose=true query param")
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(ReplaceResponse{
@@ -1591,10 +1606,10 @@ func TestReplaceInFiles(t *testing.T) {
 		})
 	})
 
-	resp, err := client.ReplaceInFiles(context.Background(), ReplaceRequest{
+	resp, err := client.ReplaceInFilesDetailed(context.Background(), ReplaceRequest{
 		"/tmp/config.txt": {Old: "localhost", New: "production.example.com"},
 	})
-	require.NoErrorf(t, err, "ReplaceInFiles")
+	require.NoErrorf(t, err, "ReplaceInFilesDetailed")
 	if resp == nil {
 		assert.Fail(t, "expected non-nil response")
 	}

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1570,6 +1570,9 @@ func TestReplaceInFiles(t *testing.T) {
 		if r.URL.Path != "/files/replace" {
 			assert.Fail(t, fmt.Sprintf("expected /files/replace, got %s", r.URL.Path))
 		}
+		if r.URL.Query().Get("verbose") != "true" {
+			assert.Fail(t, "expected verbose=true query param")
+		}
 
 		var req ReplaceRequest
 		json.NewDecoder(r.Body).Decode(&req)

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1581,13 +1581,23 @@ func TestReplaceInFiles(t *testing.T) {
 			assert.Fail(t, fmt.Sprintf("replace item = %+v", item))
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ReplaceResponse{
+			"/tmp/config.txt": {ReplacedCount: 1},
+		})
 	})
 
-	err := client.ReplaceInFiles(context.Background(), ReplaceRequest{
+	resp, err := client.ReplaceInFiles(context.Background(), ReplaceRequest{
 		"/tmp/config.txt": {Old: "localhost", New: "production.example.com"},
 	})
 	require.NoErrorf(t, err, "ReplaceInFiles")
+	if resp == nil {
+		assert.Fail(t, "expected non-nil response")
+	}
+	if resp["/tmp/config.txt"].ReplacedCount != 1 {
+		assert.Fail(t, fmt.Sprintf("expected replacedCount=1, got %d", resp["/tmp/config.txt"].ReplacedCount))
+	}
 }
 
 func TestDownloadFile(t *testing.T) {

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -102,9 +102,17 @@ func (s *Sandbox) DeleteDirectory(ctx context.Context, path string) error {
 }
 
 // ReplaceInFiles performs text replacement in files.
-func (s *Sandbox) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
+func (s *Sandbox) ReplaceInFiles(ctx context.Context, req ReplaceRequest) error {
+	if s.execd == nil {
+		return fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.ReplaceInFiles(ctx, req)
+}
+
+// ReplaceInFilesDetailed performs text replacement and returns per-file replacement counts.
+func (s *Sandbox) ReplaceInFilesDetailed(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
 	if s.execd == nil {
 		return nil, fmt.Errorf("opensandbox: execd client not initialized")
 	}
-	return s.execd.ReplaceInFiles(ctx, req)
+	return s.execd.ReplaceInFilesDetailed(ctx, req)
 }

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -102,9 +102,9 @@ func (s *Sandbox) DeleteDirectory(ctx context.Context, path string) error {
 }
 
 // ReplaceInFiles performs text replacement in files.
-func (s *Sandbox) ReplaceInFiles(ctx context.Context, req ReplaceRequest) error {
+func (s *Sandbox) ReplaceInFiles(ctx context.Context, req ReplaceRequest) (ReplaceResponse, error) {
 	if s.execd == nil {
-		return fmt.Errorf("opensandbox: execd client not initialized")
+		return nil, fmt.Errorf("opensandbox: execd client not initialized")
 	}
 	return s.execd.ReplaceInFiles(ctx, req)
 }

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -386,6 +386,14 @@ type ReplaceItem struct {
 // ReplaceRequest maps file paths to their replacement operations.
 type ReplaceRequest map[string]ReplaceItem
 
+// ReplaceResult holds the result of a content replacement for a single file.
+type ReplaceResult struct {
+	ReplacedCount int `json:"replacedCount"`
+}
+
+// ReplaceResponse maps file paths to their replacement results.
+type ReplaceResponse map[string]ReplaceResult
+
 // FileMetadata is the metadata sent alongside file uploads.
 type FileMetadata struct {
 	Path  string `json:"path"`

--- a/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
@@ -342,7 +342,20 @@ export class FilesystemAdapter implements SandboxFiles {
     throwOnOpenApiFetchError({ error, response }, "Move files failed");
   }
 
-  async replaceContents(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]> {
+  async replaceContents(entries: ContentReplaceEntry[]): Promise<void> {
+    const req: Record<string, ReplaceFileContentItem> = {};
+    for (const e of entries) {
+      req[e.path] = { old: e.oldContent, new: e.newContent };
+    }
+    const body =
+      req as unknown as typeof FilesystemAdapter.Api.ReplaceContentsRequest;
+    const { error, response } = await this.client.POST("/files/replace", {
+      body,
+    });
+    throwOnOpenApiFetchError({ error, response }, "Replace contents failed");
+  }
+
+  async replaceContentsDetailed(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]> {
     const req: Record<string, ReplaceFileContentItem> = {};
     for (const e of entries) {
       req[e.path] = { old: e.oldContent, new: e.newContent };

--- a/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
@@ -350,6 +350,7 @@ export class FilesystemAdapter implements SandboxFiles {
     const body =
       req as unknown as typeof FilesystemAdapter.Api.ReplaceContentsRequest;
     const { data, error, response } = await this.client.POST("/files/replace", {
+      params: { query: { verbose: true } },
       body,
     });
     throwOnOpenApiFetchError({ error, response }, "Replace contents failed");

--- a/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
@@ -18,6 +18,7 @@ import type { SandboxFiles } from "../services/filesystem.js";
 import type { paths as ExecdPaths } from "../api/execd.js";
 import type {
   ContentReplaceEntry,
+  ContentReplaceResult,
   FileInfo,
   FileMetadata,
   FilesInfoResponse,
@@ -218,6 +219,8 @@ export class FilesystemAdapter implements SandboxFiles {
       null as unknown as ExecdPaths["/files/mv"]["post"]["requestBody"]["content"]["application/json"],
     ReplaceContentsRequest:
       null as unknown as ExecdPaths["/files/replace"]["post"]["requestBody"]["content"]["application/json"],
+    ReplaceContentsOk:
+      null as unknown as ExecdPaths["/files/replace"]["post"]["responses"][200]["content"]["application/json"],
   };
 
   constructor(
@@ -339,17 +342,24 @@ export class FilesystemAdapter implements SandboxFiles {
     throwOnOpenApiFetchError({ error, response }, "Move files failed");
   }
 
-  async replaceContents(entries: ContentReplaceEntry[]): Promise<void> {
+  async replaceContents(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]> {
     const req: Record<string, ReplaceFileContentItem> = {};
     for (const e of entries) {
       req[e.path] = { old: e.oldContent, new: e.newContent };
     }
     const body =
       req as unknown as typeof FilesystemAdapter.Api.ReplaceContentsRequest;
-    const { error, response } = await this.client.POST("/files/replace", {
+    const { data, error, response } = await this.client.POST("/files/replace", {
       body,
     });
     throwOnOpenApiFetchError({ error, response }, "Replace contents failed");
+
+    const ok = data as typeof FilesystemAdapter.Api.ReplaceContentsOk | undefined;
+    if (!ok) return [];
+    return Object.entries(ok).map(([path, result]) => ({
+      path,
+      replacedCount: result.replacedCount,
+    }));
   }
 
   async search(entry: SearchEntry): Promise<SearchFilesResponse> {

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -415,6 +415,9 @@ export interface paths {
          * @description Performs text replacement in one or multiple files. Replaces all occurrences
          *     of the old string with the new string (similar to strings.ReplaceAll).
          *     Preserves file permissions. Useful for batch text substitution across files.
+         *
+         *     When `verbose=true` is set, the response includes per-file replacement counts.
+         *     Without this parameter, the response body is empty (backward-compatible behavior).
          */
         post: operations["replaceContent"];
         delete?: never;
@@ -1556,7 +1559,10 @@ export interface operations {
     };
     replaceContent: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description When true, return per-file replacement counts in the response body. */
+                verbose?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1581,7 +1587,10 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Content replaced successfully */
+            /**
+             * @description Content replaced successfully. When `verbose=true`, returns per-file
+             *     replacement counts. Otherwise, the response body is empty.
+             */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -863,7 +863,7 @@ export interface components {
         /** @description Content replacement operation */
         ReplaceFileContentItem: {
             /**
-             * @description String to be replaced
+             * @description String to be replaced (must not be empty)
              * @example localhost
              */
             old: string;

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -870,6 +870,14 @@ export interface components {
              */
             new: string;
         };
+        /** @description Result of a content replacement operation on a single file */
+        ReplaceFileContentResult: {
+            /**
+             * @description Number of occurrences replaced. 0 means oldContent was not found in the file.
+             * @example 1
+             */
+            replacedCount: number;
+        };
         /** @description System resource usage metrics */
         Metrics: {
             /**
@@ -1578,7 +1586,21 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    /**
+                     * @example {
+                     *       "/workspace/config.yaml": {
+                     *         "replacedCount": 1
+                     *       },
+                     *       "/workspace/app.py": {
+                     *         "replacedCount": 0
+                     *       }
+                     *     }
+                     */
+                    "application/json": {
+                        [key: string]: components["schemas"]["ReplaceFileContentResult"];
+                    };
+                };
             };
             400: components["responses"]["BadRequest"];
             500: components["responses"]["InternalServerError"];

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -117,6 +117,7 @@ export { Sandbox } from "./sandbox.js";
 
 export type {
   ContentReplaceEntry,
+  ContentReplaceResult,
   MoveEntry,
   SearchEntry,
   SetPermissionEntry,

--- a/sdks/sandbox/javascript/src/models/filesystem.ts
+++ b/sdks/sandbox/javascript/src/models/filesystem.ts
@@ -95,6 +95,11 @@ export interface ContentReplaceEntry {
   newContent: string;
 }
 
+export interface ContentReplaceResult {
+  path: string;
+  replacedCount: number;
+}
+
 export interface SetPermissionEntry {
   path: string;
   mode: number;

--- a/sdks/sandbox/javascript/src/services/filesystem.ts
+++ b/sdks/sandbox/javascript/src/services/filesystem.ts
@@ -43,6 +43,7 @@ export interface SandboxFiles {
 
   deleteFiles(paths: string[]): Promise<void>;
   moveFiles(entries: MoveEntry[]): Promise<void>;
-  replaceContents(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]>;
+  replaceContents(entries: ContentReplaceEntry[]): Promise<void>;
+  replaceContentsDetailed(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]>;
   setPermissions(entries: SetPermissionEntry[]): Promise<void>;
 }

--- a/sdks/sandbox/javascript/src/services/filesystem.ts
+++ b/sdks/sandbox/javascript/src/services/filesystem.ts
@@ -15,6 +15,7 @@
 import type { SearchFilesResponse } from "../models/filesystem.js";
 import type {
   ContentReplaceEntry,
+  ContentReplaceResult,
   FileInfo,
   MoveEntry,
   SearchEntry,
@@ -42,6 +43,6 @@ export interface SandboxFiles {
 
   deleteFiles(paths: string[]): Promise<void>;
   moveFiles(entries: MoveEntry[]): Promise<void>;
-  replaceContents(entries: ContentReplaceEntry[]): Promise<void>;
+  replaceContents(entries: ContentReplaceEntry[]): Promise<ContentReplaceResult[]>;
   setPermissions(entries: SetPermissionEntry[]): Promise<void>;
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
@@ -284,6 +284,17 @@ class ContentReplaceEntry private constructor(
 }
 
 /**
+ * Result of a content replacement operation on a single file.
+ *
+ * @property path File path where replacement was performed
+ * @property replacedCount Number of occurrences replaced. 0 means old content was not found.
+ */
+data class ContentReplaceResult(
+    val path: String,
+    val replacedCount: Int,
+)
+
+/**
  * Request to search for files matching a pattern.
  *
  * Searches the filesystem starting from the specified path to find files

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -186,10 +186,18 @@ interface Filesystem {
      * Replaces content in files based on search and replace patterns.
      *
      * @param entries List of ContentReplaceEntry objects specifying replacement operations
+     * @throws SandboxException if the operation fails
+     */
+    fun replaceContents(entries: List<ContentReplaceEntry>)
+
+    /**
+     * Replaces content in files and returns per-file replacement counts.
+     *
+     * @param entries List of ContentReplaceEntry objects specifying replacement operations
      * @return List of ContentReplaceResult with replacement counts per file
      * @throws SandboxException if the operation fails
      */
-    fun replaceContents(entries: List<ContentReplaceEntry>): List<ContentReplaceResult>
+    fun replaceContentsDetailed(entries: List<ContentReplaceEntry>): List<ContentReplaceResult>
 
     /**
      * Searches for files and directories based on the specified criteria.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -17,6 +17,7 @@
 package com.alibaba.opensandbox.sandbox.domain.services
 
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceEntry
+import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceResult
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.EntryInfo
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.MoveEntry
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.SearchEntry
@@ -185,9 +186,10 @@ interface Filesystem {
      * Replaces content in files based on search and replace patterns.
      *
      * @param entries List of ContentReplaceEntry objects specifying replacement operations
+     * @return List of ContentReplaceResult with replacement counts per file
      * @throws SandboxException if the operation fails
      */
-    fun replaceContents(entries: List<ContentReplaceEntry>)
+    fun replaceContents(entries: List<ContentReplaceEntry>): List<ContentReplaceResult>
 
     /**
      * Searches for files and directories based on the specified criteria.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -309,7 +309,17 @@ internal class FilesystemAdapter(
         }
     }
 
-    override fun replaceContents(entries: List<ContentReplaceEntry>): List<ContentReplaceResult> {
+    override fun replaceContents(entries: List<ContentReplaceEntry>) {
+        return try {
+            val replaceMap = entries.toApiReplaceFileContentMap()
+            api.replaceContent(replaceMap)
+        } catch (e: Exception) {
+            logger.error("Failed to replace contents", e)
+            throw e.toSandboxException()
+        }
+    }
+
+    override fun replaceContentsDetailed(entries: List<ContentReplaceEntry>): List<ContentReplaceResult> {
         return try {
             val replaceMap = entries.toApiReplaceFileContentMap()
             val jsonBody =

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -328,7 +328,7 @@ internal class FilesystemAdapter(
             val baseUrl = "${httpClientProvider.config.protocol}://${execdEndpoint.endpoint}"
             val request =
                 Request.Builder()
-                    .url("$baseUrl/files/replace")
+                    .url("$baseUrl/files/replace?verbose=true")
                     .post(jsonBody.toRequestBody("application/json".toMediaType()))
                     .apply { execdEndpoint.headers.forEach { (k, v) -> header(k, v) } }
                     .build()

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -312,21 +312,26 @@ internal class FilesystemAdapter(
     override fun replaceContents(entries: List<ContentReplaceEntry>): List<ContentReplaceResult> {
         return try {
             val replaceMap = entries.toApiReplaceFileContentMap()
-            val jsonBody = buildJsonObject {
-                replaceMap.forEach { (path, item) ->
-                    put(path, buildJsonObject {
-                        put("old", item.old)
-                        put("new", item.new)
-                    })
-                }
-            }.toString()
+            val jsonBody =
+                buildJsonObject {
+                    replaceMap.forEach { (path, item) ->
+                        put(
+                            path,
+                            buildJsonObject {
+                                put("old", item.old)
+                                put("new", item.new)
+                            },
+                        )
+                    }
+                }.toString()
 
             val baseUrl = "${httpClientProvider.config.protocol}://${execdEndpoint.endpoint}"
-            val request = Request.Builder()
-                .url("$baseUrl/files/replace")
-                .post(jsonBody.toRequestBody("application/json".toMediaType()))
-                .apply { execdEndpoint.headers.forEach { (k, v) -> header(k, v) } }
-                .build()
+            val request =
+                Request.Builder()
+                    .url("$baseUrl/files/replace")
+                    .post(jsonBody.toRequestBody("application/json".toMediaType()))
+                    .apply { execdEndpoint.headers.forEach { (k, v) -> header(k, v) } }
+                    .build()
 
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -40,6 +40,8 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.isFileN
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -345,7 +347,7 @@ internal class FilesystemAdapter(
                     parsed.map { (path, result) ->
                         ContentReplaceResult(
                             path = path,
-                            replacedCount = result["replacedCount"]?.toString()?.toIntOrNull() ?: 0,
+                            replacedCount = result["replacedCount"]?.jsonPrimitive?.intOrNull ?: 0,
                         )
                     }
                 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -310,7 +310,7 @@ internal class FilesystemAdapter(
     }
 
     override fun replaceContents(entries: List<ContentReplaceEntry>) {
-        return try {
+        try {
             val replaceMap = entries.toApiReplaceFileContentMap()
             api.replaceContent(replaceMap)
         } catch (e: Exception) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -23,6 +23,7 @@ import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceEntry
+import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceResult
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.EntryInfo
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.MoveEntry
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.SearchEntry
@@ -306,10 +307,49 @@ internal class FilesystemAdapter(
         }
     }
 
-    override fun replaceContents(entries: List<ContentReplaceEntry>) {
+    override fun replaceContents(entries: List<ContentReplaceEntry>): List<ContentReplaceResult> {
         return try {
             val replaceMap = entries.toApiReplaceFileContentMap()
-            api.replaceContent(replaceMap)
+            val jsonBody = buildJsonObject {
+                replaceMap.forEach { (path, item) ->
+                    put(path, buildJsonObject {
+                        put("old", item.old)
+                        put("new", item.new)
+                    })
+                }
+            }.toString()
+
+            val baseUrl = "${httpClientProvider.config.protocol}://${execdEndpoint.endpoint}"
+            val request = Request.Builder()
+                .url("$baseUrl/files/replace")
+                .post(jsonBody.toRequestBody("application/json".toMediaType()))
+                .apply { execdEndpoint.headers.forEach { (k, v) -> header(k, v) } }
+                .build()
+
+            httpClientProvider.httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    val errorBody = response.body?.string()
+                    val sandboxError = parseSandboxError(errorBody)
+                    throw SandboxApiException(
+                        message = "Failed to replace contents. Status: ${response.code}, Body: $errorBody",
+                        statusCode = response.code,
+                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
+                        requestId = response.header("X-Request-ID"),
+                    )
+                }
+                val body = response.body?.string()
+                if (body.isNullOrBlank()) {
+                    emptyList()
+                } else {
+                    val parsed = kotlinx.serialization.json.Json.decodeFromString<Map<String, kotlinx.serialization.json.JsonObject>>(body)
+                    parsed.map { (path, result) ->
+                        ContentReplaceResult(
+                            path = path,
+                            replacedCount = result["replacedCount"]?.toString()?.toIntOrNull() ?: 0,
+                        )
+                    }
+                }
+            }
         } catch (e: Exception) {
             logger.error("Failed to replace contents", e)
             throw e.toSandboxException()

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/filesystem_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/filesystem_model_converter.py
@@ -27,6 +27,7 @@ from typing import Any
 from opensandbox.api.execd.models import FileInfo
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SetPermissionEntry,
@@ -126,6 +127,30 @@ class FilesystemModelConverter:
             for entry in entries
         }
         return ReplaceContentBody.from_dict(replace_data)
+
+    @staticmethod
+    def to_replace_results(api_response: Any) -> list[ContentReplaceResult]:
+        """Convert API replace response to list of ContentReplaceResult."""
+        if not api_response:
+            return []
+
+        results: list[ContentReplaceResult] = []
+        items: dict = {}
+        if hasattr(api_response, "additional_properties"):
+            items = api_response.additional_properties
+        elif isinstance(api_response, dict):
+            items = api_response
+
+        for path, result_data in items.items():
+            if hasattr(result_data, "replaced_count"):
+                count = result_data.replaced_count
+            elif isinstance(result_data, dict):
+                count = result_data.get("replacedCount", 0)
+            else:
+                count = 0
+            results.append(ContentReplaceResult(path=path, replaced_count=count))
+
+        return results
 
     @staticmethod
     def to_api_rename_file_items(entries: list[MoveEntry]):

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -411,8 +411,25 @@ class FilesystemAdapter(Filesystem):
             logger.error("Failed to set permissions", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
-    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
         """Replace file contents using auto-generated API."""
+        try:
+            from opensandbox.api.execd.api.filesystem import replace_content
+
+            client = await self._get_client()
+            response_obj = await replace_content.asyncio_detailed(
+                client=client,
+                body=FilesystemModelConverter.to_api_replace_content_body(entries),
+            )
+
+            handle_api_error(response_obj, "Replace contents")
+
+        except Exception as e:
+            logger.error("Failed to replace contents", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def replace_contents_detailed(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+        """Replace file contents and return per-file replacement counts."""
         try:
             from opensandbox.api.execd.api.filesystem import replace_content
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -414,18 +414,13 @@ class FilesystemAdapter(Filesystem):
     async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         """Replace file contents using auto-generated API."""
         try:
-            from json import JSONDecodeError
-
             from opensandbox.api.execd.api.filesystem import replace_content
 
             client = await self._get_client()
-            try:
-                response_obj = await replace_content.asyncio_detailed(
-                    client=client,
-                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
-                )
-            except JSONDecodeError:
-                return []
+            response_obj = await replace_content.asyncio_detailed(
+                client=client,
+                body=FilesystemModelConverter.to_api_replace_content_body(entries),
+            )
 
             handle_api_error(response_obj, "Replace contents")
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -414,15 +414,19 @@ class FilesystemAdapter(Filesystem):
     async def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
         """Replace file contents using auto-generated API."""
         try:
+            from json import JSONDecodeError
+
             from opensandbox.api.execd.api.filesystem import replace_content
 
             client = await self._get_client()
-            response_obj = await replace_content.asyncio_detailed(
-                client=client,
-                body=FilesystemModelConverter.to_api_replace_content_body(entries),
-            )
-
-            handle_api_error(response_obj, "Replace contents")
+            try:
+                response_obj = await replace_content.asyncio_detailed(
+                    client=client,
+                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                )
+                handle_api_error(response_obj, "Replace contents")
+            except JSONDecodeError:
+                pass
 
         except Exception as e:
             logger.error("Failed to replace contents", exc_info=e)

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -414,13 +414,18 @@ class FilesystemAdapter(Filesystem):
     async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         """Replace file contents using auto-generated API."""
         try:
+            from json import JSONDecodeError
+
             from opensandbox.api.execd.api.filesystem import replace_content
 
             client = await self._get_client()
-            response_obj = await replace_content.asyncio_detailed(
-                client=client,
-                body=FilesystemModelConverter.to_api_replace_content_body(entries),
-            )
+            try:
+                response_obj = await replace_content.asyncio_detailed(
+                    client=client,
+                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                )
+            except JSONDecodeError:
+                return []
 
             handle_api_error(response_obj, "Replace contents")
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -43,6 +43,7 @@ from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -410,7 +411,7 @@ class FilesystemAdapter(Filesystem):
             logger.error("Failed to set permissions", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
-    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
+    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         """Replace file contents using auto-generated API."""
         try:
             from opensandbox.api.execd.api.filesystem import replace_content
@@ -422,6 +423,8 @@ class FilesystemAdapter(Filesystem):
             )
 
             handle_api_error(response_obj, "Replace contents")
+
+            return FilesystemModelConverter.to_replace_results(response_obj.parsed)
 
         except Exception as e:
             logger.error("Failed to replace contents", exc_info=e)

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -420,6 +420,7 @@ class FilesystemAdapter(Filesystem):
             response_obj = await replace_content.asyncio_detailed(
                 client=client,
                 body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                verbose=True,
             )
 
             handle_api_error(response_obj, "Replace contents")

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
@@ -36,6 +36,7 @@ def _get_kwargs(
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/files/replace",
+        "params": {"verbose": "true"},
     }
 
     _kwargs["json"] = body.to_dict()

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
@@ -15,7 +15,7 @@
 #
 
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 
 import httpx
 
@@ -23,6 +23,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.replace_content_body import ReplaceContentBody
+from ...models.replace_content_response_200 import ReplaceContentResponse200
 from ...types import Response
 
 
@@ -45,9 +46,15 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | ErrorResponse | None:
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | ReplaceContentResponse200 | None:
     if response.status_code == 200:
-        response_200 = cast(Any, None)
+        # Backward compat: older execd versions return 200 with empty body
+        if not response.content or not response.content.strip():
+            return ReplaceContentResponse200()
+        response_200 = ReplaceContentResponse200.from_dict(response.json())
+
         return response_200
 
     if response.status_code == 400:
@@ -66,7 +73,9 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | ErrorResponse]:
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | ReplaceContentResponse200]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -79,7 +88,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ErrorResponse | ReplaceContentResponse200]:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -94,7 +103,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ErrorResponse | ReplaceContentResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -112,7 +121,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Any | ErrorResponse | None:
+) -> ErrorResponse | ReplaceContentResponse200 | None:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -127,7 +136,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | ErrorResponse
+        ErrorResponse | ReplaceContentResponse200
     """
 
     return sync_detailed(
@@ -140,7 +149,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ErrorResponse | ReplaceContentResponse200]:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -155,7 +164,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ErrorResponse | ReplaceContentResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +180,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Any | ErrorResponse | None:
+) -> ErrorResponse | ReplaceContentResponse200 | None:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -186,7 +195,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | ErrorResponse
+        ErrorResponse | ReplaceContentResponse200
     """
 
     return (

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
@@ -50,9 +50,6 @@ def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> ErrorResponse | ReplaceContentResponse200 | None:
     if response.status_code == 200:
-        # Backward compat: older execd versions return 200 with empty body
-        if not response.content or not response.content.strip():
-            return ReplaceContentResponse200()
         response_200 = ReplaceContentResponse200.from_dict(response.json())
 
         return response_200

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
@@ -24,19 +24,26 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.replace_content_body import ReplaceContentBody
 from ...models.replace_content_response_200 import ReplaceContentResponse200
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: ReplaceContentBody,
+    verbose: bool | Unset = False,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["verbose"] = verbose
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/files/replace",
-        "params": {"verbose": "true"},
+        "params": params,
     }
 
     _kwargs["json"] = body.to_dict()
@@ -86,6 +93,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
+    verbose: bool | Unset = False,
 ) -> Response[ErrorResponse | ReplaceContentResponse200]:
     """Replace file content
 
@@ -93,7 +101,11 @@ def sync_detailed(
     of the old string with the new string (similar to strings.ReplaceAll).
     Preserves file permissions. Useful for batch text substitution across files.
 
+    When `verbose=true` is set, the response includes per-file replacement counts.
+    Without this parameter, the response body is empty (backward-compatible behavior).
+
     Args:
+        verbose (bool | Unset):  Default: False.
         body (ReplaceContentBody):
 
     Raises:
@@ -106,6 +118,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        verbose=verbose,
     )
 
     response = client.get_httpx_client().request(
@@ -119,6 +132,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
+    verbose: bool | Unset = False,
 ) -> ErrorResponse | ReplaceContentResponse200 | None:
     """Replace file content
 
@@ -126,7 +140,11 @@ def sync(
     of the old string with the new string (similar to strings.ReplaceAll).
     Preserves file permissions. Useful for batch text substitution across files.
 
+    When `verbose=true` is set, the response includes per-file replacement counts.
+    Without this parameter, the response body is empty (backward-compatible behavior).
+
     Args:
+        verbose (bool | Unset):  Default: False.
         body (ReplaceContentBody):
 
     Raises:
@@ -140,6 +158,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        verbose=verbose,
     ).parsed
 
 
@@ -147,6 +166,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
+    verbose: bool | Unset = False,
 ) -> Response[ErrorResponse | ReplaceContentResponse200]:
     """Replace file content
 
@@ -154,7 +174,11 @@ async def asyncio_detailed(
     of the old string with the new string (similar to strings.ReplaceAll).
     Preserves file permissions. Useful for batch text substitution across files.
 
+    When `verbose=true` is set, the response includes per-file replacement counts.
+    Without this parameter, the response body is empty (backward-compatible behavior).
+
     Args:
+        verbose (bool | Unset):  Default: False.
         body (ReplaceContentBody):
 
     Raises:
@@ -167,6 +191,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        verbose=verbose,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -178,6 +203,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
+    verbose: bool | Unset = False,
 ) -> ErrorResponse | ReplaceContentResponse200 | None:
     """Replace file content
 
@@ -185,7 +211,11 @@ async def asyncio(
     of the old string with the new string (similar to strings.ReplaceAll).
     Preserves file permissions. Useful for batch text substitution across files.
 
+    When `verbose=true` is set, the response includes per-file replacement counts.
+    Without this parameter, the response body is empty (backward-compatible behavior).
+
     Args:
+        verbose (bool | Unset):  Default: False.
         body (ReplaceContentBody):
 
     Raises:
@@ -200,5 +230,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            verbose=verbose,
         )
     ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -31,7 +31,9 @@ from .metrics import Metrics
 from .permission import Permission
 from .rename_file_item import RenameFileItem
 from .replace_content_body import ReplaceContentBody
+from .replace_content_response_200 import ReplaceContentResponse200
 from .replace_file_content_item import ReplaceFileContentItem
+from .replace_file_content_result import ReplaceFileContentResult
 from .run_code_request import RunCodeRequest
 from .run_command_request import RunCommandRequest
 from .run_command_request_envs import RunCommandRequestEnvs
@@ -58,7 +60,9 @@ __all__ = (
     "Permission",
     "RenameFileItem",
     "ReplaceContentBody",
+    "ReplaceContentResponse200",
     "ReplaceFileContentItem",
+    "ReplaceFileContentResult",
     "RunCodeRequest",
     "RunCommandRequest",
     "RunCommandRequestEnvs",

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.replace_file_content_result import ReplaceFileContentResult
+
+
+T = TypeVar("T", bound="ReplaceContentResponse200")
+
+
+@_attrs_define
+class ReplaceContentResponse200:
+    """ """
+
+    additional_properties: dict[str, ReplaceFileContentResult] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop.to_dict()
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.replace_file_content_result import ReplaceFileContentResult
+
+        d = dict(src_dict)
+        replace_content_response_200 = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = ReplaceFileContentResult.from_dict(prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        replace_content_response_200.additional_properties = additional_properties
+        return replace_content_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> ReplaceFileContentResult:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: ReplaceFileContentResult) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_file_content_result.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_file_content_result.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ReplaceFileContentResult")
+
+
+@_attrs_define
+class ReplaceFileContentResult:
+    """Result of a content replacement operation on a single file
+
+    Attributes:
+        replaced_count (int): Number of occurrences replaced. 0 means oldContent was not found in the file. Example: 1.
+    """
+
+    replaced_count: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        replaced_count = self.replaced_count
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "replacedCount": replaced_count,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        replaced_count = d.pop("replacedCount")
+
+        replace_file_content_result = cls(
+            replaced_count=replaced_count,
+        )
+
+        replace_file_content_result.additional_properties = d
+        return replace_file_content_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -33,6 +33,7 @@ from opensandbox.models.execd import (
 )
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -77,6 +78,7 @@ __all__ = [
     "MoveEntry",
     "SetPermissionEntry",
     "ContentReplaceEntry",
+    "ContentReplaceResult",
     "SearchEntry",
     # Sandbox models
     "SandboxInfo",

--- a/sdks/sandbox/python/src/opensandbox/models/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/models/filesystem.py
@@ -177,6 +177,15 @@ class ContentReplaceEntry(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class ContentReplaceResult(BaseModel):
+    """
+    Result of a content replacement operation on a single file.
+    """
+
+    path: str = Field(description="File path where replacement was performed")
+    replaced_count: int = Field(description="Number of occurrences replaced. 0 means old content was not found.")
+
+
 class SearchEntry(BaseModel):
     """
     Request to search for files matching a pattern.

--- a/sdks/sandbox/python/src/opensandbox/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/services/filesystem.py
@@ -196,9 +196,21 @@ class Filesystem(Protocol):
         """
         ...
 
-    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
         """
         Replace content in files based on search and replace patterns.
+
+        Args:
+            entries: List of ContentReplaceEntry objects specifying replacement operations
+
+        Raises:
+            SandboxException: if the operation fails
+        """
+        ...
+
+    async def replace_contents_detailed(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+        """
+        Replace content in files and return per-file replacement counts.
 
         Args:
             entries: List of ContentReplaceEntry objects specifying replacement operations

--- a/sdks/sandbox/python/src/opensandbox/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/services/filesystem.py
@@ -24,6 +24,7 @@ from typing import Protocol
 
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -195,12 +196,15 @@ class Filesystem(Protocol):
         """
         ...
 
-    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
+    async def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         """
         Replace content in files based on search and replace patterns.
 
         Args:
             entries: List of ContentReplaceEntry objects specifying replacement operations
+
+        Returns:
+            List of ContentReplaceResult with replacement counts per file
 
         Raises:
             SandboxException: if the operation fails

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -287,7 +287,21 @@ class FilesystemAdapterSync(FilesystemSync):
             logger.error("Failed to set permissions", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
-    def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+    def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
+        try:
+            from opensandbox.api.execd.api.filesystem import replace_content
+
+            response_obj = replace_content.sync_detailed(
+                client=self._client,
+                body=FilesystemModelConverter.to_api_replace_content_body(entries),
+            )
+
+            handle_api_error(response_obj, "Replace contents")
+        except Exception as e:
+            logger.error("Failed to replace contents", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def replace_contents_detailed(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         try:
             from opensandbox.api.execd.api.filesystem import replace_content
 

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -289,17 +289,12 @@ class FilesystemAdapterSync(FilesystemSync):
 
     def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         try:
-            from json import JSONDecodeError
-
             from opensandbox.api.execd.api.filesystem import replace_content
 
-            try:
-                response_obj = replace_content.sync_detailed(
-                    client=self._client,
-                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
-                )
-            except JSONDecodeError:
-                return []
+            response_obj = replace_content.sync_detailed(
+                client=self._client,
+                body=FilesystemModelConverter.to_api_replace_content_body(entries),
+            )
 
             handle_api_error(response_obj, "Replace contents")
 

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -289,14 +289,18 @@ class FilesystemAdapterSync(FilesystemSync):
 
     def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
         try:
+            from json import JSONDecodeError
+
             from opensandbox.api.execd.api.filesystem import replace_content
 
-            response_obj = replace_content.sync_detailed(
-                client=self._client,
-                body=FilesystemModelConverter.to_api_replace_content_body(entries),
-            )
-
-            handle_api_error(response_obj, "Replace contents")
+            try:
+                response_obj = replace_content.sync_detailed(
+                    client=self._client,
+                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                )
+                handle_api_error(response_obj, "Replace contents")
+            except JSONDecodeError:
+                pass
         except Exception as e:
             logger.error("Failed to replace contents", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -40,6 +40,7 @@ from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -286,7 +287,7 @@ class FilesystemAdapterSync(FilesystemSync):
             logger.error("Failed to set permissions", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
-    def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
+    def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         try:
             from opensandbox.api.execd.api.filesystem import replace_content
 
@@ -295,6 +296,8 @@ class FilesystemAdapterSync(FilesystemSync):
                 body=FilesystemModelConverter.to_api_replace_content_body(entries),
             )
             handle_api_error(response_obj, "Replace contents")
+
+            return FilesystemModelConverter.to_replace_results(response_obj.parsed)
         except Exception as e:
             logger.error("Failed to replace contents", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -289,12 +289,18 @@ class FilesystemAdapterSync(FilesystemSync):
 
     def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         try:
+            from json import JSONDecodeError
+
             from opensandbox.api.execd.api.filesystem import replace_content
 
-            response_obj = replace_content.sync_detailed(
-                client=self._client,
-                body=FilesystemModelConverter.to_api_replace_content_body(entries),
-            )
+            try:
+                response_obj = replace_content.sync_detailed(
+                    client=self._client,
+                    body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                )
+            except JSONDecodeError:
+                return []
+
             handle_api_error(response_obj, "Replace contents")
 
             return FilesystemModelConverter.to_replace_results(response_obj.parsed)

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -294,6 +294,7 @@ class FilesystemAdapterSync(FilesystemSync):
             response_obj = replace_content.sync_detailed(
                 client=self._client,
                 body=FilesystemModelConverter.to_api_replace_content_body(entries),
+                verbose=True,
             )
 
             handle_api_error(response_obj, "Replace contents")

--- a/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
@@ -203,9 +203,21 @@ class FilesystemSync(Protocol):
         """
         ...
 
-    def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+    def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
         """
         Replace content in files based on search and replace patterns.
+
+        Args:
+            entries: List of ContentReplaceEntry objects specifying replacement operations.
+
+        Raises:
+            SandboxException: If the operation fails.
+        """
+        ...
+
+    def replace_contents_detailed(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+        """
+        Replace content in files and return per-file replacement counts.
 
         Args:
             entries: List of ContentReplaceEntry objects specifying replacement operations.

--- a/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
@@ -26,6 +26,7 @@ from typing import Protocol
 
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
+    ContentReplaceResult,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -202,12 +203,15 @@ class FilesystemSync(Protocol):
         """
         ...
 
-    def replace_contents(self, entries: list[ContentReplaceEntry]) -> None:
+    def replace_contents(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
         """
         Replace content in files based on search and replace patterns.
 
         Args:
             entries: List of ContentReplaceEntry objects specifying replacement operations.
+
+        Returns:
+            List of ContentReplaceResult with replacement counts per file.
 
         Raises:
             SandboxException: If the operation fails.

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -1345,7 +1345,8 @@ components:
       properties:
         old:
           type: string
-          description: String to be replaced
+          description: String to be replaced (must not be empty)
+          minLength: 1
           example: "localhost"
         new:
           type: string

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -745,9 +745,20 @@ paths:
         Performs text replacement in one or multiple files. Replaces all occurrences
         of the old string with the new string (similar to strings.ReplaceAll).
         Preserves file permissions. Useful for batch text substitution across files.
+
+        When `verbose=true` is set, the response includes per-file replacement counts.
+        Without this parameter, the response body is empty (backward-compatible behavior).
       operationId: replaceContent
       tags:
         - Filesystem
+      parameters:
+        - name: verbose
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When true, return per-file replacement counts in the response body.
       requestBody:
         required: true
         content:
@@ -765,7 +776,9 @@ paths:
                 new: "DEBUG = False"
       responses:
         "200":
-          description: Content replaced successfully
+          description: |
+            Content replaced successfully. When `verbose=true`, returns per-file
+            replacement counts. Otherwise, the response body is empty.
           content:
             application/json:
               schema:

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -766,6 +766,17 @@ paths:
       responses:
         "200":
           description: Content replaced successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/ReplaceFileContentResult"
+              example:
+                "/workspace/config.yaml":
+                  replacedCount: 1
+                "/workspace/app.py":
+                  replacedCount: 0
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -1328,6 +1339,16 @@ components:
           description: Replacement string
           example: "0.0.0.0"
       required: [old, new]
+
+    ReplaceFileContentResult:
+      type: object
+      description: Result of a content replacement operation on a single file
+      properties:
+        replacedCount:
+          type: integer
+          description: Number of occurrences replaced. 0 means oldContent was not found in the file.
+          example: 1
+      required: [replacedCount]
 
     Metrics:
       type: object

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -866,7 +866,7 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         AssertModifiedUpdated(beforeUpdate.ModifiedAt, afterUpdate.ModifiedAt, 1, 1000);
 
         await Task.Delay(50);
-        var replaceResults = await sandbox.Files.ReplaceContentsAsync(new[]
+        var replaceResults = await sandbox.Files.ReplaceContentsDetailedAsync(new[]
         {
             new ContentReplaceEntry
             {
@@ -884,7 +884,7 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         Assert.DoesNotContain("Appended line.", replaced, StringComparison.Ordinal);
 
         // No match → ReplacedCount=0
-        var noMatchResults = await sandbox.Files.ReplaceContentsAsync(new[]
+        var noMatchResults = await sandbox.Files.ReplaceContentsDetailedAsync(new[]
         {
             new ContentReplaceEntry { Path = testFile1, OldContent = "nonexistent string", NewContent = "irrelevant" }
         });
@@ -896,7 +896,7 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         {
             new WriteEntry { Path = $"{testDir1}/multi.txt", Data = "foo bar foo baz foo" }
         });
-        var multiResults = await sandbox.Files.ReplaceContentsAsync(new[]
+        var multiResults = await sandbox.Files.ReplaceContentsDetailedAsync(new[]
         {
             new ContentReplaceEntry { Path = $"{testDir1}/multi.txt", OldContent = "foo", NewContent = "qux" }
         });

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -866,7 +866,7 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         AssertModifiedUpdated(beforeUpdate.ModifiedAt, afterUpdate.ModifiedAt, 1, 1000);
 
         await Task.Delay(50);
-        await sandbox.Files.ReplaceContentsAsync(new[]
+        var replaceResults = await sandbox.Files.ReplaceContentsAsync(new[]
         {
             new ContentReplaceEntry
             {
@@ -875,10 +875,33 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
                 NewContent = "Replaced line."
             }
         });
+        Assert.Single(replaceResults);
+        Assert.Equal(testFile1, replaceResults[0].Path);
+        Assert.Equal(1, replaceResults[0].ReplacedCount);
 
         var replaced = await sandbox.Files.ReadFileAsync(testFile1, new ReadFileOptions { Encoding = "utf-8" });
         Assert.Contains("Replaced line.", replaced, StringComparison.Ordinal);
         Assert.DoesNotContain("Appended line.", replaced, StringComparison.Ordinal);
+
+        // No match → ReplacedCount=0
+        var noMatchResults = await sandbox.Files.ReplaceContentsAsync(new[]
+        {
+            new ContentReplaceEntry { Path = testFile1, OldContent = "nonexistent string", NewContent = "irrelevant" }
+        });
+        Assert.Single(noMatchResults);
+        Assert.Equal(0, noMatchResults[0].ReplacedCount);
+
+        // Multiple matches
+        await sandbox.Files.WriteFilesAsync(new[]
+        {
+            new WriteEntry { Path = $"{testDir1}/multi.txt", Data = "foo bar foo baz foo" }
+        });
+        var multiResults = await sandbox.Files.ReplaceContentsAsync(new[]
+        {
+            new ContentReplaceEntry { Path = $"{testDir1}/multi.txt", OldContent = "foo", NewContent = "qux" }
+        });
+        Assert.Single(multiResults);
+        Assert.Equal(3, multiResults[0].ReplacedCount);
 
         var movedPath = $"{testDir2}/moved_file3.txt";
         await sandbox.Files.MoveFilesAsync(new[] { new MoveEntry { Src = testFile3, Dest = movedPath } });

--- a/tests/go/filesystem_e2e_test.go
+++ b/tests/go/filesystem_e2e_test.go
@@ -172,7 +172,7 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-e2e.txt"}) })
 
-	resp, err := sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+	resp, err := sb.ReplaceInFilesDetailed(ctx, opensandbox.ReplaceRequest{
 		"/tmp/replace-e2e.txt": {Old: "localhost", New: "example.com"},
 	})
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	require.Contains(t, exec.Text(), "example.com")
 
 	// No match → replacedCount=0
-	resp, err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+	resp, err = sb.ReplaceInFilesDetailed(ctx, opensandbox.ReplaceRequest{
 		"/tmp/replace-e2e.txt": {Old: "nonexistent", New: "irrelevant"},
 	})
 	require.NoError(t, err)
@@ -194,9 +194,15 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	_, err = sb.RunCommand(ctx, `echo "foo bar foo baz foo" > /tmp/replace-multi.txt`, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-multi.txt"}) })
-	resp, err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+	resp, err = sb.ReplaceInFilesDetailed(ctx, opensandbox.ReplaceRequest{
 		"/tmp/replace-multi.txt": {Old: "foo", New: "qux"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 3, resp["/tmp/replace-multi.txt"].ReplacedCount)
+
+	// Verify original ReplaceInFiles (error-only) still works
+	err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+		"/tmp/replace-multi.txt": {Old: "qux", New: "done"},
+	})
+	require.NoError(t, err)
 }

--- a/tests/go/filesystem_e2e_test.go
+++ b/tests/go/filesystem_e2e_test.go
@@ -172,12 +172,31 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-e2e.txt"}) })
 
-	err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+	resp, err := sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
 		"/tmp/replace-e2e.txt": {Old: "localhost", New: "example.com"},
 	})
 	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 1, resp["/tmp/replace-e2e.txt"].ReplacedCount)
 
 	exec, err := sb.RunCommand(ctx, "cat /tmp/replace-e2e.txt", nil)
 	require.NoError(t, err)
 	require.Contains(t, exec.Text(), "example.com")
+
+	// No match → replacedCount=0
+	resp, err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+		"/tmp/replace-e2e.txt": {Old: "nonexistent", New: "irrelevant"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, resp["/tmp/replace-e2e.txt"].ReplacedCount)
+
+	// Multiple matches
+	_, err = sb.RunCommand(ctx, `echo "foo bar foo baz foo" > /tmp/replace-multi.txt`, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-multi.txt"}) })
+	resp, err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
+		"/tmp/replace-multi.txt": {Old: "foo", New: "qux"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, resp["/tmp/replace-multi.txt"].ReplacedCount)
 }

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1369,7 +1369,7 @@ public class SandboxE2ETest extends BaseE2ETest {
         assertEquals(0, noMatchResults.get(0).getReplacedCount());
 
         // Multiple matches
-        sandbox.files().writeFiles(List.of(
+        sandbox.files().write(List.of(
                 WriteEntry.builder().path(testDir1 + "/multi.txt").data("foo bar foo baz foo").build()));
         var multiResults = sandbox.files().replaceContents(List.of(
                 ContentReplaceEntry.builder()

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1342,7 +1342,7 @@ public class SandboxE2ETest extends BaseE2ETest {
         } catch (InterruptedException ignored) {
         }
         var replaceResults = sandbox.files()
-                .replaceContents(
+                .replaceContentsDetailed(
                         List.of(
                                 ContentReplaceEntry.builder()
                                         .path(testFile1)
@@ -1359,7 +1359,7 @@ public class SandboxE2ETest extends BaseE2ETest {
         assertModifiedUpdated(beforeReplace.getModifiedAt(), afterReplace.getModifiedAt(), 1, 1000);
 
         // No match → replacedCount=0
-        var noMatchResults = sandbox.files().replaceContents(List.of(
+        var noMatchResults = sandbox.files().replaceContentsDetailed(List.of(
                 ContentReplaceEntry.builder()
                         .path(testFile1)
                         .oldContent("nonexistent string")
@@ -1371,7 +1371,7 @@ public class SandboxE2ETest extends BaseE2ETest {
         // Multiple matches
         sandbox.files().write(List.of(
                 WriteEntry.builder().path(testDir1 + "/multi.txt").data("foo bar foo baz foo").build()));
-        var multiResults = sandbox.files().replaceContents(List.of(
+        var multiResults = sandbox.files().replaceContentsDetailed(List.of(
                 ContentReplaceEntry.builder()
                         .path(testDir1 + "/multi.txt")
                         .oldContent("foo")

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1380,6 +1380,8 @@ public class SandboxE2ETest extends BaseE2ETest {
         assertEquals(1, multiResults.size());
         assertEquals(3, multiResults.get(0).getReplacedCount());
 
+        sandbox.files().deleteFiles(List.of(testDir1 + "/multi.txt"));
+
         // Move file3
         String movedPath = testDir2 + "/moved_file3.txt";
         sandbox.files()

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1341,7 +1341,7 @@ public class SandboxE2ETest extends BaseE2ETest {
             Thread.sleep(50);
         } catch (InterruptedException ignored) {
         }
-        sandbox.files()
+        var replaceResults = sandbox.files()
                 .replaceContents(
                         List.of(
                                 ContentReplaceEntry.builder()
@@ -1349,11 +1349,36 @@ public class SandboxE2ETest extends BaseE2ETest {
                                         .oldContent("Appended line to file1")
                                         .newContent("Replaced line in file1")
                                         .build()));
+        assertEquals(1, replaceResults.size());
+        assertEquals(testFile1, replaceResults.get(0).getPath());
+        assertEquals(1, replaceResults.get(0).getReplacedCount());
         String replaced = sandbox.files().readFile(testFile1, "UTF-8", null);
         assertTrue(replaced.contains("Replaced line in file1"));
         assertFalse(replaced.contains("Appended line to file1"));
         EntryInfo afterReplace = sandbox.files().readFileInfo(List.of(testFile1)).get(testFile1);
         assertModifiedUpdated(beforeReplace.getModifiedAt(), afterReplace.getModifiedAt(), 1, 1000);
+
+        // No match → replacedCount=0
+        var noMatchResults = sandbox.files().replaceContents(List.of(
+                ContentReplaceEntry.builder()
+                        .path(testFile1)
+                        .oldContent("nonexistent string")
+                        .newContent("irrelevant")
+                        .build()));
+        assertEquals(1, noMatchResults.size());
+        assertEquals(0, noMatchResults.get(0).getReplacedCount());
+
+        // Multiple matches
+        sandbox.files().writeFiles(List.of(
+                WriteEntry.builder().path(testDir1 + "/multi.txt").data("foo bar foo baz foo").build()));
+        var multiResults = sandbox.files().replaceContents(List.of(
+                ContentReplaceEntry.builder()
+                        .path(testDir1 + "/multi.txt")
+                        .oldContent("foo")
+                        .newContent("qux")
+                        .build()));
+        assertEquals(1, multiResults.size());
+        assertEquals(3, multiResults.get(0).getReplacedCount());
 
         // Move file3
         String movedPath = testDir2 + "/moved_file3.txt";

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -957,6 +957,12 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   expect(await sandbox.files.readFile(batchA)).toBe("hi world");
   expect(await sandbox.files.readFile(batchB)).toBe("hi hi");
 
+  // Verify original replaceContents (void return) still works
+  await sandbox.files.replaceContents([
+    { path: file1, oldContent: "Replaced line in file1", newContent: "Final line in file1" },
+  ]);
+  expect((await sandbox.files.readFile(file1)).includes("Final line in file1")).toBe(true);
+
   const movedPath = `${dir2}/moved_file3.txt`;
   await sandbox.files.moveFiles([{ src: file3, dest: movedPath }]);
   expect(await sandbox.files.readFile(movedPath)).toBe(content);

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -906,7 +906,7 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   expect(await sandbox.files.readFile(file2)).toBe(updated2);
 
   await new Promise((r) => setTimeout(r, 50));
-  const replaceResults = await sandbox.files.replaceContents([
+  const replaceResults = await sandbox.files.replaceContentsDetailed([
     {
       path: file1,
       oldContent: "Appended line to file1",
@@ -921,7 +921,7 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   expect(replaced.includes("Appended line to file1")).toBe(false);
 
   // Replace with no match (replacedCount=0)
-  const noMatchResults = await sandbox.files.replaceContents([
+  const noMatchResults = await sandbox.files.replaceContentsDetailed([
     { path: file1, oldContent: "this string does not exist", newContent: "irrelevant" },
   ]);
   expect(noMatchResults.length).toBe(1);
@@ -932,7 +932,7 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   // Replace with multiple matches (replacedCount>1)
   const multiFile = `${dir1}/multi_match.txt`;
   await sandbox.files.writeFiles([{ path: multiFile, data: "foo bar foo baz foo" }]);
-  const multiResults = await sandbox.files.replaceContents([
+  const multiResults = await sandbox.files.replaceContentsDetailed([
     { path: multiFile, oldContent: "foo", newContent: "qux" },
   ]);
   expect(multiResults.length).toBe(1);
@@ -946,7 +946,7 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
     { path: batchA, data: "hello world" },
     { path: batchB, data: "hello hello" },
   ]);
-  const batchResults = await sandbox.files.replaceContents([
+  const batchResults = await sandbox.files.replaceContentsDetailed([
     { path: batchA, oldContent: "hello", newContent: "hi" },
     { path: batchB, oldContent: "hello", newContent: "hi" },
   ]);

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -906,16 +906,56 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   expect(await sandbox.files.readFile(file2)).toBe(updated2);
 
   await new Promise((r) => setTimeout(r, 50));
-  await sandbox.files.replaceContents([
+  const replaceResults = await sandbox.files.replaceContents([
     {
       path: file1,
       oldContent: "Appended line to file1",
       newContent: "Replaced line in file1",
     },
   ]);
+  expect(replaceResults.length).toBe(1);
+  expect(replaceResults[0].path).toBe(file1);
+  expect(replaceResults[0].replacedCount).toBe(1);
   const replaced = await sandbox.files.readFile(file1);
   expect(replaced.includes("Replaced line in file1")).toBe(true);
   expect(replaced.includes("Appended line to file1")).toBe(false);
+
+  // Replace with no match (replacedCount=0)
+  const noMatchResults = await sandbox.files.replaceContents([
+    { path: file1, oldContent: "this string does not exist", newContent: "irrelevant" },
+  ]);
+  expect(noMatchResults.length).toBe(1);
+  expect(noMatchResults[0].path).toBe(file1);
+  expect(noMatchResults[0].replacedCount).toBe(0);
+  expect(await sandbox.files.readFile(file1)).toBe(replaced);
+
+  // Replace with multiple matches (replacedCount>1)
+  const multiFile = `${dir1}/multi_match.txt`;
+  await sandbox.files.writeFiles([{ path: multiFile, data: "foo bar foo baz foo" }]);
+  const multiResults = await sandbox.files.replaceContents([
+    { path: multiFile, oldContent: "foo", newContent: "qux" },
+  ]);
+  expect(multiResults.length).toBe(1);
+  expect(multiResults[0].replacedCount).toBe(3);
+  expect(await sandbox.files.readFile(multiFile)).toBe("qux bar qux baz qux");
+
+  // Batch replace across multiple files
+  const batchA = `${dir1}/batch_a.txt`;
+  const batchB = `${dir1}/batch_b.txt`;
+  await sandbox.files.writeFiles([
+    { path: batchA, data: "hello world" },
+    { path: batchB, data: "hello hello" },
+  ]);
+  const batchResults = await sandbox.files.replaceContents([
+    { path: batchA, oldContent: "hello", newContent: "hi" },
+    { path: batchB, oldContent: "hello", newContent: "hi" },
+  ]);
+  expect(batchResults.length).toBe(2);
+  const byPath = Object.fromEntries(batchResults.map((r) => [r.path, r.replacedCount]));
+  expect(byPath[batchA]).toBe(1);
+  expect(byPath[batchB]).toBe(2);
+  expect(await sandbox.files.readFile(batchA)).toBe("hi world");
+  expect(await sandbox.files.readFile(batchB)).toBe("hi hi");
 
   const movedPath = `${dir2}/moved_file3.txt`;
   await sandbox.files.moveFiles([{ src: file3, dest: movedPath }]);

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -1484,7 +1484,7 @@ class TestSandboxE2E:
             old_content="Appended line to file1",
             new_content="Replaced line in file1",
         )
-        replace_results = await sandbox.files.replace_contents([replace_entry])
+        replace_results = await sandbox.files.replace_contents_detailed([replace_entry])
         assert len(replace_results) == 1
         assert replace_results[0].path == test_file1
         assert replace_results[0].replaced_count == 1
@@ -1537,6 +1537,12 @@ class TestSandboxE2E:
         assert await sandbox.files.read_file(batch_file_b, encoding="utf-8") == "hi hi"
 
         await sandbox.files.delete_files([multi_match_file, batch_file_a, batch_file_b])
+
+        logger.info("Step 8d: Verify original replace_contents (no return value) still works")
+        await sandbox.files.replace_contents([
+            ContentReplaceEntry(path=test_file1, old_content="Replaced line in file1", new_content="Final line in file1")
+        ])
+        assert "Final line in file1" in await sandbox.files.read_file(test_file1, encoding="utf-8")
 
         logger.info("Step 9: Move/rename a file via API (move_files)")
         moved_path = f"{test_dir2}/moved_file3.txt"

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -1496,7 +1496,7 @@ class TestSandboxE2E:
         _assert_modified_updated(before_replace_info.modified_at, after_replace_info.modified_at, min_delta_ms=1)
 
         logger.info("Step 8a: Replace with no match (replacedCount=0)")
-        no_match_results = await sandbox.files.replace_contents([
+        no_match_results = await sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(
                 path=test_file1,
                 old_content="this string does not exist in file",
@@ -1511,7 +1511,7 @@ class TestSandboxE2E:
         logger.info("Step 8b: Replace with multiple matches (replacedCount>1)")
         multi_match_file = f"{test_dir1}/multi_match.txt"
         await sandbox.files.write_files([WriteEntry(path=multi_match_file, data="foo bar foo baz foo")])
-        multi_results = await sandbox.files.replace_contents([
+        multi_results = await sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(path=multi_match_file, old_content="foo", new_content="qux")
         ])
         assert len(multi_results) == 1
@@ -1525,7 +1525,7 @@ class TestSandboxE2E:
             WriteEntry(path=batch_file_a, data="hello world"),
             WriteEntry(path=batch_file_b, data="hello hello"),
         ])
-        batch_results = await sandbox.files.replace_contents([
+        batch_results = await sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(path=batch_file_a, old_content="hello", new_content="hi"),
             ContentReplaceEntry(path=batch_file_b, old_content="hello", new_content="hi"),
         ])

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -1536,6 +1536,8 @@ class TestSandboxE2E:
         assert await sandbox.files.read_file(batch_file_a, encoding="utf-8") == "hi world"
         assert await sandbox.files.read_file(batch_file_b, encoding="utf-8") == "hi hi"
 
+        await sandbox.files.delete_files([multi_match_file, batch_file_a, batch_file_b])
+
         logger.info("Step 9: Move/rename a file via API (move_files)")
         moved_path = f"{test_dir2}/moved_file3.txt"
         await sandbox.files.move_files([MoveEntry(src=test_file3, dest=moved_path)])

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -1484,13 +1484,57 @@ class TestSandboxE2E:
             old_content="Appended line to file1",
             new_content="Replaced line in file1",
         )
-        await sandbox.files.replace_contents([replace_entry])
+        replace_results = await sandbox.files.replace_contents([replace_entry])
+        assert len(replace_results) == 1
+        assert replace_results[0].path == test_file1
+        assert replace_results[0].replaced_count == 1
         replaced_content1 = await sandbox.files.read_file(test_file1, encoding="utf-8")
         assert "Replaced line in file1" in replaced_content1
         assert "Appended line to file1" not in replaced_content1
 
         after_replace_info = (await sandbox.files.get_file_info([test_file1]))[test_file1]
         _assert_modified_updated(before_replace_info.modified_at, after_replace_info.modified_at, min_delta_ms=1)
+
+        logger.info("Step 8a: Replace with no match (replacedCount=0)")
+        no_match_results = await sandbox.files.replace_contents([
+            ContentReplaceEntry(
+                path=test_file1,
+                old_content="this string does not exist in file",
+                new_content="irrelevant",
+            )
+        ])
+        assert len(no_match_results) == 1
+        assert no_match_results[0].path == test_file1
+        assert no_match_results[0].replaced_count == 0
+        assert await sandbox.files.read_file(test_file1, encoding="utf-8") == replaced_content1
+
+        logger.info("Step 8b: Replace with multiple matches (replacedCount>1)")
+        multi_match_file = f"{test_dir1}/multi_match.txt"
+        await sandbox.files.write_files([WriteEntry(path=multi_match_file, data="foo bar foo baz foo")])
+        multi_results = await sandbox.files.replace_contents([
+            ContentReplaceEntry(path=multi_match_file, old_content="foo", new_content="qux")
+        ])
+        assert len(multi_results) == 1
+        assert multi_results[0].replaced_count == 3
+        assert await sandbox.files.read_file(multi_match_file, encoding="utf-8") == "qux bar qux baz qux"
+
+        logger.info("Step 8c: Batch replace across multiple files")
+        batch_file_a = f"{test_dir1}/batch_a.txt"
+        batch_file_b = f"{test_dir1}/batch_b.txt"
+        await sandbox.files.write_files([
+            WriteEntry(path=batch_file_a, data="hello world"),
+            WriteEntry(path=batch_file_b, data="hello hello"),
+        ])
+        batch_results = await sandbox.files.replace_contents([
+            ContentReplaceEntry(path=batch_file_a, old_content="hello", new_content="hi"),
+            ContentReplaceEntry(path=batch_file_b, old_content="hello", new_content="hi"),
+        ])
+        assert len(batch_results) == 2
+        results_by_path = {r.path: r.replaced_count for r in batch_results}
+        assert results_by_path[batch_file_a] == 1
+        assert results_by_path[batch_file_b] == 2
+        assert await sandbox.files.read_file(batch_file_a, encoding="utf-8") == "hi world"
+        assert await sandbox.files.read_file(batch_file_b, encoding="utf-8") == "hi hi"
 
         logger.info("Step 9: Move/rename a file via API (move_files)")
         moved_path = f"{test_dir2}/moved_file3.txt"

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -1230,6 +1230,12 @@ class TestSandboxE2ESync:
 
         sandbox.files.delete_files([multi_match_file, batch_file_a, batch_file_b])
 
+        # Verify original replace_contents (no return value) still works
+        sandbox.files.replace_contents([
+            ContentReplaceEntry(path=test_file1, old_content="Replaced line in file1", new_content="Final line in file1")
+        ])
+        assert "Final line in file1" in sandbox.files.read_file(test_file1, encoding="utf-8")
+
         # Move/rename a file via API (move_files)
         moved_path = f"{test_dir2}/moved_file3.txt"
         sandbox.files.move_files([MoveEntry(src=test_file3, dest=moved_path)])

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -1169,7 +1169,7 @@ class TestSandboxE2ESync:
         # Replace file contents via API (replace_contents)
         before_replace_info = after_update_info
         time.sleep(0.05)
-        replace_results = sandbox.files.replace_contents(
+        replace_results = sandbox.files.replace_contents_detailed(
             [
                 ContentReplaceEntry(
                     path=test_file1,
@@ -1188,7 +1188,7 @@ class TestSandboxE2ESync:
         _assert_modified_updated(before_replace_info.modified_at, after_replace_info.modified_at, min_delta_ms=1)
 
         # Replace with no match (replacedCount=0)
-        no_match_results = sandbox.files.replace_contents([
+        no_match_results = sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(
                 path=test_file1,
                 old_content="this string does not exist in file",
@@ -1203,7 +1203,7 @@ class TestSandboxE2ESync:
         # Replace with multiple matches (replacedCount>1)
         multi_match_file = f"{test_dir1}/multi_match.txt"
         sandbox.files.write_files([WriteEntry(path=multi_match_file, data="foo bar foo baz foo")])
-        multi_results = sandbox.files.replace_contents([
+        multi_results = sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(path=multi_match_file, old_content="foo", new_content="qux")
         ])
         assert len(multi_results) == 1
@@ -1217,7 +1217,7 @@ class TestSandboxE2ESync:
             WriteEntry(path=batch_file_a, data="hello world"),
             WriteEntry(path=batch_file_b, data="hello hello"),
         ])
-        batch_results = sandbox.files.replace_contents([
+        batch_results = sandbox.files.replace_contents_detailed([
             ContentReplaceEntry(path=batch_file_a, old_content="hello", new_content="hi"),
             ContentReplaceEntry(path=batch_file_b, old_content="hello", new_content="hi"),
         ])

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -1228,6 +1228,8 @@ class TestSandboxE2ESync:
         assert sandbox.files.read_file(batch_file_a, encoding="utf-8") == "hi world"
         assert sandbox.files.read_file(batch_file_b, encoding="utf-8") == "hi hi"
 
+        sandbox.files.delete_files([multi_match_file, batch_file_a, batch_file_b])
+
         # Move/rename a file via API (move_files)
         moved_path = f"{test_dir2}/moved_file3.txt"
         sandbox.files.move_files([MoveEntry(src=test_file3, dest=moved_path)])

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -1169,7 +1169,7 @@ class TestSandboxE2ESync:
         # Replace file contents via API (replace_contents)
         before_replace_info = after_update_info
         time.sleep(0.05)
-        sandbox.files.replace_contents(
+        replace_results = sandbox.files.replace_contents(
             [
                 ContentReplaceEntry(
                     path=test_file1,
@@ -1178,11 +1178,55 @@ class TestSandboxE2ESync:
                 )
             ]
         )
+        assert len(replace_results) == 1
+        assert replace_results[0].path == test_file1
+        assert replace_results[0].replaced_count == 1
         replaced_content1 = sandbox.files.read_file(test_file1, encoding="utf-8")
         assert "Replaced line in file1" in replaced_content1
         assert "Appended line to file1" not in replaced_content1
         after_replace_info = sandbox.files.get_file_info([test_file1])[test_file1]
         _assert_modified_updated(before_replace_info.modified_at, after_replace_info.modified_at, min_delta_ms=1)
+
+        # Replace with no match (replacedCount=0)
+        no_match_results = sandbox.files.replace_contents([
+            ContentReplaceEntry(
+                path=test_file1,
+                old_content="this string does not exist in file",
+                new_content="irrelevant",
+            )
+        ])
+        assert len(no_match_results) == 1
+        assert no_match_results[0].path == test_file1
+        assert no_match_results[0].replaced_count == 0
+        assert sandbox.files.read_file(test_file1, encoding="utf-8") == replaced_content1
+
+        # Replace with multiple matches (replacedCount>1)
+        multi_match_file = f"{test_dir1}/multi_match.txt"
+        sandbox.files.write_files([WriteEntry(path=multi_match_file, data="foo bar foo baz foo")])
+        multi_results = sandbox.files.replace_contents([
+            ContentReplaceEntry(path=multi_match_file, old_content="foo", new_content="qux")
+        ])
+        assert len(multi_results) == 1
+        assert multi_results[0].replaced_count == 3
+        assert sandbox.files.read_file(multi_match_file, encoding="utf-8") == "qux bar qux baz qux"
+
+        # Batch replace across multiple files
+        batch_file_a = f"{test_dir1}/batch_a.txt"
+        batch_file_b = f"{test_dir1}/batch_b.txt"
+        sandbox.files.write_files([
+            WriteEntry(path=batch_file_a, data="hello world"),
+            WriteEntry(path=batch_file_b, data="hello hello"),
+        ])
+        batch_results = sandbox.files.replace_contents([
+            ContentReplaceEntry(path=batch_file_a, old_content="hello", new_content="hi"),
+            ContentReplaceEntry(path=batch_file_b, old_content="hello", new_content="hi"),
+        ])
+        assert len(batch_results) == 2
+        results_by_path = {r.path: r.replaced_count for r in batch_results}
+        assert results_by_path[batch_file_a] == 1
+        assert results_by_path[batch_file_b] == 2
+        assert sandbox.files.read_file(batch_file_a, encoding="utf-8") == "hi world"
+        assert sandbox.files.read_file(batch_file_b, encoding="utf-8") == "hi hi"
 
         # Move/rename a file via API (move_files)
         moved_path = f"{test_dir2}/moved_file3.txt"


### PR DESCRIPTION
## Summary

- Add `replacedCount` field per file in the `POST /files/replace` response, so callers can detect no-match and multi-match scenarios
- Update all language SDKs (Python, JavaScript, Go, Kotlin, C#) and MCP server to expose the new response
- Add e2e test coverage for no-match (`replacedCount=0`), multi-match (`replacedCount>1`), and batch replace across all test suites

Closes #982

## Changes

| Layer | What changed |
|-------|-------------|
| **OpenAPI spec** | `execd-api.yaml` — 200 response schema + `ReplaceFileContentResult` |
| **execd handler** | `strings.Count()` before replace, return per-file results (unix + windows) |
| **Python SDK** | New `ContentReplaceResult` model, adapter/service return `list[ContentReplaceResult]` |
| **JS SDK** | New `ContentReplaceResult` interface, adapter/service return `ContentReplaceResult[]` |
| **Go SDK** | New `ReplaceResult`/`ReplaceResponse` types, `ReplaceInFiles()` returns `(ReplaceResponse, error)` |
| **Kotlin SDK** | New `ContentReplaceResult` data class, adapter uses direct OkHttp call to parse response |
| **C# SDK** | New `ContentReplaceResult` class, adapter returns `IReadOnlyList<ContentReplaceResult>` |
| **MCP server** | Returns `list[ContentReplaceResult]` instead of `StatusResponse` |
| **E2E tests** | All 6 test suites (Python async/sync, JS, Go, Java, C#) — assert return values + 3 new scenarios |

## Backward compatibility

- **Old SDK + new execd**: safe — old SDK ignores response body
- **New SDK + old execd**: Python handles empty body gracefully; JS returns `[]`; Go decodes empty → nil map
- Response going from empty to JSON body is non-breaking
- SDK return type changes from `void`/`None` to result list — callers not using return value are unaffected

## Test plan

- [ ] `go build ./...` in `components/execd` — passed locally
- [ ] `pnpm run build` in `sdks/sandbox/javascript` — passed locally
- [ ] Python import check — passed locally
- [ ] E2E tests require running sandbox — verify in CI
- [ ] Kotlin `./gradlew build` to regenerate API from spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)