### PR TITLE
feat(execd): add PTY session takeover (?takeover=1) for device handoff

### DIFF
--- a/components/execd/PTY.md
+++ b/components/execd/PTY.md
@@ -23,10 +23,11 @@ Use this when you need a **long-lived Bash** driven over **WebSocket**: PTY mode
    |-------|-----|
    | `pty=0` | Pipe mode instead of PTY |
    | `since=<offset>` | After reconnect, replay from byte offset (use `output_offset` from `GET /pty/:id`) |
+   | `takeover=1` | Evict the current holder instead of getting **409**, then attach to the same shell (combine with `since=` to replay scrollback) |
 
 3. **Traffic** — after a JSON `connected` frame, the server sends **binary** chunks: first byte is the channel (`0x01` stdout, `0x02` stderr in pipe mode only, `0x03` replay with an 8-byte offset header). Send **stdin** as binary: `0x00` + raw bytes. For **resize** / **signals** / **ping**, send **JSON text** frames, e.g. `{"type":"resize","cols":120,"rows":40}`, `{"type":"signal","signal":"SIGINT"}`, `{"type":"ping"}`.
 
-4. **One WebSocket per session** — a second connection gets **409** until the first closes.
+4. **One WebSocket per session** — a second connection gets **409** until the first closes, unless it passes **`?takeover=1`**: the current holder is then closed with WebSocket code **4001** (reason `TAKEN_OVER`) and the new connection takes over the **same** shell. This lets a session move between clients/devices without restarting Bash.
 
 5. **End** — when Bash exits, you get a JSON `exit` frame with `exit_code` and the socket closes. Use **`DELETE /pty/:id`** to tear down the session from the server side.
 

--- a/components/execd/pkg/runtime/pty_session.go
+++ b/components/execd/pkg/runtime/pty_session.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/alibaba/opensandbox/internal/safego"
 	"github.com/creack/pty"
@@ -40,6 +41,9 @@ import (
 type PTYSession interface {
 	LockWS() bool
 	UnlockWS()
+	TakeoverWS(timeout time.Duration) bool
+	SetEvictHandler(fn func()) uint64
+	ClearEvictHandler(gen uint64)
 	IsRunning() bool
 	IsPTY() bool
 	ExitCode() int
@@ -93,6 +97,14 @@ type ptySession struct {
 	// WS exclusive lock: only one WebSocket client at a time.
 	wsConnected atomic.Bool
 
+	// Eviction hook for session takeover. The active WS handler registers a function
+	// that closes its own connection (and stops its pumps) so a newer client can take
+	// over the session. Guarded by evictMu; evictGen lets a handler clear only its own
+	// hook and never a successor's (see SetEvictHandler / ClearEvictHandler).
+	evictMu  sync.Mutex
+	evict    func()
+	evictGen uint64
+
 	// Output broadcast (guards stdoutW / stderrW).
 	// The broadcast goroutine holds outMu only while reading the pointer; writes
 	// to the pipe happen outside the lock to avoid blocking broadcast on slow clients.
@@ -119,6 +131,58 @@ func (s *ptySession) LockWS() bool {
 // UnlockWS releases the WebSocket connection lock.
 func (s *ptySession) UnlockWS() {
 	s.wsConnected.Store(false)
+}
+
+// SetEvictHandler registers fn as the current connection's eviction hook and returns
+// a generation token. A newer handler calling this overwrites the previous hook. Pass
+// the returned token to ClearEvictHandler on teardown.
+func (s *ptySession) SetEvictHandler(fn func()) uint64 {
+	s.evictMu.Lock()
+	defer s.evictMu.Unlock()
+	s.evictGen++
+	s.evict = fn
+	return s.evictGen
+}
+
+// ClearEvictHandler removes the eviction hook only if it still belongs to gen, so a
+// handler tearing down never clears a successor's hook (which would race after a
+// takeover hands the session to a new connection).
+func (s *ptySession) ClearEvictHandler(gen uint64) {
+	s.evictMu.Lock()
+	defer s.evictMu.Unlock()
+	if s.evictGen == gen {
+		s.evict = nil
+	}
+}
+
+// triggerEvict invokes the current eviction hook, if any. The hook is expected to be
+// idempotent (closing an already-closed WS is a no-op), so repeated calls are safe.
+func (s *ptySession) triggerEvict() {
+	s.evictMu.Lock()
+	fn := s.evict
+	s.evictMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+// TakeoverWS forcibly acquires the WS lock for a new client. It repeatedly evicts the
+// current holder (closing its WS) and retries LockWS until it wins or timeout elapses.
+// The shell process keeps running throughout; the new client reattaches with replay.
+// Returns true if the lock was acquired.
+func (s *ptySession) TakeoverWS(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if s.LockWS() {
+			return true
+		}
+		s.triggerEvict()
+		if time.Now().After(deadline) {
+			// One last attempt in case the holder released just now.
+			return s.LockWS()
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // IsRunning returns true if the bash process is currently alive.

--- a/components/execd/pkg/runtime/pty_session_windows.go
+++ b/components/execd/pkg/runtime/pty_session_windows.go
@@ -20,6 +20,7 @@ package runtime
 import (
 	"errors"
 	"io"
+	"time"
 )
 
 // ptySession is an opaque stub on Windows (real type in pty_session.go, !windows).
@@ -32,6 +33,9 @@ type ptySession struct{}
 type PTYSession interface {
 	LockWS() bool
 	UnlockWS()
+	TakeoverWS(timeout time.Duration) bool
+	SetEvictHandler(fn func()) uint64
+	ClearEvictHandler(gen uint64)
 	IsRunning() bool
 	IsPTY() bool
 	ExitCode() int
@@ -73,6 +77,9 @@ func (c *Controller) GetPTYSessionStatus(id string) (bool, int64, error) { //nol
 
 func (s *ptySession) LockWS() bool                                 { return false }
 func (s *ptySession) UnlockWS()                                    {}
+func (s *ptySession) TakeoverWS(_ time.Duration) bool              { return false }
+func (s *ptySession) SetEvictHandler(_ func()) uint64              { return 0 }
+func (s *ptySession) ClearEvictHandler(_ uint64)                   {}
 func (s *ptySession) IsRunning() bool                              { return false }
 func (s *ptySession) IsPTY() bool                                  { return false }
 func (s *ptySession) ExitCode() int                                { return -1 }

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -46,6 +46,9 @@ const (
 	// wsTakeoverTimeout bounds how long a ?takeover=1 request waits for the current
 	// holder to release after being evicted, before giving up with 409.
 	wsTakeoverTimeout = 5 * time.Second
+	// wsTakeoverCloseTimeout bounds the best-effort close-frame write sent to an
+	// evicted holder, so a full/unresponsive client socket cannot stall the takeover.
+	wsTakeoverCloseTimeout = 200 * time.Millisecond
 )
 
 // PTYSessionWebSocket handles GET /pty/:sessionId/ws.
@@ -84,8 +87,10 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 	//    instead of failing: the shell keeps running, the old client's WS is closed
 	//    with WSCloseTakenOver, and this client reattaches with replay (?since=...).
 	//    This lets a session move between devices without an orchestrator round-trip.
+	//    Gate on a real WS handshake so a plain HTTP GET (curl/proxy probe) cannot
+	//    evict the holder and then fail to upgrade, leaving the session unattached.
 	locked := session.LockWS()
-	if !locked && ctx.Query("takeover") == "1" {
+	if !locked && ctx.Query("takeover") == "1" && websocket.IsWebSocketUpgrade(ctx.Request) {
 		locked = session.TakeoverWS(wsTakeoverTimeout)
 	}
 	if !locked {
@@ -163,13 +168,30 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		_ = conn.Close()
 	}
 
+	// evictClose is the non-blocking close used by the takeover eviction hook. Unlike
+	// closeConn it must not wait behind a stalled output writer: a takeover targets
+	// exactly the slow/abandoned-client case, so blocking on connMu (held by a pump
+	// stuck in WriteMessage) until wsWriteDeadline would defeat wsTakeoverTimeout. It
+	// therefore sends the close frame only on a best-effort basis (TryLock, short
+	// deadline) and always closes the conn, which unblocks any stuck writer. A client
+	// too backed-up to receive the frame could not have received it anyway.
+	evictClose := func(code int, text string) {
+		if connMu.TryLock() {
+			_ = conn.SetWriteDeadline(time.Now().Add(wsTakeoverCloseTimeout))
+			_ = conn.WriteMessage(websocket.CloseMessage,
+				websocket.FormatCloseMessage(code, text))
+			connMu.Unlock()
+		}
+		_ = conn.Close()
+	}
+
 	// Register the eviction hook so a later ?takeover=1 client can reclaim this
 	// session: it closes our WS with WSCloseTakenOver (unblocking the read loop) and
 	// cancels our goroutines; the deferred cleanup then releases the lock for the new
 	// client. clearEvictHandler(gen) only clears if the hook is still ours, so it never
 	// races a successor that already registered its own hook after taking over.
 	evictGen := session.SetEvictHandler(func() {
-		closeConn(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
+		evictClose(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
 		cancelOnce()
 	})
 	defer session.ClearEvictHandler(evictGen)

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -54,13 +54,16 @@ const (
 // PTYSessionWebSocket handles GET /pty/:sessionId/ws.
 //
 //  1. Look up session → 404 before upgrade if missing
-//  2. Acquire exclusive WS lock → 409 if already held
+//  2. Acquire WS lock without eviction → 409 if held and not a ?takeover=1 request
 //  3. Upgrade HTTP → WebSocket
+//     3b. Takeover (if requested): evict the holder and acquire — only now that the
+//         handshake is accepted, so a failed upgrade never evicts anyone
 //  4. Start bash if not already running
 //     5+6. AtomicAttachOutputWithSnapshot (snapshot + attach under outMu — no loss window)
-//  7. defer: detach → pumpWg.Wait → UnlockWS
+//  7. defer: detach → pumpWg.Wait → UnlockWS → ClearEvictHandler (hook live through cleanup)
 //  8. Send replay frame if snapshot non-empty
-//  9. Send connected frame
+//  9. Send connected frame, then register the eviction hook (after the unsynchronized
+//     initial writes, before the pumps start)
 //  10. Start RFC 6455 ping, streamPump(s), exitWatcher goroutines
 //  11. Read loop: dispatch client frames
 func PTYSessionWebSocket(ctx *gin.Context) {
@@ -83,33 +86,44 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		return
 	}
 
-	// 2. Acquire exclusive WS lock. With ?takeover=1, evict the current holder
-	//    instead of failing: the shell keeps running, the old client's WS is closed
-	//    with WSCloseTakenOver, and this client reattaches with replay (?since=...).
-	//    This lets a session move between devices without an orchestrator round-trip.
-	//    Gate on a real WS handshake so a plain HTTP GET (curl/proxy probe) cannot
-	//    evict the holder and then fail to upgrade, leaving the session unattached.
+	// 2. Decide how to acquire the exclusive WS lock. Try without evicting first; a
+	//    plain "already connected" with no takeover is refused with HTTP 409 *before*
+	//    the upgrade. A ?takeover=1 request (on a real WS handshake) instead evicts the
+	//    current holder — but only AFTER the handshake is fully accepted (step 3b), so a
+	//    request that announces an upgrade yet fails the handshake never evicts anyone.
 	locked := session.LockWS()
-	if !locked && ctx.Query("takeover") == "1" && websocket.IsWebSocketUpgrade(ctx.Request) {
-		locked = session.TakeoverWS(wsTakeoverTimeout)
-	}
-	if !locked {
+	wantsTakeover := !locked && ctx.Query("takeover") == "1" && websocket.IsWebSocketUpgrade(ctx.Request)
+	if !locked && !wantsTakeover {
 		ctx.JSON(http.StatusConflict, model.ErrorResponse{
 			Code:    model.WSErrCodeAlreadyConnected,
 			Message: "another client is already connected to pty session " + id,
 		})
 		return
 	}
-	// NOTE: the lock is released at the very end of this function (see defer below),
-	// only after all pump goroutines have exited.
 
-	// 3. Upgrade HTTP connection to WebSocket.
+	// 3. Upgrade HTTP connection to WebSocket. For a takeover this happens BEFORE
+	//    evicting, so a bad or incomplete handshake cannot kill the current holder.
 	conn, err := wsUpgrader.Upgrade(ctx.Writer, ctx.Request, nil)
 	if err != nil {
 		log.Warning("pty ws upgrade failed for session %s: %v", id, err)
-		session.UnlockWS()
+		if locked {
+			session.UnlockWS()
+		}
 		return
 	}
+
+	// 3b. Takeover: the handshake succeeded, so now evict the current holder and
+	//     acquire the lock. The shell keeps running; this client reattaches with replay.
+	if !locked {
+		if !session.TakeoverWS(wsTakeoverTimeout) {
+			writeErrFrame(conn, model.WSErrCodeAlreadyConnected,
+				"another client is already connected to pty session "+id)
+			_ = conn.Close()
+			return
+		}
+	}
+	// From here we hold the lock; it is released at the very end of this function (see
+	// defer below), only after all pump goroutines have exited.
 
 	// Resolve query parameters.
 	pipeMode := ctx.Query("pty") == "0"
@@ -137,12 +151,20 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 	//      would be dropped by fanout (stdoutW still nil) yet missed by snapshot.
 	stdoutR, stderrR, detach, snapshotBytes, snapshotOffset := session.AttachOutputWithSnapshot(since)
 
-	// 7. Deferred cleanup order: detach writers → wait for pump goroutines → unlock WS.
+	// 7. Deferred cleanup order: detach writers → wait for pump goroutines → unlock WS
+	//    → clear our eviction hook. The hook is cleared LAST (after UnlockWS) so it stays
+	//    live throughout cleanup: a ?takeover=1 arriving while a pump is still blocked
+	//    writing to a dead client can then fire it, and closing the conn unblocks that
+	//    pump so pumpWg.Wait() returns. ClearEvictHandler is generation-guarded, so it
+	//    never clears a successor's hook; a zero evictGen (hook never registered, e.g. an
+	//    early return below) is a no-op.
 	var pumpWg sync.WaitGroup
+	var evictGen uint64
 	defer func() {
 		detach()
 		pumpWg.Wait()
 		session.UnlockWS()
+		session.ClearEvictHandler(evictGen)
 	}()
 
 	// cancelCh is closed to signal all goroutines to stop.
@@ -185,17 +207,6 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		_ = conn.Close()
 	}
 
-	// Register the eviction hook so a later ?takeover=1 client can reclaim this
-	// session: it closes our WS with WSCloseTakenOver (unblocking the read loop) and
-	// cancels our goroutines; the deferred cleanup then releases the lock for the new
-	// client. clearEvictHandler(gen) only clears if the hook is still ours, so it never
-	// races a successor that already registered its own hook after taking over.
-	evictGen := session.SetEvictHandler(func() {
-		evictClose(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
-		cancelOnce()
-	})
-	defer session.ClearEvictHandler(evictGen)
-
 	// Set initial read deadline; pong handler resets it.
 	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
 	conn.SetPongHandler(func(string) error {
@@ -229,6 +240,18 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		log.Warning("pty ws send connected for session %s: %v", id, err2)
 		return
 	}
+
+	// Register the eviction hook now — after the replay/connected frames, which run
+	// without connMu (no pumps started yet), so a concurrent ?takeover=1 can never write
+	// a close frame while those initial writes are in flight (single-writer invariant).
+	// From here every write to conn is serialized by connMu (pumps + evictClose's
+	// TryLock). The hook closes our WS with WSCloseTakenOver (unblocking the read loop)
+	// and cancels our goroutines; the deferred cleanup then releases the lock. It is
+	// generation-tokened so a tearing-down handler never clears a successor's hook.
+	evictGen = session.SetEvictHandler(func() {
+		evictClose(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
+		cancelOnce()
+	})
 
 	// 10a. RFC 6455 binary ping goroutine (30 s interval).
 	safego.Go(func() { ptyPingLoop(conn, &connMu, cancelCh, cancelOnce) })

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -61,9 +61,11 @@ const (
 //  4. Start bash if not already running
 //     5+6. AtomicAttachOutputWithSnapshot (snapshot + attach under outMu — no loss window)
 //  7. defer: detach → pumpWg.Wait → UnlockWS → ClearEvictHandler (hook live through cleanup)
+//     Register close-only eviction hook (before initial writes, so a stalled replay can
+//     be interrupted without a connMu race)
 //  8. Send replay frame if snapshot non-empty
-//  9. Send connected frame, then register the eviction hook (after the unsynchronized
-//     initial writes, before the pumps start)
+//  9. Send connected frame, then upgrade hook to full evictClose+cancelOnce
+//     (initial writes done; all subsequent writes serialized by connMu)
 //  10. Start RFC 6455 ping, streamPump(s), exitWatcher goroutines
 //  11. Read loop: dispatch client frames
 func PTYSessionWebSocket(ctx *gin.Context) {
@@ -117,7 +119,7 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 	if !locked {
 		if !session.TakeoverWS(wsTakeoverTimeout) {
 			writeErrFrame(conn, model.WSErrCodeAlreadyConnected,
-				"another client is already connected to pty session "+id)
+				"takeover timed out for pty session "+id)
 			_ = conn.Close()
 			return
 		}
@@ -213,6 +215,18 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		return conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
 	})
 
+	// Register a close-only eviction hook BEFORE the initial writes so a concurrent
+	// ?takeover=1 can interrupt a holder stalled during a large replay or the connected
+	// frame. At this point the initial writes run without connMu (pumps not yet started),
+	// so the hook must not acquire connMu or write to conn — only close it. Closing
+	// unblocks any blocked WriteMessage and makes the subsequent read loop exit, which
+	// triggers the deferred cleanup and releases the lock. cancelOnce is also called so
+	// all goroutines stop once the pumps do start.
+	evictGen = session.SetEvictHandler(func() {
+		cancelOnce()
+		_ = conn.Close()
+	})
+
 	// 8. Send replay frame if there is missed output.
 	if len(snapshotBytes) > 0 {
 		frame := make([]byte, 1+8+len(snapshotBytes))
@@ -241,13 +255,11 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		return
 	}
 
-	// Register the eviction hook now — after the replay/connected frames, which run
-	// without connMu (no pumps started yet), so a concurrent ?takeover=1 can never write
-	// a close frame while those initial writes are in flight (single-writer invariant).
-	// From here every write to conn is serialized by connMu (pumps + evictClose's
-	// TryLock). The hook closes our WS with WSCloseTakenOver (unblocking the read loop)
-	// and cancels our goroutines; the deferred cleanup then releases the lock. It is
-	// generation-tokened so a tearing-down handler never clears a successor's hook.
+	// Upgrade the eviction hook now that the initial writes are done and all subsequent
+	// writes will be serialized by connMu (pumps + evictClose's TryLock). The full hook
+	// sends the WSCloseTakenOver close frame best-effort so the client can distinguish an
+	// intentional handoff from a network drop, then closes the conn and cancels goroutines.
+	// Generation-tokened: a tearing-down handler never clears a successor's hook.
 	evictGen = session.SetEvictHandler(func() {
 		evictClose(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
 		cancelOnce()

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -57,7 +57,7 @@ const (
 //  2. Acquire WS lock without eviction → 409 if held and not a ?takeover=1 request
 //  3. Upgrade HTTP → WebSocket
 //     3b. Takeover (if requested): evict the holder and acquire — only now that the
-//         handshake is accepted, so a failed upgrade never evicts anyone
+//     handshake is accepted, so a failed upgrade never evicts anyone
 //  4. Start bash if not already running
 //     5+6. AtomicAttachOutputWithSnapshot (snapshot + attach under outMu — no loss window)
 //  7. defer: detach → pumpWg.Wait → UnlockWS → ClearEvictHandler (hook live through cleanup)

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -43,6 +43,9 @@ const (
 	wsPingInterval  = 30 * time.Second
 	wsReadDeadline  = 60 * time.Second
 	wsWriteDeadline = 10 * time.Second
+	// wsTakeoverTimeout bounds how long a ?takeover=1 request waits for the current
+	// holder to release after being evicted, before giving up with 409.
+	wsTakeoverTimeout = 5 * time.Second
 )
 
 // PTYSessionWebSocket handles GET /pty/:sessionId/ws.
@@ -77,8 +80,15 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		return
 	}
 
-	// 2. Acquire exclusive WS lock.
-	if !session.LockWS() {
+	// 2. Acquire exclusive WS lock. With ?takeover=1, evict the current holder
+	//    instead of failing: the shell keeps running, the old client's WS is closed
+	//    with WSCloseTakenOver, and this client reattaches with replay (?since=...).
+	//    This lets a session move between devices without an orchestrator round-trip.
+	locked := session.LockWS()
+	if !locked && ctx.Query("takeover") == "1" {
+		locked = session.TakeoverWS(wsTakeoverTimeout)
+	}
+	if !locked {
 		ctx.JSON(http.StatusConflict, model.ErrorResponse{
 			Code:    model.WSErrCodeAlreadyConnected,
 			Message: "another client is already connected to pty session " + id,
@@ -152,6 +162,17 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 		connMu.Unlock()
 		_ = conn.Close()
 	}
+
+	// Register the eviction hook so a later ?takeover=1 client can reclaim this
+	// session: it closes our WS with WSCloseTakenOver (unblocking the read loop) and
+	// cancels our goroutines; the deferred cleanup then releases the lock for the new
+	// client. clearEvictHandler(gen) only clears if the hook is still ours, so it never
+	// races a successor that already registered its own hook after taking over.
+	evictGen := session.SetEvictHandler(func() {
+		closeConn(model.WSCloseTakenOver, model.WSErrCodeTakenOver)
+		cancelOnce()
+	})
+	defer session.ClearEvictHandler(evictGen)
 
 	// Set initial read deadline; pong handler resets it.
 	_ = conn.SetReadDeadline(time.Now().Add(wsReadDeadline))

--- a/components/execd/pkg/web/controller/pty_ws_test.go
+++ b/components/execd/pkg/web/controller/pty_ws_test.go
@@ -382,6 +382,32 @@ func TestPTYWS_TakeoverOnFreeSessionConnects(t *testing.T) {
 	require.Equal(t, id, f.SessionID)
 }
 
+// TestPTYWS_TakeoverRequiresWebSocketUpgrade verifies a plain HTTP GET carrying
+// takeover=1 does NOT evict the holder: without a WS handshake it would evict and
+// then fail to upgrade, orphaning the session. It must return 409 and leave the
+// holder attached and functional.
+func TestPTYWS_TakeoverRequiresWebSocketUpgrade(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found")
+	}
+	srv := newPTYTestServer(t)
+	defer srv.Close()
+
+	id := ptyCreateSession(t, srv)
+	conn1 := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "")
+	ptyWaitFrame(t, conn1, "connected", 10*time.Second)
+
+	// Plain HTTP GET (no Upgrade header) with takeover=1 → must be refused, not evict.
+	resp, err := http.Get(srv.URL + "/pty/" + id + "/ws?takeover=1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+
+	// The holder is untouched: it still drives the shell.
+	ptyWriteStdin(t, conn1, "echo still_here\n")
+	ptyOutputContains(t, conn1, "still_here", 8*time.Second)
+}
+
 func TestPTYWS_ResizeFrame(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not found")

--- a/components/execd/pkg/web/controller/pty_ws_test.go
+++ b/components/execd/pkg/web/controller/pty_ws_test.go
@@ -323,6 +323,65 @@ func TestPTYWS_ReplayOnReconnect(t *testing.T) {
 	require.True(t, gotReplay, "expected replay frame containing 'replay_test'")
 }
 
+// TestPTYWS_TakeoverEvictsHolder verifies that ?takeover=1 evicts the current
+// holder (closing its WS with WSCloseTakenOver) and that the taking-over client
+// reattaches to the SAME shell: it replays the prior scrollback and can read a
+// shell variable set by the evicted client.
+func TestPTYWS_TakeoverEvictsHolder(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found")
+	}
+	srv := newPTYTestServer(t)
+	defer srv.Close()
+
+	id := ptyCreateSession(t, srv)
+
+	// Holder connects, sets a shell var, and emits a marker.
+	conn1 := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "")
+	ptyWaitFrame(t, conn1, "connected", 10*time.Second)
+	ptyWriteStdin(t, conn1, "TAKEOVER_VAR=alive\n")
+	ptyWriteStdin(t, conn1, "echo holder_marker\n")
+	ptyOutputContains(t, conn1, "holder_marker", 8*time.Second)
+
+	// A new client takes over.
+	conn2 := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "takeover=1&since=0")
+
+	// 1. The holder's connection is closed with the takeover close code.
+	var closeErr *websocket.CloseError
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, err := conn1.ReadMessage(); err != nil {
+			_ = errors.As(err, &closeErr)
+			break
+		}
+	}
+	require.NotNil(t, closeErr, "holder should be closed with a WS CloseError after takeover")
+	require.Equal(t, model.WSCloseTakenOver, closeErr.Code)
+
+	// 2. The taking-over client replays the prior scrollback...
+	ptyOutputContains(t, conn2, "holder_marker", 8*time.Second)
+	ptyWaitFrame(t, conn2, "connected", 8*time.Second)
+
+	// 3. ...and it is the SAME shell: the var set on conn1 is still readable.
+	ptyWriteStdin(t, conn2, "echo SAMESHELL_$TAKEOVER_VAR\n")
+	ptyOutputContains(t, conn2, "SAMESHELL_alive", 8*time.Second)
+}
+
+// TestPTYWS_TakeoverOnFreeSessionConnects verifies ?takeover=1 is a no-op when the
+// session is free: it connects normally (there is no holder to evict).
+func TestPTYWS_TakeoverOnFreeSessionConnects(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found")
+	}
+	srv := newPTYTestServer(t)
+	defer srv.Close()
+
+	id := ptyCreateSession(t, srv)
+	conn := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "takeover=1")
+	f := ptyWaitFrame(t, conn, "connected", 10*time.Second)
+	require.Equal(t, id, f.SessionID)
+}
+
 func TestPTYWS_ResizeFrame(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not found")

--- a/components/execd/pkg/web/controller/pty_ws_test.go
+++ b/components/execd/pkg/web/controller/pty_ws_test.go
@@ -26,6 +26,8 @@ import (
 	"net/http/httptest"
 	"os/exec"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -406,6 +408,63 @@ func TestPTYWS_TakeoverRequiresWebSocketUpgrade(t *testing.T) {
 	// The holder is untouched: it still drives the shell.
 	ptyWriteStdin(t, conn1, "echo still_here\n")
 	ptyOutputContains(t, conn1, "still_here", 8*time.Second)
+}
+
+// TestPTYWS_ConcurrentTakeovers hammers a session with several simultaneous
+// ?takeover=1 reconnects (each with non-empty replay). They must serialize through
+// the lock without tripping the race detector — exercising the initial replay/connected
+// writes vs. eviction and the cleanup-window paths — and the shell must survive.
+func TestPTYWS_ConcurrentTakeovers(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found")
+	}
+	srv := newPTYTestServer(t)
+	defer srv.Close()
+
+	id := ptyCreateSession(t, srv)
+
+	// Holder seeds output so every takeover gets a non-empty replay frame.
+	conn0 := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "")
+	ptyWaitFrame(t, conn0, "connected", 10*time.Second)
+	ptyWriteStdin(t, conn0, "echo seed_output\n")
+	ptyOutputContains(t, conn0, "seed_output", 8*time.Second)
+
+	const n = 6
+	var wg sync.WaitGroup
+	var connectedCount int32
+	wsURL := "ws" + strings.TrimPrefix(srv.URL+"/pty/"+id+"/ws", "http") + "?takeover=1&since=0"
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				return
+			}
+			defer func() { _ = c.Close() }()
+			deadline := time.Now().Add(6 * time.Second)
+			for time.Now().Before(deadline) {
+				f, err := ptyReadFrame(c, time.Until(deadline))
+				if err != nil {
+					return
+				}
+				if f.Type == "connected" {
+					atomic.AddInt32(&connectedCount, 1)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// They serialize via the lock; at least one must have attached.
+	require.GreaterOrEqual(t, atomic.LoadInt32(&connectedCount), int32(1))
+
+	// The session is still reclaimable and the shell survived the storm.
+	winner := wsDialPTY(t, srv.URL, "/pty/"+id+"/ws", "takeover=1&since=0")
+	ptyWaitFrame(t, winner, "connected", 8*time.Second)
+	ptyWriteStdin(t, winner, "echo still_alive_after_storm\n")
+	ptyOutputContains(t, winner, "still_alive_after_storm", 8*time.Second)
 }
 
 func TestPTYWS_ResizeFrame(t *testing.T) {

--- a/components/execd/pkg/web/model/pty_ws.go
+++ b/components/execd/pkg/web/model/pty_ws.go
@@ -51,5 +51,12 @@ const (
 	WSErrCodeStdinWriteFailed = "STDIN_WRITE_FAILED"
 	WSErrCodeInvalidFrame     = "INVALID_FRAME"
 	WSErrCodeAlreadyConnected = "ALREADY_CONNECTED"
+	WSErrCodeTakenOver        = "TAKEN_OVER"
 	WSErrCodeRuntimeError     = "RUNTIME_ERROR"
 )
+
+// WSCloseTakenOver is the WebSocket close code sent to a client whose session was
+// taken over by another client (via ?takeover=1). It lives in the application-private
+// range (4000–4999, RFC 6455 §7.4.2) so clients can distinguish an intentional
+// handoff from a network drop and avoid auto-reconnecting into the new holder.
+const WSCloseTakenOver = 4001


### PR DESCRIPTION
# Summary

Adds an opt-in `?takeover=1` query parameter to `GET /pty/:sessionId/ws` so a new
client can **reclaim a live PTY session** instead of getting `409 ALREADY_CONNECTED`.

Today a session allows only one WebSocket at a time (second connection → 409 until
the first closes). There is no way for a new client to take over a session whose
previous holder is effectively gone (crashed browser tab, sleeping phone, dropped
network), nor to intentionally **move a running shell from one device to another** —
you must wait for the old WS to hit its read timeout.

With `takeover=1`, when the lock is already held execd **evicts the current holder**:
the old WebSocket is closed with application close code **`4001` (reason `TAKEN_OVER`)**,
the **shell process keeps running untouched**, and the new client attaches to the
same session. Combined with the existing `?since=<offset>`, the new client replays the
scrollback and the screen is restored seamlessly. This enables device-to-device
session handoff (e.g. desktop ⇄ mobile) without restarting the shell and without a
control round-trip through an orchestrator.

Motivation / use case: opensandbox-group/OpenSandbox#996.

### How it works
- `ptySession` gains an eviction hook (`SetEvictHandler`/`ClearEvictHandler`) and
  `TakeoverWS(timeout)`, which repeatedly triggers the current holder's hook and
  retries `LockWS` until it wins or the timeout (5s) elapses.
- The WS handler registers a hook that closes its own connection (unblocking the read
  loop) and cancels its pump goroutines; the existing deferred cleanup then releases
  the lock for the new client. A generation token ensures a tearing-down handler never
  clears a successor's hook after a takeover.
- New `WSCloseTakenOver` (4001) close code + `WSErrCodeTakenOver` string so clients can
  distinguish an intentional handoff from a network drop (and avoid auto-reconnecting
  into the new holder).

### Backward compatibility
Fully backward compatible: without `?takeover=1` the behaviour is unchanged — a second
connection still gets `409 ALREADY_CONNECTED`.

# Testing
- [x] Unit tests
- [x] e2e / manual verification

New unit tests in `pty_ws_test.go`:
- `TestPTYWS_TakeoverEvictsHolder` — the holder is closed with code 4001, and the
  taking-over client replays the scrollback **and reads a shell variable set by the
  evicted client** (proving it is the same shell, not a restart).
- `TestPTYWS_TakeoverOnFreeSessionConnects` — `takeover=1` is a no-op on a free session.
- Existing `TestPTYWS_AlreadyConnectedReturns409` still passes (unchanged 409 path).

Verified end-to-end through the **ingress gateway** (client → gateway → execd) on a kind
cluster: WS-A holds a session, WS-B connects with `?takeover=1&since=0`, WS-A receives
the 4001/`TAKEN_OVER` close, WS-B replays the prior output and continues the same shell;
a plain (no-takeover) reconnect while held still returns 409. `go test -race` clean;
`GOOS=windows` cross-compile passes (stubs updated).

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation (#996)
- [x] Added/updated docs (if needed) — `PTY.md` query-param table + handoff note
- [x] Added/updated tests (if needed)
- [x] Security impact considered — opt-in only; same single-writer invariant (exactly
      one live WS per session is preserved; takeover transfers the lock atomically)
- [x] Backward compatibility considered — no behaviour change without `?takeover=1`
