### PR TITLE
feat(execd): report replacedCount for file replacements

### DIFF
--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -333,8 +333,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
-	for file, item := range request {
-		file, err := pathutil.ExpandAbsPath(file)
+	response := make(map[string]model.ReplaceContentResultItem, len(request))
+
+	for requestedPath, item := range request {
+		file, err := pathutil.ExpandAbsPath(requestedPath)
 		if err != nil {
 			c.handleFileError(err)
 			return
@@ -358,6 +360,7 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
+		replacedCount := strings.Count(string(content), item.Old)
 		newContent := strings.ReplaceAll(string(content), item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
@@ -365,8 +368,10 @@ func (c *FilesystemController) ReplaceContent() {
 			c.handleFileError(err)
 			return
 		}
+
+		response[requestedPath] = model.ReplaceContentResultItem{ReplacedCount: replacedCount}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(nil)
+	c.RespondSuccess(response)
 }

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -91,6 +91,9 @@ func TestFilesystemControllerReplaceContent(t *testing.T) {
 	ctrl.ReplaceContent()
 
 	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]model.ReplaceContentResultItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp[target].ReplacedCount)
 	data, err := os.ReadFile(target)
 	require.NoError(t, err)
 	require.Equal(t, "hello universe", string(data))
@@ -116,6 +119,9 @@ func TestFilesystemControllerReplaceContentSupportsHomePath(t *testing.T) {
 	ctrl.ReplaceContent()
 
 	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]model.ReplaceContentResultItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp["~/content.txt"].ReplacedCount)
 	data, err := os.ReadFile(target)
 	require.NoError(t, err)
 	require.Equal(t, "hello home", string(data))
@@ -128,6 +134,56 @@ func TestFilesystemControllerSearchFilesHandlesAbsentDir(t *testing.T) {
 	ctrl.SearchFiles()
 
 	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestFilesystemControllerReplaceContentReportsZeroWhenNoMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "content.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hello world"), 0o644))
+
+	body, err := json.Marshal(map[string]model.ReplaceFileContentItem{
+		target: {
+			Old: "missing",
+			New: "unused",
+		},
+	})
+	require.NoError(t, err)
+
+	ctrl, rec := newFilesystemController(t, http.MethodPost, "/files/replace", body)
+	ctrl.ReplaceContent()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]model.ReplaceContentResultItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp[target].ReplacedCount)
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+}
+
+func TestFilesystemControllerReplaceContentReportsMultipleMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "content.txt")
+	require.NoError(t, os.WriteFile(target, []byte("one two one"), 0o644))
+
+	body, err := json.Marshal(map[string]model.ReplaceFileContentItem{
+		target: {
+			Old: "one",
+			New: "ONE",
+		},
+	})
+	require.NoError(t, err)
+
+	ctrl, rec := newFilesystemController(t, http.MethodPost, "/files/replace", body)
+	ctrl.ReplaceContent()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]model.ReplaceContentResultItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 2, resp[target].ReplacedCount)
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "ONE two ONE", string(data))
 }
 
 func TestReplaceContentFailsUnknownFile(t *testing.T) {

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -319,8 +319,10 @@ func (c *FilesystemController) ReplaceContent() {
 		return
 	}
 
-	for file, item := range request {
-		file, err := pathutil.ExpandAbsPath(file)
+	response := make(map[string]model.ReplaceContentResultItem, len(request))
+
+	for requestedPath, item := range request {
+		file, err := pathutil.ExpandAbsPath(requestedPath)
 		if err != nil {
 			c.handleFileError(err)
 			return
@@ -344,6 +346,7 @@ func (c *FilesystemController) ReplaceContent() {
 		}
 		mode := fileInfo.Mode()
 
+		replacedCount := strings.Count(string(content), item.Old)
 		newContent := strings.ReplaceAll(string(content), item.Old, item.New)
 
 		err = os.WriteFile(file, []byte(newContent), mode)
@@ -351,8 +354,10 @@ func (c *FilesystemController) ReplaceContent() {
 			c.handleFileError(err)
 			return
 		}
+
+		response[requestedPath] = model.ReplaceContentResultItem{ReplacedCount: replacedCount}
 	}
 
 	rec.MarkSuccess()
-	c.RespondSuccess(nil)
+	c.RespondSuccess(response)
 }

--- a/components/execd/pkg/web/model/filesystem.go
+++ b/components/execd/pkg/web/model/filesystem.go
@@ -48,3 +48,8 @@ type ReplaceFileContentItem struct {
 	Old string `json:"old,omitempty"`
 	New string `json:"new,omitempty"`
 }
+
+// ReplaceContentResultItem reports how many replacements were applied to a file
+type ReplaceContentResultItem struct {
+	ReplacedCount int `json:"replacedCount"`
+}

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -870,6 +870,14 @@ export interface components {
              */
             new: string;
         };
+        /** @description Replacement result for a single file */
+        ReplaceContentResultItem: {
+            /**
+             * @description Number of replacements applied to the file
+             * @example 2
+             */
+            replacedCount: number;
+        };
         /** @description System resource usage metrics */
         Metrics: {
             /**
@@ -1578,7 +1586,11 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["ReplaceContentResultItem"];
+                    };
+                };
             };
             400: components["responses"]["BadRequest"];
             500: components["responses"]["InternalServerError"];

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py
@@ -15,7 +15,7 @@
 #
 
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any
 
 import httpx
 
@@ -23,6 +23,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.replace_content_body import ReplaceContentBody
+from ...models.replace_content_response_200 import ReplaceContentResponse200
 from ...types import Response
 
 
@@ -45,9 +46,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | ErrorResponse | None:
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ReplaceContentResponse200 | ErrorResponse | None:
     if response.status_code == 200:
-        response_200 = cast(Any, None)
+        response_200 = ReplaceContentResponse200.from_dict(response.json())
         return response_200
 
     if response.status_code == 400:
@@ -66,7 +67,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | ErrorResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ReplaceContentResponse200 | ErrorResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -79,7 +80,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ReplaceContentResponse200 | ErrorResponse]:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -94,7 +95,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ReplaceContentResponse200 | ErrorResponse]
     """
 
     kwargs = _get_kwargs(
@@ -112,7 +113,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Any | ErrorResponse | None:
+) -> ReplaceContentResponse200 | ErrorResponse | None:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -127,7 +128,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | ErrorResponse
+        ReplaceContentResponse200 | ErrorResponse
     """
 
     return sync_detailed(
@@ -140,7 +141,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Response[Any | ErrorResponse]:
+) -> Response[ReplaceContentResponse200 | ErrorResponse]:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -155,7 +156,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | ErrorResponse]
+        Response[ReplaceContentResponse200 | ErrorResponse]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +172,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: ReplaceContentBody,
-) -> Any | ErrorResponse | None:
+) -> ReplaceContentResponse200 | ErrorResponse | None:
     """Replace file content
 
      Performs text replacement in one or multiple files. Replaces all occurrences
@@ -186,7 +187,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | ErrorResponse
+        ReplaceContentResponse200 | ErrorResponse
     """
 
     return (

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -31,6 +31,8 @@ from .metrics import Metrics
 from .permission import Permission
 from .rename_file_item import RenameFileItem
 from .replace_content_body import ReplaceContentBody
+from .replace_content_response_200 import ReplaceContentResponse200
+from .replace_content_result_item import ReplaceContentResultItem
 from .replace_file_content_item import ReplaceFileContentItem
 from .run_code_request import RunCodeRequest
 from .run_command_request import RunCommandRequest
@@ -58,6 +60,8 @@ __all__ = (
     "Permission",
     "RenameFileItem",
     "ReplaceContentBody",
+    "ReplaceContentResponse200",
+    "ReplaceContentResultItem",
     "ReplaceFileContentItem",
     "RunCodeRequest",
     "RunCommandRequest",

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.replace_content_result_item import ReplaceContentResultItem
+
+T = TypeVar("T", bound="ReplaceContentResponse200")
+
+
+@_attrs_define
+class ReplaceContentResponse200:
+    additional_properties: dict[str, ReplaceContentResultItem] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop.to_dict()
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.replace_content_result_item import ReplaceContentResultItem
+
+        d = dict(src_dict)
+        resp = cls()
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_properties[prop_name] = ReplaceContentResultItem.from_dict(prop_dict)
+        resp.additional_properties = additional_properties
+        return resp
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> ReplaceContentResultItem:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: ReplaceContentResultItem) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_result_item.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_result_item.py
@@ -1,0 +1,45 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ReplaceContentResultItem")
+
+
+@_attrs_define
+class ReplaceContentResultItem:
+    replaced_count: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict["replacedCount"] = self.replaced_count
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        replaced_count = d.pop("replacedCount")
+        item = cls(replaced_count=replaced_count)
+        item.additional_properties = d
+        return item

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -766,6 +766,15 @@ paths:
       responses:
         "200":
           description: Content replaced successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReplaceContentResponse"
+              example:
+                "/workspace/config.yaml":
+                  replacedCount: 1
+                "/workspace/app.py":
+                  replacedCount: 0
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -1328,6 +1337,22 @@ components:
           description: Replacement string
           example: "0.0.0.0"
       required: [old, new]
+
+    ReplaceContentResultItem:
+      type: object
+      description: Replacement result for a single file
+      properties:
+        replacedCount:
+          type: integer
+          description: Number of replacements applied to the file
+          example: 2
+      required: [replacedCount]
+
+    ReplaceContentResponse:
+      type: object
+      description: Replacement results keyed by file path
+      additionalProperties:
+        $ref: "#/components/schemas/ReplaceContentResultItem"
 
     Metrics:
       type: object


### PR DESCRIPTION
# Summary
- Fixes #982 by returning a per-file `replacedCount` result body from `POST /files/replace`.
- Keeps the existing replace-all behavior and request shape intact.
- Aligns the committed execd OpenAPI spec plus low-level JS/Python API contract files with the new success response.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Executed:
- `cd components/execd && go test ./pkg/web/controller -run 'TestFilesystemControllerReplaceContent|TestFilesystemControllerReplaceContentSupportsHomePath|TestFilesystemControllerReplaceContentReportsZeroWhenNoMatch|TestFilesystemControllerReplaceContentReportsMultipleMatches'`
- `cd server && uv run ruff check ../sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py ../sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py ../sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_result_item.py opensandbox_server tests`
- `cd server && uv run python -m py_compile ../sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/replace_content.py ../sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_response_200.py ../sdks/sandbox/python/src/opensandbox/api/execd/models/replace_content_result_item.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
