### PR TITLE
refactor: flatten execd install path and unify bootstrap.sh

### DIFF
--- a/docs/execd-path-migration.md
+++ b/docs/execd-path-migration.md
@@ -31,24 +31,34 @@ and chained commands.
 
 | User profile | Impact |
 |---|---|
-| **code-interpreter SDK users** | Must upgrade to code-interpreter `>=v1.1.0` |
+| **code-interpreter image `<=v1.0.2`** | **Must upgrade to `v1.1.0`** — emptyDir at `/opt/opensandbox` shadows old scripts under `/opt/opensandbox/` |
 | **Pool CR with custom templates** | Must update execd init container paths and volume mount |
 | **Custom execd images** | Must now include `/bootstrap.sh` alongside `/execd` |
 | **Docker runtime users (default)** | No manual action — bootstrap.sh is auto-installed |
-| **Kubernetes runtime via server (no Pool CR)** | No action — paths are built programmatically |
 
 ## Migration steps
 
-### 1. code-interpreter SDK
+### 1. code-interpreter image
 
-Upgrade to v1.1.0 or later:
+**Must upgrade the image from `v1.0.2` to `v1.1.0`.**
 
-```bash
-pip install --upgrade opensandbox-code-interpreter>=1.1.0
+In code-interpreter `v1.0.2`, the entrypoint scripts (`code-interpreter.sh`,
+`code-interpreter-env.sh`) live directly under `/opt/opensandbox/`. Before this PR,
+the emptyDir volume was mounted at `/opt/opensandbox/bin/`, shadowing only that
+subdirectory. Now the emptyDir mounts at `/opt/opensandbox/`, shadowing the entire
+directory — including those scripts. The pod starts but cannot find its own entrypoint.
+
+[PR #1012](https://github.com/opensandbox-group/OpenSandbox/pull/1012) moved all
+code-interpreter scripts from `/opt/opensandbox/` to `/opt/code-interpreter/`,
+avoiding the conflict. Version `v1.1.0` is the first image with that change.
+
+```yaml
+# In your Pool CR or sandbox creation request:
+image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.1.0
 ```
 
-SDK versions before v1.1.0 internally reference `/opt/opensandbox/bin/task-executor` and
-will fail when running against the updated server.
+The Python SDK (`opensandbox-code-interpreter`) does not require an upgrade — it
+communicates with execd over the network and does not reference filesystem paths.
 
 ### 2. Pool CR template
 
@@ -144,7 +154,7 @@ template referencing them will fail with "file not found".
 
 | Scenario | Failure mode |
 |---|---|
-| Old code-interpreter SDK version | `task-executor` not found; sandbox enters error state |
+| Old code-interpreter image (`<=v1.0.2`) | emptyDir at `/opt/opensandbox` shadows `code-interpreter.sh`; pod starts but entrypoint not found |
 | Old Pool CR template | execd init container succeeds (it copies to its own mount), but main container cannot find `/opt/opensandbox/bin/bootstrap.sh` |
 | Old custom execd image (no bootstrap.sh) | Docker sandbox creation fails with "bootstrap.sh not found in execd image cache" |
 
@@ -167,7 +177,7 @@ For release note authors: include a summary that links to this document.
 ### Breaking: execd install path flattened
 
 execd and bootstrap.sh are now installed to `/opt/opensandbox/` instead of
-`/opt/opensandbox/bin/`. code-interpreter SDK users must upgrade to `>=v1.1.0`.
+`/opt/opensandbox/bin/`. code-interpreter image users must upgrade to `>=v1.1.0`.
 Custom Pool CR templates and custom execd images require updates.
 
 See [execd Path Migration Guide](docs/execd-path-migration.md) for full details.

--- a/docs/execd-path-migration.md
+++ b/docs/execd-path-migration.md
@@ -1,0 +1,174 @@
+# execd Path Migration Guide
+
+PR: [#1014](https://github.com/opensandbox-group/OpenSandbox/pull/1014)
+
+## Background
+
+OpenSandbox previously installed execd and bootstrap.sh to `/opt/opensandbox/bin/`, creating
+unnecessary nesting. The execd image already places these artifacts at the root:
+
+```
+/execd
+/bootstrap.sh
+```
+
+While bootstrap.sh defaults to `EXECD=/opt/opensandbox/execd` (no `bin/`), the Kubernetes
+provider and Pool CR templates historically injected files into a `bin/` subdirectory. This
+PR flattens the layout:
+
+| Before | After |
+|---|---|
+| `/opt/opensandbox/bin/execd` | `/opt/opensandbox/execd` |
+| `/opt/opensandbox/bin/bootstrap.sh` | `/opt/opensandbox/bootstrap.sh` |
+| `/opt/opensandbox/bin/task-executor` | `/opt/opensandbox/task-executor` |
+
+Additionally, the Docker runtime now uses the **full** `bootstrap.sh` from the execd image
+instead of a minimal 15-line inline-generated shim. This gives Docker sandboxes the same
+capabilities as Kubernetes: MITM CA trust setup, SIGTERM forwarding, pre-script sourcing,
+and chained commands.
+
+## Who is affected
+
+| User profile | Impact |
+|---|---|
+| **code-interpreter SDK users** | Must upgrade to code-interpreter `>=v1.1.0` |
+| **Pool CR with custom templates** | Must update execd init container paths and volume mount |
+| **Custom execd images** | Must now include `/bootstrap.sh` alongside `/execd` |
+| **Docker runtime users (default)** | No manual action — bootstrap.sh is auto-installed |
+| **Kubernetes runtime via server (no Pool CR)** | No action — paths are built programmatically |
+
+## Migration steps
+
+### 1. code-interpreter SDK
+
+Upgrade to v1.1.0 or later:
+
+```bash
+pip install --upgrade opensandbox-code-interpreter>=1.1.0
+```
+
+SDK versions before v1.1.0 internally reference `/opt/opensandbox/bin/task-executor` and
+will fail when running against the updated server.
+
+### 2. Pool CR template
+
+If you maintain a custom Pool CR that defines the execd init container, update it:
+
+```yaml
+# Before
+initContainers:
+  - name: execd-installer
+    image: opensandbox/execd:latest
+    args:
+      - |
+        cp ./execd /opt/opensandbox/bin/execd &&
+        cp ./bootstrap.sh /opt/opensandbox/bin/bootstrap.sh &&
+        chmod +x /opt/opensandbox/bin/execd &&
+        chmod +x /opt/opensandbox/bin/bootstrap.sh
+    volumeMounts:
+      - name: opensandbox-bin
+        mountPath: /opt/opensandbox/bin
+
+# After
+initContainers:
+  - name: execd-installer
+    image: opensandbox/execd:latest
+    args:
+      - |
+        cp ./execd /opt/opensandbox/execd &&
+        cp ./bootstrap.sh /opt/opensandbox/bootstrap.sh &&
+        chmod +x /opt/opensandbox/execd &&
+        chmod +x /opt/opensandbox/bootstrap.sh
+    volumeMounts:
+      - name: opensandbox-bin
+        mountPath: /opt/opensandbox
+```
+
+The same update applies to the task-executor init container if used:
+
+```yaml
+# Before
+cp /workspace/server /opt/opensandbox/bin/task-executor && chmod +x /opt/opensandbox/bin/task-executor
+# After
+cp /workspace/server /opt/opensandbox/task-executor && chmod +x /opt/opensandbox/task-executor
+```
+
+And the main container's env vars and volume mount:
+
+```yaml
+# Before
+- name: EXECD
+  value: /opt/opensandbox/bin/execd
+volumeMounts:
+  - name: opensandbox-bin
+    mountPath: /opt/opensandbox/bin
+
+# After
+- name: EXECD
+  value: /opt/opensandbox/execd
+volumeMounts:
+  - name: opensandbox-bin
+    mountPath: /opt/opensandbox
+```
+
+### 3. Custom execd images (Docker)
+
+If you override `[runtime].execd_image` with a custom image, that image must now
+contain `/bootstrap.sh` **in addition to** `/execd`. Previously only `/execd` was
+required because the Docker runtime generated a minimal inline bootstrap script.
+
+If your custom execd image is built from a Dockerfile that only copies the execd
+binary, add bootstrap.sh:
+
+```dockerfile
+COPY bootstrap.sh /bootstrap.sh
+```
+
+The official `opensandbox/execd` image already includes both files and requires
+no change.
+
+### 4. Custom entrypoint scripts
+
+If you hardcode `/opt/opensandbox/bin/execd` or `/opt/opensandbox/bin/bootstrap.sh`
+in entrypoint scripts or build pipelines, update those references to `/opt/opensandbox/`.
+
+## Compatibility
+
+### Old paths are not available
+
+After this change, the paths `/opt/opensandbox/bin/execd` and
+`/opt/opensandbox/bin/bootstrap.sh` no longer exist. Any script, tool, or
+template referencing them will fail with "file not found".
+
+### How failures manifest
+
+| Scenario | Failure mode |
+|---|---|
+| Old code-interpreter SDK version | `task-executor` not found; sandbox enters error state |
+| Old Pool CR template | execd init container succeeds (it copies to its own mount), but main container cannot find `/opt/opensandbox/bin/bootstrap.sh` |
+| Old custom execd image (no bootstrap.sh) | Docker sandbox creation fails with "bootstrap.sh not found in execd image cache" |
+
+### Verification
+
+After migration, confirm the sandbox starts successfully:
+
+```bash
+# In a running sandbox:
+ls /opt/opensandbox/execd /opt/opensandbox/bootstrap.sh
+# Both should exist. Verify /opt/opensandbox/bin/ does NOT exist:
+test -d /opt/opensandbox/bin && echo "STALE PATH EXISTS" || echo "OK"
+```
+
+## Release notes
+
+For release note authors: include a summary that links to this document.
+
+```markdown
+### Breaking: execd install path flattened
+
+execd and bootstrap.sh are now installed to `/opt/opensandbox/` instead of
+`/opt/opensandbox/bin/`. code-interpreter SDK users must upgrade to `>=v1.1.0`.
+Custom Pool CR templates and custom execd images require updates.
+
+See [execd Path Migration Guide](docs/execd-path-migration.md) for full details.
+```

--- a/examples/windows/pool-win-example.yaml
+++ b/examples/windows/pool-win-example.yaml
@@ -41,7 +41,7 @@ spec:
             - NET_RAW
           privileged: true
         volumeMounts:
-        - mountPath: /opt/opensandbox/bin
+        - mountPath: /opt/opensandbox
           name: opensandbox-bin
         - mountPath: /oem
           name: opensandbox-win-oem
@@ -61,7 +61,7 @@ spec:
         image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.18
         name: execd-installer
         volumeMounts:
-        - mountPath: /opt/opensandbox/bin
+        - mountPath: /opt/opensandbox
           name: opensandbox-bin
         - mountPath: /oem
           name: opensandbox-win-oem

--- a/kubernetes/charts/opensandbox-server/Chart.yaml
+++ b/kubernetes/charts/opensandbox-server/Chart.yaml
@@ -18,6 +18,7 @@ description: OpenSandbox Lifecycle API server for sandbox creation and managemen
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+# execd bootstrap.sh installed to /opt/opensandbox (flattened from /opt/opensandbox/bin)
 
 keywords:
   - sandbox

--- a/kubernetes/config/samples/sandbox_v1alpha1_pool.yaml
+++ b/kubernetes/config/samples/sandbox_v1alpha1_pool.yaml
@@ -25,23 +25,23 @@ spec:
           command: [ "/bin/sh", "-c" ]
           args:
             - |
-              cp /workspace/server /opt/opensandbox/bin/task-executor && 
-              chmod +x /opt/opensandbox/bin/task-executor
+              cp /workspace/server /opt/opensandbox/task-executor && 
+              chmod +x /opt/opensandbox/task-executor
           volumeMounts:
             - name: opensandbox-bin
-              mountPath: /opt/opensandbox/bin
+              mountPath: /opt/opensandbox
         - name: execd-installer
           image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.18
           command: [ "/bin/sh", "-c" ]
           args:
             - |
-              cp ./execd /opt/opensandbox/bin/execd && 
-              cp ./bootstrap.sh /opt/opensandbox/bin/bootstrap.sh &&
-              chmod +x /opt/opensandbox/bin/execd &&
-              chmod +x /opt/opensandbox/bin/bootstrap.sh
+              cp ./execd /opt/opensandbox/execd && 
+              cp ./bootstrap.sh /opt/opensandbox/bootstrap.sh &&
+              chmod +x /opt/opensandbox/execd &&
+              chmod +x /opt/opensandbox/bootstrap.sh
           volumeMounts:
             - name: opensandbox-bin
-              mountPath: /opt/opensandbox/bin
+              mountPath: /opt/opensandbox
       containers:
         - name: sandbox
           image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.1.0
@@ -49,19 +49,19 @@ spec:
           - "/bin/sh"
           - "-c"
           - |
-            /opt/opensandbox/bin/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
+            /opt/opensandbox/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
           env:
           - name: SANDBOX_MAIN_CONTAINER
             value: main
           - name: EXECD_ENVS
             value: /opt/opensandbox/.env
           - name: EXECD
-            value: /opt/opensandbox/bin/execd
+            value: /opt/opensandbox/execd
           volumeMounts:
             - name: sandbox-storage
               mountPath: /var/lib/sandbox
             - name: opensandbox-bin
-              mountPath: /opt/opensandbox/bin
+              mountPath: /opt/opensandbox
             - name: sandbox-logs
               mountPath: /workspace/logs
       tolerations:

--- a/kubernetes/config/samples/sandbox_v1alpha1_pool_restart.yaml
+++ b/kubernetes/config/samples/sandbox_v1alpha1_pool_restart.yaml
@@ -24,42 +24,42 @@ spec:
             - /bin/sh
             - -c
             - |
-              exec /opt/opensandbox/bin/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
+              exec /opt/opensandbox/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
           env:
             - name: SANDBOX_MAIN_CONTAINER
               value: main
             - name: EXECD_ENVS
               value: /opt/opensandbox/.env
             - name: EXECD
-              value: /opt/opensandbox/bin/execd
+              value: /opt/opensandbox/execd
           image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.1.0
           name: sandbox
           volumeMounts:
             - mountPath: /var/lib/sandbox
               name: sandbox-storage
-            - mountPath: /opt/opensandbox/bin
+            - mountPath: /opt/opensandbox
               name: opensandbox-bin
       initContainers:
         - args:
-            - "cp /workspace/server /opt/opensandbox/bin/task-executor && \nchmod +x /opt/opensandbox/bin/task-executor\n"
+            - "cp /workspace/server /opt/opensandbox/task-executor && \nchmod +x /opt/opensandbox/task-executor\n"
           command:
             - /bin/sh
             - -c
           image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/task-executor:v0.1.0
           name: task-executor-installer
           volumeMounts:
-            - mountPath: /opt/opensandbox/bin
+            - mountPath: /opt/opensandbox
               name: opensandbox-bin
         - args:
-            - "cp ./execd /opt/opensandbox/bin/execd && \ncp ./bootstrap.sh /opt/opensandbox/bin/bootstrap.sh
-          &&\nchmod +x /opt/opensandbox/bin/execd &&\nchmod +x /opt/opensandbox/bin/bootstrap.sh\n"
+            - "cp ./execd /opt/opensandbox/execd && \ncp ./bootstrap.sh /opt/opensandbox/bootstrap.sh
+          &&\nchmod +x /opt/opensandbox/execd &&\nchmod +x /opt/opensandbox/bootstrap.sh\n"
           command:
             - /bin/sh
             - -c
           image: sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd:v1.0.18
           name: execd-installer
           volumeMounts:
-            - mountPath: /opt/opensandbox/bin
+            - mountPath: /opt/opensandbox
               name: opensandbox-bin
       tolerations:
         - operator: Exists

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -154,6 +154,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self.execd_image = runtime_config.execd_image
         self.network_mode = (self.app_config.docker.network_mode or HOST_NETWORK_MODE).lower()
         self._execd_archive_cache: Dict[str, bytes] = {}
+        self._bootstrap_script_cache: Dict[str, bytes] = {}
         self._windows_profile_cache: Dict[str, bytes] = {}
         self._daemon_platform: Optional[PlatformSpec] = None
         self._metadata_store = DockerMetadataStore()
@@ -198,6 +199,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             )
         self._expiration_lock = Lock()
         self._execd_archive_lock = Lock()
+        self._bootstrap_script_lock = Lock()
         self._sandbox_expirations: Dict[str, datetime] = {}
         self._expiration_timers: Dict[str, Timer] = {}
         self._pending_sandboxes: Dict[str, PendingSandbox] = {}

--- a/server/opensandbox_server/services/docker/runtime.py
+++ b/server/opensandbox_server/services/docker/runtime.py
@@ -112,6 +112,11 @@ class DockerRuntimeMixin:
                 with self._docker_operation("execd cache read archive", "execd-cache"):
                     stream, _ = container.get_archive("/execd")
                     data = b"".join(stream)
+                # Also cache the full bootstrap.sh while the container is running.
+                if cache_key not in self._bootstrap_script_cache:
+                    with self._docker_operation("execd cache read bootstrap", "execd-cache"):
+                        bs_stream, _ = container.get_archive("/bootstrap.sh")
+                        self._bootstrap_script_cache[cache_key] = b"".join(bs_stream)
             except DockerException as exc:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -183,43 +188,36 @@ class DockerRuntimeMixin:
                 },
             ) from exc
 
-    def _install_bootstrap_script(self, container, sandbox_id: str) -> None:
-        """Install the bootstrap launcher that starts execd then chains to user command."""
-        script_path = BOOTSTRAP_PATH
-        script_dir = posixpath.dirname(script_path)
-        self._ensure_directory(container, script_dir, sandbox_id)
-        execd_binary = EXECED_INSTALL_PATH
-        script_content = "\n".join(
-            [
-                "#!/bin/sh",
-                "set -e",
-                'if [ -z "${EXECD_ENVS:-}" ]; then',
-                f'  EXECD_ENVS="{DEFAULT_EXECD_ENVS_PATH}"',
-                "fi",
-                'if ! mkdir -p "$(dirname "$EXECD_ENVS")" 2>/dev/null; then',
-                '  echo "warning: failed to create dir for EXECD_ENVS=$EXECD_ENVS" >&2',
-                "fi",
-                'if ! touch "$EXECD_ENVS" 2>/dev/null; then',
-                '  echo "warning: failed to touch EXECD_ENVS=$EXECD_ENVS" >&2',
-                "fi",
-                "export EXECD_ENVS",
-                f"{execd_binary} >/tmp/execd.log 2>&1 &",
-                'exec "$@"',
-                "",
-            ]
-        ).encode("utf-8")
+    def _install_bootstrap_script(
+        self,
+        container,
+        sandbox_id: str,
+        platform: Optional[PlatformSpec] = None,
+    ) -> None:
+        """Install the full bootstrap.sh from the execd image into the sandbox.
 
-        tar_stream = io.BytesIO()
-        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
-            info = tarfile.TarInfo(name=script_path.lstrip("/"))
-            info.mode = 0o755
-            info.size = len(script_content)
-            info.mtime = int(time.time())
-            tar.addfile(info, io.BytesIO(script_content))
-        tar_stream.seek(0)
+        Uses the same execd container that _copy_execd_to_container already
+        created, so there is no extra container lifecycle overhead.
+        """
+        cache_key = self._normalize_platform_key(platform)
+        # _copy_execd_to_container is called first and ensures both the execd
+        # archive and the bootstrap script are already in the caches.
+        archive = self._bootstrap_script_cache.get(cache_key)
+        if archive is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "code": SandboxErrorCodes.BOOTSTRAP_INSTALL_FAILED,
+                    "message": "bootstrap.sh not found in execd image cache",
+                },
+            )
+
+        script_dir = posixpath.dirname(BOOTSTRAP_PATH)
+        self._ensure_directory(container, script_dir, sandbox_id)
+
         try:
             with self._docker_operation("install bootstrap script", sandbox_id):
-                container.put_archive(path="/", data=tar_stream.getvalue())
+                container.put_archive(path=script_dir, data=archive)
         except DockerException as exc:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -237,4 +235,4 @@ class DockerRuntimeMixin:
     ) -> None:
         """Copy execd artifacts and bootstrap launcher into the sandbox container."""
         self._copy_execd_to_container(container, sandbox_id, platform)
-        self._install_bootstrap_script(container, sandbox_id)
+        self._install_bootstrap_script(container, sandbox_id, platform)

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -440,7 +440,7 @@ class BatchSandboxProvider(WorkloadProvider):
     ) -> Dict[str, Any]:
         """Build pool taskTemplate with shell-escaped bootstrap command."""
         escaped_entrypoint = ' '.join(shlex.quote(arg) for arg in entrypoint)
-        user_process_cmd = f"/opt/opensandbox/bin/bootstrap.sh {escaped_entrypoint} &"
+        user_process_cmd = f"/opt/opensandbox/bootstrap.sh {escaped_entrypoint} &"
         
         wrapped_command = ["/bin/sh", "-c", user_process_cmd]
 

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -115,10 +115,10 @@ def _build_execd_init_container(
     disable_ipv6_for_egress: bool = False,
 ) -> V1Container:
     script = (
-        "cp ./execd /opt/opensandbox/bin/execd && "
-        "cp ./bootstrap.sh /opt/opensandbox/bin/bootstrap.sh && "
-        "chmod +x /opt/opensandbox/bin/execd && "
-        "chmod +x /opt/opensandbox/bin/bootstrap.sh"
+        "cp ./execd /opt/opensandbox/execd && "
+        "cp ./bootstrap.sh /opt/opensandbox/bootstrap.sh && "
+        "chmod +x /opt/opensandbox/execd && "
+        "chmod +x /opt/opensandbox/bootstrap.sh"
     )
     security_context = None
     if disable_ipv6_for_egress:
@@ -140,7 +140,7 @@ def _build_execd_init_container(
         volume_mounts=[
             V1VolumeMount(
                 name="opensandbox-bin",
-                mount_path="/opt/opensandbox/bin",
+                mount_path="/opt/opensandbox",
             )
         ],
         resources=resources,
@@ -158,7 +158,7 @@ def _build_main_container(
     image_pull_policy: Optional[str] = None,
 ) -> V1Container:
     env_vars = [V1EnvVar(name=k, value=v) for k, v in env.items()]
-    env_vars.append(V1EnvVar(name="EXECD", value="/opt/opensandbox/bin/execd"))
+    env_vars.append(V1EnvVar(name="EXECD", value="/opt/opensandbox/execd"))
 
     translated_limits = _translate_resource_limits_for_k8s(resource_limits)
     resources = None
@@ -171,7 +171,7 @@ def _build_main_container(
     volume_mounts = [
         V1VolumeMount(
             name="opensandbox-bin",
-            mount_path="/opt/opensandbox/bin",
+            mount_path="/opt/opensandbox",
         )
     ]
 
@@ -184,7 +184,7 @@ def _build_main_container(
         name="sandbox",
         image=image_spec.uri,
         image_pull_policy=image_pull_policy,
-        command=["/opt/opensandbox/bin/bootstrap.sh"] + entrypoint,
+        command=["/opt/opensandbox/bootstrap.sh"] + entrypoint,
         env=env_vars if env_vars else None,
         resources=resources,
         volume_mounts=volume_mounts,

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -463,7 +463,7 @@ spec:
         main_container = body["spec"]["template"]["spec"]["containers"][0]
         
         assert main_container["command"] == [
-            "/opt/opensandbox/bin/bootstrap.sh",
+            "/opt/opensandbox/bootstrap.sh",
             "/usr/bin/python",
             "app.py"
         ]
@@ -495,7 +495,7 @@ spec:
         assert env_dict["FOO"] == "bar"
         assert env_dict["BAZ"] == "qux"
         # Verify EXECD is automatically injected
-        assert env_dict["EXECD"] == "/opt/opensandbox/bin/execd"
+        assert env_dict["EXECD"] == "/opt/opensandbox/execd"
 
     def test_create_workload_merges_template_volumes_and_mounts(self, mock_k8s_client, tmp_path):
         template_file = tmp_path / "template.yaml"
@@ -564,7 +564,7 @@ spec:
         - name: sandbox
           volumeMounts:
             - name: opensandbox-bin
-              mountPath: /opt/opensandbox/bin
+              mountPath: /opt/opensandbox
             - name: sandbox-shared-data
               mountPath: /data
 """
@@ -1373,8 +1373,8 @@ spec:
         assert command[0] == "/bin/sh"
         assert command[1] == "-c"
         # Command should contain bootstrap.sh execution
-        # Example: /opt/opensandbox/bin/bootstrap.sh python app.py &
-        assert "/opt/opensandbox/bin/bootstrap.sh python app.py" in command[2]
+        # Example: /opt/opensandbox/bootstrap.sh python app.py &
+        assert "/opt/opensandbox/bootstrap.sh python app.py" in command[2]
         assert command[2].endswith(" &")
         assert task_template["spec"]["process"]["env"] == [{"name": "FOO", "value": "bar"}]
     
@@ -1388,7 +1388,7 @@ spec:
         - Env list formatted correctly for K8s
         
         Generated command example:
-        /bin/sh -c "/opt/opensandbox/bin/bootstrap.sh /usr/bin/python app.py &"
+        /bin/sh -c "/opt/opensandbox/bootstrap.sh /usr/bin/python app.py &"
         """
         provider = BatchSandboxProvider(mock_k8s_client)
         
@@ -1406,7 +1406,7 @@ spec:
         assert command[0] == "/bin/sh"
         assert command[1] == "-c"
         # Should execute via bootstrap.sh in background (&)
-        assert "/opt/opensandbox/bin/bootstrap.sh" in command[2]
+        assert "/opt/opensandbox/bootstrap.sh" in command[2]
         assert "/usr/bin/python" in command[2]
         assert "app.py" in command[2]
         # Should end with & (run in background)
@@ -1425,7 +1425,7 @@ spec:
         Verifies command is wrapped in shell and executes via bootstrap.sh in background.
         
         Generated command example:
-        /bin/sh -c "/opt/opensandbox/bin/bootstrap.sh /usr/bin/python app.py &"
+        /bin/sh -c "/opt/opensandbox/bootstrap.sh /usr/bin/python app.py &"
         """
         provider = BatchSandboxProvider(mock_k8s_client)
         
@@ -1443,7 +1443,7 @@ spec:
         assert command[0] == "/bin/sh"
         assert command[1] == "-c"
         # Check escaped entrypoint
-        assert "/opt/opensandbox/bin/bootstrap.sh" in command[2]
+        assert "/opt/opensandbox/bootstrap.sh" in command[2]
         assert "/usr/bin/python" in command[2]
         assert "app.py" in command[2]
         assert command[2].endswith(" &")
@@ -1465,7 +1465,7 @@ spec:
         
         command = result["spec"]["process"]["command"][2]
         # Should execute bootstrap.sh in background
-        assert "/opt/opensandbox/bin/bootstrap.sh" in command
+        assert "/opt/opensandbox/bootstrap.sh" in command
         assert "python" in command
         assert "app.py" in command
         assert command.endswith(" &")

--- a/server/tests/k8s/test_egress_helper.py
+++ b/server/tests/k8s/test_egress_helper.py
@@ -343,7 +343,7 @@ class TestApplyEgressToSpec:
 
 class TestPrepExecdInitForEgress:
     def test_returns_privileged_security_dict_and_prefixed_script(self):
-        base = "cp ./execd /opt/opensandbox/bin/execd"
+        base = "cp ./execd /opt/opensandbox/execd"
         script, sc = prep_execd_init_for_egress(base)
         assert sc == {"privileged": True}
         assert "/proc/sys/net/ipv6/conf/all/disable_ipv6" in script

--- a/server/tests/k8s/test_k8s_windows_profile.py
+++ b/server/tests/k8s/test_k8s_windows_profile.py
@@ -114,9 +114,9 @@ class TestApplyWindowsProfileOverrides:
                     "name": "execd-installer",
                     "image": "execd:test",
                     "command": ["/bin/sh", "-c"],
-                    "args": ["cp ./execd /opt/opensandbox/bin/execd"],
+                    "args": ["cp ./execd /opt/opensandbox/execd"],
                     "volumeMounts": [
-                        {"name": "opensandbox-bin", "mountPath": "/opt/opensandbox/bin"}
+                        {"name": "opensandbox-bin", "mountPath": "/opt/opensandbox"}
                     ],
                 }
             ],
@@ -124,10 +124,10 @@ class TestApplyWindowsProfileOverrides:
                 {
                     "name": "sandbox",
                     "image": "dockurr/windows:latest",
-                    "command": ["/opt/opensandbox/bin/bootstrap.sh", "tail", "-f", "/dev/null"],
-                    "env": [{"name": "EXECD", "value": "/opt/opensandbox/bin/execd"}],
+                    "command": ["/opt/opensandbox/bootstrap.sh", "tail", "-f", "/dev/null"],
+                    "env": [{"name": "EXECD", "value": "/opt/opensandbox/execd"}],
                     "volumeMounts": [
-                        {"name": "opensandbox-bin", "mountPath": "/opt/opensandbox/bin"}
+                        {"name": "opensandbox-bin", "mountPath": "/opt/opensandbox"}
                     ],
                 }
             ],

--- a/server/tests/test_docker_runtime_bootstrap.py
+++ b/server/tests/test_docker_runtime_bootstrap.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import io
+import pathlib
 import tarfile
 from unittest.mock import MagicMock, patch
 
 from opensandbox_server.config import AppConfig, IngressConfig, RuntimeConfig, ServerConfig
 from opensandbox_server.services.docker import DockerSandboxService
-from opensandbox_server.services.docker.runtime import BOOTSTRAP_PATH, DEFAULT_EXECD_ENVS_PATH
 
 
 def _app_config() -> AppConfig:
@@ -31,16 +31,46 @@ def _app_config() -> AppConfig:
 
 def _extract_bootstrap_script(archive_bytes: bytes) -> str:
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:") as tar:
-        member = tar.getmember(BOOTSTRAP_PATH.lstrip("/"))
+        member = tar.getmember("bootstrap.sh")
         extracted = tar.extractfile(member)
         assert extracted is not None
         return extracted.read().decode("utf-8")
 
 
+def _read_full_bootstrap_sh() -> bytes:
+    """Read the real execd bootstrap.sh from the components directory."""
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    bs_path = repo_root / "components" / "execd" / "bootstrap.sh"
+    script_bytes = bs_path.read_bytes()
+
+    # Wrap as a tar archive so it can be consumed by _install_bootstrap_script
+    # via put_archive, just like Docker's get_archive returns.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name="bootstrap.sh")
+        info.mode = 0o755
+        info.size = len(script_bytes)
+        tar.addfile(info, io.BytesIO(script_bytes))
+    return buf.getvalue()
+
+
 @patch("opensandbox_server.services.docker.docker_service.docker")
-def test_install_bootstrap_script_sets_default_execd_envs(mock_docker):
+def test_install_bootstrap_script_uses_full_bootstrap_sh(mock_docker):
+    """Verify _install_bootstrap_script writes the full bootstrap.sh from the cache.
+
+    The test pre-populates _bootstrap_script_cache with the real bootstrap.sh
+    from components/execd/bootstrap.sh and asserts that the installed content
+    contains features from the full script (MITM CA handling, signal forwarding,
+    etc.) that were absent from the old inline-generated shim.
+    """
     mock_docker.from_env.return_value = MagicMock()
     service = DockerSandboxService(config=_app_config())
+
+    # Pre-populate the cache as _copy_execd_to_container would.
+    cache_key = service._normalize_platform_key(None)
+    archive = _read_full_bootstrap_sh()
+    service._bootstrap_script_cache[cache_key] = archive
+
     mock_container = MagicMock()
 
     with patch.object(service, "_ensure_directory") as mock_ensure_dir, patch.object(
@@ -52,9 +82,13 @@ def test_install_bootstrap_script_sets_default_execd_envs(mock_docker):
     archive_bytes = mock_container.put_archive.call_args.kwargs["data"]
     script = _extract_bootstrap_script(archive_bytes)
 
+    # Full bootstrap.sh features (absent from the old inline shim).
+    assert "trust_mitm_ca" in script
+    assert "_forward_signal" in script
+    assert "OPENSANDBOX_MERGED_CA" in script
+    assert "EXECD_BOOTSTRAP_PRE_SCRIPT" in script
+
+    # Core execd lifecycle shared by both old and new.
+    assert 'EXECD="${EXECD:=/opt/opensandbox/execd}"' in script or "EXECD=" in script
     assert 'if [ -z "${EXECD_ENVS:-}" ]; then' in script
-    assert f'EXECD_ENVS="{DEFAULT_EXECD_ENVS_PATH}"' in script
     assert 'export EXECD_ENVS' in script
-    assert 'mkdir -p "$(dirname "$EXECD_ENVS")"' in script
-    assert 'touch "$EXECD_ENVS"' in script
-    assert 'exec "$@"' in script


### PR DESCRIPTION
## Summary

- Flatten execd emptyDir mount from `/opt/opensandbox/bin` to `/opt/opensandbox` in k8s provider, removing one unnecessary nesting level
- Replace Docker runtime's inline-generated 15-line bootstrap shim with the full `components/execd/bootstrap.sh` from the execd image, gaining MITM CA trust, SIGTERM forwarding, pre-script support, and chained commands
- Aligns k8s paths with bootstrap.sh defaults (`EXECD=/opt/opensandbox/execd`)

## Breaking Change

This is a **breaking change** shipped in server **v0.2.x**. Full migration guide: [`docs/execd-path-migration.md`](https://github.com/opensandbox-group/OpenSandbox/blob/refactor/execd-mount-path-to-opensandbox/docs/execd-path-migration.md)

| Removed path | Replacement |
|---|---|
| `/opt/opensandbox/bin/execd` | `/opt/opensandbox/execd` |
| `/opt/opensandbox/bin/bootstrap.sh` | `/opt/opensandbox/bootstrap.sh` |
| `/opt/opensandbox/bin/task-executor` | `/opt/opensandbox/task-executor` |
| `mountPath: /opt/opensandbox/bin` (volume) | `mountPath: /opt/opensandbox` |

### Quick actions by user profile

| Profile | Action |
|---|---|
| code-interpreter image `<=v1.0.2` | **Must upgrade to `v1.1.0`** — emptyDir now shadows `/opt/opensandbox/`, hiding old entrypoint scripts |
| Custom Pool CR template | Update execd/task-executor mountPath and env vars |
| Custom execd image (Docker) | Must now include `/bootstrap.sh` |

- The code-interpreter SDK (Python package) does **not** require an upgrade.

## Changes

| Area | File | Description |
|---|---|---|
| k8s provider | `provider_common.py` | mount_path, cp commands, EXECD env, bootstrap.sh command all use `/opt/opensandbox` |
| k8s samples | `pool.yaml`, `pool_restart.yaml`, `pool-win-example.yaml` | same path flattening |
| Docker runtime | `runtime.py`, `docker_service.py` | `_fetch_execd_archive` also caches bootstrap.sh; `_install_bootstrap_script` writes full script |
| Docs | `docs/execd-path-migration.md` | migration guide with background, steps, compatibility matrix |
| Tests | 4 test files | updated assertions to match new paths and full bootstrap.sh content |

## Test plan

- [x] Full server unit tests (1129 passed)
- [ ] k8s nightly e2e (triggered by charts/ change)
- [x] ruff clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)