### PR TITLE
feat(execd): add directory listing endpoint

### DIFF
--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -256,9 +256,21 @@ func (c *FilesystemController) ListDirectory() {
 		return
 	}
 
-	info, err := os.Stat(path)
+	// Use Lstat so a symlink passed as the root is detected and rejected
+	// rather than silently followed: /directories/list never traverses
+	// symlinks (see the public spec), so listing through a symlink-as-root
+	// would expose a different subtree than the caller asked for.
+	info, err := os.Lstat(path)
 	if err != nil {
 		c.handleFileError(err)
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidRequest,
+			fmt.Sprintf("path is a symbolic link, refusing to traverse: %s", path),
+		)
 		return
 	}
 	if !info.IsDir() {

--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/gin-gonic/gin"
 
@@ -219,6 +217,111 @@ func (c *FilesystemController) RemoveDirs() {
 	c.RespondSuccess(nil)
 }
 
+// ListDirectory lists directory contents with optional depth control
+func (c *FilesystemController) ListDirectory() {
+	rec := beginFilesystemMetric("listdir")
+	defer rec.Finish(c.basicController)
+
+	path := c.ctx.Query("path")
+	if path == "" {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeMissingQuery,
+			"missing query parameter 'path'",
+		)
+		return
+	}
+
+	depth := 1
+	if rawDepth := c.ctx.Query("depth"); rawDepth != "" {
+		parsedDepth, err := strconv.Atoi(rawDepth)
+		if err != nil || parsedDepth < 0 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidRequest,
+				fmt.Sprintf("invalid query parameter 'depth': %s", rawDepth),
+			)
+			return
+		}
+		depth = parsedDepth
+	}
+
+	path, err := pathutil.ExpandAbsPath(path)
+	if err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error converting path %s to absolute. %v", path, err),
+		)
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		c.handleFileError(err)
+		return
+	}
+	if !info.IsDir() {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidRequest,
+			fmt.Sprintf("path is not a directory: %s", path),
+		)
+		return
+	}
+
+	entries, err := listDirectoryEntries(path, depth)
+	if err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error listing directory %s. %v", path, err),
+		)
+		return
+	}
+
+	rec.MarkSuccess()
+	c.RespondSuccess(entries)
+}
+
+func listDirectoryEntries(root string, maxDepth int) ([]model.FileInfo, error) {
+	entries := make([]model.FileInfo, 0, 16)
+	if maxDepth == 0 {
+		return entries, nil
+	}
+
+	var walk func(string, int) error
+	walk = func(dir string, currentDepth int) error {
+		dirEntries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range dirEntries {
+			entryPath := filepath.Join(dir, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+
+			entryInfo, err := buildFileInfo(entryPath, info)
+			if err != nil {
+				return err
+			}
+			entries = append(entries, entryInfo)
+
+			if entry.IsDir() && currentDepth+1 < maxDepth {
+				if err := walk(entryPath, currentDepth+1); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	return entries, walk(root, 0)
+}
+
 // SearchFiles searches for files matching a pattern in a directory
 func (c *FilesystemController) SearchFiles() {
 	rec := beginFilesystemMetric("search")
@@ -273,33 +376,11 @@ func (c *FilesystemController) SearchFiles() {
 		}
 
 		if match {
-			sys := info.Sys().(*syscall.Stat_t)
-
-			owner, err := user.LookupId(strconv.FormatUint(uint64(sys.Uid), 10))
+			fileInfo, err := buildFileInfo(filePath, info)
 			if err != nil {
-				return fmt.Errorf("error lookup owner for file %s: %w", filePath, err)
+				return err
 			}
-
-			group, err := user.LookupGroupId(strconv.FormatUint(uint64(sys.Gid), 10))
-			if err != nil {
-				return fmt.Errorf("error lookup group for file %s: %w", filePath, err)
-			}
-
-			files = append(files, model.FileInfo{
-				Path:       filePath,
-				Size:       info.Size(),
-				ModifiedAt: info.ModTime(),
-				CreatedAt:  getFileCreateTime(info),
-				Permission: model.Permission{
-					Owner: owner.Username,
-					Group: group.Name,
-					Mode: func() int {
-						mode := strconv.FormatInt(int64(info.Mode().Perm()), 8)
-						i, _ := strconv.Atoi(mode)
-						return i
-					}(),
-				},
-			})
+			files = append(files, fileInfo)
 		}
 
 		return nil

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -198,6 +198,44 @@ func TestFilesystemControllerListDirectoryReportsSymlinkWithoutRecursing(t *test
 	require.Contains(t, byPath, targetFile)
 }
 
+func TestFilesystemControllerListDirectoryReturnsLexicalOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create entries in non-lexical creation order to make sure the response
+	// reflects the contracted lexical-by-name ordering rather than insertion
+	// order or os-specific listing order.
+	for _, name := range []string{"charlie.txt", "alpha", "bravo.txt"} {
+		full := filepath.Join(tmpDir, name)
+		if name == "alpha" {
+			require.NoError(t, os.MkdirAll(full, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(full, "y.txt"), []byte("y"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(full, "x.txt"), []byte("x"), 0o644))
+			continue
+		}
+		require.NoError(t, os.WriteFile(full, []byte(name), 0o644))
+	}
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s&depth=2", url.QueryEscape(tmpDir))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+
+	paths := make([]string, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	require.Equal(t, []string{
+		filepath.Join(tmpDir, "alpha"),
+		filepath.Join(tmpDir, "alpha", "x.txt"),
+		filepath.Join(tmpDir, "alpha", "y.txt"),
+		filepath.Join(tmpDir, "bravo.txt"),
+		filepath.Join(tmpDir, "charlie.txt"),
+	}, paths)
+}
+
 func TestFilesystemControllerListDirectoryRejectsInvalidRequests(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "file.txt")

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -51,7 +51,30 @@ func TestFilesystemControllerGetFilesInfo(t *testing.T) {
 	info, ok := resp[target]
 	require.True(t, ok, "response missing entry for %s", target)
 	require.NotEmpty(t, info.Path)
+	require.Equal(t, "file", info.Type)
 	require.NotZero(t, info.Size)
+}
+
+func TestFilesystemControllerGetFilesInfoReportsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+	linkPath := filepath.Join(tmpDir, "link.txt")
+	require.NoError(t, os.WriteFile(target, []byte("demo"), 0o644))
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	query := fmt.Sprintf("/files/info?path=%s", url.QueryEscape(linkPath))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, query, nil)
+
+	ctrl.GetFilesInfo()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	info, ok := resp[linkPath]
+	require.True(t, ok, "response missing entry for %s", linkPath)
+	require.Equal(t, "symlink", info.Type)
 }
 
 func TestFilesystemControllerSearchFiles(t *testing.T) {
@@ -71,6 +94,134 @@ func TestFilesystemControllerSearchFiles(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &files))
 	require.Len(t, files, 1)
 	require.Equal(t, a, files[0].Path)
+	require.Equal(t, "file", files[0].Type)
+}
+
+func TestFilesystemControllerListDirectoryDefaultDepth(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "alpha.txt")
+	dirPath := filepath.Join(tmpDir, "nested")
+	deepFile := filepath.Join(dirPath, "deep.txt")
+	require.NoError(t, os.MkdirAll(dirPath, 0o755))
+	require.NoError(t, os.WriteFile(filePath, []byte("alpha"), 0o644))
+	require.NoError(t, os.WriteFile(deepFile, []byte("deep"), 0o644))
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s", url.QueryEscape(tmpDir))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	require.Len(t, entries, 2)
+
+	byPath := map[string]model.FileInfo{}
+	for _, entry := range entries {
+		byPath[entry.Path] = entry
+	}
+	require.Equal(t, "file", byPath[filePath].Type)
+	require.Equal(t, "directory", byPath[dirPath].Type)
+	require.NotContains(t, byPath, deepFile)
+}
+
+func TestFilesystemControllerListDirectoryDepth(t *testing.T) {
+	tmpDir := t.TempDir()
+	nested := filepath.Join(tmpDir, "nested")
+	deeper := filepath.Join(nested, "deeper")
+	deepFile := filepath.Join(nested, "deep.txt")
+	tooDeep := filepath.Join(deeper, "too-deep.txt")
+	require.NoError(t, os.MkdirAll(deeper, 0o755))
+	require.NoError(t, os.WriteFile(deepFile, []byte("deep"), 0o644))
+	require.NoError(t, os.WriteFile(tooDeep, []byte("too deep"), 0o644))
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s&depth=2", url.QueryEscape(tmpDir))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+
+	byPath := map[string]model.FileInfo{}
+	for _, entry := range entries {
+		byPath[entry.Path] = entry
+	}
+	require.Equal(t, "directory", byPath[nested].Type)
+	require.Equal(t, "directory", byPath[deeper].Type)
+	require.Equal(t, "file", byPath[deepFile].Type)
+	require.NotContains(t, byPath, tooDeep)
+}
+
+func TestFilesystemControllerListDirectoryDepthZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "alpha.txt"), []byte("alpha"), 0o644))
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s&depth=0", url.QueryEscape(tmpDir))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	require.Empty(t, entries)
+}
+
+func TestFilesystemControllerListDirectoryReportsSymlinkWithoutRecursing(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "target")
+	linkPath := filepath.Join(tmpDir, "link")
+	targetFile := filepath.Join(targetDir, "target.txt")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(targetFile, []byte("target"), 0o644))
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s&depth=2", url.QueryEscape(tmpDir))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []model.FileInfo
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+
+	byPath := map[string]model.FileInfo{}
+	for _, entry := range entries {
+		byPath[entry.Path] = entry
+	}
+	require.Equal(t, "symlink", byPath[linkPath].Type)
+	require.NotContains(t, byPath, filepath.Join(linkPath, "target.txt"))
+	require.Contains(t, byPath, targetFile)
+}
+
+func TestFilesystemControllerListDirectoryRejectsInvalidRequests(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("file"), 0o644))
+
+	tests := []struct {
+		name   string
+		rawURL string
+		want   int
+	}{
+		{name: "missing path", rawURL: "/directories/list", want: http.StatusBadRequest},
+		{name: "missing directory", rawURL: "/directories/list?path=/not/exists", want: http.StatusNotFound},
+		{name: "file path", rawURL: fmt.Sprintf("/directories/list?path=%s", url.QueryEscape(filePath)), want: http.StatusBadRequest},
+		{name: "invalid depth", rawURL: fmt.Sprintf("/directories/list?path=%s&depth=abc", url.QueryEscape(tmpDir)), want: http.StatusBadRequest},
+		{name: "negative depth", rawURL: fmt.Sprintf("/directories/list?path=%s&depth=-1", url.QueryEscape(tmpDir)), want: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, rec := newFilesystemController(t, http.MethodGet, tt.rawURL, nil)
+			ctrl.ListDirectory()
+			require.Equal(t, tt.want, rec.Code)
+		})
+	}
 }
 
 func TestFilesystemControllerReplaceContent(t *testing.T) {

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -236,6 +236,26 @@ func TestFilesystemControllerListDirectoryReturnsLexicalOrder(t *testing.T) {
 	}, paths)
 }
 
+func TestFilesystemControllerListDirectoryRejectsSymlinkRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "real")
+	linkPath := filepath.Join(tmpDir, "link-to-real")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "leak.txt"), []byte("leak"), 0o644))
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	rawURL := fmt.Sprintf("/directories/list?path=%s", url.QueryEscape(linkPath))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.ListDirectory()
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, "symlink as root should be rejected per spec")
+	// Make sure the response body does not leak the target directory contents.
+	require.NotContains(t, rec.Body.String(), "leak.txt")
+}
+
 func TestFilesystemControllerListDirectoryRejectsInvalidRequests(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "file.txt")

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -256,9 +256,21 @@ func (c *FilesystemController) ListDirectory() {
 		return
 	}
 
-	info, err := os.Stat(path)
+	// Use Lstat so a symlink passed as the root is detected and rejected
+	// rather than silently followed: /directories/list never traverses
+	// symlinks (see the public spec), so listing through a symlink-as-root
+	// would expose a different subtree than the caller asked for.
+	info, err := os.Lstat(path)
 	if err != nil {
 		c.handleFileError(err)
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidRequest,
+			fmt.Sprintf("path is a symbolic link, refusing to traverse: %s", path),
+		)
 		return
 	}
 	if !info.IsDir() {

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -217,6 +217,111 @@ func (c *FilesystemController) RemoveDirs() {
 	c.RespondSuccess(nil)
 }
 
+// ListDirectory lists directory contents with optional depth control
+func (c *FilesystemController) ListDirectory() {
+	rec := beginFilesystemMetric("listdir")
+	defer rec.Finish(c.basicController)
+
+	path := c.ctx.Query("path")
+	if path == "" {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeMissingQuery,
+			"missing query parameter 'path'",
+		)
+		return
+	}
+
+	depth := 1
+	if rawDepth := c.ctx.Query("depth"); rawDepth != "" {
+		parsedDepth, err := strconv.Atoi(rawDepth)
+		if err != nil || parsedDepth < 0 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidRequest,
+				fmt.Sprintf("invalid query parameter 'depth': %s", rawDepth),
+			)
+			return
+		}
+		depth = parsedDepth
+	}
+
+	path, err := pathutil.ExpandAbsPath(path)
+	if err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error converting path %s to absolute. %v", path, err),
+		)
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		c.handleFileError(err)
+		return
+	}
+	if !info.IsDir() {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidRequest,
+			fmt.Sprintf("path is not a directory: %s", path),
+		)
+		return
+	}
+
+	entries, err := listDirectoryEntries(path, depth)
+	if err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error listing directory %s. %v", path, err),
+		)
+		return
+	}
+
+	rec.MarkSuccess()
+	c.RespondSuccess(entries)
+}
+
+func listDirectoryEntries(root string, maxDepth int) ([]model.FileInfo, error) {
+	entries := make([]model.FileInfo, 0, 16)
+	if maxDepth == 0 {
+		return entries, nil
+	}
+
+	var walk func(string, int) error
+	walk = func(dir string, currentDepth int) error {
+		dirEntries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range dirEntries {
+			entryPath := filepath.Join(dir, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+
+			entryInfo, err := buildFileInfo(entryPath, info)
+			if err != nil {
+				return err
+			}
+			entries = append(entries, entryInfo)
+
+			if entry.IsDir() && currentDepth+1 < maxDepth {
+				if err := walk(entryPath, currentDepth+1); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	return entries, walk(root, 0)
+}
+
 // SearchFiles searches for files matching a pattern in a directory
 func (c *FilesystemController) SearchFiles() {
 	rec := beginFilesystemMetric("search")
@@ -271,21 +376,11 @@ func (c *FilesystemController) SearchFiles() {
 		}
 
 		if match {
-			files = append(files, model.FileInfo{
-				Path:       filePath,
-				Size:       info.Size(),
-				ModifiedAt: info.ModTime(),
-				CreatedAt:  getFileCreateTime(info),
-				Permission: model.Permission{
-					Owner: "",
-					Group: "",
-					Mode: func() int {
-						mode := strconv.FormatInt(int64(info.Mode().Perm()), 8)
-						i, _ := strconv.Atoi(mode)
-						return i
-					}(),
-				},
-			})
+			fileInfo, err := buildFileInfo(filePath, info)
+			if err != nil {
+				return err
+			}
+			files = append(files, fileInfo)
 		}
 
 		return nil

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -162,20 +162,21 @@ func MakeDir(dir string, perm model.Permission) error {
 	return ChmodFile(abs, perm)
 }
 
-func GetFileInfo(filePath string) (model.FileInfo, error) {
-	absPath, err := pathutil.ExpandAbsPath(filePath)
-	if err != nil {
-		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
+func fileType(fileInfo os.FileInfo) string {
+	mode := fileInfo.Mode()
+	if mode&os.ModeSymlink != 0 {
+		return "symlink"
 	}
-
-	fileInfo, err := os.Stat(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
-		}
-		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
+	if fileInfo.IsDir() {
+		return "directory"
 	}
+	if mode.IsRegular() {
+		return "file"
+	}
+	return "other"
+}
 
+func buildFileInfo(absPath string, fileInfo os.FileInfo) (model.FileInfo, error) {
 	stat := fileInfo.Sys().(*syscall.Stat_t)
 
 	owner := strconv.FormatUint(uint64(stat.Uid), 10)
@@ -192,6 +193,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 
 	return model.FileInfo{
 		Path:       absPath,
+		Type:       fileType(fileInfo),
 		Size:       fileInfo.Size(),
 		ModifiedAt: fileInfo.ModTime(),
 		CreatedAt:  getFileCreateTime(fileInfo),
@@ -201,6 +203,23 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 			Mode:  func() int { i, _ := strconv.Atoi(mode); return i }(),
 		},
 	}, nil
+}
+
+func GetFileInfo(filePath string) (model.FileInfo, error) {
+	absPath, err := pathutil.ExpandAbsPath(filePath)
+	if err != nil {
+		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
+	}
+
+	fileInfo, err := os.Lstat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
+		}
+		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
+	}
+
+	return buildFileInfo(absPath, fileInfo)
 }
 
 func SearchFileMetadata(metadata map[string]model.FileMetadata, filePath string) (string, model.FileMetadata, bool) {

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -126,20 +126,21 @@ func MakeDir(dir string, perm model.Permission) error {
 	return ChmodFile(abs, perm)
 }
 
-func GetFileInfo(filePath string) (model.FileInfo, error) {
-	absPath, err := pathutil.ExpandAbsPath(filePath)
-	if err != nil {
-		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
+func fileType(fileInfo os.FileInfo) string {
+	mode := fileInfo.Mode()
+	if mode&os.ModeSymlink != 0 {
+		return "symlink"
 	}
-
-	fileInfo, err := os.Stat(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
-		}
-		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
+	if fileInfo.IsDir() {
+		return "directory"
 	}
+	if mode.IsRegular() {
+		return "file"
+	}
+	return "other"
+}
 
+func buildFileInfo(absPath string, fileInfo os.FileInfo) (model.FileInfo, error) {
 	createdAt := getFileCreateTime(fileInfo)
 	if data, ok := fileInfo.Sys().(*syscall.Win32FileAttributeData); ok && data != nil {
 		createdAt = time.Unix(0, data.CreationTime.Nanoseconds())
@@ -149,6 +150,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 
 	return model.FileInfo{
 		Path:       absPath,
+		Type:       fileType(fileInfo),
 		Size:       fileInfo.Size(),
 		ModifiedAt: fileInfo.ModTime(),
 		CreatedAt:  createdAt,
@@ -161,6 +163,23 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 			}(),
 		},
 	}, nil
+}
+
+func GetFileInfo(filePath string) (model.FileInfo, error) {
+	absPath, err := pathutil.ExpandAbsPath(filePath)
+	if err != nil {
+		return model.FileInfo{}, fmt.Errorf("invalid path %s: %w", filePath, err)
+	}
+
+	fileInfo, err := os.Lstat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
+		}
+		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
+	}
+
+	return buildFileInfo(absPath, fileInfo)
 }
 
 func SearchFileMetadata(metadata map[string]model.FileMetadata, filePath string) (string, model.FileMetadata, bool) {

--- a/components/execd/pkg/web/model/filesystem.go
+++ b/components/execd/pkg/web/model/filesystem.go
@@ -19,6 +19,7 @@ import "time"
 // FileInfo represents file metadata including path and permissions
 type FileInfo struct {
 	Path       string    `json:"path,omitempty"`
+	Type       string    `json:"type,omitempty"`
 	Size       int64     `json:"size"`
 	ModifiedAt time.Time `json:"modified_at,omitempty"`
 	CreatedAt  time.Time `json:"created_at,omitempty"`

--- a/components/execd/pkg/web/router.go
+++ b/components/execd/pkg/web/router.go
@@ -47,6 +47,7 @@ func NewRouter(accessToken string) *gin.Engine {
 
 	directories := r.Group("/directories")
 	{
+		directories.GET("/list", withFilesystem(func(c *controller.FilesystemController) { c.ListDirectory() }))
 		directories.POST("", withFilesystem(func(c *controller.FilesystemController) { c.MakeDirs() }))
 		directories.DELETE("", withFilesystem(func(c *controller.FilesystemController) { c.RemoveDirs() }))
 	}

--- a/components/execd/tests/smoke_api.py
+++ b/components/execd/tests/smoke_api.py
@@ -224,6 +224,18 @@ def filesystem_smoke():
     info = session.get(f"{BASE_URL}/files/info", params={"path": [file_path]}, timeout=10)
     expect(info.status_code == 200, f"info failed: {info.status_code} {info.text}")
 
+    # list directory contents
+    listed = session.get(f"{BASE_URL}/directories/list", params={"path": sub_dir}, timeout=10)
+    expect(listed.status_code == 200, f"list directory failed: {listed.status_code} {listed.text}")
+    listed_file = None
+    for entry in listed.json():
+        p = entry.get("path")
+        if p and pathlib.Path(p).resolve() == pathlib.Path(file_path).resolve():
+            listed_file = entry
+            break
+    expect(listed_file is not None, "directory list did not find file")
+    expect(listed_file.get("type") == "file", f"directory list file type mismatch: {listed_file}")
+
     # search
     search = session.get(f"{BASE_URL}/files/search", params={"path": base_dir, "pattern": "*.txt"}, timeout=10)
     expect(search.status_code == 200, f"search failed: {search.status_code} {search.text}")

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -106,9 +106,12 @@ internal sealed class FilesystemAdapter : ISandboxFiles
     {
         var queryParams = new Dictionary<string, string?>
         {
-            ["path"] = path,
-            ["depth"] = depth?.ToString()
+            ["path"] = path
         };
+        if (depth.HasValue)
+        {
+            queryParams["depth"] = depth.Value.ToString();
+        }
 
         var response = await _client.GetAsync<JsonElement>("/directories/list", queryParams, cancellationToken).ConfigureAwait(false);
         return ParseSearchFilesResponse(response);

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -99,6 +99,21 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         await _client.DeleteAsync(pathWithQuery, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<SandboxFileInfo>> ListDirectoryAsync(
+        string path,
+        int? depth = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queryParams = new Dictionary<string, string?>
+        {
+            ["path"] = path,
+            ["depth"] = depth?.ToString()
+        };
+
+        var response = await _client.GetAsync<JsonElement>("/directories/list", queryParams, cancellationToken).ConfigureAwait(false);
+        return ParseSearchFilesResponse(response);
+    }
+
     public async Task WriteFilesAsync(
         IEnumerable<WriteEntry> entries,
         CancellationToken cancellationToken = default)
@@ -381,6 +396,7 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         return new SandboxFileInfo
         {
             Path = element.GetProperty("path").GetString() ?? string.Empty,
+            Type = element.TryGetProperty("type", out var type) ? type.GetString() : null,
             Size = element.TryGetProperty("size", out var size) && size.ValueKind == JsonValueKind.Number
                 ? size.GetInt64()
                 : null,

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
@@ -28,6 +28,12 @@ public class SandboxFileInfo
     public required string Path { get; set; }
 
     /// <summary>
+    /// Gets or sets the entry type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
     /// Gets or sets the file size in bytes.
     /// </summary>
     [JsonPropertyName("size")]

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxFiles.cs
@@ -69,6 +69,20 @@ public interface ISandboxFiles
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists directory contents with optional depth control.
+    /// </summary>
+    /// <param name="path">The directory path to list.</param>
+    /// <param name="depth">Optional maximum child depth to include.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of directory entries with metadata.</returns>
+    /// <exception cref="InvalidArgumentException">Thrown when request values are invalid.</exception>
+    /// <exception cref="SandboxException">Thrown when the execd service request fails.</exception>
+    Task<IReadOnlyList<SandboxFileInfo>> ListDirectoryAsync(
+        string path,
+        int? depth = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Writes files to the sandbox.
     /// </summary>
     /// <param name="entries">The file entries to write.</param>

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/FilesystemAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/FilesystemAdapterTests.cs
@@ -55,6 +55,22 @@ public class FilesystemAdapterTests
         entries[0].Type.Should().Be("symlink");
     }
 
+    [Fact]
+    public async Task ListDirectoryAsync_ShouldOmitDepthWhenNull()
+    {
+        var handler = new CaptureJsonHandler("[]");
+        using var client = new HttpClient(handler);
+        var wrapper = new HttpClientWrapper(client, "http://localhost:8080");
+        var adapter = new FilesystemAdapter(wrapper, client, "http://localhost:8080", new Dictionary<string, string>());
+
+        var entries = await adapter.ListDirectoryAsync("/workspace");
+
+        handler.LastRequestUri.Should().NotBeNull();
+        handler.LastRequestUri!.Query.Should().Contain("path=%2Fworkspace");
+        handler.LastRequestUri!.Query.Should().NotContain("depth=");
+        entries.Should().BeEmpty();
+    }
+
     private sealed class CaptureJsonHandler(string payload) : HttpMessageHandler
     {
         public Uri? LastRequestUri { get; private set; }

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/FilesystemAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/FilesystemAdapterTests.cs
@@ -1,0 +1,72 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using OpenSandbox.Adapters;
+using OpenSandbox.Internal;
+using Xunit;
+
+namespace OpenSandbox.Tests;
+
+public class FilesystemAdapterTests
+{
+    [Fact]
+    public async Task ListDirectoryAsync_ShouldParseEntryTypeAndSendDepthZero()
+    {
+        var payload = """
+        [
+          {
+            "path": "/workspace/link",
+            "type": "symlink",
+            "size": 11,
+            "modified_at": "2026-06-08T10:00:00Z",
+            "created_at": "2026-06-08T10:00:00Z",
+            "owner": "root",
+            "group": "root",
+            "mode": 777
+          }
+        ]
+        """;
+        var handler = new CaptureJsonHandler(payload);
+        using var client = new HttpClient(handler);
+        var wrapper = new HttpClientWrapper(client, "http://localhost:8080");
+        var adapter = new FilesystemAdapter(wrapper, client, "http://localhost:8080", new Dictionary<string, string>());
+
+        var entries = await adapter.ListDirectoryAsync("/workspace", depth: 0);
+
+        handler.LastRequestUri.Should().NotBeNull();
+        handler.LastRequestUri!.PathAndQuery.Should().Contain("/directories/list");
+        handler.LastRequestUri!.Query.Should().Contain("path=%2Fworkspace");
+        handler.LastRequestUri!.Query.Should().Contain("depth=0");
+        entries.Should().ContainSingle();
+        entries[0].Type.Should().Be("symlink");
+    }
+
+    private sealed class CaptureJsonHandler(string payload) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -349,6 +349,9 @@ public class SandboxEgressLifecycleTests
         public Task DeleteDirectoriesAsync(IEnumerable<string> paths, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
+        public Task<IReadOnlyList<SandboxFileInfo>> ListDirectoryAsync(string path, int? depth = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
         public Task WriteFilesAsync(IEnumerable<WriteEntry> entries, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 

--- a/sdks/sandbox/go/README.md
+++ b/sdks/sandbox/go/README.md
@@ -159,7 +159,8 @@ Created with `NewExecdClient(baseURL, accessToken string, opts ...Option)`.
 | `SetPermissions(ctx, req)` | Change file permissions |
 | `MoveFiles(ctx, req)` | Move/rename files |
 | `SearchFiles(ctx, dir, pattern)` | Search files by glob pattern |
-| `ListDirectory(ctx, path, depth)` | List directory contents with depth control |
+| `ListDirectory(ctx, path)` | List immediate directory contents (server-side default depth) |
+| `ListDirectoryWithDepth(ctx, path, depth)` | List directory contents up to the given depth (`0` returns empty) |
 | `ReplaceInFiles(ctx, req)` | Text replacement in files |
 | `UploadFile(ctx, file, opts)` | Upload a file to the sandbox |
 | `UploadFiles(ctx, entries)` | Upload multiple files to the sandbox |

--- a/sdks/sandbox/go/README.md
+++ b/sdks/sandbox/go/README.md
@@ -159,6 +159,7 @@ Created with `NewExecdClient(baseURL, accessToken string, opts ...Option)`.
 | `SetPermissions(ctx, req)` | Change file permissions |
 | `MoveFiles(ctx, req)` | Move/rename files |
 | `SearchFiles(ctx, dir, pattern)` | Search files by glob pattern |
+| `ListDirectory(ctx, path, depth)` | List directory contents with depth control |
 | `ReplaceInFiles(ctx, req)` | Text replacement in files |
 | `UploadFile(ctx, file, opts)` | Upload a file to the sandbox |
 | `UploadFiles(ctx, entries)` | Upload multiple files to the sandbox |

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -255,12 +255,29 @@ func (e *ExecdClient) SearchFiles(ctx context.Context, dir string, pattern strin
 	return result, err
 }
 
-// ListDirectory lists directory contents with optional depth control.
-func (e *ExecdClient) ListDirectory(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+// ListDirectory lists the immediate children of the given directory using the
+// server-side default depth (1). Use ListDirectoryWithDepth to override.
+func (e *ExecdClient) ListDirectory(ctx context.Context, path string) ([]FileInfo, error) {
+	return e.listDirectory(ctx, path, nil)
+}
+
+// ListDirectoryWithDepth lists directory contents up to the given depth.
+// depth=0 returns an empty slice (the directory itself is not listed).
+// depth=1 returns the immediate children. Larger values include descendants
+// up to that many levels below path. Negative values are rejected by the
+// server.
+func (e *ExecdClient) ListDirectoryWithDepth(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+	d := depth
+	return e.listDirectory(ctx, path, &d)
+}
+
+func (e *ExecdClient) listDirectory(ctx context.Context, path string, depth *int) ([]FileInfo, error) {
 	var result []FileInfo
 	params := url.Values{}
 	params.Set("path", path)
-	params.Set("depth", strconv.Itoa(depth))
+	if depth != nil {
+		params.Set("depth", strconv.Itoa(*depth))
+	}
 	reqPath := "/directories/list?" + params.Encode()
 	err := e.client.doRequest(ctx, http.MethodGet, reqPath, nil, &result)
 	return result, err

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -255,6 +255,17 @@ func (e *ExecdClient) SearchFiles(ctx context.Context, dir string, pattern strin
 	return result, err
 }
 
+// ListDirectory lists directory contents with optional depth control.
+func (e *ExecdClient) ListDirectory(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+	var result []FileInfo
+	params := url.Values{}
+	params.Set("path", path)
+	params.Set("depth", strconv.Itoa(depth))
+	reqPath := "/directories/list?" + params.Encode()
+	err := e.client.doRequest(ctx, http.MethodGet, reqPath, nil, &result)
+	return result, err
+}
+
 // ReplaceInFiles performs text replacement in the specified files.
 func (e *ExecdClient) ReplaceInFiles(ctx context.Context, req ReplaceRequest) error {
 	return e.client.doRequest(ctx, http.MethodPost, "/files/replace", req, nil)

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1531,7 +1531,7 @@ func TestSearchFiles(t *testing.T) {
 	}
 }
 
-func TestListDirectory(t *testing.T) {
+func TestListDirectoryDefault(t *testing.T) {
 	want := []FileInfo{
 		{Path: "/sandbox/src", Type: "directory", Size: 0, Owner: "root", Group: "root", Mode: 755},
 		{Path: "/sandbox/README.md", Type: "file", Size: 256, Owner: "root", Group: "root", Mode: 644},
@@ -1547,6 +1547,28 @@ func TestListDirectory(t *testing.T) {
 		if r.URL.Query().Get("path") != "/sandbox" {
 			assert.Fail(t, fmt.Sprintf("expected path=/sandbox, got %s", r.URL.Query().Get("path")))
 		}
+		// ListDirectory should not pin a depth value; the server applies the
+		// default. Sending depth=... here would be a regression.
+		if _, ok := r.URL.Query()["depth"]; ok {
+			assert.Fail(t, fmt.Sprintf("expected depth to be omitted, got %q", r.URL.Query().Get("depth")))
+		}
+
+		jsonResponse(w, http.StatusOK, want)
+	})
+
+	got, err := client.ListDirectory(context.Background(), "/sandbox")
+	require.NoErrorf(t, err, "ListDirectory")
+	require.Len(t, got, 2)
+	require.Equal(t, "directory", got[0].Type)
+	require.Equal(t, "file", got[1].Type)
+}
+
+func TestListDirectoryWithDepth(t *testing.T) {
+	want := []FileInfo{
+		{Path: "/sandbox/src", Type: "directory", Size: 0, Owner: "root", Group: "root", Mode: 755},
+	}
+
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("depth") != "2" {
 			assert.Fail(t, fmt.Sprintf("expected depth=2, got %s", r.URL.Query().Get("depth")))
 		}
@@ -1554,14 +1576,13 @@ func TestListDirectory(t *testing.T) {
 		jsonResponse(w, http.StatusOK, want)
 	})
 
-	got, err := client.ListDirectory(context.Background(), "/sandbox", 2)
-	require.NoErrorf(t, err, "ListDirectory")
-	require.Len(t, got, 2)
+	got, err := client.ListDirectoryWithDepth(context.Background(), "/sandbox", 2)
+	require.NoErrorf(t, err, "ListDirectoryWithDepth")
+	require.Len(t, got, 1)
 	require.Equal(t, "directory", got[0].Type)
-	require.Equal(t, "file", got[1].Type)
 }
 
-func TestListDirectorySendsDepthZero(t *testing.T) {
+func TestListDirectoryWithDepthZero(t *testing.T) {
 	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/directories/list" {
 			assert.Fail(t, fmt.Sprintf("expected /directories/list, got %s", r.URL.Path))
@@ -1573,8 +1594,8 @@ func TestListDirectorySendsDepthZero(t *testing.T) {
 		jsonResponse(w, http.StatusOK, []FileInfo{})
 	})
 
-	got, err := client.ListDirectory(context.Background(), "/sandbox", 0)
-	require.NoErrorf(t, err, "ListDirectory")
+	got, err := client.ListDirectoryWithDepth(context.Background(), "/sandbox", 0)
+	require.NoErrorf(t, err, "ListDirectoryWithDepth")
 	require.Len(t, got, 0)
 }
 

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1531,6 +1531,53 @@ func TestSearchFiles(t *testing.T) {
 	}
 }
 
+func TestListDirectory(t *testing.T) {
+	want := []FileInfo{
+		{Path: "/sandbox/src", Type: "directory", Size: 0, Owner: "root", Group: "root", Mode: 755},
+		{Path: "/sandbox/README.md", Type: "file", Size: 256, Owner: "root", Group: "root", Mode: 644},
+	}
+
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			assert.Fail(t, fmt.Sprintf("expected GET, got %s", r.Method))
+		}
+		if r.URL.Path != "/directories/list" {
+			assert.Fail(t, fmt.Sprintf("expected /directories/list, got %s", r.URL.Path))
+		}
+		if r.URL.Query().Get("path") != "/sandbox" {
+			assert.Fail(t, fmt.Sprintf("expected path=/sandbox, got %s", r.URL.Query().Get("path")))
+		}
+		if r.URL.Query().Get("depth") != "2" {
+			assert.Fail(t, fmt.Sprintf("expected depth=2, got %s", r.URL.Query().Get("depth")))
+		}
+
+		jsonResponse(w, http.StatusOK, want)
+	})
+
+	got, err := client.ListDirectory(context.Background(), "/sandbox", 2)
+	require.NoErrorf(t, err, "ListDirectory")
+	require.Len(t, got, 2)
+	require.Equal(t, "directory", got[0].Type)
+	require.Equal(t, "file", got[1].Type)
+}
+
+func TestListDirectorySendsDepthZero(t *testing.T) {
+	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/directories/list" {
+			assert.Fail(t, fmt.Sprintf("expected /directories/list, got %s", r.URL.Path))
+		}
+		if r.URL.Query().Get("depth") != "0" {
+			assert.Fail(t, fmt.Sprintf("expected depth=0, got %s", r.URL.Query().Get("depth")))
+		}
+
+		jsonResponse(w, http.StatusOK, []FileInfo{})
+	})
+
+	got, err := client.ListDirectory(context.Background(), "/sandbox", 0)
+	require.NoErrorf(t, err, "ListDirectory")
+	require.Len(t, got, 0)
+}
+
 func TestSetPermissions(t *testing.T) {
 	_, client := newExecdServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -52,12 +52,23 @@ func (s *Sandbox) SearchFiles(ctx context.Context, dir, pattern string) ([]FileI
 	return s.execd.SearchFiles(ctx, dir, pattern)
 }
 
-// ListDirectory lists directory contents with optional depth control.
-func (s *Sandbox) ListDirectory(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+// ListDirectory lists the immediate children of the given directory using
+// the server-side default depth (1). Use ListDirectoryWithDepth to override.
+func (s *Sandbox) ListDirectory(ctx context.Context, path string) ([]FileInfo, error) {
 	if s.execd == nil {
 		return nil, fmt.Errorf("opensandbox: execd client not initialized")
 	}
-	return s.execd.ListDirectory(ctx, path, depth)
+	return s.execd.ListDirectory(ctx, path)
+}
+
+// ListDirectoryWithDepth lists directory contents up to the given depth.
+// depth=0 returns an empty slice; depth=1 lists immediate children; larger
+// values include descendants up to that many levels below path.
+func (s *Sandbox) ListDirectoryWithDepth(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+	if s.execd == nil {
+		return nil, fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.ListDirectoryWithDepth(ctx, path, depth)
 }
 
 // SetPermissions changes file permissions.

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -52,6 +52,14 @@ func (s *Sandbox) SearchFiles(ctx context.Context, dir, pattern string) ([]FileI
 	return s.execd.SearchFiles(ctx, dir, pattern)
 }
 
+// ListDirectory lists directory contents with optional depth control.
+func (s *Sandbox) ListDirectory(ctx context.Context, path string, depth int) ([]FileInfo, error) {
+	if s.execd == nil {
+		return nil, fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.ListDirectory(ctx, path, depth)
+}
+
 // SetPermissions changes file permissions.
 func (s *Sandbox) SetPermissions(ctx context.Context, req PermissionsRequest) error {
 	if s.execd == nil {

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -350,6 +350,7 @@ type CommandLogsResponse struct {
 // FileInfo contains file metadata including path and permissions.
 type FileInfo struct {
 	Path       string    `json:"path"`
+	Type       string    `json:"type,omitempty"`
 	Size       int64     `json:"size"`
 	ModifiedAt time.Time `json:"modified_at"`
 	CreatedAt  time.Time `json:"created_at"`

--- a/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
@@ -19,6 +19,7 @@ import type { paths as ExecdPaths } from "../api/execd.js";
 import type {
   ContentReplaceEntry,
   ContentReplaceResult,
+  DirectoryListEntry,
   FileInfo,
   FileMetadata,
   FilesInfoResponse,
@@ -211,6 +212,8 @@ export class FilesystemAdapter implements SandboxFiles {
       null as unknown as ExecdPaths["/files/search"]["get"]["responses"][200]["content"]["application/json"],
     FilesInfoOk:
       null as unknown as ExecdPaths["/files/info"]["get"]["responses"][200]["content"]["application/json"],
+    ListDirectoryOk:
+      null as unknown as ExecdPaths["/directories/list"]["get"]["responses"][200]["content"]["application/json"],
     MakeDirsRequest:
       null as unknown as ExecdPaths["/directories"]["post"]["requestBody"]["content"]["application/json"],
     SetPermissionsRequest:
@@ -245,12 +248,13 @@ export class FilesystemAdapter implements SandboxFiles {
     null as unknown as (typeof FilesystemAdapter.Api.SearchFilesOk)[number];
 
   private mapApiFileInfo(raw: typeof FilesystemAdapter._ApiFileInfo): FileInfo {
-    const { path, size, created_at, modified_at, mode, owner, group, ...rest } =
+    const { path, type, size, created_at, modified_at, mode, owner, group, ...rest } =
       raw;
 
     return {
       ...rest,
       path,
+      type,
       size,
       mode,
       owner,
@@ -314,6 +318,22 @@ export class FilesystemAdapter implements SandboxFiles {
       params: { query: { path: paths } },
     });
     throwOnOpenApiFetchError({ error, response }, "Delete directories failed");
+  }
+
+  async listDirectory(entry: DirectoryListEntry): Promise<FileInfo[]> {
+    const { data, error, response } = await this.client.GET("/directories/list", {
+      params: { query: { path: entry.path, depth: entry.depth } },
+    });
+    throwOnOpenApiFetchError({ error, response }, "List directory failed");
+
+    const ok = data as typeof FilesystemAdapter.Api.ListDirectoryOk | undefined;
+    if (!ok) return [];
+    if (!Array.isArray(ok)) {
+      throw new Error(
+        `List directory failed: unexpected response shape (expected array, got ${typeof ok})`
+      );
+    }
+    return ok.map((x) => this.mapApiFileInfo(x));
   }
 
   async setPermissions(entries: SetPermissionEntry[]): Promise<void> {

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -471,6 +471,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/directories/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List directory contents
+         * @description Lists entries under a directory with optional depth control. By default,
+         *     only immediate children are returned (`depth=1`). Set `depth` to a larger
+         *     value to include descendants up to that many levels below `path`. The
+         *     root directory itself is not included in the response.
+         */
+        get: operations["listDirectory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/directories": {
         parameters: {
             query?: never;
@@ -771,6 +794,12 @@ export interface components {
              * @example /workspace/file.txt
              */
             path: string;
+            /**
+             * @description Entry type
+             * @example file
+             * @enum {string}
+             */
+            type?: "file" | "directory" | "symlink" | "other";
             /**
              * Format: int64
              * @description File size in bytes
@@ -1708,6 +1737,64 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listDirectory: {
+        parameters: {
+            query: {
+                /**
+                 * @description Directory path to list
+                 * @example /workspace/project
+                 */
+                path: string;
+                /**
+                 * @description Maximum child depth to include. `1` lists immediate children only.
+                 * @example 2
+                 */
+                depth?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Array of directory entries with metadata */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example [
+                     *       {
+                     *         "path": "/workspace/project/src",
+                     *         "type": "directory",
+                     *         "size": 0,
+                     *         "modified_at": "2025-11-16T14:30:45Z",
+                     *         "created_at": "2025-11-16T14:30:45Z",
+                     *         "owner": "admin",
+                     *         "group": "admin",
+                     *         "mode": 755
+                     *       },
+                     *       {
+                     *         "path": "/workspace/project/README.md",
+                     *         "type": "file",
+                     *         "size": 2048,
+                     *         "modified_at": "2025-11-16T14:30:45Z",
+                     *         "created_at": "2025-11-16T14:30:45Z",
+                     *         "owner": "admin",
+                     *         "group": "admin",
+                     *         "mode": 644
+                     *       }
+                     *     ]
+                     */
+                    "application/json": components["schemas"]["FileInfo"][];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -64,6 +64,7 @@ export type { SandboxFilter, SandboxManagerOptions } from "./manager.js";
 export type { ExecdHealth } from "./services/execdHealth.js";
 export type { ExecdMetrics } from "./services/execdMetrics.js";
 export type {
+  FileEntryType,
   FileInfo,
   FileMetadata,
   Permission,
@@ -118,6 +119,7 @@ export { Sandbox } from "./sandbox.js";
 export type {
   ContentReplaceEntry,
   ContentReplaceResult,
+  DirectoryListEntry,
   MoveEntry,
   SearchEntry,
   SetPermissionEntry,

--- a/sdks/sandbox/javascript/src/models/filesystem.ts
+++ b/sdks/sandbox/javascript/src/models/filesystem.ts
@@ -20,8 +20,11 @@
  * - They are intentionally stable and JS-friendly.
  */
 
+export type FileEntryType = "file" | "directory" | "symlink" | "other";
+
 export interface FileInfo extends Record<string, unknown> {
   path: string;
+  type?: FileEntryType;
   size?: number;
   /**
    * Last modification time.
@@ -82,6 +85,11 @@ export interface WriteEntry {
 export interface SearchEntry {
   path: string;
   pattern?: string;
+}
+
+export interface DirectoryListEntry {
+  path: string;
+  depth?: number;
 }
 
 export interface MoveEntry {

--- a/sdks/sandbox/javascript/src/services/filesystem.ts
+++ b/sdks/sandbox/javascript/src/services/filesystem.ts
@@ -16,6 +16,7 @@ import type { SearchFilesResponse } from "../models/filesystem.js";
 import type {
   ContentReplaceEntry,
   ContentReplaceResult,
+  DirectoryListEntry,
   FileInfo,
   MoveEntry,
   SearchEntry,
@@ -32,6 +33,7 @@ import type {
 export interface SandboxFiles {
   getFileInfo(paths: string[]): Promise<Record<string, FileInfo>>;
   search(entry: SearchEntry): Promise<SearchFilesResponse>;
+  listDirectory(entry: DirectoryListEntry): Promise<FileInfo[]>;
 
   createDirectories(entries: Pick<WriteEntry, "path" | "mode" | "owner" | "group">[]): Promise<void>;
   deleteDirectories(paths: string[]): Promise<void>;

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/filesystem/FilesystemModels.kt
@@ -40,6 +40,7 @@ class EntryInfo(
     val size: Long,
     val modifiedAt: OffsetDateTime,
     val createdAt: OffsetDateTime,
+    val type: String? = null,
 )
 
 /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -170,14 +170,23 @@ interface Filesystem {
      * Lists directory contents with optional depth control.
      *
      * @param path Directory path to list
-     * @param depth Optional maximum child depth to include
+     * @param depth Optional maximum child depth to include. `null` lets the
+     *   server apply its default (currently 1 — immediate children only).
+     *   `0` returns an empty list. Larger values include descendants up to
+     *   that many levels below `path`.
      * @return List of EntryInfo objects containing metadata for directory entries
      * @throws SandboxException if the operation fails
      */
     fun listDirectory(
         path: String,
-        depth: Int? = null,
+        depth: Int?,
     ): List<EntryInfo>
+
+    /**
+     * Java-friendly overload of [listDirectory] that uses the server-side
+     * default depth (currently 1). Equivalent to `listDirectory(path, null)`.
+     */
+    fun listDirectory(path: String): List<EntryInfo> = listDirectory(path, null)
 
     /**
      * Moves files from source to destination paths.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -167,6 +167,19 @@ interface Filesystem {
     fun deleteDirectories(paths: List<String>)
 
     /**
+     * Lists directory contents with optional depth control.
+     *
+     * @param path Directory path to list
+     * @param depth Optional maximum child depth to include
+     * @return List of EntryInfo objects containing metadata for directory entries
+     * @throws SandboxException if the operation fails
+     */
+    fun listDirectory(
+        path: String,
+        depth: Int? = null,
+    ): List<EntryInfo>
+
+    /**
      * Moves files from source to destination paths.
      *
      * @param entries List of MoveEntry objects specifying source and destination paths

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/FilesystemConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/FilesystemConverter.kt
@@ -44,6 +44,7 @@ object FilesystemConverter {
             createdAt = this.createdAt,
             modifiedAt = this.modifiedAt,
             size = this.propertySize,
+            type = this.type?.value,
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -289,6 +289,18 @@ internal class FilesystemAdapter(
         }
     }
 
+    override fun listDirectory(
+        path: String,
+        depth: Int?,
+    ): List<EntryInfo> {
+        return try {
+            api.listDirectory(path, depth).map { it.toEntryInfo() }
+        } catch (e: Exception) {
+            logger.error("Failed to list directory {}", path, e)
+            throw e.toSandboxException()
+        }
+    }
+
     override fun moveFiles(entries: List<MoveEntry>) {
         return try {
             val renameItems = entries.toApiRenameFileItems()

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/filesystem_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/filesystem_model_converter.py
@@ -25,6 +25,7 @@ This converter is designed to work with openapi-python-client generated models.
 from typing import Any
 
 from opensandbox.api.execd.models import FileInfo
+from opensandbox.api.execd.types import UNSET
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
@@ -46,8 +47,13 @@ class FilesystemModelConverter:
     @staticmethod
     def to_entry_info(api_file_info: FileInfo) -> EntryInfo:
         """Convert API FileInfo to domain EntryInfo."""
+        entry_type = None
+        if api_file_info.type_ is not UNSET:
+            entry_type = str(api_file_info.type_)
+
         return EntryInfo(
             path=api_file_info.path,
+            type=entry_type,
             mode=api_file_info.mode,
             owner=api_file_info.owner,
             group=api_file_info.group,

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -44,6 +44,7 @@ from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
+    DirectoryListEntry,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -480,6 +481,37 @@ class FilesystemAdapter(Filesystem):
 
         except Exception as e:
             logger.error("Failed to search files", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def list_directory(self, entry: DirectoryListEntry) -> list[EntryInfo]:
+        """List directory contents using auto-generated API."""
+        try:
+            from opensandbox.api.execd.api.filesystem import list_directory
+            from opensandbox.api.execd.models import FileInfo
+            from opensandbox.api.execd.types import UNSET
+
+            client = await self._get_client()
+            response_obj = await list_directory.asyncio_detailed(
+                client=client,
+                path=entry.path,
+                depth=entry.depth if entry.depth is not None else UNSET,
+            )
+
+            handle_api_error(response_obj, "List directory")
+
+            parsed = response_obj.parsed
+            if not parsed:
+                return []
+
+            if isinstance(parsed, list) and all(isinstance(x, FileInfo) for x in parsed):
+                return FilesystemModelConverter.to_entry_info_list(parsed)
+            raise SandboxApiException(
+                message="List directory failed: unexpected response type",
+                request_id=extract_request_id(getattr(response_obj, "headers", None)),
+            )
+
+        except Exception as e:
+            logger.error("Failed to list directory", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_file_info(self, paths: list[str]) -> dict[str, EntryInfo]:

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/list_directory.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/list_directory.py
@@ -1,0 +1,231 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.file_info import FileInfo
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    path: str,
+    depth: int | Unset = 1,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["path"] = path
+
+    params["depth"] = depth
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/directories/list",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | list[FileInfo] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = FileInfo.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 500:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | list[FileInfo]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    depth: int | Unset = 1,
+) -> Response[ErrorResponse | list[FileInfo]]:
+    """List directory contents
+
+     Lists entries under a directory with optional depth control. By default,
+    only immediate children are returned (`depth=1`). Set `depth` to a larger
+    value to include descendants up to that many levels below `path`. The
+    root directory itself is not included in the response.
+
+    Args:
+        path (str):
+        depth (int | Unset):  Default: 1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | list[FileInfo]]
+    """
+
+    kwargs = _get_kwargs(
+        path=path,
+        depth=depth,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    depth: int | Unset = 1,
+) -> ErrorResponse | list[FileInfo] | None:
+    """List directory contents
+
+     Lists entries under a directory with optional depth control. By default,
+    only immediate children are returned (`depth=1`). Set `depth` to a larger
+    value to include descendants up to that many levels below `path`. The
+    root directory itself is not included in the response.
+
+    Args:
+        path (str):
+        depth (int | Unset):  Default: 1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | list[FileInfo]
+    """
+
+    return sync_detailed(
+        client=client,
+        path=path,
+        depth=depth,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    depth: int | Unset = 1,
+) -> Response[ErrorResponse | list[FileInfo]]:
+    """List directory contents
+
+     Lists entries under a directory with optional depth control. By default,
+    only immediate children are returned (`depth=1`). Set `depth` to a larger
+    value to include descendants up to that many levels below `path`. The
+    root directory itself is not included in the response.
+
+    Args:
+        path (str):
+        depth (int | Unset):  Default: 1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | list[FileInfo]]
+    """
+
+    kwargs = _get_kwargs(
+        path=path,
+        depth=depth,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    depth: int | Unset = 1,
+) -> ErrorResponse | list[FileInfo] | None:
+    """List directory contents
+
+     Lists entries under a directory with optional depth control. By default,
+    only immediate children are returned (`depth=1`). Set `depth` to a larger
+    value to include descendants up to that many levels below `path`. The
+    root directory itself is not included in the response.
+
+    Args:
+        path (str):
+        depth (int | Unset):  Default: 1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | list[FileInfo]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            path=path,
+            depth=depth,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -24,6 +24,7 @@ from .create_session_request import CreateSessionRequest
 from .create_session_response import CreateSessionResponse
 from .error_response import ErrorResponse
 from .file_info import FileInfo
+from .file_info_type import FileInfoType
 from .file_metadata import FileMetadata
 from .get_files_info_response_200 import GetFilesInfoResponse200
 from .make_dirs_body import MakeDirsBody
@@ -53,6 +54,7 @@ __all__ = (
     "CreateSessionResponse",
     "ErrorResponse",
     "FileInfo",
+    "FileInfoType",
     "FileMetadata",
     "GetFilesInfoResponse200",
     "MakeDirsBody",

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/file_info.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/file_info.py
@@ -24,6 +24,9 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.file_info_type import FileInfoType
+from ..types import UNSET, Unset
+
 T = TypeVar("T", bound="FileInfo")
 
 
@@ -39,6 +42,7 @@ class FileInfo:
         owner (str): File owner username Example: admin.
         group (str): File group name Example: admin.
         mode (int): File permissions in octal format Example: 755.
+        type_ (FileInfoType | Unset): Entry type Example: file.
     """
 
     path: str
@@ -48,6 +52,7 @@ class FileInfo:
     owner: str
     group: str
     mode: int
+    type_: FileInfoType | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -65,6 +70,10 @@ class FileInfo:
 
         mode = self.mode
 
+        type_: str | Unset = UNSET
+        if not isinstance(self.type_, Unset):
+            type_ = self.type_.value
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -78,6 +87,8 @@ class FileInfo:
                 "mode": mode,
             }
         )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
 
         return field_dict
 
@@ -98,6 +109,13 @@ class FileInfo:
 
         mode = d.pop("mode")
 
+        _type_ = d.pop("type", UNSET)
+        type_: FileInfoType | Unset
+        if isinstance(_type_, Unset):
+            type_ = UNSET
+        else:
+            type_ = FileInfoType(_type_)
+
         file_info = cls(
             path=path,
             size=size,
@@ -106,6 +124,7 @@ class FileInfo:
             owner=owner,
             group=group,
             mode=mode,
+            type_=type_,
         )
 
         file_info.additional_properties = d

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/file_info_type.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/file_info_type.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class FileInfoType(str, Enum):
+    DIRECTORY = "directory"
+    FILE = "file"
+    OTHER = "other"
+    SYMLINK = "symlink"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -34,6 +34,7 @@ from opensandbox.models.execd import (
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
+    DirectoryListEntry,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -76,6 +77,7 @@ __all__ = [
     "EntryInfo",
     "WriteEntry",
     "MoveEntry",
+    "DirectoryListEntry",
     "SetPermissionEntry",
     "ContentReplaceEntry",
     "ContentReplaceResult",

--- a/sdks/sandbox/python/src/opensandbox/models/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/models/filesystem.py
@@ -34,6 +34,7 @@ class EntryInfo(BaseModel):
     """
 
     path: str = Field(description="Absolute path of the file or directory")
+    entry_type: str | None = Field(default=None, description="Entry type", alias="type")
     mode: int = Field(description="Unix file mode/permissions as integer (e.g., 644)")
     owner: str = Field(description="Owner username of the file or directory")
     group: str = Field(description="Group name of the file or directory")
@@ -87,6 +88,29 @@ class WriteEntry(BaseModel):
     def encoding_must_not_be_empty(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("Encoding cannot be blank")
+        return v
+
+
+class DirectoryListEntry(BaseModel):
+    """Request to list directory contents with optional depth control."""
+
+    path: str = Field(description="Directory path to list")
+    depth: int | None = Field(
+        default=None, description="Maximum child depth to include"
+    )
+
+    @field_validator("path")
+    @classmethod
+    def path_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Path cannot be blank")
+        return v
+
+    @field_validator("depth")
+    @classmethod
+    def depth_must_be_non_negative(cls, v: int | None) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError("Depth must be non-negative")
         return v
 
 

--- a/sdks/sandbox/python/src/opensandbox/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/services/filesystem.py
@@ -25,6 +25,7 @@ from typing import Protocol
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
+    DirectoryListEntry,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -232,6 +233,21 @@ class Filesystem(Protocol):
 
         Returns:
             List of EntryInfo objects containing metadata for matching files/directories
+
+        Raises:
+            SandboxException: if the operation fails
+        """
+        ...
+
+    async def list_directory(self, entry: DirectoryListEntry) -> list[EntryInfo]:
+        """
+        List directory contents with optional depth control.
+
+        Args:
+            entry: DirectoryListEntry object containing path and optional depth
+
+        Returns:
+            List of EntryInfo objects containing metadata for directory entries
 
         Raises:
             SandboxException: if the operation fails

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -41,6 +41,7 @@ from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
+    DirectoryListEntry,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -344,6 +345,31 @@ class FilesystemAdapterSync(FilesystemSync):
             )
         except Exception as e:
             logger.error("Failed to search files", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def list_directory(self, entry: DirectoryListEntry) -> list[EntryInfo]:
+        try:
+            from opensandbox.api.execd.api.filesystem import list_directory
+            from opensandbox.api.execd.models import FileInfo
+            from opensandbox.api.execd.types import UNSET
+
+            response_obj = list_directory.sync_detailed(
+                client=self._client,
+                path=entry.path,
+                depth=entry.depth if entry.depth is not None else UNSET,
+            )
+            handle_api_error(response_obj, "List directory")
+            parsed = response_obj.parsed
+            if not parsed:
+                return []
+            if isinstance(parsed, list) and all(isinstance(x, FileInfo) for x in parsed):
+                return FilesystemModelConverter.to_entry_info_list(parsed)
+            raise SandboxApiException(
+                message="List directory failed: unexpected response type",
+                request_id=extract_request_id(getattr(response_obj, "headers", None)),
+            )
+        except Exception as e:
+            logger.error("Failed to list directory", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_file_info(self, paths: list[str]) -> dict[str, EntryInfo]:

--- a/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
@@ -27,6 +27,7 @@ from typing import Protocol
 from opensandbox.models.filesystem import (
     ContentReplaceEntry,
     ContentReplaceResult,
+    DirectoryListEntry,
     EntryInfo,
     MoveEntry,
     SearchEntry,
@@ -239,6 +240,21 @@ class FilesystemSync(Protocol):
 
         Returns:
             List of EntryInfo objects containing metadata for matching files/directories.
+
+        Raises:
+            SandboxException: If the operation fails.
+        """
+        ...
+
+    def list_directory(self, entry: DirectoryListEntry) -> list[EntryInfo]:
+        """
+        List directory contents with optional depth control.
+
+        Args:
+            entry: DirectoryListEntry object containing path and optional depth.
+
+        Returns:
+            List of EntryInfo objects containing metadata for directory entries.
 
         Raises:
             SandboxException: If the operation fails.

--- a/sdks/sandbox/python/tests/test_models_stability.py
+++ b/sdks/sandbox/python/tests/test_models_stability.py
@@ -32,7 +32,12 @@ from opensandbox.models.execd import (
     ExecutionResult,
     OutputMessage,
 )
-from opensandbox.models.filesystem import MoveEntry, WriteEntry
+from opensandbox.models.filesystem import (
+    DirectoryListEntry,
+    EntryInfo,
+    MoveEntry,
+    WriteEntry,
+)
 from opensandbox.models.sandboxes import (
     OSSFS,
     PVC,
@@ -144,6 +149,25 @@ def test_filesystem_models_aliases_and_validation() -> None:
     m = MoveEntry(source="/a", destination="/b")
     assert m.src == "/a"
     assert m.dest == "/b"
+
+    info = EntryInfo(
+        path="/workspace/file.txt",
+        type="file",
+        mode=644,
+        owner="root",
+        group="root",
+        size=1,
+        modified_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    assert info.entry_type == "file"
+    assert info.model_dump(by_alias=True)["type"] == "file"
+
+    list_entry = DirectoryListEntry(path="/workspace", depth=2)
+    assert list_entry.depth == 2
+
+    with pytest.raises(ValueError):
+        DirectoryListEntry(path="/workspace", depth=-1)
 
     with pytest.raises(ValueError):
         WriteEntry(path="  ", data="x")

--- a/specs/README.md
+++ b/specs/README.md
@@ -98,6 +98,7 @@ Defines interfaces for executing code, commands, and file operations within sand
 - `GET /files/download` - Download files (supports range requests)
 
 **Directory Operations:**
+- `GET /directories/list` - List directory contents with optional depth control
 - `POST /directories` - Create directories with permissions (mkdir -p semantics)
 - `DELETE /directories` - Recursively delete directories
 

--- a/specs/README_zh.md
+++ b/specs/README_zh.md
@@ -98,6 +98,7 @@
 - `GET /files/download` - 下载文件（支持断点续传）
 
 **目录操作：**
+- `GET /directories/list` - 按可选深度列出目录内容
 - `POST /directories` - 按权限配置创建目录（mkdir -p 语义）
 - `DELETE /directories` - 递归删除目录
 

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -913,6 +913,15 @@ paths:
         only immediate children are returned (`depth=1`). Set `depth` to a larger
         value to include descendants up to that many levels below `path`. The
         root directory itself is not included in the response.
+
+        Symbolic links are reported with `type=symlink` and are not traversed:
+        the listing never descends into a link target, even when `depth` would
+        otherwise allow it.
+
+        Entries are returned in lexical order by entry name within each
+        directory. Descendants reported via `depth>1` follow their parent in
+        the same lexical order, so a depth-2 listing yields stable, predictable
+        output for file-browser style clients.
       operationId: listDirectory
       tags:
         - Filesystem

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -905,6 +905,68 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /directories/list:
+    get:
+      summary: List directory contents
+      description: |
+        Lists entries under a directory with optional depth control. By default,
+        only immediate children are returned (`depth=1`). Set `depth` to a larger
+        value to include descendants up to that many levels below `path`. The
+        root directory itself is not included in the response.
+      operationId: listDirectory
+      tags:
+        - Filesystem
+      parameters:
+        - name: path
+          in: query
+          required: true
+          description: Directory path to list
+          schema:
+            type: string
+          example: /workspace/project
+        - name: depth
+          in: query
+          required: false
+          description: Maximum child depth to include. `1` lists immediate children only.
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 1
+          example: 2
+      responses:
+        "200":
+          description: Array of directory entries with metadata
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FileInfo"
+              example:
+                - path: /workspace/project/src
+                  type: directory
+                  size: 0
+                  modified_at: 2025-11-16T14:30:45Z
+                  created_at: 2025-11-16T14:30:45Z
+                  owner: admin
+                  group: admin
+                  mode: 755
+                - path: /workspace/project/README.md
+                  type: file
+                  size: 2048
+                  modified_at: 2025-11-16T14:30:45Z
+                  created_at: 2025-11-16T14:30:45Z
+                  owner: admin
+                  group: admin
+                  mode: 644
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /directories:
     post:
       summary: Create directories
@@ -1256,6 +1318,11 @@ components:
           type: string
           description: Absolute file path
           example: /workspace/file.txt
+        type:
+          type: string
+          description: Entry type
+          enum: [file, directory, symlink, other]
+          example: file
         size:
           type: integer
           format: int64

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -916,7 +916,9 @@ paths:
 
         Symbolic links are reported with `type=symlink` and are not traversed:
         the listing never descends into a link target, even when `depth` would
-        otherwise allow it.
+        otherwise allow it. For the same reason, when `path` itself resolves to
+        a symbolic link the request is rejected with `400`; callers must pass
+        the real directory path they want listed.
 
         Entries are returned in lexical order by entry name within each
         directory. Descendants reported via `depth>1` follow their parent in


### PR DESCRIPTION
## Summary

- add `GET /directories/list` to execd with `depth`-controlled directory traversal
- add `FileInfo.type` (`file`, `directory`, `symlink`, `other`) and preserve symlink type via `Lstat`
- expose directory listing and entry type support across Python, JavaScript, Go, Kotlin, and C# sandbox SDKs

## Design notes

- `depth` defaults to `1`, which lists only immediate children.
- `depth=0` is accepted and returns an empty list because the root directory itself is not included.
- Symlinks are reported as `type=symlink` and are not recursively traversed by `/directories/list`.
- `/files/info` now uses `Lstat` so symlinks are reported as symlinks instead of being resolved to their target type.
- The public spec remains additive/backward-compatible: `FileInfo.type` is optional in the schema.

## Verification

- `cd components/execd && go test ./pkg/web/controller`
- `cd sdks/sandbox/go && go test ./...`
- `cd sdks/sandbox/javascript && pnpm run typecheck`
- `cd sdks/sandbox/python && uv run pytest tests/test_models_stability.py -q && uv run pyright`
- `cd sdks/sandbox/kotlin && JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :sandbox:test`
- `cd sdks/sandbox/csharp && PATH="$HOME/.dotnet:$PATH" dotnet test OpenSandbox.sln`
- `git diff --check`

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
