### PR TITLE
fix: skip chmod/chown on pre-existing dirs in MakeDir

### DIFF
--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/alibaba/opensandbox/execd/pkg/log"
 	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
@@ -77,17 +76,19 @@ func ChmodFile(file string, perms model.Permission) error {
 }
 
 func SetFileOwnership(absPath string, owner string, group string) error {
+	if owner == "" && group == "" {
+		return nil
+	}
+
 	uid := -1
 	if owner != "" {
 		userInfo, err := user.Lookup(owner)
 		if err != nil {
-			log.Warning("Failed to lookup user %s: %v", owner, err)
-		} else {
-			uid, err = strconv.Atoi(userInfo.Uid)
-			if err != nil {
-				log.Warning("Failed to convert uid for user %s: %v", owner, err)
-				uid = -1
-			}
+			return fmt.Errorf("failed to lookup user %s: %w", owner, err)
+		}
+		uid, err = strconv.Atoi(userInfo.Uid)
+		if err != nil {
+			return fmt.Errorf("failed to convert uid for user %s: %w", owner, err)
 		}
 	}
 
@@ -95,21 +96,12 @@ func SetFileOwnership(absPath string, owner string, group string) error {
 	if group != "" {
 		groupInfo, err := user.LookupGroup(group)
 		if err != nil {
-			log.Warning("Failed to lookup group %s: %v", group, err)
-		} else {
-			gid, err = strconv.Atoi(groupInfo.Gid)
-			if err != nil {
-				log.Warning("Failed to convert gid for group %s: %v", group, err)
-				gid = -1
-			}
+			return fmt.Errorf("failed to lookup group %s: %w", group, err)
 		}
-	}
-
-	if uid == -1 && gid == -1 {
-		if _, err := os.Stat(absPath); err != nil {
-			return fmt.Errorf("failed to set owner/group for %s: %w", absPath, err)
+		gid, err = strconv.Atoi(groupInfo.Gid)
+		if err != nil {
+			return fmt.Errorf("failed to convert gid for group %s: %w", group, err)
 		}
-		return nil
 	}
 
 	if err := os.Chown(absPath, uid, gid); err != nil {

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -106,6 +106,9 @@ func SetFileOwnership(absPath string, owner string, group string) error {
 	}
 
 	if uid == -1 && gid == -1 {
+		if _, err := os.Stat(absPath); err != nil {
+			return fmt.Errorf("failed to set owner/group for %s: %w", absPath, err)
+		}
 		return nil
 	}
 

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -106,8 +106,7 @@ func SetFileOwnership(absPath string, owner string, group string) error {
 	}
 
 	if uid == -1 && gid == -1 {
-		uid = os.Getuid()
-		gid = os.Getgid()
+		return nil
 	}
 
 	if err := os.Chown(absPath, uid, gid); err != nil {
@@ -154,12 +153,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
+
+	_, statErr := os.Stat(abs)
+	existed := statErr == nil
+
 	err = os.MkdirAll(abs, os.ModePerm)
 	if err != nil {
 		return err
 	}
 
-	return ChmodFile(abs, perm)
+	if !existed {
+		return ChmodFile(abs, perm)
+	}
+	return nil
 }
 
 func fileType(fileInfo os.FileInfo) string {

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
@@ -82,7 +83,9 @@ func TestMakeDir_NewDir(t *testing.T) {
 	info, err := os.Stat(newDir)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
-	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	}
 }
 
 func TestSetFileOwnership_EmptyOwnerGroup(t *testing.T) {
@@ -92,6 +95,11 @@ func TestSetFileOwnership_EmptyOwnerGroup(t *testing.T) {
 
 	err := SetFileOwnership(file, "", "")
 	require.NoError(t, err, "empty owner and group should be a no-op")
+}
+
+func TestSetFileOwnership_MissingFile(t *testing.T) {
+	err := SetFileOwnership("/nonexistent/path/file.txt", "", "")
+	require.Error(t, err, "empty owner/group on missing file should return error")
 }
 
 func TestSearchFileMetadata(t *testing.T) {

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -55,6 +55,45 @@ func TestRenameFile(t *testing.T) {
 	require.Error(t, RenameFile(model.RenameFileItem{Src: src, Dest: dst}), "expected error when destination already exists")
 }
 
+func TestMakeDir_PreExistingDir(t *testing.T) {
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing")
+	require.NoError(t, os.Mkdir(existing, 0o755))
+
+	origInfo, err := os.Stat(existing)
+	require.NoError(t, err)
+	origMode := origInfo.Mode().Perm()
+
+	err = MakeDir(existing, model.Permission{Mode: 700})
+	require.NoError(t, err, "MakeDir on pre-existing dir should not fail")
+
+	afterInfo, err := os.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, origMode, afterInfo.Mode().Perm(), "permissions of pre-existing dir should be unchanged")
+}
+
+func TestMakeDir_NewDir(t *testing.T) {
+	tmp := t.TempDir()
+	newDir := filepath.Join(tmp, "brand-new")
+
+	err := MakeDir(newDir, model.Permission{Mode: 755})
+	require.NoError(t, err)
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestSetFileOwnership_EmptyOwnerGroup(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "test.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0o644))
+
+	err := SetFileOwnership(file, "", "")
+	require.NoError(t, err, "empty owner and group should be a no-op")
+}
+
 func TestSearchFileMetadata(t *testing.T) {
 	metadata := map[string]model.FileMetadata{
 		"/tmp/a/notes.txt": {Path: "/tmp/a/notes.txt"},

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -98,8 +98,23 @@ func TestSetFileOwnership_EmptyOwnerGroup(t *testing.T) {
 }
 
 func TestSetFileOwnership_MissingFile(t *testing.T) {
-	err := SetFileOwnership("/nonexistent/path/file.txt", "", "")
-	require.Error(t, err, "empty owner/group on missing file should return error")
+	if runtime.GOOS == "windows" {
+		t.Skip("SetFileOwnership is a no-op on Windows")
+	}
+	err := SetFileOwnership("/nonexistent/path/file.txt", "root", "")
+	require.Error(t, err, "chown on missing file should return error")
+}
+
+func TestSetFileOwnership_InvalidOwner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SetFileOwnership is a no-op on Windows")
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "test.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0o644))
+
+	err := SetFileOwnership(file, "nonexistent_user_xyz", "")
+	require.Error(t, err, "invalid owner should return error")
 }
 
 func TestSearchFileMetadata(t *testing.T) {

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -118,12 +118,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
+
+	_, statErr := os.Stat(abs)
+	existed := statErr == nil
+
 	err = os.MkdirAll(abs, os.ModePerm)
 	if err != nil {
 		return err
 	}
 
-	return ChmodFile(abs, perm)
+	if !existed {
+		return ChmodFile(abs, perm)
+	}
+	return nil
 }
 
 func fileType(fileInfo os.FileInfo) string {


### PR DESCRIPTION
## Summary

- `MakeDir` now checks if directory exists before `MkdirAll`; only applies `ChmodFile` to newly created dirs
- `SetFileOwnership` returns nil when both owner and group are empty, instead of forcing chown to current uid/gid
- Adds tests for both fixes

Closes #1024

## Test plan

- [x] `TestMakeDir_PreExistingDir` — pre-existing dir not chmod'd, no error
- [x] `TestMakeDir_NewDir` — new dir created with correct permissions
- [x] `TestSetFileOwnership_EmptyOwnerGroup` — empty owner/group is no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)