### PR TITLE
fix(js-sdk): accept empty background log tails

### DIFF
--- a/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/commandsAdapter.ts
@@ -38,8 +38,6 @@ type ApiRunCommandRequest =
   ExecdPaths["/command"]["post"]["requestBody"]["content"]["application/json"];
 type ApiCommandStatusOk =
   ExecdPaths["/command/status/{id}"]["get"]["responses"][200]["content"]["application/json"];
-type ApiCommandLogsOk =
-  ExecdPaths["/command/{id}/logs"]["get"]["responses"][200]["content"]["text/plain"];
 type ApiCreateSessionRequest =
   NonNullable<ExecdPaths["/session"]["post"]["requestBody"]>["content"]["application/json"];
 type ApiCreateSessionOk =
@@ -249,14 +247,20 @@ export class CommandsAdapter implements ExecdCommands {
       parseAs: "text",
     });
     throwOnOpenApiFetchError({ error, response }, "Get command logs failed");
-    const ok = data as ApiCommandLogsOk | undefined;
-    if (typeof ok !== "string") {
+
+    let content: string;
+    if (typeof data === "string") {
+      content = data;
+    } else if (data == null && response.ok) {
+      content = "";
+    } else {
       throw new Error("Get command logs failed: unexpected response shape");
     }
+
     const cursorHeader = response.headers.get("EXECD-COMMANDS-TAIL-CURSOR");
-    const parsedCursor = (cursorHeader != null && cursorHeader !== "") ? Number(cursorHeader) : undefined;
+    const parsedCursor = cursorHeader != null && cursorHeader !== "" ? Number(cursorHeader) : undefined;
     return {
-      content: ok,
+      content,
       cursor: Number.isFinite(parsedCursor ?? NaN) ? parsedCursor : undefined,
     };
   }

--- a/sdks/sandbox/javascript/tests/commands.get-logs-empty-tail.test.mjs
+++ b/sdks/sandbox/javascript/tests/commands.get-logs-empty-tail.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { CommandsAdapter, createExecdClient } from "../dist/internal.js";
 
-function createAdapter({ body = "", cursor = "42" } = {}) {
+function createTransportAdapter({ body = "", cursor = "42" } = {}) {
   const client = createExecdClient({
     baseUrl: "http://127.0.0.1:8080",
     async fetch(request) {
@@ -24,8 +24,40 @@ function createAdapter({ body = "", cursor = "42" } = {}) {
   });
 }
 
-test("CommandsAdapter.getBackgroundCommandLogs accepts an empty tail body", async () => {
-  const adapter = createAdapter({ body: "", cursor: "42" });
+function createNullBodyAdapter({ cursor = "42" } = {}) {
+  return new CommandsAdapter(
+    {
+      async GET() {
+        return {
+          data: null,
+          error: undefined,
+          response: new Response(null, {
+            status: 200,
+            headers: {
+              "content-type": "text/plain",
+              "EXECD-COMMANDS-TAIL-CURSOR": cursor,
+            },
+          }),
+        };
+      },
+    },
+    {
+      baseUrl: "http://127.0.0.1:8080",
+    },
+  );
+}
+
+test("CommandsAdapter.getBackgroundCommandLogs accepts an empty transport body", async () => {
+  const adapter = createTransportAdapter({ body: "", cursor: "42" });
+
+  const logs = await adapter.getBackgroundCommandLogs("cmd-1", 42);
+
+  assert.equal(logs.content, "");
+  assert.equal(logs.cursor, 42);
+});
+
+test("CommandsAdapter.getBackgroundCommandLogs accepts a null parsed body on 200 responses", async () => {
+  const adapter = createNullBodyAdapter({ cursor: "42" });
 
   const logs = await adapter.getBackgroundCommandLogs("cmd-1", 42);
 

--- a/sdks/sandbox/javascript/tests/commands.get-logs-empty-tail.test.mjs
+++ b/sdks/sandbox/javascript/tests/commands.get-logs-empty-tail.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CommandsAdapter, createExecdClient } from "../dist/internal.js";
+
+function createAdapter({ body = "", cursor = "42" } = {}) {
+  const client = createExecdClient({
+    baseUrl: "http://127.0.0.1:8080",
+    async fetch(request) {
+      assert.equal(new URL(request.url).pathname, "/command/cmd-1/logs");
+      assert.equal(new URL(request.url).searchParams.get("cursor"), "42");
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          "EXECD-COMMANDS-TAIL-CURSOR": cursor,
+        },
+      });
+    },
+  });
+
+  return new CommandsAdapter(client, {
+    baseUrl: "http://127.0.0.1:8080",
+  });
+}
+
+test("CommandsAdapter.getBackgroundCommandLogs accepts an empty tail body", async () => {
+  const adapter = createAdapter({ body: "", cursor: "42" });
+
+  const logs = await adapter.getBackgroundCommandLogs("cmd-1", 42);
+
+  assert.equal(logs.content, "");
+  assert.equal(logs.cursor, 42);
+});


### PR DESCRIPTION
## Summary
- accept successful empty `GET /command/{id}/logs` responses as an empty log chunk instead of throwing `unexpected response shape`
- keep parsing the tail cursor header so callers can continue polling from the returned offset
- add a regression test covering an empty-tail poll at the current cursor

## Testing
- `cd sdks && pnpm install --frozen-lockfile`
- `cd sdks/sandbox/javascript && pnpm run build`
- `cd sdks/sandbox/javascript && pnpm test`
- `cd sdks/sandbox/javascript && pnpm run lint`
- `cd sdks/sandbox/javascript && pnpm run typecheck`
