### PR TITLE
fix(execd): return 404 for missing source in POST /files/mv

### DIFF
--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -90,6 +90,22 @@ func TestFilesystemControllerGetFilesInfoReturnsNotFoundForMissingPath(t *testin
 	require.Equal(t, model.ErrorCodeFileNotFound, resp.Code)
 }
 
+func TestFilesystemControllerRenameFilesReturnsNotFoundForMissingSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingSrc := filepath.Join(tmpDir, "missing.txt")
+	dst := filepath.Join(tmpDir, "dest.txt")
+	payload, err := json.Marshal([]model.RenameFileItem{{Src: missingSrc, Dest: dst}})
+	require.NoError(t, err)
+	ctrl, rec := newFilesystemController(t, http.MethodPost, "/files/mv", payload)
+
+	ctrl.RenameFiles()
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var resp model.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, model.ErrorCodeFileNotFound, resp.Code)
+}
+
 func TestFilesystemControllerSearchFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	a := filepath.Join(tmpDir, "alpha.txt")
@@ -363,7 +379,10 @@ func TestReplaceContentFailsUnknownFile(t *testing.T) {
 
 	ctrl.ReplaceContent()
 
-	require.Contains(t, []int{http.StatusNotFound, http.StatusInternalServerError}, rec.Code, "expected failure status")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var resp model.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, model.ErrorCodeFileNotFound, resp.Code)
 }
 
 func TestFormatContentDisposition(t *testing.T) {

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -129,7 +129,7 @@ func RenameFile(item model.RenameFileItem) error {
 	}
 
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
-		return fmt.Errorf("source path not found: %s", item.Src)
+		return fmt.Errorf("source path not found: %s: %w", item.Src, err)
 	}
 
 	dstDir := filepath.Dir(dstPath)

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -93,7 +93,7 @@ func RenameFile(item model.RenameFileItem) error {
 	}
 
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
-		return fmt.Errorf("source path not found: %s", item.Src)
+		return fmt.Errorf("source path not found: %s: %w", item.Src, err)
 	}
 
 	dstDir := filepath.Dir(dstPath)


### PR DESCRIPTION
# Summary

Follow-up to #1026, addressing the sibling bug @Pangjiping flagged in [their review](https://github.com/opensandbox-group/OpenSandbox/pull/1026#pullrequestreview-4482183042).

`RenameFile` ([utils.go:132](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/utils.go#L132), [utils_windows.go:96](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/utils_windows.go#L96)) had the same `%s`-instead-of-`%w` sentinel-stripping mistake as `GetFileInfo`:

```go
if _, err := os.Stat(srcPath); os.IsNotExist(err) {
    return fmt.Errorf("source path not found: %s", item.Src)  // sentinel lost
}
```

This flows through `RenameFiles` → `handleFileError`, so `/files/mv` on a missing source path returned HTTP 500 `RUNTIME_ERROR` instead of 404 `FILE_NOT_FOUND`. Switch the not-found branch to `%w`. With `handleFileError` already using `errors.Is(err, fs.ErrNotExist)` from #1026, the sentinel propagates and the handler reaches its 404 branch.

## Reproduction

```bash
curl -s -X POST 'http://<sandbox>/files/mv' \
  -H 'content-type: application/json' \
  -d '[{"src":"/does-not-exist","dest":"/anywhere"}]' -i
# Before: HTTP/1.1 500 Internal Server Error
#         {"code":"RUNTIME_ERROR","message":"error accessing file: source path not found: /does-not-exist"}
# After:  HTTP/1.1 404 Not Found
#         {"code":"FILE_NOT_FOUND","message":"file not found. source path not found: /does-not-exist: ..."}
```

## Bonus: tightens the smelly TestReplaceContentFailsUnknownFile

The same review confirmed `TestReplaceContentFailsUnknownFile` ([filesystem_test.go:355](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/execd/pkg/web/controller/filesystem_test.go#L355)) was an earlier workaround for the same class of bug from a different code path. It asserted `require.Contains(t, []int{404, 500}, rec.Code)` — accepting either status.

`ReplaceContent` passes raw `os.Stat` errors directly to `handleFileError` (no intermediate wrapping), so after #1026 it reliably returns 404. Tighten the assertion to exactly `404 + FILE_NOT_FOUND`.

# Testing

- [x] Unit tests — added `TestFilesystemControllerRenameFilesReturnsNotFoundForMissingSource` (fails on main, passes after the fix); tightened `TestReplaceContentFailsUnknownFile`.
- [x] Full `components/execd` test suite passes (`go test ./...`).
- [x] `gofmt -l` clean; `go vet ./...` clean.

# Breaking Changes

- [x] None — restores the documented/intended 404. The 500 was a bug, not a contract.

# Checklist

- [x] Linked motivation: #1026 + [@Pangjiping's review](https://github.com/opensandbox-group/OpenSandbox/pull/1026#pullrequestreview-4482183042)
- [ ] Added/updated docs — no docs reference these status codes
- [x] Added/updated tests
- [x] Security impact considered — none (status code change only)
- [x] Backward compatibility considered — improvement only

## Out of scope (per the same review)

The remaining `os.IsNotExist` calls in `utils.go` (lines 43, 131, 176) operate on raw `os.Stat`/`os.Lstat` errors, so they work correctly today. Modernizing them to `errors.Is` would be pure consistency — happy to do it as a separate PR if useful, but skipped here to keep this narrowly scoped to the actual bug.