### PR TITLE
refactor(execd): modernize os.IsNotExist to errors.Is(err, fs.ErrNotExist)

### DIFF
--- a/components/execd/pkg/runtime/workingdir.go
+++ b/components/execd/pkg/runtime/workingdir.go
@@ -34,7 +34,7 @@ func ValidateWorkingDir(cwd string) error {
 	fi, err := os.Stat(resolvedCwd)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("working directory does not exist: %s", cwd)
+			return fmt.Errorf("working directory does not exist: %s: %w", cwd, err)
 		}
 		return fmt.Errorf("cannot access working directory %q: %w", cwd, err)
 	}

--- a/components/execd/pkg/runtime/workingdir.go
+++ b/components/execd/pkg/runtime/workingdir.go
@@ -15,7 +15,9 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
@@ -31,7 +33,7 @@ func ValidateWorkingDir(cwd string) error {
 	}
 	fi, err := os.Stat(resolvedCwd)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("working directory does not exist: %s", cwd)
 		}
 		return fmt.Errorf("cannot access working directory %q: %w", cwd, err)

--- a/components/execd/pkg/web/controller/filesystem.go
+++ b/components/execd/pkg/web/controller/filesystem.go
@@ -374,7 +374,7 @@ func (c *FilesystemController) SearchFiles() {
 
 	files := make([]model.FileInfo, 0, 16)
 	err = filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		if err != nil {

--- a/components/execd/pkg/web/controller/filesystem_windows.go
+++ b/components/execd/pkg/web/controller/filesystem_windows.go
@@ -374,7 +374,7 @@ func (c *FilesystemController) SearchFiles() {
 
 	files := make([]model.FileInfo, 0, 16)
 	err = filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		if err != nil {

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -40,7 +41,7 @@ func DeleteFile(filePath string) error {
 
 	fileInfo, err := os.Stat(absPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return err
@@ -213,7 +214,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 
 	fileInfo, err := os.Lstat(absPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return model.FileInfo{}, fmt.Errorf("file not found: %s: %w", filePath, err)
 		}
 		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -39,7 +40,7 @@ func DeleteFile(filePath string) error {
 
 	fileInfo, err := os.Stat(absPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return err
@@ -173,7 +174,7 @@ func GetFileInfo(filePath string) (model.FileInfo, error) {
 
 	fileInfo, err := os.Lstat(absPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return model.FileInfo{}, fmt.Errorf("file not found: %s: %w", filePath, err)
 		}
 		return model.FileInfo{}, fmt.Errorf("error accessing file %s: %w", filePath, err)


### PR DESCRIPTION
# Summary

Two narrowly-scoped cleanups in the area #1026 and #1028 already touched, addressing the non-blocking note in [@Pangjiping's review of #1026](https://github.com/opensandbox-group/OpenSandbox/pull/1026#pullrequestreview-4482183042):

> Modernizing them to `errors.Is` would be pure consistency — fine to leave as-is.

1. **Modernize `os.IsNotExist` → `errors.Is(err, fs.ErrNotExist)`** at 7 callsites across 5 files. Every site operates on a raw `os.Stat` / `os.Lstat` / `filepath.Walk` error that doesn't pass through `%w` wrapping today, so `os.IsNotExist` and `errors.Is(err, fs.ErrNotExist)` are functionally equivalent — the change is idiomatic-style only and future-proofs against the same sentinel-stripping mistake recurring locally.
2. **Pre-emptive `%w` fix in `ValidateWorkingDir`** — the missing-directory branch built a fresh error with `%s`, losing the `os.ErrNotExist` sentinel. No caller does `errors.Is(err, fs.ErrNotExist)` on the result today, so this isn't an observable bug — fixed while we're in the area, same antipattern as the bugs already fixed by #1026 and #1028.

Per [Go docs](https://pkg.go.dev/os#IsNotExist):

> This function predates `errors.Is`. ... New code should use `errors.Is(err, fs.ErrNotExist)`.

## Callsites updated (7 across 5 files)

| File | Function | Context |
|---|---|---|
| `pkg/web/controller/utils.go:43` | `DeleteFile` | raw `os.Stat` |
| `pkg/web/controller/utils.go:216` | `GetFileInfo` | raw `os.Lstat` |
| `pkg/web/controller/utils_windows.go:42` | `DeleteFile` | mirror |
| `pkg/web/controller/utils_windows.go:176` | `GetFileInfo` | mirror |
| `pkg/web/controller/filesystem.go:377` | `SearchFiles` | inside `filepath.Walk` callback |
| `pkg/web/controller/filesystem_windows.go:377` | `SearchFiles` | mirror |
| `pkg/runtime/workingdir.go:34` | `ValidateWorkingDir` | raw `os.Stat` |

Plus `workingdir.go:37`: `%s` → `%w` to preserve the wrapped sentinel.

## Deliberately skipped

`utils.go:131` and `utils_windows.go:95` (`RenameFile`) — those exact lines are being touched by #1028 to fix an actual sentinel-stripping bug. Leaving them alone here avoids a textual conflict.

`utils_test.go:34` and `:51` — test scaffolding asserting on raw `os.Remove` returns. Leaving as-is to keep this PR strictly focused on production code.

# Testing

- [x] `go test ./...` in `components/execd` — all packages pass
- [x] `gofmt -l` clean
- [x] `go vet ./...` clean

# Breaking Changes

- [x] None — the modernization is functionally equivalent today, and no caller of `ValidateWorkingDir` does `errors.Is` on its return.

# Checklist

- [x] Linked motivation: #1026 review note
- [ ] Added/updated docs — n/a
- [ ] Added/updated tests — n/a (existing tests cover all affected code paths)
- [x] Security impact considered — none
- [x] Backward compatibility considered — none affected