### PR TITLE
feat(execd): support line-based file reading with offset + limit

### DIFF
--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -148,31 +148,36 @@ func (c *FilesystemController) serveLineRange(filePath string, offset, limit int
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	// Increase buffer for long lines (default 64KB -> 1MB)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	
+	reader := bufio.NewReader(file)
 	currentLine := 1
 	linesWritten := 0
 
 	c.ctx.Header("Content-Type", "text/plain")
 
-	for scanner.Scan() && linesWritten < limit {
+	for linesWritten < limit {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				// If we have partial line without newline, process it
+				if len(line) > 0 && currentLine >= offset {
+					c.ctx.Writer.Write(line)
+					linesWritten++
+				}
+				break
+			}
+			c.RespondError(
+				http.StatusInternalServerError,
+				model.ErrorCodeRuntimeError,
+				fmt.Sprintf("error reading file: %v", err),
+			)
+			return
+		}
+
 		if currentLine >= offset {
-			c.ctx.Writer.Write(scanner.Bytes())
-			c.ctx.Writer.Write([]byte("\n"))
+			c.ctx.Writer.Write(line)
 			linesWritten++
 		}
 		currentLine++
-	}
-
-	if err := scanner.Err(); err != nil {
-		c.RespondError(
-			http.StatusInternalServerError,
-			model.ErrorCodeRuntimeError,
-			fmt.Sprintf("error reading file: %v", err),
-		)
-		return
 	}
 
 	rec.MarkSuccess()

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,6 +42,7 @@ func (c *FilesystemController) DownloadFile() {
 		)
 		return
 	}
+
 	resolvedFilePath, err := pathutil.ExpandPath(filePath)
 	if err != nil {
 		c.RespondError(
@@ -48,6 +50,35 @@ func (c *FilesystemController) DownloadFile() {
 			model.ErrorCodeRuntimeError,
 			fmt.Sprintf("error resolving file path: %s. %v", filePath, err),
 		)
+		return
+	}
+
+	// Check for line-based reading parameters
+	offsetStr := c.ctx.Query("offset")
+	limitStr := c.ctx.Query("limit")
+
+	if offsetStr != "" && limitStr != "" {
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil || offset < 1 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidParameter,
+				"offset must be a positive integer (1-based)",
+			)
+			return
+		}
+
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil || limit < 1 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidParameter,
+				"limit must be a positive integer",
+			)
+			return
+		}
+
+		c.serveLineRange(resolvedFilePath, offset, limit)
 		return
 	}
 
@@ -96,6 +127,39 @@ func (c *FilesystemController) DownloadFile() {
 
 	rec.MarkSuccess()
 	http.ServeContent(c.ctx.Writer, c.ctx.Request, filepath.Base(resolvedFilePath), fileInfo.ModTime(), file)
+}
+
+// serveLineRange serves a specific range of lines from a file
+func (c *FilesystemController) serveLineRange(filePath string, offset, limit int) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		c.handleFileError(err)
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	currentLine := 1
+	linesWritten := 0
+
+	c.ctx.Header("Content-Type", "text/plain")
+
+	for scanner.Scan() && linesWritten < limit {
+		if currentLine >= offset {
+			c.ctx.Writer.Write(scanner.Bytes())
+			c.ctx.Writer.Write([]byte("\n"))
+			linesWritten++
+		}
+		currentLine++
+	}
+
+	if err := scanner.Err(); err != nil {
+		c.RespondError(
+			http.StatusInternalServerError,
+			model.ErrorCodeRuntimeError,
+			fmt.Sprintf("error reading file: %v", err),
+		)
+	}
 }
 
 // formatContentDisposition formats the Content-Disposition header value with proper

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -57,6 +57,16 @@ func (c *FilesystemController) DownloadFile() {
 	offsetStr := c.ctx.Query("offset")
 	limitStr := c.ctx.Query("limit")
 
+	// Check if only one of offset/limit is provided
+	if (offsetStr != "" && limitStr == "") || (offsetStr == "" && limitStr != "") {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidParameter,
+			"both offset and limit must be provided together for line-based reading",
+		)
+		return
+	}
+
 	if offsetStr != "" && limitStr != "" {
 		offset, err := strconv.Atoi(offsetStr)
 		if err != nil || offset < 1 {
@@ -78,7 +88,7 @@ func (c *FilesystemController) DownloadFile() {
 			return
 		}
 
-		c.serveLineRange(resolvedFilePath, offset, limit)
+		c.serveLineRange(resolvedFilePath, offset, limit, rec)
 		return
 	}
 
@@ -130,7 +140,7 @@ func (c *FilesystemController) DownloadFile() {
 }
 
 // serveLineRange serves a specific range of lines from a file
-func (c *FilesystemController) serveLineRange(filePath string, offset, limit int) {
+func (c *FilesystemController) serveLineRange(filePath string, offset, limit int, rec *filesystemMetricRecorder) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		c.handleFileError(err)
@@ -139,6 +149,9 @@ func (c *FilesystemController) serveLineRange(filePath string, offset, limit int
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+	// Increase buffer for long lines (default 64KB -> 1MB)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	
 	currentLine := 1
 	linesWritten := 0
 
@@ -159,7 +172,10 @@ func (c *FilesystemController) serveLineRange(filePath string, offset, limit int
 			model.ErrorCodeRuntimeError,
 			fmt.Sprintf("error reading file: %v", err),
 		)
+		return
 	}
+
+	rec.MarkSuccess()
 }
 
 // formatContentDisposition formats the Content-Disposition header value with proper

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -63,7 +63,7 @@ func (c *FilesystemController) DownloadFile() {
 	} else if offsetStr == "" || limitStr == "" {
 		c.RespondError(
 			http.StatusBadRequest,
-			model.ErrorCodeInvalidParameter,
+			model.ErrorCodeInvalidRequest,
 			"both offset and limit must be provided together for line-based reading",
 		)
 		return
@@ -74,7 +74,7 @@ func (c *FilesystemController) DownloadFile() {
 		if err != nil || offset < 1 {
 			c.RespondError(
 				http.StatusBadRequest,
-				model.ErrorCodeInvalidParameter,
+				model.ErrorCodeInvalidRequest,
 				"offset must be a positive integer (1-based)",
 			)
 			return
@@ -84,7 +84,7 @@ func (c *FilesystemController) DownloadFile() {
 		if err != nil || limit < 1 {
 			c.RespondError(
 				http.StatusBadRequest,
-				model.ErrorCodeInvalidParameter,
+				model.ErrorCodeInvalidRequest,
 				"limit must be a positive integer",
 			)
 			return

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -57,8 +57,10 @@ func (c *FilesystemController) DownloadFile() {
 	offsetStr := c.ctx.Query("offset")
 	limitStr := c.ctx.Query("limit")
 
-	// Check if only one of offset/limit is provided
-	if (offsetStr != "" && limitStr == "") || (offsetStr == "" && limitStr != "") {
+	// Reject empty string values (e.g., ?offset=&limit=)
+	if offsetStr == "" && limitStr == "" {
+		// Both empty, continue to normal download
+	} else if offsetStr == "" || limitStr == "" {
 		c.RespondError(
 			http.StatusBadRequest,
 			model.ErrorCodeInvalidParameter,
@@ -160,7 +162,11 @@ func (c *FilesystemController) serveLineRange(filePath string, offset, limit int
 			if err == io.EOF {
 				// If we have partial line without newline, process it
 				if len(line) > 0 && currentLine >= offset {
-					c.ctx.Writer.Write(line)
+					_, writeErr := c.ctx.Writer.Write(line)
+					if writeErr != nil {
+						// Client disconnected, stop reading
+						return
+					}
 					linesWritten++
 				}
 				break
@@ -174,7 +180,11 @@ func (c *FilesystemController) serveLineRange(filePath string, offset, limit int
 		}
 
 		if currentLine >= offset {
-			c.ctx.Writer.Write(line)
+			_, writeErr := c.ctx.Writer.Write(line)
+			if writeErr != nil {
+				// Client disconnected, stop reading
+				return
+			}
 			linesWritten++
 		}
 		currentLine++

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -460,7 +460,8 @@ export interface paths {
          * Download file from sandbox
          * @description Downloads a file from the specified path within the sandbox. Supports HTTP
          *     range requests for resumable downloads and partial content retrieval.
-         *     Returns file as octet-stream with appropriate headers.
+         *     Also supports line-based reading with offset and limit parameters.
+         *     Returns file as octet-stream or plain text with appropriate headers.
          */
         get: operations["downloadFile"];
         put?: never;
@@ -1658,10 +1659,20 @@ export interface operations {
                  * @example /workspace/data.csv
                  */
                 path: string;
+                /**
+                 * @description Starting line number (1-based). When provided with limit, enables line-based reading.
+                 * @example 100
+                 */
+                offset?: number;
+                /**
+                 * @description Number of lines to return. Requires offset to be specified.
+                 * @example 20
+                 */
+                limit?: number;
             };
             header?: {
                 /**
-                 * @description HTTP Range header for partial content requests
+                 * @description HTTP Range header for partial content requests (byte range)
                  * @example bytes=0-1023
                  */
                 Range?: string;
@@ -1682,6 +1693,7 @@ export interface operations {
                 };
                 content: {
                     "application/octet-stream": string;
+                    "text/plain": string;
                 };
             };
             /** @description Partial file content (when Range header is provided) */

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/download_file.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/download_file.py
@@ -30,6 +30,8 @@ def _get_kwargs(
     *,
     path: str,
     range_: str | Unset = UNSET,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     if not isinstance(range_, Unset):
@@ -38,6 +40,12 @@ def _get_kwargs(
     params: dict[str, Any] = {}
 
     params["path"] = path
+    
+    if not isinstance(offset, Unset):
+        params["offset"] = offset
+    
+    if not isinstance(limit, Unset):
+        params["limit"] = limit
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -104,16 +112,20 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     path: str,
     range_: str | Unset = UNSET,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> Response[ErrorResponse | File]:
     """Download file from sandbox
 
      Downloads a file from the specified path within the sandbox. Supports HTTP
     range requests for resumable downloads and partial content retrieval.
-    Returns file as octet-stream with appropriate headers.
+    Also supports line-based reading with offset and limit parameters.
 
     Args:
-        path (str):
-        range_ (str | Unset):
+        path (str): File path to download
+        range_ (str | Unset): HTTP Range header for byte ranges
+        offset (int | Unset): Starting line number (1-based)
+        limit (int | Unset): Number of lines to return
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,6 +138,8 @@ def sync_detailed(
     kwargs = _get_kwargs(
         path=path,
         range_=range_,
+        offset=offset,
+        limit=limit,
     )
 
     response = client.get_httpx_client().request(
@@ -140,16 +154,20 @@ def sync(
     client: AuthenticatedClient | Client,
     path: str,
     range_: str | Unset = UNSET,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> ErrorResponse | File | None:
     """Download file from sandbox
 
      Downloads a file from the specified path within the sandbox. Supports HTTP
     range requests for resumable downloads and partial content retrieval.
-    Returns file as octet-stream with appropriate headers.
+    Also supports line-based reading with offset and limit parameters.
 
     Args:
-        path (str):
-        range_ (str | Unset):
+        path (str): File path to download
+        range_ (str | Unset): HTTP Range header for byte ranges
+        offset (int | Unset): Starting line number (1-based)
+        limit (int | Unset): Number of lines to return
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -163,6 +181,8 @@ def sync(
         client=client,
         path=path,
         range_=range_,
+        offset=offset,
+        limit=limit,
     ).parsed
 
 
@@ -171,16 +191,20 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     path: str,
     range_: str | Unset = UNSET,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> Response[ErrorResponse | File]:
     """Download file from sandbox
 
      Downloads a file from the specified path within the sandbox. Supports HTTP
     range requests for resumable downloads and partial content retrieval.
-    Returns file as octet-stream with appropriate headers.
+    Also supports line-based reading with offset and limit parameters.
 
     Args:
-        path (str):
-        range_ (str | Unset):
+        path (str): File path to download
+        range_ (str | Unset): HTTP Range header for byte ranges
+        offset (int | Unset): Starting line number (1-based)
+        limit (int | Unset): Number of lines to return
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -193,6 +217,8 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         path=path,
         range_=range_,
+        offset=offset,
+        limit=limit,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -205,16 +231,20 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     path: str,
     range_: str | Unset = UNSET,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> ErrorResponse | File | None:
     """Download file from sandbox
 
      Downloads a file from the specified path within the sandbox. Supports HTTP
     range requests for resumable downloads and partial content retrieval.
-    Returns file as octet-stream with appropriate headers.
+    Also supports line-based reading with offset and limit parameters.
 
     Args:
-        path (str):
-        range_ (str | Unset):
+        path (str): File path to download
+        range_ (str | Unset): HTTP Range header for byte ranges
+        offset (int | Unset): Starting line number (1-based)
+        limit (int | Unset): Number of lines to return
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -229,5 +259,7 @@ async def asyncio(
             client=client,
             path=path,
             range_=range_,
+            offset=offset,
+            limit=limit,
         )
     ).parsed

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -840,7 +840,8 @@ paths:
       description: |
         Downloads a file from the specified path within the sandbox. Supports HTTP
         range requests for resumable downloads and partial content retrieval.
-        Returns file as octet-stream with appropriate headers.
+        Also supports line-based reading with offset and limit parameters.
+        Returns file as octet-stream or plain text with appropriate headers.
       operationId: downloadFile
       tags:
         - Filesystem
@@ -852,10 +853,26 @@ paths:
           schema:
             type: string
           example: /workspace/data.csv
+        - name: offset
+          in: query
+          required: false
+          description: Starting line number (1-based). When provided with limit, enables line-based reading.
+          schema:
+            type: integer
+            minimum: 1
+          example: 100
+        - name: limit
+          in: query
+          required: false
+          description: Number of lines to return. Requires offset to be specified.
+          schema:
+            type: integer
+            minimum: 1
+          example: 20
         - name: Range
           in: header
           required: false
-          description: HTTP Range header for partial content requests
+          description: HTTP Range header for partial content requests (byte range)
           schema:
             type: string
           example: "bytes=0-1023"
@@ -867,6 +884,9 @@ paths:
               schema:
                 type: string
                 format: binary
+            text/plain:
+              schema:
+                type: string
           headers:
             Content-Disposition:
               schema:
@@ -1440,3 +1460,4 @@ components:
           example:
             code: RUNTIME_ERROR
             message: "error running code execution"
+            


### PR DESCRIPTION
## What
Adds line-based file reading to `/files/download` endpoint with `offset` and `limit` query parameters.

## Why
Enables paginated log viewing and large file browsing without downloading entire files.

## Changes
- Added `offset` and `limit` parameters to `DownloadFile()` handler
- Added `serveLineRange()` method for line-based streaming
- Offset is 1-based (first line = offset=1)
- Returns empty when offset exceeds total lines
- Returns remaining lines when limit exceeds EOF

## Testing
- [x] Manual test with valid offset+limit
- [x] Offset beyond EOF returns empty
- [x] Limit beyond EOF returns remaining lines
- [x] Without parameters - byte range mode still works

Closes #1003