### PR TITLE
refactor!: migrate code-interpreter paths from /opt/opensandbox to /opt/code-interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ async def main() -> None:
     # 1. Create a sandbox
     sandbox = await Sandbox.create(
         "opensandbox/code-interpreter:v1.0.2",
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
         env={"PYTHON_VERSION": "3.11"},
         timeout=timedelta(minutes=10),
     )

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -135,7 +135,7 @@ async def main() -> None:
     # 1. Create a sandbox
     sandbox = await Sandbox.create(
         "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.2",
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
         env={"PYTHON_VERSION": "3.11"},
         timeout=timedelta(minutes=10),
     )

--- a/examples/code-interpreter/main.py
+++ b/examples/code-interpreter/main.py
@@ -38,7 +38,7 @@ async def main() -> None:
     sandbox = await Sandbox.create(
         image,
         connection_config=config,
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"]
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"]
     )
 
     async with sandbox:

--- a/examples/code-interpreter/main_use_pool.py
+++ b/examples/code-interpreter/main_use_pool.py
@@ -39,7 +39,7 @@ async def main() -> None:
         image,
         connection_config=config,
         extensions={"poolRef":"pool-sample"},
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
         env={
             "TEST_ENV": "test",
         },

--- a/examples/rl-training/main.py
+++ b/examples/rl-training/main.py
@@ -98,7 +98,7 @@ async def _run_command(sandbox: Sandbox, command: str) -> bool:
 def _with_python_env(command: str) -> str:
     return (
         "bash -lc '"
-        "source /opt/opensandbox/code-interpreter-env.sh "
+        "source /opt/code-interpreter/code-interpreter-env.sh "
         "python ${PYTHON_VERSION:-3.14} >/dev/null "
         "&& "
         f"{command}"

--- a/sandboxes/code-interpreter/Dockerfile
+++ b/sandboxes/code-interpreter/Dockerfile
@@ -35,7 +35,7 @@ RUN set -euo pipefail \
     && versions=("3.10" "3.11" "3.12" "3.13" "3.14") \
     && for version in "${versions[@]}"; do \
         echo "Setting up ipykernel for Python $version" \
-        && . /opt/opensandbox/code-interpreter-env.sh python $version \
+        && . /opt/code-interpreter/code-interpreter-env.sh python $version \
         && python3 --version \
         && python3 -m pip install ipykernel jupyter bash_kernel --break-system-packages; \
     done \
@@ -56,7 +56,7 @@ RUN set -euo pipefail \
     && versions=("18" "20" "22") \
     && for version in "${versions[@]}"; do \
         echo "Setting up tslab for Node $version" \
-        && . /opt/opensandbox/code-interpreter-env.sh node $version \
+        && . /opt/code-interpreter/code-interpreter-env.sh node $version \
         && node --version \
         && npm --version \
         && npm install -g tslab; \
@@ -69,7 +69,7 @@ RUN set -euo pipefail \
     && versions=("1.25" "1.24" "1.23") \
     && for version in "${versions[@]}"; do \
         echo "Setting up gonb for Go $version" \
-        && . /opt/opensandbox/code-interpreter-env.sh go $version \
+        && . /opt/code-interpreter/code-interpreter-env.sh go $version \
         && go version \
         && go install github.com/janpfeifer/gonb@latest \
         && go install golang.org/x/tools/cmd/goimports@latest \
@@ -85,9 +85,9 @@ ENV JUPYTER_HOST=http://127.0.0.1:44771 \
     GO_VERSION=1.25 \
     JAVA_VERSION=21
 
-COPY scripts/code-interpreter.sh /opt/opensandbox/code-interpreter.sh
+COPY scripts/code-interpreter.sh /opt/code-interpreter/code-interpreter.sh
 COPY scripts/jupyter_notebook_config.py /root/.jupyter/
-RUN chmod +x /opt/opensandbox/code-interpreter.sh
+RUN chmod +x /opt/code-interpreter/code-interpreter.sh
 
 WORKDIR /workspace
-ENTRYPOINT ["/opt/opensandbox/code-interpreter.sh"]
+ENTRYPOINT ["/opt/code-interpreter/code-interpreter.sh"]

--- a/sandboxes/code-interpreter/Dockerfile_base
+++ b/sandboxes/code-interpreter/Dockerfile_base
@@ -106,8 +106,8 @@ RUN mkdir -p ${GO_ROOT} && \
 ENV GOROOT=${GO_ROOT}/${GO_V1_25} \
     PATH="${NODE_ROOT}/v${NODE_V22}/bin:${GO_ROOT}/${GO_V1_25}/bin:${PATH}"
 
-RUN mkdir -p /opt/opensandbox
-COPY scripts/code-interpreter-env.sh /opt/opensandbox/code-interpreter-env.sh
-RUN chmod +x /opt/opensandbox/code-interpreter-env.sh
+RUN mkdir -p /opt/code-interpreter
+COPY scripts/code-interpreter-env.sh /opt/code-interpreter/code-interpreter-env.sh
+RUN chmod +x /opt/code-interpreter/code-interpreter-env.sh
 
 CMD ["/bin/bash"]

--- a/sandboxes/code-interpreter/README.md
+++ b/sandboxes/code-interpreter/README.md
@@ -65,13 +65,13 @@ If you set `EXECD_CLONE3_COMPAT` to `1`, `true`, `yes`, `on`, or `reexec` (same 
 
 ## Version Switching
 
-The image includes a built-in version switching script `/opt/opensandbox/code-interpreter-env.sh`. You need to use the
+The image includes a built-in version switching script `/opt/code-interpreter/code-interpreter-env.sh`. You need to use the
 `source` command to load it to modify the current shell's environment variables.
 
 ### Basic Usage
 
 ```bash
-source /opt/opensandbox/code-interpreter-env.sh <language> <version>
+source /opt/code-interpreter/code-interpreter-env.sh <language> <version>
 ```
 
 ### Examples
@@ -80,7 +80,7 @@ source /opt/opensandbox/code-interpreter-env.sh <language> <version>
 
 ```bash
 # Switch to Python 3.11
-source /opt/opensandbox/code-interpreter-env.sh python 3.11
+source /opt/code-interpreter/code-interpreter-env.sh python 3.11
 python3 --version
 # Output: Python 3.11.x
 ```
@@ -89,7 +89,7 @@ python3 --version
 
 ```bash
 # Switch to Java 8
-source /opt/opensandbox/code-interpreter-env.sh java 8
+source /opt/code-interpreter/code-interpreter-env.sh java 8
 java -version
 ```
 
@@ -97,7 +97,7 @@ java -version
 
 ```bash
 # Switch to Node 22
-source /opt/opensandbox/code-interpreter-env.sh node 22
+source /opt/code-interpreter/code-interpreter-env.sh node 22
 node -v
 ```
 
@@ -105,7 +105,7 @@ node -v
 
 ```bash
 # Switch to Go 1.25
-source /opt/opensandbox/code-interpreter-env.sh go 1.25
+source /opt/code-interpreter/code-interpreter-env.sh go 1.25
 go version
 ```
 
@@ -115,16 +115,16 @@ If you don't specify a version number, the script will list all available versio
 
 ```bash
 # List all Python versions
-source /opt/opensandbox/code-interpreter-env.sh python
+source /opt/code-interpreter/code-interpreter-env.sh python
 
 # List all Java versions
-source /opt/opensandbox/code-interpreter-env.sh java
+source /opt/code-interpreter/code-interpreter-env.sh java
 
 # List all Node.js versions
-source /opt/opensandbox/code-interpreter-env.sh node
+source /opt/code-interpreter/code-interpreter-env.sh node
 
 # List all Go versions
-source /opt/opensandbox/code-interpreter-env.sh go
+source /opt/code-interpreter/code-interpreter-env.sh go
 ```
 
 ## Default Versions
@@ -154,7 +154,7 @@ The image comes with pre-configured Jupyter kernels for all supported languages:
 ### Starting Jupyter
 
 ```bash
-/opt/opensandbox/code-interpreter.sh
+/opt/code-interpreter/code-interpreter.sh
 ```
 
 ### Environment Variables
@@ -230,7 +230,7 @@ code-interpreter/
 If a specific version is not found, list available versions:
 
 ```bash
-source /opt/opensandbox/code-interpreter-env.sh <language>
+source /opt/code-interpreter/code-interpreter-env.sh <language>
 ```
 
 ## License

--- a/sandboxes/code-interpreter/README_zh.md
+++ b/sandboxes/code-interpreter/README_zh.md
@@ -64,13 +64,13 @@ docker run -it --rm \
 
 ## 如何切换版本
 
-镜像内置了一个环境切换脚本 `/opt/opensandbox/code-interpreter-env.sh`，你需要使用 `source` 命令加载它来修改当前 Shell
+镜像内置了一个环境切换脚本 `/opt/code-interpreter/code-interpreter-env.sh`，你需要使用 `source` 命令加载它来修改当前 Shell
 的环境变量。
 
 ### 基本用法
 
 ```bash
-source /opt/opensandbox/code-interpreter-env.sh <language> <version>
+source /opt/code-interpreter/code-interpreter-env.sh <language> <version>
 ```
 
 ### 示例
@@ -79,7 +79,7 @@ source /opt/opensandbox/code-interpreter-env.sh <language> <version>
 
 ```bash
 # 切换到 Python 3.11
-source /opt/opensandbox/code-interpreter-env.sh python 3.11
+source /opt/code-interpreter/code-interpreter-env.sh python 3.11
 python3 --version
 # Output: Python 3.11.x
 ```
@@ -88,7 +88,7 @@ python3 --version
 
 ```bash
 # 切换到 Java 8
-source /opt/opensandbox/code-interpreter-env.sh java 8
+source /opt/code-interpreter/code-interpreter-env.sh java 8
 java -version
 ```
 
@@ -96,7 +96,7 @@ java -version
 
 ```bash
 # 切换到 Node 22
-source /opt/opensandbox/code-interpreter-env.sh node 22
+source /opt/code-interpreter/code-interpreter-env.sh node 22
 node -v
 ```
 
@@ -104,7 +104,7 @@ node -v
 
 ```bash
 # 切换到 Go 1.25
-source /opt/opensandbox/code-interpreter-env.sh go 1.25
+source /opt/code-interpreter/code-interpreter-env.sh go 1.25
 go version
 ```
 
@@ -114,16 +114,16 @@ go version
 
 ```bash
 # 查看所有 Python 版本
-source /opt/opensandbox/code-interpreter-env.sh python
+source /opt/code-interpreter/code-interpreter-env.sh python
 
 # 查看所有 Java 版本
-source /opt/opensandbox/code-interpreter-env.sh java
+source /opt/code-interpreter/code-interpreter-env.sh java
 
 # 查看所有 Node.js 版本
-source /opt/opensandbox/code-interpreter-env.sh node
+source /opt/code-interpreter/code-interpreter-env.sh node
 
 # 查看所有 Go 版本
-source /opt/opensandbox/code-interpreter-env.sh go
+source /opt/code-interpreter/code-interpreter-env.sh go
 ```
 
 ## 默认版本
@@ -152,7 +152,7 @@ source /opt/opensandbox/code-interpreter-env.sh go
 ### 启动 Jupyter
 
 ```bash
-/opt/opensandbox/code-interpreter.sh
+/opt/code-interpreter/code-interpreter.sh
 ```
 
 ### 环境变量

--- a/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter-env.sh
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 # This script is used to switch versions of different languages in the OpenSandbox environment
-# Usage: source /opt/opensandbox/code-interpreter-env.sh <language> <version>
+# Usage: source /opt/code-interpreter/code-interpreter-env.sh <language> <version>
 # Examples:
-#   source /opt/opensandbox/code-interpreter-env.sh python 3.13
-#   source /opt/opensandbox/code-interpreter-env.sh java 21
-#   source /opt/opensandbox/code-interpreter-env.sh node 22
-#   source /opt/opensandbox/code-interpreter-env.sh go 1.25
+#   source /opt/code-interpreter/code-interpreter-env.sh python 3.13
+#   source /opt/code-interpreter/code-interpreter-env.sh java 21
+#   source /opt/code-interpreter/code-interpreter-env.sh node 22
+#   source /opt/code-interpreter/code-interpreter-env.sh go 1.25
 
 function usage() {
 	echo "Usage: source code-interpreter-env.sh <language> <version>"

--- a/sandboxes/code-interpreter/scripts/code-interpreter.sh
+++ b/sandboxes/code-interpreter/scripts/code-interpreter.sh
@@ -62,41 +62,41 @@ record_env_selection() {
 	tmp_file=$(mktemp)
 
 	if [ -f "$BASHRC_FILE" ]; then
-		grep -vE "^source /opt/opensandbox/code-interpreter-env.sh ${lang}(\\s|$)" "$BASHRC_FILE" >"$tmp_file" || true
+		grep -vE "^source /opt/code-interpreter/code-interpreter-env.sh ${lang}(\\s|$)" "$BASHRC_FILE" >"$tmp_file" || true
 	else
 		: >"$tmp_file"
 	fi
 
-	echo "source /opt/opensandbox/code-interpreter-env.sh ${lang} ${version}" >>"$tmp_file"
+	echo "source /opt/code-interpreter/code-interpreter-env.sh ${lang} ${version}" >>"$tmp_file"
 	mv "$tmp_file" "$BASHRC_FILE"
 }
 
 if [ -n "${PYTHON_VERSION:-}" ]; then
-	source /opt/opensandbox/code-interpreter-env.sh python "${PYTHON_VERSION}"
+	source /opt/code-interpreter/code-interpreter-env.sh python "${PYTHON_VERSION}"
 	record_env_selection python "${PYTHON_VERSION}"
 else
-	source /opt/opensandbox/code-interpreter-env.sh python
+	source /opt/code-interpreter/code-interpreter-env.sh python
 fi
 
 if [ -n "${JAVA_VERSION:-}" ]; then
-	source /opt/opensandbox/code-interpreter-env.sh java "${JAVA_VERSION}"
+	source /opt/code-interpreter/code-interpreter-env.sh java "${JAVA_VERSION}"
 	record_env_selection java "${JAVA_VERSION}"
 else
-	source /opt/opensandbox/code-interpreter-env.sh java
+	source /opt/code-interpreter/code-interpreter-env.sh java
 fi
 
 if [ -n "${NODE_VERSION:-}" ]; then
-	source /opt/opensandbox/code-interpreter-env.sh node "${NODE_VERSION}"
+	source /opt/code-interpreter/code-interpreter-env.sh node "${NODE_VERSION}"
 	record_env_selection node "${NODE_VERSION}"
 else
-	source /opt/opensandbox/code-interpreter-env.sh node
+	source /opt/code-interpreter/code-interpreter-env.sh node
 fi
 
 if [ -n "${GO_VERSION:-}" ]; then
-	source /opt/opensandbox/code-interpreter-env.sh go "${GO_VERSION}"
+	source /opt/code-interpreter/code-interpreter-env.sh go "${GO_VERSION}"
 	record_env_selection go "${GO_VERSION}"
 else
-	source /opt/opensandbox/code-interpreter-env.sh go
+	source /opt/code-interpreter/code-interpreter-env.sh go
 fi
 
 setup_python() {
@@ -167,4 +167,4 @@ pids+=($!)
 setup_bash &
 pids+=($!)
 
-jupyter notebook --ip=127.0.0.1 --port="${JUPYTER_PORT:-44771}" --allow-root --no-browser --NotebookApp.token="${JUPYTER_TOKEN:-opensandboxcodeinterpreterjupyter}" >/opt/opensandbox/jupyter.log
+jupyter notebook --ip=127.0.0.1 --port="${JUPYTER_PORT:-44771}" --allow-root --no-browser --NotebookApp.token="${JUPYTER_TOKEN:-opensandboxcodeinterpreterjupyter}" >/opt/code-interpreter/jupyter.log

--- a/sdks/code-interpreter/csharp/README.md
+++ b/sdks/code-interpreter/csharp/README.md
@@ -41,7 +41,7 @@ try
     {
         ConnectionConfig = config,
         Image = "opensandbox/code-interpreter:v1.0.2",
-        Entrypoint = new[] { "/opt/opensandbox/code-interpreter.sh" },
+        Entrypoint = new[] { "/opt/code-interpreter/code-interpreter.sh" },
         Env = new Dictionary<string, string>
         {
             ["PYTHON_VERSION"] = "3.11",
@@ -89,7 +89,7 @@ await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
 {
     ConnectionConfig = new ConnectionConfig(),
     Image = "opensandbox/code-interpreter:v1.0.2",
-    Entrypoint = new[] { "/opt/opensandbox/code-interpreter.sh" },
+    Entrypoint = new[] { "/opt/code-interpreter/code-interpreter.sh" },
     Diagnostics = new SdkDiagnosticsOptions
     {
         LoggerFactory = loggerFactory

--- a/sdks/code-interpreter/csharp/README_zh.md
+++ b/sdks/code-interpreter/csharp/README_zh.md
@@ -48,7 +48,7 @@ await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
 {
     ConnectionConfig = config,
     Image = "opensandbox/code-interpreter:v1.0.2",
-    Entrypoint = new[] { "/opt/opensandbox/code-interpreter.sh" },
+    Entrypoint = new[] { "/opt/code-interpreter/code-interpreter.sh" },
     Env = new Dictionary<string, string>
     {
         ["PYTHON_VERSION"] = "3.11",
@@ -132,7 +132,7 @@ await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
 {
     ConnectionConfig = config,
     Image = "opensandbox/code-interpreter:v1.0.2",
-    Entrypoint = new[] { "/opt/opensandbox/code-interpreter.sh" },
+    Entrypoint = new[] { "/opt/code-interpreter/code-interpreter.sh" },
     Env = new Dictionary<string, string>
     {
         ["JAVA_VERSION"] = "17",

--- a/sdks/code-interpreter/javascript/README.md
+++ b/sdks/code-interpreter/javascript/README.md
@@ -50,7 +50,7 @@ const config = new ConnectionConfig({
 const sandbox = await Sandbox.create({
   connectionConfig: config,
   image: "opensandbox/code-interpreter:v1.0.2",
-  entrypoint: ["/opt/opensandbox/code-interpreter.sh"],
+  entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
   env: {
     PYTHON_VERSION: "3.11",
     JAVA_VERSION: "17",
@@ -100,7 +100,7 @@ You can specify the desired version of a programming language by setting the cor
 const sandbox = await Sandbox.create({
   connectionConfig: config,
   image: "opensandbox/code-interpreter:v1.0.2",
-  entrypoint: ["/opt/opensandbox/code-interpreter.sh"],
+  entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
   env: {
     JAVA_VERSION: "17",
     GO_VERSION: "1.24",

--- a/sdks/code-interpreter/javascript/README_zh.md
+++ b/sdks/code-interpreter/javascript/README_zh.md
@@ -50,7 +50,7 @@ const config = new ConnectionConfig({
 const sandbox = await Sandbox.create({
   connectionConfig: config,
   image: "opensandbox/code-interpreter:v1.0.2",
-  entrypoint: ["/opt/opensandbox/code-interpreter.sh"],
+  entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
   env: {
     PYTHON_VERSION: "3.11",
     JAVA_VERSION: "17",
@@ -100,7 +100,7 @@ Code Interpreter SDK 依赖于特定的运行环境。请确保你的沙箱服�
 const sandbox = await Sandbox.create({
   connectionConfig: config,
   image: "opensandbox/code-interpreter:v1.0.2",
-  entrypoint: ["/opt/opensandbox/code-interpreter.sh"],
+  entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
   env: {
     JAVA_VERSION: "17",
     GO_VERSION: "1.24",

--- a/sdks/code-interpreter/kotlin/README.md
+++ b/sdks/code-interpreter/kotlin/README.md
@@ -56,7 +56,7 @@ public class QuickStart {
         try (Sandbox sandbox = Sandbox.builder()
                 .connectionConfig(config)
                 .image("opensandbox/code-interpreter:v1.0.2")
-                .entrypoint("/opt/opensandbox/code-interpreter.sh")
+                .entrypoint("/opt/code-interpreter/code-interpreter.sh")
                 .env("PYTHON_VERSION", "3.11") // Select specific language version
                 .build()) {
 
@@ -112,7 +112,7 @@ Code Interpreter entrypoint:
 ```java
 Sandbox sandbox = Sandbox.builder()
     .image("opensandbox/code-interpreter:v1.0.2")
-    .entrypoint("/opt/opensandbox/code-interpreter.sh")
+    .entrypoint("/opt/code-interpreter/code-interpreter.sh")
     .env("PYTHON_VERSION", "3.11")
     .build();
 ```
@@ -138,7 +138,7 @@ You can specify the desired version of a programming language by setting the cor
 ```java
 Sandbox sandbox = Sandbox.builder()
     .image("opensandbox/code-interpreter:v1.0.2")
-    .entrypoint("/opt/opensandbox/code-interpreter.sh")
+    .entrypoint("/opt/code-interpreter/code-interpreter.sh")
     .env("JAVA_VERSION", "17")
     .env("GO_VERSION", "1.23")
     .build();

--- a/sdks/code-interpreter/kotlin/README_zh.md
+++ b/sdks/code-interpreter/kotlin/README_zh.md
@@ -56,7 +56,7 @@ public class QuickStart {
         try (Sandbox sandbox = Sandbox.builder()
                 .connectionConfig(config)
                 .image("sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.2")
-                .entrypoint("/opt/opensandbox/code-interpreter.sh")
+                .entrypoint("/opt/code-interpreter/code-interpreter.sh")
                 .env("PYTHON_VERSION", "3.11") // 指定语言版本
                 .build()) {
 
@@ -111,7 +111,7 @@ Code Interpreter SDK 依赖于特定的运行环境。请确保你的沙箱服�
 ```java
 Sandbox sandbox = Sandbox.builder()
     .image("opensandbox/code-interpreter:v1.0.2")
-    .entrypoint("/opt/opensandbox/code-interpreter.sh")
+    .entrypoint("/opt/code-interpreter/code-interpreter.sh")
     .env("PYTHON_VERSION", "3.11")
     .build();
 ```
@@ -135,7 +135,7 @@ Sandbox sandbox = Sandbox.builder()
 ```java
 Sandbox sandbox = Sandbox.builder()
     .image("opensandbox/code-interpreter:v1.0.2")
-    .entrypoint("/opt/opensandbox/code-interpreter.sh")
+    .entrypoint("/opt/code-interpreter/code-interpreter.sh")
     .env("JAVA_VERSION", "17")
     .env("GO_VERSION", "1.23")
     .build();

--- a/sdks/code-interpreter/python/README.md
+++ b/sdks/code-interpreter/python/README.md
@@ -54,7 +54,7 @@ async def main() -> None:
     sandbox = await Sandbox.create(
         "opensandbox/code-interpreter:v1.0.2",
         connection_config=config,
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
         env={
             "PYTHON_VERSION": "3.11",
             "JAVA_VERSION": "17",
@@ -115,7 +115,7 @@ config = ConnectionConfigSync(
 sandbox = SandboxSync.create(
     "opensandbox/code-interpreter:v1.0.2",
     connection_config=config,
-    entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+    entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
     env={"PYTHON_VERSION": "3.11"},
 )
 with sandbox:

--- a/sdks/code-interpreter/python/README_zh.md
+++ b/sdks/code-interpreter/python/README_zh.md
@@ -50,7 +50,7 @@ async def main() -> None:
     sandbox = await Sandbox.create(
         "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.2",
         connection_config=config,
-        entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+        entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
         env={
             "PYTHON_VERSION": "3.11",
             "JAVA_VERSION": "17",
@@ -110,7 +110,7 @@ config = ConnectionConfigSync(
 sandbox = SandboxSync.create(
     "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.2",
     connection_config=config,
-    entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+    entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
     env={"PYTHON_VERSION": "3.11"},
 )
 with sandbox:

--- a/sdks/sandbox/go/code_interpreter.go
+++ b/sdks/sandbox/go/code_interpreter.go
@@ -23,7 +23,7 @@ import (
 const CodeInterpreterImage = "opensandbox/code-interpreter:latest"
 
 // CodeInterpreterEntrypoint is the default entrypoint for the code interpreter.
-var CodeInterpreterEntrypoint = []string{"/opt/opensandbox/code-interpreter.sh"}
+var CodeInterpreterEntrypoint = []string{"/opt/code-interpreter/code-interpreter.sh"}
 
 // CodeInterpreterCreateOptions configures code interpreter creation.
 type CodeInterpreterCreateOptions struct {

--- a/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/CodeInterpreterE2ETests.cs
@@ -671,7 +671,7 @@ public sealed class CodeInterpreterE2ETestFixture : IAsyncLifetime
         {
             ConnectionConfig = _baseFixture.ConnectionConfig,
             Image = _baseFixture.DefaultImage,
-            Entrypoint = new[] { "/opt/opensandbox/code-interpreter.sh" },
+            Entrypoint = new[] { "/opt/code-interpreter/code-interpreter.sh" },
             TimeoutSeconds = _baseFixture.DefaultTimeoutSeconds,
             ReadyTimeoutSeconds = _baseFixture.DefaultReadyTimeoutSeconds,
             Resource = new Dictionary<string, string>

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CodeInterpreterE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CodeInterpreterE2ETest.java
@@ -131,7 +131,7 @@ public class CodeInterpreterE2ETest extends BaseE2ETest {
         sandbox =
                 Sandbox.builder()
                         .connectionConfig(sharedConnectionConfig)
-                        .entrypoint(List.of("/opt/opensandbox/code-interpreter.sh"))
+                        .entrypoint(List.of("/opt/code-interpreter/code-interpreter.sh"))
                         .image(getSandboxImage())
                         .resource(java.util.Map.of("cpu", "2", "memory", "4Gi"))
                         .timeout(Duration.ofMinutes(20))

--- a/tests/javascript/tests/test_code_interpreter_e2e.test.ts
+++ b/tests/javascript/tests/test_code_interpreter_e2e.test.ts
@@ -39,7 +39,7 @@ function sandboxCreateOptions() {
   return {
     connectionConfig: createConnectionConfig(),
     image: getSandboxImage(),
-    entrypoint: ["/opt/opensandbox/code-interpreter.sh"],
+    entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
     timeoutSeconds: 15 * 60,
     readyTimeoutSeconds: 60,
     metadata: { tag: "e2e-code-interpreter" },

--- a/tests/python/tests/test_code_interpreter_e2e.py
+++ b/tests/python/tests/test_code_interpreter_e2e.py
@@ -367,7 +367,7 @@ class TestCodeInterpreterE2E:
         connection_config = create_connection_config()
         sandbox = await Sandbox.create(
             image=SandboxImageSpec(get_sandbox_image()),
-            entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+            entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
             connection_config=connection_config,
             resource=get_e2e_sandbox_resource(),
             timeout=timedelta(minutes=15),
@@ -420,7 +420,7 @@ class TestCodeInterpreterE2E:
 
         cls.sandbox = await Sandbox.create(
             image=SandboxImageSpec(get_sandbox_image()),
-            entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+            entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
             connection_config=cls.connection_config,
             resource=get_e2e_sandbox_resource(),
             timeout=timedelta(minutes=15),

--- a/tests/python/tests/test_code_interpreter_e2e_sync.py
+++ b/tests/python/tests/test_code_interpreter_e2e_sync.py
@@ -294,7 +294,7 @@ class TestCodeInterpreterE2ESync:
         connection_config = create_connection_config_sync()
         sandbox = SandboxSync.create(
             image=SandboxImageSpec(get_sandbox_image()),
-            entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+            entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
             connection_config=connection_config,
             resource=get_e2e_sandbox_resource(),
             timeout=timedelta(minutes=15),
@@ -346,7 +346,7 @@ class TestCodeInterpreterE2ESync:
 
         cls.sandbox = SandboxSync.create(
             image=SandboxImageSpec(get_sandbox_image()),
-            entrypoint=["/opt/opensandbox/code-interpreter.sh"],
+            entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
             connection_config=cls.connection_config,
             resource=get_e2e_sandbox_resource(),
             timeout=timedelta(minutes=15),


### PR DESCRIPTION
## Summary

Migrate all code-interpreter paths from `/opt/opensandbox/` to `/opt/code-interpreter/`, unifying the directory structure under `/opt/code-interpreter` for architectural consistency with the injection point `/opt/opensandbox`.

## Breaking Change

This is a **breaking change**. The following paths are removed:

| Removed path | Replacement |
|---|---|
| `/opt/opensandbox/code-interpreter.sh` | `/opt/code-interpreter/code-interpreter.sh` |
| `/opt/opensandbox/code-interpreter-env.sh` | `/opt/code-interpreter/code-interpreter-env.sh` |
| `/opt/opensandbox/jupyter.log` | `/opt/code-interpreter/jupyter.log` |

## Migration Guide

### If you use `opensandbox/code-interpreter:latest`

Update your sandbox creation to use the new entrypoint:

```python
# Before
sandbox = client.create_sandbox(
    image="opensandbox/code-interpreter:latest",
    entrypoint=["/opt/opensandbox/code-interpreter.sh"],
)

# After
sandbox = client.create_sandbox(
    image="opensandbox/code-interpreter:latest",
    entrypoint=["/opt/code-interpreter/code-interpreter.sh"],
)
```

### If you pin a specific tag (e.g., `v1.0.2`)

No action needed — existing tagged images are immutable and continue to work with `/opt/opensandbox/code-interpreter.sh`. Only switch to the new path when upgrading to a tag that includes this change.

### If you source the env script interactively

```bash
# Before
source /opt/opensandbox/code-interpreter-env.sh python 3.14

# After
source /opt/code-interpreter/code-interpreter-env.sh python 3.14
```

### If you use the Go SDK (`sdks/sandbox/go`)

The `CodeInterpreterEntrypoint` constant has been updated. If you use `CreateCodeInterpreter()` without explicitly setting `Entrypoint`, no change needed. If you hardcoded the old path, update to the new constant.

## Changed Files

25 files: Dockerfiles, entrypoint scripts, SDK constants, E2E tests, examples, and READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)