### PR TITLE
fix(docker): default EXECD_ENVS in bootstrap launcher

### DIFF
--- a/server/opensandbox_server/services/docker/runtime.py
+++ b/server/opensandbox_server/services/docker/runtime.py
@@ -42,6 +42,7 @@ OPENSANDBOX_DIR = "/opt/opensandbox"
 # even when the server runs on Windows.
 EXECED_INSTALL_PATH = posixpath.join(OPENSANDBOX_DIR, "execd")
 BOOTSTRAP_PATH = posixpath.join(OPENSANDBOX_DIR, "bootstrap.sh")
+DEFAULT_EXECD_ENVS_PATH = posixpath.join(OPENSANDBOX_DIR, ".env")
 
 
 class DockerRuntimeMixin:
@@ -192,7 +193,17 @@ class DockerRuntimeMixin:
             [
                 "#!/bin/sh",
                 "set -e",
-                f"  {execd_binary} >/tmp/execd.log 2>&1 &",
+                'if [ -z "${EXECD_ENVS:-}" ]; then',
+                f'  EXECD_ENVS="{DEFAULT_EXECD_ENVS_PATH}"',
+                "fi",
+                'if ! mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null; then',
+                '  echo "warning: failed to create dir for EXECD_ENVS=$EXECD_ENVS" >&2',
+                "fi",
+                'if ! touch "$EXECD_ENVS" 2>/dev/null; then',
+                '  echo "warning: failed to touch EXECD_ENVS=$EXECD_ENVS" >&2',
+                "fi",
+                "export EXECD_ENVS",
+                f"{execd_binary} >/tmp/execd.log 2>&1 &",
                 'exec "$@"',
                 "",
             ]

--- a/server/tests/test_docker_runtime_bootstrap.py
+++ b/server/tests/test_docker_runtime_bootstrap.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import tarfile
+from unittest.mock import MagicMock, patch
+
+from opensandbox_server.config import AppConfig, IngressConfig, RuntimeConfig, ServerConfig
+from opensandbox_server.services.docker import DockerSandboxService
+from opensandbox_server.services.docker.runtime import BOOTSTRAP_PATH, DEFAULT_EXECD_ENVS_PATH
+
+
+def _app_config() -> AppConfig:
+    return AppConfig(
+        server=ServerConfig(),
+        runtime=RuntimeConfig(type="docker", execd_image="ghcr.io/opensandbox/platform:latest"),
+        ingress=IngressConfig(mode="direct"),
+    )
+
+
+def _extract_bootstrap_script(archive_bytes: bytes) -> str:
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:") as tar:
+        member = tar.getmember(BOOTSTRAP_PATH.lstrip("/"))
+        extracted = tar.extractfile(member)
+        assert extracted is not None
+        return extracted.read().decode("utf-8")
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_install_bootstrap_script_sets_default_execd_envs(mock_docker):
+    mock_docker.from_env.return_value = MagicMock()
+    service = DockerSandboxService(config=_app_config())
+    mock_container = MagicMock()
+
+    with patch.object(service, "_ensure_directory") as mock_ensure_dir, patch.object(
+        service, "_docker_operation"
+    ):
+        service._install_bootstrap_script(mock_container, "test-sandbox")
+
+    mock_ensure_dir.assert_called_once()
+    archive_bytes = mock_container.put_archive.call_args.kwargs["data"]
+    script = _extract_bootstrap_script(archive_bytes)
+
+    assert 'if [ -z "${EXECD_ENVS:-}" ]; then' in script
+    assert f'EXECD_ENVS="{DEFAULT_EXECD_ENVS_PATH}"' in script
+    assert 'export EXECD_ENVS' in script
+    assert 'mkdir -p "$(dirname "$EXECD_ENVS")"' in script
+    assert 'touch "$EXECD_ENVS"' in script
+    assert 'exec "$@"' in script


### PR DESCRIPTION
# Summary
- Fixes #998 by defaulting and exporting `EXECD_ENVS` in the Docker-generated bootstrap launcher before `execd` starts.
- Aligns the Docker bootstrap behavior with the existing `components/execd/bootstrap.sh` expectation.
- Adds a focused server regression test that inspects the generated bootstrap script archive.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Executed:
- `cd server && uv run pytest tests/test_docker_runtime_bootstrap.py tests/test_docker_service.py -q -k 'test_install_bootstrap_script_sets_default_execd_envs or test_create_and_start_container_uses_unconstrained_platform_for_execd'`
- `cd server && uv run ruff check opensandbox_server/services/docker/runtime.py tests/test_docker_runtime_bootstrap.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
