### PR TITLE
fix(server): handle None entrypoint in pool-mode BatchSandbox creation

### DIFF
--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -331,6 +331,7 @@ class BatchSandboxProvider(WorkloadProvider):
         annotations: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Create a BatchSandbox by referencing an existing pool."""
+        entrypoint = entrypoint or DEFAULT_ENTRYPOINT
         spec: Dict[str, Any] = {
             "replicas": 1,
             "poolRef": pool_ref,

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -1593,6 +1593,34 @@ spec:
         task_template = body["spec"]["taskTemplate"]
         assert task_template["spec"]["process"]["env"] == [{"name": "VERSION", "value": "11"}]
 
+    def test_create_workload_poolref_none_entrypoint_no_env_omits_task_template(self, mock_k8s_client):
+        """When entrypoint is None and env is empty, taskTemplate is omitted.
+
+        SDK pool mode callers omit entrypoint entirely (None), expecting the pool's
+        default command to run. This must not raise a TypeError.
+        """
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=None,
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=None,
+            execd_image="execd:latest",
+            extensions={"poolRef": "my-pool"},
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        assert body["spec"]["poolRef"] == "my-pool"
+        assert "taskTemplate" not in body["spec"]
+
 
 class TestBatchSandboxProviderEgress:
     """BatchSandboxProvider egress sidecar tests"""


### PR DESCRIPTION
## Summary

- Pool-mode sandbox creation crashes with `TypeError: 'NoneType' object is not iterable` when `entrypoint` is omitted by the SDK caller
- `kubernetes_service.py` correctly skips `ensure_entrypoint()` for pool requests (entrypoint is optional in pool mode), but `None` propagates into `_create_workload_from_pool` where `None != DEFAULT_ENTRYPOINT` evaluates `True`, triggering `_build_task_template(None)` which crashes on `for arg in None`
- Fix: normalise `None` to `DEFAULT_ENTRYPOINT` at the top of `_create_workload_from_pool`

## Root cause call chain

```
kubernetes_service.py:410   if not has_pool_ref → skip ensure_entrypoint()
kubernetes_service.py:455   create_workload(entrypoint=None)
batchsandbox_provider.py:338  None != DEFAULT_ENTRYPOINT → True → needs_task_template=True
batchsandbox_provider.py:340  _build_task_template(None, env)
batchsandbox_provider.py:442  for arg in None → TypeError
```

## Changes

- `server/opensandbox_server/services/k8s/batchsandbox_provider.py`: add `entrypoint = entrypoint or DEFAULT_ENTRYPOINT` at the start of `_create_workload_from_pool`
- `server/tests/k8s/test_batchsandbox_provider.py`: add regression test `test_create_workload_poolref_none_entrypoint_no_env_omits_task_template`

## Test plan

- [x] New regression test passes: `entrypoint=None` + empty env → no crash, no `taskTemplate` in CR
- [x] All 115 existing `TestBatchSandboxProvider` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)