### PR TITLE
fix(execd): return 404 for missing path in GET /files/info

### DIFF
--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -18,7 +18,9 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -42,7 +44,7 @@ func NewFilesystemController(ctx *gin.Context) *FilesystemController {
 }
 
 func (c *FilesystemController) handleFileError(err error) {
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		c.RespondError(
 			http.StatusNotFound,
 			model.ErrorCodeFileNotFound,

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -77,6 +77,19 @@ func TestFilesystemControllerGetFilesInfoReportsSymlink(t *testing.T) {
 	require.Equal(t, "symlink", info.Type)
 }
 
+func TestFilesystemControllerGetFilesInfoReturnsNotFoundForMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "definitely-does-not-exist.txt")
+	query := fmt.Sprintf("/files/info?path=%s", url.QueryEscape(missing))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, query, nil)
+
+	ctrl.GetFilesInfo()
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var resp model.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, model.ErrorCodeFileNotFound, resp.Code)
+}
+
 func TestFilesystemControllerSearchFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	a := filepath.Join(tmpDir, "alpha.txt")

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -18,7 +18,9 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -42,7 +44,7 @@ func NewFilesystemController(ctx *gin.Context) *FilesystemController {
 }
 
 func (c *FilesystemController) handleFileError(err error) {
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		c.RespondError(
 			http.StatusNotFound,
 			model.ErrorCodeFileNotFound,

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -214,7 +214,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 	fileInfo, err := os.Lstat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
+			return model.FileInfo{}, fmt.Errorf("file not found: %s: %w", filePath, err)
 		}
 		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
 	}

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -174,7 +174,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 	fileInfo, err := os.Lstat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return model.FileInfo{}, fmt.Errorf("file not found: %s", filePath)
+			return model.FileInfo{}, fmt.Errorf("file not found: %s: %w", filePath, err)
 		}
 		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)
 	}


### PR DESCRIPTION
# Summary

`GET /files/info` currently returns **HTTP 500 RUNTIME_ERROR** when any requested path doesn't exist, instead of **HTTP 404 FILE_NOT_FOUND** as the handler's intent in [filesystem.go#handleFileError](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/filesystem.go#L44) suggests. The 404 branch exists but is unreachable.

Two cooperating bugs erase the `os.ErrNotExist` sentinel between the helper that produces the error and the handler that branches on it:

1. **`controller.GetFileInfo`** ([utils.go](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/utils.go) and [utils_windows.go](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/utils_windows.go)) wraps the sentinel with `fmt.Errorf("file not found: %s", filePath)` — `%s` instead of `%w`. The returned error no longer satisfies `errors.Is(err, fs.ErrNotExist)`.
2. **`handleFileError`** ([filesystem.go#L44-45](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/filesystem.go#L44-L45)) tests with `os.IsNotExist(err)`, which doesn't walk `%w` wrapping. Per [Go docs](https://pkg.go.dev/os#IsNotExist): *"This function predates errors.Is ... New code should use `errors.Is(err, fs.ErrNotExist)`."*

Either bug alone breaks the contract, so this PR fixes both.

## Reproduction

```bash
curl -s 'http://<sandbox>/files/info?path=/does-not-exist' -i
# Before: HTTP/1.1 500 Internal Server Error
#         {"code":"RUNTIME_ERROR","message":"error accessing file: file not found: /does-not-exist"}
# After:  HTTP/1.1 404 Not Found
#         {"code":"FILE_NOT_FOUND","message":"file not found. file not found: /does-not-exist: ..."}
```

I noticed this from the SDK side while building a `pathExists` wrapper over `getFileInfo` — the 500 status meant the wrapper couldn't cleanly distinguish "path missing" from "real server error" without string-matching the message body.

## The fix

- `utils.go` / `utils_windows.go`: switch the not-found branch from `%s` to `%w`, preserving the wrapped sentinel.
- `filesystem.go` / `filesystem_windows.go`: switch `handleFileError` to `errors.Is(err, fs.ErrNotExist)`, the modern form that walks wrapped errors. This also future-proofs against the same wrapping mistake recurring at any other call site.

# Testing

- [x] Unit tests — added `TestFilesystemControllerGetFilesInfoReturnsNotFoundForMissingPath` in `components/execd/pkg/web/controller/filesystem_test.go`. Fails on `main` (expected 404, got 500); passes after the fix.
- [x] Full `components/execd` test suite passes (`go test ./...`).
- [x] `gofmt -l` clean; `go vet ./...` clean.
- [ ] Integration tests — none added (handler-level coverage is sufficient and matches the existing test style in `filesystem_test.go`).

# Breaking Changes

- [x] None — this restores the documented/intended 404 status. The 500 was a bug, not a contract. Clients that defensively accept either status (e.g. `[StatusNotFound, StatusInternalServerError]`) keep working.

# Checklist

- [x] Linked motivation above (no separate issue; the bug is small and self-contained)
- [ ] Added/updated docs — no docs reference the missing-path status code
- [x] Added/updated tests
- [x] Security impact considered — none (status code change only)
- [x] Backward compatibility considered — improvement only; the prior behavior was an unintentional 500

## Related smell

[`TestReplaceContentFailsUnknownFile`](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/filesystem_test.go#L353) accepts either 404 or 500 (`require.Contains(t, []int{http.StatusNotFound, http.StatusInternalServerError}, rec.Code)`). That looks like an earlier accommodation of the same root cause from a different code path. I didn't widen this PR to investigate; happy to file a follow-up if it'd be useful.