### PR TITLE
fix(server): handle null spec.template in _workload_platform_constraint_scope

### DIFF
--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -228,10 +228,12 @@ def _workload_platform_constraint_scope(
     pod_template_key: str,
     analyzer: Callable[[Any], tuple[bool, bool]],
 ) -> tuple[bool, bool]:
-    # Use `or {}` instead of `.get(key, {})`: in pool mode the BatchSandbox CR
-    # has spec.template explicitly set to null (the key exists but the value is
-    # None), so `.get("template", {})` returns None rather than {}, causing
-    # the next chained `.get()` to raise AttributeError.
+    # Use `or {}` instead of `.get(key, {})`: when a CRD field is declared
+    # without `omitempty`, Kubernetes serialises an absent value as explicit
+    # null rather than omitting the key.  `.get(key, {})` only substitutes
+    # the default when the key is absent — not when its value is None — so
+    # chaining `.get()` on the result raises AttributeError.  `or {}` treats
+    # both absent keys and explicit None as empty dicts.
     spec = workload.get("spec") or {}
     template = spec.get(pod_template_key) or {}
     pod_spec = template.get("spec") or {}

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -228,11 +228,13 @@ def _workload_platform_constraint_scope(
     pod_template_key: str,
     analyzer: Callable[[Any], tuple[bool, bool]],
 ) -> tuple[bool, bool]:
-    pod_spec = (
-        workload.get("spec", {})
-        .get(pod_template_key, {})
-        .get("spec", {})
-    )
+    # Use `or {}` instead of `.get(key, {})`: in pool mode the BatchSandbox CR
+    # has spec.template explicitly set to null (the key exists but the value is
+    # None), so `.get("template", {})` returns None rather than {}, causing
+    # the next chained `.get()` to raise AttributeError.
+    spec = workload.get("spec") or {}
+    template = spec.get(pod_template_key) or {}
+    pod_spec = template.get("spec") or {}
     return analyzer(pod_spec)
 
 

--- a/server/tests/k8s/test_provider_common.py
+++ b/server/tests/k8s/test_provider_common.py
@@ -90,29 +90,17 @@ def test_translate_resource_limits_empty_dict():
 # _workload_platform_constraint_scope
 # ---------------------------------------------------------------------------
 
-def test_platform_constraint_scope_null_template_does_not_crash():
-    # Regression: pool-mode BatchSandbox CRs have spec.template: null.
-    # .get("template", {}) returns None when the key exists with value None,
-    # causing AttributeError on the next chained .get().
-    workload = {"spec": {"template": None, "poolRef": "pool-runc"}}
+@pytest.mark.parametrize("workload", [
+    {"spec": {"template": None, "poolRef": "pool-runc"}},  # key exists, value None (pool mode)
+    {"spec": {"poolRef": "pool-runc"}},                    # key absent entirely
+    {"spec": None},                                         # spec itself is None
+    {},                                                     # empty workload
+    {"spec": {"template": {"spec": None}}},                # template present, inner spec is None
+])
+def test_platform_constraint_scope_no_crash_on_null_fields(workload):
+    # Regression: chained .get(key, {}) raises AttributeError when any level
+    # is explicitly None.  `or {}` must handle all these shapes safely.
     result = _workload_platform_constraint_scope(workload, "template", _analyzer)
-    assert result == (False, False)
-
-
-def test_platform_constraint_scope_missing_template_key():
-    workload = {"spec": {"poolRef": "pool-runc"}}
-    result = _workload_platform_constraint_scope(workload, "template", _analyzer)
-    assert result == (False, False)
-
-
-def test_platform_constraint_scope_null_spec():
-    workload = {"spec": None}
-    result = _workload_platform_constraint_scope(workload, "template", _analyzer)
-    assert result == (False, False)
-
-
-def test_platform_constraint_scope_empty_workload():
-    result = _workload_platform_constraint_scope({}, "template", _analyzer)
     assert result == (False, False)
 
 

--- a/server/tests/k8s/test_provider_common.py
+++ b/server/tests/k8s/test_provider_common.py
@@ -18,7 +18,19 @@ from fastapi import HTTPException
 from opensandbox_server.services.constants import SandboxErrorCodes
 from opensandbox_server.services.k8s.provider_common import (
     _translate_resource_limits_for_k8s,
+    _workload_platform_constraint_scope,
 )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _workload_platform_constraint_scope tests
+# ---------------------------------------------------------------------------
+
+def _analyzer(pod_spec):
+    """Return whether pod_spec has nodeSelector / nodeName (platform constraints)."""
+    has_platform = bool(pod_spec.get("nodeSelector") or pod_spec.get("nodeName"))
+    has_non_platform = bool(pod_spec.get("affinity"))
+    return has_platform, has_non_platform
 
 
 def test_translate_resource_limits_passes_gpu_count():
@@ -72,3 +84,65 @@ def test_translate_resource_limits_drops_invalid_gpu(bad_value):
 
 def test_translate_resource_limits_empty_dict():
     assert _translate_resource_limits_for_k8s({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _workload_platform_constraint_scope
+# ---------------------------------------------------------------------------
+
+def test_platform_constraint_scope_null_template_does_not_crash():
+    # Regression: pool-mode BatchSandbox CRs have spec.template: null.
+    # .get("template", {}) returns None when the key exists with value None,
+    # causing AttributeError on the next chained .get().
+    workload = {"spec": {"template": None, "poolRef": "pool-runc"}}
+    result = _workload_platform_constraint_scope(workload, "template", _analyzer)
+    assert result == (False, False)
+
+
+def test_platform_constraint_scope_missing_template_key():
+    workload = {"spec": {"poolRef": "pool-runc"}}
+    result = _workload_platform_constraint_scope(workload, "template", _analyzer)
+    assert result == (False, False)
+
+
+def test_platform_constraint_scope_null_spec():
+    workload = {"spec": None}
+    result = _workload_platform_constraint_scope(workload, "template", _analyzer)
+    assert result == (False, False)
+
+
+def test_platform_constraint_scope_empty_workload():
+    result = _workload_platform_constraint_scope({}, "template", _analyzer)
+    assert result == (False, False)
+
+
+def test_platform_constraint_scope_detects_node_selector():
+    workload = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "nodeSelector": {"kubernetes.io/arch": "amd64"},
+                }
+            }
+        }
+    }
+    has_platform, has_non_platform = _workload_platform_constraint_scope(
+        workload, "template", _analyzer
+    )
+    assert has_platform is True
+    assert has_non_platform is False
+
+
+def test_platform_constraint_scope_pod_template_key_alias():
+    # AgentSandbox uses "podTemplate" instead of "template"
+    workload = {
+        "spec": {
+            "podTemplate": {
+                "spec": {"nodeSelector": {"kubernetes.io/os": "linux"}}
+            }
+        }
+    }
+    has_platform, _ = _workload_platform_constraint_scope(
+        workload, "podTemplate", _analyzer
+    )
+    assert has_platform is True


### PR DESCRIPTION
## Problem

In pool mode (`extensions.poolRef`), BatchSandbox CRs have `spec.template`
explicitly set to `null` — the key exists with value `None` because the CRD
declares `template` as an optional field without `omitempty`.

`_workload_platform_constraint_scope` in `provider_common.py` used chained
`.get(key, {})` calls:

```python
pod_spec = (
    workload.get("spec", {})
    .get(pod_template_key, {})   # returns None when key exists but value is None
    .get("spec", {})             # AttributeError: 'NoneType' has no attribute 'get'
)
```

`dict.get(key, default)` only returns `default` when the key is **absent** —
not when the key is present with value `None`. So chaining `.get()` on a
`None` value raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This function is called from both `BatchSandboxProvider.get_status()` and
`AgentSandboxProvider.get_status()` during the `_wait_for_sandbox_ready`
polling loop, so pool-mode sandbox creation fails during status polling.

## Fix

Replace chained `.get(key, {})` with `.get(key) or {}`, which treats both
absent keys and explicit `None` values as empty dicts:

```python
spec = workload.get("spec") or {}
template = spec.get(pod_template_key) or {}
pod_spec = template.get("spec") or {}
```

The same pattern was applied to `workload_mapper.py` in #910.

## Tests

Added regression tests to `test_provider_common.py` covering:
- `spec.template == None` (pool mode — the crash case)
- `spec.template` key missing entirely
- `spec` itself is `None`
- Empty workload dict `{}`
- Normal nodeSelector detection (non-regression)
- `podTemplate` key alias used by AgentSandbox

## Notes

The root cause is that the CRD field is declared without `omitempty`:

```go
Template *corev1.PodTemplateSpec `json:"template"` // no omitempty
```

This causes Kubernetes to serialize an absent template as `"template": null`
rather than omitting the field. A follow-up to add `omitempty` would prevent
the null from being stored, but the defensive `or {}` fix is the safer
near-term change.