### PR TITLE
Add credential vault CLI commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -6,6 +6,7 @@
 - run commands inside a sandbox
 - read and modify sandbox files
 - inspect runtime egress policy
+- manage sandbox-local Credential Vault state
 - collect low-level diagnostics
 - install OpenSandbox-specific skills for coding agents
 
@@ -148,6 +149,12 @@ osb sandbox create \
   --volumes-file volumes.json
 ```
 
+Create with Credential Vault proxy enabled:
+
+```bash
+osb sandbox create --image python:3.12 --network-policy-file network-policy.json --credential-proxy -o json
+```
+
 ### List and inspect sandboxes
 
 ```bash
@@ -221,6 +228,24 @@ If you are debugging connectivity, verify behavior with an actual command:
 ```bash
 osb command run <sandbox-id> -o raw -- curl -I https://pypi.org
 ```
+
+### Manage Credential Vault
+
+Credential Vault operations call the sandbox egress sidecar through the Python SDK.
+Create the sandbox with `--credential-proxy` and an explicit network policy before
+writing vault state.
+
+```bash
+osb credential-vault create <sandbox-id> --file vault.yaml -o json
+osb credential-vault get <sandbox-id> -o json
+osb credential-vault patch <sandbox-id> --file mutation.yaml -o json
+osb credential-vault credential list <sandbox-id> -o json
+osb credential-vault binding list <sandbox-id> -o json
+osb credential-vault delete <sandbox-id> -o json
+```
+
+Use `--file -` to read a JSON/YAML payload from stdin. Do not pass plaintext
+credential values as command-line flags; keep them in the payload stream or file.
 
 ### Collect diagnostics
 

--- a/cli/src/opensandbox_cli/commands/credential_vault.py
+++ b/cli/src/opensandbox_cli/commands/credential_vault.py
@@ -1,0 +1,306 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sandbox-local Credential Vault commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+
+from opensandbox_cli.client import ClientContext
+from opensandbox_cli.utils import handle_errors, output_option, prepare_output
+
+
+def _read_payload(payload_file: str) -> dict[str, Any]:
+    """Read a JSON/YAML object from a file path or stdin."""
+    try:
+        if payload_file == "-":
+            raw = click.get_text_stream("stdin").read()
+        else:
+            path = Path(payload_file)
+            if not path.is_file():
+                raise click.ClickException(f"Payload file not found: {payload_file}")
+            raw = path.read_text(encoding="utf-8")
+        payload = yaml.safe_load(raw)
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to read credential vault payload from {payload_file}."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise click.ClickException("Credential vault payload must be a JSON/YAML object.")
+    return payload
+
+
+def _require_list(payload: dict[str, Any], key: str) -> list[Any]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise click.ClickException(f"Credential vault payload field '{key}' must be a list.")
+    return value
+
+
+def _get_expected_revision(payload: dict[str, Any]) -> int | None:
+    raw = payload.get("expectedRevision", payload.get("expected_revision"))
+    if raw is None:
+        return None
+    if type(raw) is not int:
+        raise click.ClickException("Credential vault expectedRevision must be an integer.")
+    return raw
+
+
+def _optional_object(payload: dict[str, Any], key: str) -> dict[str, Any] | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise click.ClickException(f"Credential vault patch field '{key}' must be an object.")
+    return value
+
+
+@click.group("credential-vault", invoke_without_command=True)
+@click.pass_context
+def credential_vault_group(ctx: click.Context) -> None:
+    """Manage sandbox-local Credential Vault state."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@credential_vault_group.command("create")
+@click.argument("sandbox_id")
+@click.option(
+    "--file",
+    "payload_file",
+    required=True,
+    help="JSON/YAML payload file, or '-' to read from stdin.",
+)
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_vault_create(
+    obj: ClientContext,
+    sandbox_id: str,
+    payload_file: str,
+    output_format: str | None,
+) -> None:
+    """Create the initial Credential Vault state."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    payload = _read_payload(payload_file)
+    credentials = _require_list(payload, "credentials")
+    bindings = _require_list(payload, "bindings")
+
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        state = sandbox.credential_vault.create(
+            credentials=credentials,
+            bindings=bindings,
+        )
+        obj.output.print_model(state, title="Credential Vault")
+    finally:
+        sandbox.close()
+
+
+@credential_vault_group.command("get")
+@click.argument("sandbox_id")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_vault_get(
+    obj: ClientContext,
+    sandbox_id: str,
+    output_format: str | None,
+) -> None:
+    """Get sanitized Credential Vault state."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        state = sandbox.credential_vault.get()
+        obj.output.print_model(state, title="Credential Vault")
+    finally:
+        sandbox.close()
+
+
+@credential_vault_group.command("patch")
+@click.argument("sandbox_id")
+@click.option(
+    "--file",
+    "payload_file",
+    required=True,
+    help="JSON/YAML mutation payload file, or '-' to read from stdin.",
+)
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_vault_patch(
+    obj: ClientContext,
+    sandbox_id: str,
+    payload_file: str,
+    output_format: str | None,
+) -> None:
+    """Atomically mutate credentials and bindings."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    payload = _read_payload(payload_file)
+    credentials = _optional_object(payload, "credentials")
+    bindings = _optional_object(payload, "bindings")
+    if credentials is None and bindings is None:
+        raise click.ClickException(
+            "Credential vault patch payload must include credentials or bindings."
+        )
+
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        state = sandbox.credential_vault.patch(
+            expected_revision=_get_expected_revision(payload),
+            credentials=credentials,
+            bindings=bindings,
+        )
+        obj.output.print_model(state, title="Credential Vault")
+    finally:
+        sandbox.close()
+
+
+@credential_vault_group.command("delete")
+@click.argument("sandbox_id")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_vault_delete(
+    obj: ClientContext,
+    sandbox_id: str,
+    output_format: str | None,
+) -> None:
+    """Delete the sandbox-local Credential Vault."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        sandbox.credential_vault.delete()
+        obj.output.success_panel(
+            {"sandbox_id": sandbox.id, "status": "deleted"},
+            title="Credential Vault Deleted",
+        )
+    finally:
+        sandbox.close()
+
+
+@credential_vault_group.group("credential", invoke_without_command=True)
+@click.pass_context
+def credential_group(ctx: click.Context) -> None:
+    """Inspect sanitized Credential Vault credential metadata."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@credential_group.command("list")
+@click.argument("sandbox_id")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_list(
+    obj: ClientContext,
+    sandbox_id: str,
+    output_format: str | None,
+) -> None:
+    """List sanitized credential metadata."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        credentials = sandbox.credential_vault.list_credentials()
+        obj.output.print_models(
+            credentials,
+            columns=["name", "source_type", "revision"],
+            title="Credential Vault Credentials",
+        )
+    finally:
+        sandbox.close()
+
+
+@credential_group.command("get")
+@click.argument("sandbox_id")
+@click.argument("credential_name")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def credential_get(
+    obj: ClientContext,
+    sandbox_id: str,
+    credential_name: str,
+    output_format: str | None,
+) -> None:
+    """Get sanitized metadata for one credential."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        credential = sandbox.credential_vault.get_credential(credential_name)
+        obj.output.print_model(credential, title="Credential Vault Credential")
+    finally:
+        sandbox.close()
+
+
+@credential_vault_group.group("binding", invoke_without_command=True)
+@click.pass_context
+def binding_group(ctx: click.Context) -> None:
+    """Inspect sanitized Credential Vault binding metadata."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@binding_group.command("list")
+@click.argument("sandbox_id")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def binding_list(
+    obj: ClientContext,
+    sandbox_id: str,
+    output_format: str | None,
+) -> None:
+    """List sanitized binding metadata."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        bindings = sandbox.credential_vault.list_bindings()
+        obj.output.print_models(
+            bindings,
+            columns=["name", "revision", "match", "auth"],
+            title="Credential Vault Bindings",
+        )
+    finally:
+        sandbox.close()
+
+
+@binding_group.command("get")
+@click.argument("sandbox_id")
+@click.argument("binding_name")
+@output_option("table", "json", "yaml")
+@click.pass_obj
+@handle_errors
+def binding_get(
+    obj: ClientContext,
+    sandbox_id: str,
+    binding_name: str,
+    output_format: str | None,
+) -> None:
+    """Get sanitized metadata for one binding."""
+    prepare_output(obj, output_format, allowed=("table", "json", "yaml"), fallback="table")
+    sandbox = obj.connect_sandbox(sandbox_id)
+    try:
+        binding = sandbox.credential_vault.get_binding(binding_name)
+        obj.output.print_model(binding, title="Credential Vault Binding")
+    finally:
+        sandbox.close()

--- a/cli/src/opensandbox_cli/commands/sandbox.py
+++ b/cli/src/opensandbox_cli/commands/sandbox.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import click
 from opensandbox.models.sandboxes import (
+    CredentialProxyConfig,
     NetworkPolicy,
     SandboxFilter,
     SandboxImageAuth,
@@ -107,6 +108,12 @@ def _normalize_sandbox_states(states: tuple[str, ...]) -> list[str] | None:
     help="Entrypoint argv item. Repeat to build the full entrypoint.",
 )
 @click.option("--network-policy-file", type=click.Path(exists=True), default=None, help="Network policy JSON file.")
+@click.option(
+    "--credential-proxy",
+    is_flag=True,
+    default=False,
+    help="Enable Credential Vault transparent proxy support. Requires --network-policy-file.",
+)
 @click.option("--volumes-file", type=click.Path(exists=True), default=None, help="Volumes JSON file (list of volume objects).")
 @click.option("--skip-health-check", is_flag=True, default=False, help="Skip waiting for sandbox readiness.")
 @click.option("--ready-timeout", type=DURATION, default=None, help="Max wait time for sandbox readiness (e.g. 30s).")
@@ -125,6 +132,7 @@ def sandbox_create(
     resources_kv: tuple[tuple[str, str], ...],
     entrypoint: tuple[str, ...],
     network_policy_file: str | None,
+    credential_proxy: bool,
     volumes_file: str | None,
     skip_health_check: bool,
     ready_timeout: timedelta | None,
@@ -144,6 +152,10 @@ def sandbox_create(
     if bool(image_auth_username) != bool(image_auth_password):
         raise click.ClickException(
             "Pass both --image-auth-username and --image-auth-password together."
+        )
+    if credential_proxy and not network_policy_file:
+        raise click.ClickException(
+            "--credential-proxy requires --network-policy-file because Credential Vault injection needs egress policy."
         )
 
     timeout: timedelta | None
@@ -191,6 +203,8 @@ def sandbox_create(
     if network_policy_file:
         with open(network_policy_file) as f:
             kwargs["network_policy"] = NetworkPolicy(**json.load(f))
+    if credential_proxy:
+        kwargs["credential_proxy"] = CredentialProxyConfig(enabled=True)
     if volumes_file:
         with open(volumes_file) as f:
             raw_volumes = json.load(f)

--- a/cli/src/opensandbox_cli/main.py
+++ b/cli/src/opensandbox_cli/main.py
@@ -25,6 +25,7 @@ from opensandbox_cli import __version__
 from opensandbox_cli.client import ClientContext
 from opensandbox_cli.commands.command import command_group
 from opensandbox_cli.commands.config_cmd import config_group
+from opensandbox_cli.commands.credential_vault import credential_vault_group
 from opensandbox_cli.commands.devops import devops_group
 from opensandbox_cli.commands.diagnostics import diagnostics_group
 from opensandbox_cli.commands.egress import egress_group
@@ -134,6 +135,7 @@ cli.add_command(sandbox_group)
 cli.add_command(command_group)
 cli.add_command(file_group)
 cli.add_command(egress_group)
+cli.add_command(credential_vault_group)
 cli.add_command(config_group)
 cli.add_command(diagnostics_group)
 cli.add_command(devops_group)

--- a/cli/src/opensandbox_cli/skill_registry.py
+++ b/cli/src/opensandbox_cli/skill_registry.py
@@ -90,6 +90,21 @@ BUILTIN_SKILLS: dict[str, SkillSpec] = {
         ),
         marker_id="opensandbox-network-egress",
     ),
+    "credential-vault": SkillSpec(
+        slug="credential-vault",
+        package_file="opensandbox-credential-vault.md",
+        title="OpenSandbox Credential Vault",
+        summary=(
+            "Create, inspect, patch, and delete sandbox-local Credential Vault "
+            "state without exposing plaintext secrets in shell flags."
+        ),
+        trigger_hint=(
+            "Use when the user needs outbound credential injection for tools "
+            "inside a sandbox, or wants to manage Credential Vault credentials "
+            "and bindings at runtime."
+        ),
+        marker_id="opensandbox-credential-vault",
+    ),
 }
 
 DEFAULT_SKILL = "sandbox-troubleshooting"

--- a/cli/src/opensandbox_cli/skills/opensandbox-credential-vault.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-credential-vault.md
@@ -1,0 +1,136 @@
+---
+name: credential-vault
+description: Use OpenSandbox Credential Vault commands to manage sandbox-local outbound credential injection state. Trigger when users need to write credentials and bindings, inspect sanitized vault metadata, or update runtime credential injection rules for an existing sandbox.
+---
+
+# OpenSandbox Credential Vault
+
+Manage outbound credential injection with `osb credential-vault`. Treat vault
+changes as a controlled runtime workflow: confirm the sandbox was created with
+Credential Proxy, write secrets only through payload files or stdin, inspect
+sanitized state, then verify actual outbound behavior from inside the sandbox.
+
+## When To Use
+
+- the user needs real credentials injected into outbound HTTP or HTTPS requests
+- the user wants to create, inspect, patch, or delete Credential Vault state
+- the user needs to add, replace, or remove runtime credentials or bindings
+- the user wants to keep plaintext credentials out of sandbox env vars, files,
+  shell history, and command arguments
+
+## Prerequisites
+
+Credential Vault requires an egress sidecar with transparent MITM enabled. Create
+the sandbox with both a network policy and Credential Proxy:
+
+```bash
+osb sandbox create --image python:3.12 --network-policy-file network-policy.json --credential-proxy -o json
+```
+
+If `credential-vault create`, `patch`, or `delete` returns a precondition error,
+the sandbox was likely not created with Credential Proxy, the egress API auth
+token is missing, mitmproxy is not ready, or insecure upstream TLS mode is set.
+
+## Payload Rules
+
+Use JSON or YAML payload files, or `--file -` for stdin. Do not put real secret
+values in command-line flags.
+
+Create payload shape:
+
+```yaml
+credentials:
+  - name: api-token
+    source:
+      value: secret-value
+bindings:
+  - name: api
+    match:
+      schemes: [https]
+      hosts: [api.example.com]
+      paths: [/v1/*]
+    auth:
+      type: apiKey
+      name: x-api-key
+      credential: api-token
+```
+
+Patch payload shape:
+
+```yaml
+expectedRevision: 1
+credentials:
+  add:
+    - name: runtime-token
+      source:
+        value: runtime-secret
+bindings:
+  add:
+    - name: runtime-api
+      match:
+        schemes: [https]
+        hosts: [api.example.com]
+      auth:
+        type: bearer
+        credential: runtime-token
+```
+
+## Golden Path
+
+```bash
+osb credential-vault create <sandbox-id> --file vault.yaml -o json
+osb credential-vault get <sandbox-id> -o json
+osb credential-vault credential list <sandbox-id> -o json
+osb credential-vault binding list <sandbox-id> -o json
+osb command run <sandbox-id> -o raw -- curl -I https://api.example.com
+```
+
+## Runtime Mutation
+
+Patch with optimistic concurrency when the current revision matters:
+
+```bash
+osb credential-vault get <sandbox-id> -o json
+osb credential-vault patch <sandbox-id> --file mutation.yaml -o json
+osb credential-vault get <sandbox-id> -o json
+```
+
+Delete specific credentials or bindings by naming them in the patch payload:
+
+```yaml
+expectedRevision: 2
+bindings:
+  delete: [runtime-api]
+credentials:
+  delete: [runtime-token]
+```
+
+## Inspect Metadata
+
+Vault read APIs return sanitized metadata only. Plaintext credential values are
+write-only and should not appear in command output.
+
+```bash
+osb credential-vault credential get <sandbox-id> api-token -o json
+osb credential-vault binding get <sandbox-id> api -o json
+```
+
+## Cleanup
+
+Delete all sandbox-local vault state when credential injection is no longer
+needed:
+
+```bash
+osb credential-vault delete <sandbox-id> -o json
+```
+
+## Response Pattern
+
+When helping a user:
+
+1. Confirm the active OpenSandbox config with `osb config show -o json`.
+2. Confirm the sandbox was created with `--credential-proxy` and network policy.
+3. Keep secret material in payload files or stdin, never in CLI flags.
+4. Use `get` or `list` to inspect sanitized state.
+5. Verify behavior with `osb command run ... -o raw -- curl ...` when injection
+   behavior matters.

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-lifecycle.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-lifecycle.md
@@ -110,6 +110,7 @@ osb sandbox create --image python:3.12 --entrypoint python --entrypoint -m --ent
 osb sandbox create --image python:3.12 --extension storage.id=abc123 -o json
 osb sandbox create --image python:3.12 --ready-timeout 90s -o json
 osb sandbox create --image python:3.12 --network-policy-file network-policy.json -o json
+osb sandbox create --image python:3.12 --network-policy-file network-policy.json --credential-proxy -o json
 osb sandbox create --image python:3.12 --volumes-file volumes.json -o json
 ```
 
@@ -124,6 +125,7 @@ Use these options deliberately:
 - `--extension`: repeat for opaque extension key-value pairs that should be passed through as-is
 - `--ready-timeout`: increase this when the image or workload needs more startup time
 - `--skip-health-check`: use only when the user explicitly wants object creation without waiting for readiness; do not use it to mask startup problems
+- `--credential-proxy`: enable Credential Vault transparent proxy support; requires `--network-policy-file`
 
 If the user does not specify an image, recommend one that matches the runtime they need instead of guessing silently.
 

--- a/cli/tests/test_cli_help.py
+++ b/cli/tests/test_cli_help.py
@@ -47,7 +47,17 @@ class TestRootCLI:
 
     def test_root_lists_commands(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["--help"])
-        for cmd in ("sandbox", "command", "file", "egress", "config", "diagnostics", "devops", "skills"):
+        for cmd in (
+            "sandbox",
+            "command",
+            "file",
+            "egress",
+            "credential-vault",
+            "config",
+            "diagnostics",
+            "devops",
+            "skills",
+        ):
             assert cmd in result.output
 
 
@@ -128,6 +138,36 @@ class TestEgressHelp:
         result = runner.invoke(cli, ["egress", "--help"])
         assert result.exit_code == 0
         for subcmd in ("get", "patch"):
+            assert subcmd in result.output
+
+
+# ---------------------------------------------------------------------------
+# Credential Vault sub-commands
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialVaultHelp:
+    def test_credential_vault_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["credential-vault", "--help"])
+        assert result.exit_code == 0
+        for subcmd in ("create", "get", "patch", "delete", "credential", "binding"):
+            assert subcmd in result.output
+
+    @pytest.mark.parametrize("subcmd", ["create", "get", "patch", "delete"])
+    def test_credential_vault_subcommand_help(self, runner: CliRunner, subcmd: str) -> None:
+        result = runner.invoke(cli, ["credential-vault", subcmd, "--help"])
+        assert result.exit_code == 0
+
+    def test_credential_vault_credential_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["credential-vault", "credential", "--help"])
+        assert result.exit_code == 0
+        for subcmd in ("list", "get"):
+            assert subcmd in result.output
+
+    def test_credential_vault_binding_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["credential-vault", "binding", "--help"])
+        assert result.exit_code == 0
+        for subcmd in ("list", "get"):
             assert subcmd in result.output
 
 

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -85,6 +85,7 @@ def _invoke(
     manager: MagicMock | None = None,
     sandbox: MagicMock | None = None,
     output_format: str = "json",
+    input: str | None = None,
 ) -> object:
     """Invoke CLI with mocked ClientContext."""
     mock_ctx = _build_mock_client_context(
@@ -94,7 +95,7 @@ def _invoke(
     with patch("opensandbox_cli.main.resolve_config") as mock_resolve, \
          patch("opensandbox_cli.main.ClientContext", return_value=mock_ctx):
         mock_resolve.return_value = mock_ctx.resolved_config
-        result = runner.invoke(cli, args, catch_exceptions=False)
+        result = runner.invoke(cli, args, input=input, catch_exceptions=False)
     return result
 
 
@@ -499,6 +500,59 @@ class TestSandboxCreate:
             "storage.id": "abc123",
             "runtime.profile": "fast",
         }
+
+    def test_create_passes_credential_proxy_to_sdk(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        mock_sb = MagicMock()
+        mock_sb.id = "sb-123"
+        policy_path = tmp_path / "network-policy.json"
+        policy_path.write_text(json.dumps({
+            "defaultAction": "deny",
+            "egress": [{"action": "allow", "target": "api.example.com"}],
+        }))
+
+        mock_ctx = _build_mock_client_context(sandbox=mock_sb)
+        with patch("opensandbox_cli.main.resolve_config") as mock_resolve, \
+             patch("opensandbox_cli.main.ClientContext", return_value=mock_ctx), \
+             patch("opensandbox.sync.sandbox.SandboxSync.create", return_value=mock_sb) as mock_create:
+            mock_resolve.return_value = mock_ctx.resolved_config
+            result = runner.invoke(
+                cli,
+                [
+                    "sandbox",
+                    "create",
+                    "-o",
+                    "json",
+                    "--image",
+                    "python:3.12",
+                    "--network-policy-file",
+                    str(policy_path),
+                    "--credential-proxy",
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert mock_create.call_args.kwargs["network_policy"].egress[0].target == "api.example.com"
+        assert mock_create.call_args.kwargs["credential_proxy"].enabled is True
+
+    def test_create_rejects_credential_proxy_without_network_policy(
+        self, runner: CliRunner
+    ) -> None:
+        result = _invoke(
+            runner,
+            [
+                "sandbox",
+                "create",
+                "--image",
+                "python:3.12",
+                "--credential-proxy",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--credential-proxy requires --network-policy-file" in result.output
 
 
 class TestSandboxKill:
@@ -949,6 +1003,194 @@ class TestEgressCommands:
         assert rules[0].target == "pypi.org"
         assert rules[1].action == "deny"
         assert rules[1].target == "bad.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Credential Vault commands
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialVaultCommands:
+    def test_create_reads_payload_file_and_calls_sdk(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        mock_sb = MagicMock()
+        mock_state = MagicMock()
+        mock_state.model_dump.return_value = {
+            "revision": 1,
+            "credentials": [{"name": "api-token", "source_type": "inline", "revision": 1}],
+            "bindings": [],
+        }
+        mock_sb.credential_vault.create.return_value = mock_state
+        payload_path = tmp_path / "vault.yaml"
+        payload_path.write_text(
+            """
+credentials:
+  - name: api-token
+    source:
+      value: secret-token
+bindings: []
+""".strip()
+        )
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "create", "sb-1", "--file", str(payload_path), "-o", "json"],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.create.assert_called_once_with(
+            credentials=[
+                {"name": "api-token", "source": {"value": "secret-token"}},
+            ],
+            bindings=[],
+        )
+        mock_sb.close.assert_called_once()
+        assert "secret-token" not in result.output
+        data = json.loads(result.output)
+        assert data["revision"] == 1
+
+    def test_get_calls_sdk(self, runner: CliRunner) -> None:
+        mock_sb = MagicMock()
+        mock_state = MagicMock()
+        mock_state.model_dump.return_value = {
+            "revision": 1,
+            "credentials": [],
+            "bindings": [],
+        }
+        mock_sb.credential_vault.get.return_value = mock_state
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "get", "sb-1", "-o", "json"],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.get.assert_called_once_with()
+        data = json.loads(result.output)
+        assert data["credentials"] == []
+
+    def test_patch_reads_stdin_and_calls_sdk(self, runner: CliRunner) -> None:
+        mock_sb = MagicMock()
+        mock_state = MagicMock()
+        mock_state.model_dump.return_value = {
+            "revision": 2,
+            "credentials": [{"name": "runtime-token", "source_type": "inline", "revision": 2}],
+            "bindings": [],
+        }
+        mock_sb.credential_vault.patch.return_value = mock_state
+        payload = json.dumps({
+            "expectedRevision": 1,
+            "credentials": {
+                "add": [
+                    {
+                        "name": "runtime-token",
+                        "source": {"value": "runtime-secret"},
+                    }
+                ]
+            },
+        })
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "patch", "sb-1", "--file", "-", "-o", "json"],
+            sandbox=mock_sb,
+            input=payload,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.patch.assert_called_once_with(
+            expected_revision=1,
+            credentials={
+                "add": [
+                    {
+                        "name": "runtime-token",
+                        "source": {"value": "runtime-secret"},
+                    }
+                ]
+            },
+            bindings=None,
+        )
+        assert "runtime-secret" not in result.output
+        data = json.loads(result.output)
+        assert data["revision"] == 2
+
+    def test_patch_rejects_empty_mutation_payload(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        mock_sb = MagicMock()
+        payload_path = tmp_path / "empty.yaml"
+        payload_path.write_text("expectedRevision: 1\n")
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "patch", "sb-1", "--file", str(payload_path)],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code != 0
+        assert "must include credentials or bindings" in result.output
+        mock_sb.credential_vault.patch.assert_not_called()
+
+    def test_delete_calls_sdk(self, runner: CliRunner) -> None:
+        mock_sb = MagicMock()
+        mock_sb.id = "sb-1"
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "delete", "sb-1", "-o", "json"],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.delete.assert_called_once_with()
+        data = json.loads(result.output)
+        assert data == {"sandbox_id": "sb-1", "status": "deleted"}
+
+    def test_credential_list_calls_sdk(self, runner: CliRunner) -> None:
+        mock_sb = MagicMock()
+        credential = MagicMock()
+        credential.model_dump.return_value = {
+            "name": "api-token",
+            "source_type": "inline",
+            "revision": 1,
+        }
+        mock_sb.credential_vault.list_credentials.return_value = [credential]
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "credential", "list", "sb-1", "-o", "json"],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.list_credentials.assert_called_once_with()
+        data = json.loads(result.output)
+        assert data[0]["name"] == "api-token"
+
+    def test_binding_get_calls_sdk(self, runner: CliRunner) -> None:
+        mock_sb = MagicMock()
+        binding = MagicMock()
+        binding.model_dump.return_value = {
+            "name": "api-binding",
+            "revision": 1,
+            "match": {"hosts": ["api.example.com"]},
+            "auth": {"type": "apiKey", "name": "x-api-key"},
+        }
+        mock_sb.credential_vault.get_binding.return_value = binding
+
+        result = _invoke(
+            runner,
+            ["credential-vault", "binding", "get", "sb-1", "api-binding", "-o", "json"],
+            sandbox=mock_sb,
+        )
+
+        assert result.exit_code == 0
+        mock_sb.credential_vault.get_binding.assert_called_once_with("api-binding")
+        data = json.loads(result.output)
+        assert data["auth"]["type"] == "apiKey"
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_skills.py
+++ b/cli/tests/test_skills.py
@@ -362,6 +362,18 @@ class TestSkillsCommands:
         assert "Quick Start:" in result.output
         assert "osb egress patch" in result.output
 
+    def test_show_supports_credential_vault_skill(
+        self,
+        runner: CliRunner,
+        isolated_skill_targets: None,
+    ) -> None:
+        result = runner.invoke(skills_group, ["show", "credential-vault"])
+
+        assert result.exit_code == 0
+        assert "Skill: credential-vault" in result.output
+        assert "Credential Vault" in result.output
+        assert "osb credential-vault create" in result.output
+
     def test_show_surfaces_json_shapes_for_lifecycle_skill(
         self,
         runner: CliRunner,
@@ -582,7 +594,8 @@ class TestSkillCliAlignment:
 
         assert {
             "-i", "--image", "-t", "--timeout", "--entrypoint", "--network-policy-file",
-            "--volumes-file", "--skip-health-check", "--ready-timeout", "-o", "--output",
+            "--credential-proxy", "--volumes-file", "--skip-health-check",
+            "--ready-timeout", "-o", "--output",
         } <= _option_names(create_cmd)
         assert {"--skip-health-check", "--resume-timeout", "-o", "--output"} <= _option_names(resume_cmd)
         assert {"-p", "--port", "-o", "--output"} <= _option_names(endpoint_cmd)
@@ -618,6 +631,18 @@ class TestSkillCliAlignment:
         assert {"--tail", "-n", "--since", "-s", "-o", "--output"} <= _option_names(logs_cmd)
         assert {"--limit", "-l", "-o", "--output"} <= _option_names(events_cmd)
         assert {"--tail", "-n", "--event-limit", "-o", "--output"} <= _option_names(summary_cmd)
+
+    def test_credential_vault_skill_matches_cli(self) -> None:
+        vault_group = _command(["credential-vault"])
+        assert isinstance(vault_group, Group)
+        assert {"create", "get", "patch", "delete", "credential", "binding"} <= set(vault_group.commands)
+
+        assert {"--file", "-o", "--output"} <= _option_names(_command(["credential-vault", "create"]))
+        assert {"--file", "-o", "--output"} <= _option_names(_command(["credential-vault", "patch"]))
+        assert {"-o", "--output"} <= _option_names(_command(["credential-vault", "get"]))
+        assert {"-o", "--output"} <= _option_names(_command(["credential-vault", "delete"]))
+        assert {"-o", "--output"} <= _option_names(_command(["credential-vault", "credential", "list"]))
+        assert {"-o", "--output"} <= _option_names(_command(["credential-vault", "binding", "get"]))
 
     def test_skill_osb_examples_use_explicit_output_formats(self) -> None:
         allowed_without_output = {


### PR DESCRIPTION
## Summary

- Add `osb credential-vault` commands for create/get/patch/delete and sanitized credential/binding metadata inspection.
- Add `osb sandbox create --credential-proxy` to pass Credential Proxy config through the CLI.
- Update CLI README, bundled skills, and command/help alignment tests.

## Validation

- `uv run --frozen --no-dev --with pytest pytest tests/test_cli_help.py tests/test_commands.py tests/test_skills.py -q`

## Notes

- Local `uv run --frozen ruff check` was attempted, but stalled while downloading `ruff (9.8MiB)` in this environment; no lint failure was reported.