### PR TITLE
feat(server): expose snapshot restore image reference (imageUri) in the Snapshot API

### DIFF
--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -618,6 +618,16 @@ class Snapshot(BaseModel):
         ...,
         description="Current snapshot lifecycle status and detailed state information",
     )
+    image_uri: Optional[str] = Field(
+        None,
+        alias="imageUri",
+        description=(
+            "OCI image reference to restore this snapshot from. Populated once the "
+            "snapshot reaches the Ready state. Exposing it enables restoring the "
+            "snapshot on a different server or runtime via the create-from-image path "
+            "(snapshotId restore is limited to the originating server's snapshot store)."
+        ),
+    )
     created_at: datetime = Field(
         ...,
         alias="createdAt",

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -515,6 +515,7 @@ class PersistedSnapshotService(SnapshotService):
                 message=record.status.message,
                 lastTransitionAt=record.status.last_transition_at,
             ),
+            imageUri=record.restore_config.image if record.restore_config else None,
             createdAt=record.created_at,
         )
 

--- a/server/tests/test_routes_snapshots.py
+++ b/server/tests/test_routes_snapshots.py
@@ -267,3 +267,55 @@ def test_create_snapshot_returns_501_when_runtime_is_not_supported(
 
     assert response.status_code == 501
     assert response.json()["code"] == "SNAPSHOT::NOT_IMPLEMENTED"
+
+
+def test_get_snapshot_exposes_image_uri_alias(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    class StubService:
+        @staticmethod
+        def get_snapshot(snapshot_id: str) -> Snapshot:
+            return Snapshot(
+                id=snapshot_id,
+                sandboxId="sbx-001",
+                name="ready-snap",
+                status=SnapshotStatus(state="Ready"),
+                imageUri="opensandbox-snapshots:snap-001",
+                createdAt=now,
+            )
+
+    monkeypatch.setattr(lifecycle, "snapshot_service", StubService())
+
+    response = client.get("/v1/snapshots/snap-001", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["imageUri"] == "opensandbox-snapshots:snap-001"
+
+
+def test_get_snapshot_omits_image_uri_when_absent(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    class StubService:
+        @staticmethod
+        def get_snapshot(snapshot_id: str) -> Snapshot:
+            return Snapshot(
+                id=snapshot_id,
+                sandboxId="sbx-001",
+                status=SnapshotStatus(state="Creating"),
+                createdAt=now,
+            )
+
+    monkeypatch.setattr(lifecycle, "snapshot_service", StubService())
+
+    response = client.get("/v1/snapshots/snap-001", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert "imageUri" not in response.json()

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -629,3 +629,38 @@ def test_snapshot_service_recovers_deleting_snapshot(tmp_path) -> None:
 
     assert runtime.delete_calls == [("snap-delete", "opensandbox-snapshots:snap-delete")]
     assert repo.get("snap-delete") is None
+
+
+def test_get_snapshot_exposes_image_uri_when_ready(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    repo.create(
+        _snapshot_record(
+            "snap-ready",
+            SnapshotState.READY,
+            image="opensandbox-snapshots:snap-ready",
+        )
+    )
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=StubSnapshotRuntime(),
+    )
+
+    fetched = service.get_snapshot("snap-ready")
+
+    assert fetched.image_uri == "opensandbox-snapshots:snap-ready"
+
+
+def test_snapshot_response_has_no_image_uri_while_creating(tmp_path) -> None:
+    repo = SQLiteSnapshotRepository(tmp_path / "snapshots.db")
+    service = PersistedSnapshotService(
+        repo,
+        StubSandboxService(),
+        snapshot_runtime=StubSnapshotRuntime(),
+        snapshot_executor=CapturingExecutor(),
+    )
+
+    created = service.create_snapshot("sbx-001", CreateSnapshotRequest(name="checkpoint"))
+
+    assert created.status.state == "Creating"
+    assert created.image_uri is None


### PR DESCRIPTION
## What

Expose the snapshot's restore image reference as `imageUri` in the `Snapshot` API model. It is populated once the snapshot reaches `Ready`, sourced from the value the server already stores in `SnapshotRecord.restore_config.image`.

Implements #994.

## Why

Today the `Snapshot` responses (`POST /sandboxes/{id}/snapshots`, `GET /snapshots/{id}`, `GET /snapshots`) do not return the resulting OCI image reference. The server computes and stores it, but only uses it internally to resolve *same-server* `snapshotId` restores. Since the snapshot store is per-server, restoring a snapshot on a **different server or runtime** requires the raw image ref via the create-from-image path — which clients currently cannot obtain from the API.

This blocks cross-server / cross-runtime restore (e.g. moving a sandbox between a local Docker-runtime server and a Kubernetes/`batchsandbox` server through a shared registry).

## Change

- `server/opensandbox_server/api/schema.py`: add optional `image_uri` (alias `imageUri`) to `Snapshot`.
- `server/opensandbox_server/services/snapshot_service.py`: populate it in `_to_snapshot_response` from `record.restore_config.image`.

Additive and backward-compatible: the field is `Optional` and omitted while the snapshot is not `Ready` (the endpoints already use `response_model_exclude_none=True`).

## Verification

Built the server image from this branch and ran it with `runtime=docker`:

1. Created a sandbox and took a snapshot.
2. `GET /snapshots/{id}` while `Creating` → no `imageUri` (omitted).
3. Once `Ready` → `"imageUri": "opensandbox-snapshots:<id>"`, matching the committed docker image.

The same `_to_snapshot_response` mapping serves the Kubernetes runtime, where `restore_config.image` is the registry ref pushed by the commit Job (`SandboxSnapshot.status.containers[].imageUri`).
