### PR TITLE
feat(execd): support line-based file reading with offset + limit

### DIFF
--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +28,8 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
 )
 
-// DownloadFile serves a file for download with support for range requests.
+// DownloadFile serves a file for download with support for range requests
+// and line-based reading via offset/limit query parameters.
 func (c *FilesystemController) DownloadFile() {
 	rec := beginFilesystemMetric("download")
 	defer rec.Finish(c.basicController)
@@ -51,12 +53,32 @@ func (c *FilesystemController) DownloadFile() {
 		return
 	}
 
+	rawOffset := c.ctx.Query("offset")
+	rawLimit := c.ctx.Query("limit")
+	hasLineParams := rawOffset != "" || rawLimit != ""
+	rangeHeader := c.ctx.GetHeader("Range")
+
+	if hasLineParams && rangeHeader != "" {
+		c.RespondError(
+			http.StatusBadRequest,
+			model.ErrorCodeInvalidRequest,
+			"line-based reading (offset/limit) and byte range (Range header) are mutually exclusive",
+		)
+		return
+	}
+
 	file, err := os.Open(resolvedFilePath)
 	if err != nil {
 		c.handleFileError(err)
 		return
 	}
 	defer file.Close()
+
+	if hasLineParams {
+		c.serveLineRange(file, rawOffset, rawLimit)
+		rec.MarkSuccess()
+		return
+	}
 
 	fileInfo, err := file.Stat()
 	if err != nil {
@@ -72,7 +94,7 @@ func (c *FilesystemController) DownloadFile() {
 	c.ctx.Header("Content-Disposition", formatContentDisposition(filepath.Base(resolvedFilePath)))
 	c.ctx.Header("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
 
-	if rangeHeader := c.ctx.GetHeader("Range"); rangeHeader != "" {
+	if rangeHeader != "" {
 		ranges, err := ParseRange(rangeHeader, fileInfo.Size())
 		if err != nil {
 			c.RespondError(
@@ -96,6 +118,59 @@ func (c *FilesystemController) DownloadFile() {
 
 	rec.MarkSuccess()
 	http.ServeContent(c.ctx.Writer, c.ctx.Request, filepath.Base(resolvedFilePath), fileInfo.ModTime(), file)
+}
+
+// serveLineRange reads lines from file starting at a 1-based offset and
+// returns up to limit lines as text/plain.
+func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit string) {
+	offset := int64(1)
+	if rawOffset != "" {
+		parsed, err := strconv.ParseInt(rawOffset, 10, 64)
+		if err != nil || parsed < 1 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidRequest,
+				fmt.Sprintf("invalid query parameter 'offset': %s", rawOffset),
+			)
+			return
+		}
+		offset = parsed
+	}
+
+	limit := int64(-1)
+	if rawLimit != "" {
+		parsed, err := strconv.ParseInt(rawLimit, 10, 64)
+		if err != nil || parsed < 1 {
+			c.RespondError(
+				http.StatusBadRequest,
+				model.ErrorCodeInvalidRequest,
+				fmt.Sprintf("invalid query parameter 'limit': %s", rawLimit),
+			)
+			return
+		}
+		limit = parsed
+	}
+
+	c.ctx.Header("Content-Type", "text/plain; charset=utf-8")
+	c.ctx.Status(http.StatusOK)
+
+	scanner := bufio.NewScanner(file)
+	var lineNum int64
+	var written int64
+	for scanner.Scan() {
+		lineNum++
+		if lineNum < offset {
+			continue
+		}
+		if limit >= 0 && written >= limit {
+			break
+		}
+		if written > 0 {
+			_, _ = c.ctx.Writer.Write([]byte("\n"))
+		}
+		_, _ = c.ctx.Writer.Write(scanner.Bytes())
+		written++
+	}
 }
 
 // formatContentDisposition formats the Content-Disposition header value with proper

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -165,14 +165,14 @@ func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit
 		if lineNum < offset {
 			continue
 		}
-		if limit >= 0 && written >= limit {
-			break
-		}
 		if written > 0 {
 			_, _ = c.ctx.Writer.Write([]byte("\n"))
 		}
 		_, _ = c.ctx.Writer.Write(scanner.Bytes())
 		written++
+		if limit >= 0 && written >= limit {
+			break
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		_, _ = c.ctx.Writer.Write([]byte(fmt.Sprintf("\n[error reading file: %v]", err)))

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -154,28 +155,28 @@ func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit
 	c.ctx.Header("Content-Type", "text/plain; charset=utf-8")
 	c.ctx.Status(http.StatusOK)
 
-	const maxLineSize = 1024 * 1024 // 1 MiB
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
-
+	reader := bufio.NewReader(file)
 	var lineNum int64
 	var written int64
-	for scanner.Scan() {
-		lineNum++
-		if lineNum < offset {
-			continue
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			line = bytes.TrimRight(line, "\r\n")
+			lineNum++
+			if lineNum >= offset {
+				if written > 0 {
+					_, _ = c.ctx.Writer.Write([]byte("\n"))
+				}
+				_, _ = c.ctx.Writer.Write(line)
+				written++
+				if limit >= 0 && written >= limit {
+					break
+				}
+			}
 		}
-		if written > 0 {
-			_, _ = c.ctx.Writer.Write([]byte("\n"))
-		}
-		_, _ = c.ctx.Writer.Write(scanner.Bytes())
-		written++
-		if limit >= 0 && written >= limit {
+		if err != nil {
 			break
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		_, _ = c.ctx.Writer.Write([]byte(fmt.Sprintf("\n[error reading file: %v]", err)))
 	}
 }
 

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -175,7 +175,7 @@ func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit
 		written++
 	}
 	if err := scanner.Err(); err != nil {
-		c.ctx.Writer.Write([]byte(fmt.Sprintf("\n[error reading file: %v]", err)))
+		_, _ = c.ctx.Writer.Write([]byte(fmt.Sprintf("\n[error reading file: %v]", err)))
 	}
 }
 

--- a/components/execd/pkg/web/controller/filesystem_download.go
+++ b/components/execd/pkg/web/controller/filesystem_download.go
@@ -154,7 +154,10 @@ func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit
 	c.ctx.Header("Content-Type", "text/plain; charset=utf-8")
 	c.ctx.Status(http.StatusOK)
 
+	const maxLineSize = 1024 * 1024 // 1 MiB
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+
 	var lineNum int64
 	var written int64
 	for scanner.Scan() {
@@ -170,6 +173,9 @@ func (c *FilesystemController) serveLineRange(file *os.File, rawOffset, rawLimit
 		}
 		_, _ = c.ctx.Writer.Write(scanner.Bytes())
 		written++
+	}
+	if err := scanner.Err(); err != nil {
+		c.ctx.Writer.Write([]byte(fmt.Sprintf("\n[error reading file: %v]", err)))
 	}
 }
 

--- a/components/execd/pkg/web/controller/filesystem_test.go
+++ b/components/execd/pkg/web/controller/filesystem_test.go
@@ -406,3 +406,127 @@ func TestFormatContentDisposition(t *testing.T) {
 		})
 	}
 }
+
+func writeTestFileWithLines(t *testing.T, lines []string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "lines.txt")
+	content := ""
+	for i, l := range lines {
+		if i > 0 {
+			content += "\n"
+		}
+		content += l
+	}
+	require.NoError(t, os.WriteFile(target, []byte(content), 0o644))
+	return target
+}
+
+func TestDownloadFileLineBasedReading(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1", "line2", "line3", "line4", "line5"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&offset=2&limit=2", url.QueryEscape(target))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "line2\nline3", rec.Body.String())
+	require.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+}
+
+func TestDownloadFileLineBasedOffsetOnly(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1", "line2", "line3"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&offset=2", url.QueryEscape(target))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "line2\nline3", rec.Body.String())
+}
+
+func TestDownloadFileLimitOnly(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1", "line2", "line3"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&limit=2", url.QueryEscape(target))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "line1\nline2", rec.Body.String())
+}
+
+func TestDownloadFileOffsetBeyondEOF(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1", "line2"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&offset=100", url.QueryEscape(target))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, rec.Body.String())
+}
+
+func TestDownloadFileLimitBeyondRemaining(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1", "line2", "line3"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&offset=2&limit=100", url.QueryEscape(target))
+	ctrl, rec := newFilesystemController(t, http.MethodGet, rawURL, nil)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "line2\nline3", rec.Body.String())
+}
+
+func TestDownloadFileLineRangeConflict(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1"})
+	rawURL := fmt.Sprintf("/files/download?path=%s&offset=1&limit=1", url.QueryEscape(target))
+	ctx, rec := newTestContext(http.MethodGet, rawURL, nil)
+	ctx.Request.Header.Set("Range", "bytes=0-10")
+	ctrl := NewFilesystemController(ctx)
+
+	ctrl.DownloadFile()
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp model.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, model.ErrorCodeInvalidRequest, resp.Code)
+}
+
+func TestDownloadFileInvalidOffset(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1"})
+	tests := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "non-numeric", rawURL: fmt.Sprintf("/files/download?path=%s&offset=abc", url.QueryEscape(target))},
+		{name: "zero", rawURL: fmt.Sprintf("/files/download?path=%s&offset=0", url.QueryEscape(target))},
+		{name: "negative", rawURL: fmt.Sprintf("/files/download?path=%s&offset=-1", url.QueryEscape(target))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, rec := newFilesystemController(t, http.MethodGet, tt.rawURL, nil)
+			ctrl.DownloadFile()
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestDownloadFileInvalidLimit(t *testing.T) {
+	target := writeTestFileWithLines(t, []string{"line1"})
+	tests := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "non-numeric", rawURL: fmt.Sprintf("/files/download?path=%s&limit=abc", url.QueryEscape(target))},
+		{name: "zero", rawURL: fmt.Sprintf("/files/download?path=%s&limit=0", url.QueryEscape(target))},
+		{name: "negative", rawURL: fmt.Sprintf("/files/download?path=%s&limit=-1", url.QueryEscape(target))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl, rec := newFilesystemController(t, http.MethodGet, tt.rawURL, nil)
+			ctrl.DownloadFile()
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/FilesystemAdapter.cs
@@ -180,7 +180,7 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         ReadFileOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        var bytes = await ReadBytesAsync(path, new ReadBytesOptions { Range = options?.Range }, cancellationToken).ConfigureAwait(false);
+        var bytes = await ReadBytesAsync(path, new ReadBytesOptions { Range = options?.Range, Offset = options?.Offset, Limit = options?.Limit }, cancellationToken).ConfigureAwait(false);
         var encoding = GetEncoding(options?.Encoding ?? "utf-8");
         return encoding.GetString(bytes);
     }
@@ -202,6 +202,15 @@ internal sealed class FilesystemAdapter : ISandboxFiles
             ["path"] = path
         };
 
+        if (options?.Offset != null)
+        {
+            queryParams["offset"] = options.Offset.Value.ToString();
+        }
+        if (options?.Limit != null)
+        {
+            queryParams["limit"] = options.Limit.Value.ToString();
+        }
+
         return await _client.GetBytesAsync("/files/download", queryParams, headers, cancellationToken).ConfigureAwait(false);
     }
 
@@ -211,6 +220,14 @@ internal sealed class FilesystemAdapter : ISandboxFiles
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var url = $"{_baseUrl}/files/download?path={Uri.EscapeDataString(path)}";
+        if (options?.Offset != null)
+        {
+            url += $"&offset={options.Offset.Value}";
+        }
+        if (options?.Limit != null)
+        {
+            url += $"&limit={options.Limit.Value}";
+        }
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         foreach (var header in _headers)

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Filesystem.cs
@@ -273,8 +273,21 @@ public class ReadFileOptions
 
     /// <summary>
     /// Gets or sets the byte range to read (e.g., "bytes=0-1023").
+    /// Mutually exclusive with Offset/Limit.
     /// </summary>
     public string? Range { get; set; }
+
+    /// <summary>
+    /// Gets or sets the starting line number (1-based) for line-based reading.
+    /// Mutually exclusive with Range.
+    /// </summary>
+    public int? Offset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of lines to return for line-based reading.
+    /// Mutually exclusive with Range.
+    /// </summary>
+    public int? Limit { get; set; }
 }
 
 /// <summary>
@@ -284,8 +297,21 @@ public class ReadBytesOptions
 {
     /// <summary>
     /// Gets or sets the byte range to read (e.g., "bytes=0-1023").
+    /// Mutually exclusive with Offset/Limit.
     /// </summary>
     public string? Range { get; set; }
+
+    /// <summary>
+    /// Gets or sets the starting line number (1-based) for line-based reading.
+    /// Mutually exclusive with Range.
+    /// </summary>
+    public int? Offset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of lines to return for line-based reading.
+    /// Mutually exclusive with Range.
+    /// </summary>
+    public int? Limit { get; set; }
 }
 
 /// <summary>

--- a/sdks/sandbox/go/execd.go
+++ b/sdks/sandbox/go/execd.go
@@ -409,12 +409,29 @@ func (e *ExecdClient) newUploadFilesRequest(ctx context.Context, entries []Uploa
 	return req, pr, nil
 }
 
+// DownloadFileOptions configures line-based reading for DownloadFile.
+type DownloadFileOptions struct {
+	// Offset is the starting line number (1-based). Mutually exclusive with Range header.
+	Offset int
+	// Limit is the number of lines to return. Mutually exclusive with Range header.
+	Limit int
+}
+
 // DownloadFile downloads a file from the sandbox. The caller must close the
 // returned io.ReadCloser. Pass rangeHeader (e.g. "bytes=0-1023") for partial
-// content, or empty string for the full file.
-func (e *ExecdClient) DownloadFile(ctx context.Context, remotePath string, rangeHeader string) (io.ReadCloser, error) {
+// content, or empty string for the full file. Use opts for line-based reading.
+func (e *ExecdClient) DownloadFile(ctx context.Context, remotePath string, rangeHeader string, opts ...DownloadFileOptions) (io.ReadCloser, error) {
 	params := url.Values{}
 	params.Set("path", remotePath)
+	if len(opts) > 0 {
+		o := opts[0]
+		if o.Offset > 0 {
+			params.Set("offset", strconv.Itoa(o.Offset))
+		}
+		if o.Limit > 0 {
+			params.Set("limit", strconv.Itoa(o.Limit))
+		}
+	}
 	reqPath := "/files/download?" + params.Encode()
 
 	var resp *http.Response

--- a/sdks/sandbox/go/sandbox_files.go
+++ b/sdks/sandbox/go/sandbox_files.go
@@ -96,11 +96,11 @@ func (s *Sandbox) UploadFiles(ctx context.Context, entries []UploadFileEntry) er
 }
 
 // DownloadFile downloads a file from the sandbox.
-func (s *Sandbox) DownloadFile(ctx context.Context, remotePath, rangeHeader string) (io.ReadCloser, error) {
+func (s *Sandbox) DownloadFile(ctx context.Context, remotePath, rangeHeader string, opts ...DownloadFileOptions) (io.ReadCloser, error) {
 	if s.execd == nil {
 		return nil, fmt.Errorf("opensandbox: execd client not initialized")
 	}
-	return s.execd.DownloadFile(ctx, remotePath, rangeHeader)
+	return s.execd.DownloadFile(ctx, remotePath, rangeHeader, opts...)
 }
 
 // CreateDirectory creates a directory in the sandbox.

--- a/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/filesystemAdapter.ts
@@ -520,11 +520,13 @@ export class FilesystemAdapter implements SandboxFiles {
 
   async readBytes(
     path: string,
-    opts?: { range?: string }
+    opts?: { range?: string; offset?: number; limit?: number }
   ): Promise<Uint8Array> {
-    const url =
+    let url =
       joinUrl(this.opts.baseUrl, "/files/download") +
       `?path=${encodeURIComponent(path)}`;
+    if (opts?.offset != null) url += `&offset=${opts.offset}`;
+    if (opts?.limit != null) url += `&limit=${opts.limit}`;
     const res = await this.fetch(url, {
       method: "GET",
       headers: {
@@ -552,18 +554,20 @@ export class FilesystemAdapter implements SandboxFiles {
 
   readBytesStream(
     path: string,
-    opts?: { range?: string }
+    opts?: { range?: string; offset?: number; limit?: number }
   ): AsyncIterable<Uint8Array> {
     return this.downloadStream(path, opts);
   }
 
   private async *downloadStream(
     path: string,
-    opts?: { range?: string }
+    opts?: { range?: string; offset?: number; limit?: number }
   ): AsyncIterable<Uint8Array> {
-    const url =
+    let url =
       joinUrl(this.opts.baseUrl, "/files/download") +
       `?path=${encodeURIComponent(path)}`;
+    if (opts?.offset != null) url += `&offset=${opts.offset}`;
+    if (opts?.limit != null) url += `&limit=${opts.limit}`;
     const res = await this.fetch(url, {
       method: "GET",
       headers: {
@@ -598,9 +602,9 @@ export class FilesystemAdapter implements SandboxFiles {
 
   async readFile(
     path: string,
-    opts?: { encoding?: string; range?: string }
+    opts?: { encoding?: string; range?: string; offset?: number; limit?: number }
   ): Promise<string> {
-    const bytes = await this.readBytes(path, { range: opts?.range });
+    const bytes = await this.readBytes(path, { range: opts?.range, offset: opts?.offset, limit: opts?.limit });
     const encoding = opts?.encoding ?? "utf-8";
     return new TextDecoder(encoding).decode(bytes);
   }

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -461,6 +461,10 @@ export interface paths {
          * @description Downloads a file from the specified path within the sandbox. Supports HTTP
          *     range requests for resumable downloads and partial content retrieval.
          *     Returns file as octet-stream with appropriate headers.
+         *
+         *     When offset/limit query parameters are provided, the endpoint performs
+         *     line-based reading and returns text/plain content instead. Line-based
+         *     parameters are mutually exclusive with the Range header.
          */
         get: operations["downloadFile"];
         put?: never;
@@ -484,6 +488,17 @@ export interface paths {
          *     only immediate children are returned (`depth=1`). Set `depth` to a larger
          *     value to include descendants up to that many levels below `path`. The
          *     root directory itself is not included in the response.
+         *
+         *     Symbolic links are reported with `type=symlink` and are not traversed:
+         *     the listing never descends into a link target, even when `depth` would
+         *     otherwise allow it. For the same reason, when `path` itself resolves to
+         *     a symbolic link the request is rejected with `400`; callers must pass
+         *     the real directory path they want listed.
+         *
+         *     Entries are returned in lexical order by entry name within each
+         *     directory. Descendants reported via `depth>1` follow their parent in
+         *     the same lexical order, so a depth-2 listing yields stable, predictable
+         *     output for file-browser style clients.
          */
         get: operations["listDirectory"];
         put?: never;
@@ -1687,10 +1702,20 @@ export interface operations {
                  * @example /workspace/data.csv
                  */
                 path: string;
+                /**
+                 * @description Starting line number (1-based) for line-based reading. Mutually exclusive with the Range header.
+                 * @example 100
+                 */
+                offset?: number;
+                /**
+                 * @description Number of lines to return for line-based reading. Mutually exclusive with the Range header.
+                 * @example 20
+                 */
+                limit?: number;
             };
             header?: {
                 /**
-                 * @description HTTP Range header for partial content requests
+                 * @description HTTP Range header for partial content requests. Mutually exclusive with offset/limit.
                  * @example bytes=0-1023
                  */
                 Range?: string;
@@ -1700,17 +1725,21 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description File content */
+            /**
+             * @description File content. Returns application/octet-stream for full or byte-range
+             *     downloads, or text/plain for line-based reads (when offset/limit are provided).
+             */
             200: {
                 headers: {
-                    /** @description Attachment header with filename */
+                    /** @description Attachment header with filename (byte-range mode only) */
                     "Content-Disposition"?: string;
-                    /** @description File size in bytes */
+                    /** @description File size in bytes (byte-range mode only) */
                     "Content-Length"?: number;
                     [name: string]: unknown;
                 };
                 content: {
                     "application/octet-stream": string;
+                    "text/plain": string;
                 };
             };
             /** @description Partial file content (when Range header is provided) */

--- a/sdks/sandbox/javascript/src/services/filesystem.ts
+++ b/sdks/sandbox/javascript/src/services/filesystem.ts
@@ -39,9 +39,9 @@ export interface SandboxFiles {
   deleteDirectories(paths: string[]): Promise<void>;
 
   writeFiles(entries: WriteEntry[]): Promise<void>;
-  readFile(path: string, opts?: { encoding?: string; range?: string }): Promise<string>;
-  readBytes(path: string, opts?: { range?: string }): Promise<Uint8Array>;
-  readBytesStream(path: string, opts?: { range?: string }): AsyncIterable<Uint8Array>;
+  readFile(path: string, opts?: { encoding?: string; range?: string; offset?: number; limit?: number }): Promise<string>;
+  readBytes(path: string, opts?: { range?: string; offset?: number; limit?: number }): Promise<Uint8Array>;
+  readBytesStream(path: string, opts?: { range?: string; offset?: number; limit?: number }): AsyncIterable<Uint8Array>;
 
   deleteFiles(paths: string[]): Promise<void>;
   moveFiles(entries: MoveEntry[]): Promise<void>;

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -39,7 +39,9 @@ interface Filesystem {
      *
      * @param path The absolute or relative path to the file to read
      * @param encoding Character encoding for the file content (default: UTF-8)
-     * @param range HTTP byte range to read (e.g., "bytes=0-1023").
+     * @param range HTTP byte range to read (e.g., "bytes=0-1023"). Mutually exclusive with offset/limit.
+     * @param offset Starting line number (1-based) for line-based reading. Mutually exclusive with range.
+     * @param limit Number of lines to return for line-based reading. Mutually exclusive with range.
      * @return The file content as a string
      * @throws SandboxException if the operation fails
      */
@@ -47,6 +49,8 @@ interface Filesystem {
         path: String,
         encoding: String = "UTF-8",
         range: String? = null,
+        offset: Int? = null,
+        limit: Int? = null,
     ): String
 
     /**
@@ -65,13 +69,17 @@ interface Filesystem {
      * Reads the content of a file as a byte array.
      *
      * @param path The absolute or relative path to the file to read
-     * @param range HTTP byte range to read (e.g., "bytes=0-1023").
+     * @param range HTTP byte range to read (e.g., "bytes=0-1023"). Mutually exclusive with offset/limit.
+     * @param offset Starting line number (1-based) for line-based reading. Mutually exclusive with range.
+     * @param limit Number of lines to return for line-based reading. Mutually exclusive with range.
      * @return The file content as a byte array
      * @throws SandboxException if the operation fails
      */
     fun readByteArray(
         path: String,
         range: String? = null,
+        offset: Int? = null,
+        limit: Int? = null,
     ): ByteArray
 
     /**
@@ -90,13 +98,17 @@ interface Filesystem {
      * Opens a file for reading as an InputStream.
      *
      * @param path The absolute or relative path to the file to read
-     * @param range HTTP byte range to read (e.g., "bytes=0-1023").
+     * @param range HTTP byte range to read (e.g., "bytes=0-1023"). Mutually exclusive with offset/limit.
+     * @param offset Starting line number (1-based) for line-based reading. Mutually exclusive with range.
+     * @param limit Number of lines to return for line-based reading. Mutually exclusive with range.
      * @return An InputStream for reading the file content
      * @throws SandboxException if the operation fails
      */
     fun readStream(
         path: String,
         range: String? = null,
+        offset: Int? = null,
+        limit: Int? = null,
     ): InputStream
 
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -56,7 +56,11 @@ interface Filesystem {
     /**
      * Backward-compatible overload for Java callers using positional args.
      */
-    fun readFile(path: String, encoding: String, range: String?): String {
+    fun readFile(
+        path: String,
+        encoding: String,
+        range: String?,
+    ): String {
         return readFile(path, encoding, range, null, null)
     }
 
@@ -92,7 +96,10 @@ interface Filesystem {
     /**
      * Backward-compatible overload for Java callers using positional args.
      */
-    fun readByteArray(path: String, range: String?): ByteArray {
+    fun readByteArray(
+        path: String,
+        range: String?,
+    ): ByteArray {
         return readByteArray(path, range, null, null)
     }
 
@@ -128,7 +135,10 @@ interface Filesystem {
     /**
      * Backward-compatible overload for Java callers using positional args.
      */
-    fun readStream(path: String, range: String?): InputStream {
+    fun readStream(
+        path: String,
+        range: String?,
+    ): InputStream {
         return readStream(path, range, null, null)
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Filesystem.kt
@@ -54,6 +54,13 @@ interface Filesystem {
     ): String
 
     /**
+     * Backward-compatible overload for Java callers using positional args.
+     */
+    fun readFile(path: String, encoding: String, range: String?): String {
+        return readFile(path, encoding, range, null, null)
+    }
+
+    /**
      * Convenience overload for reading a file as a string using UTF-8.
      *
      * Equivalent to: `readFile(path, "UTF-8", null)`
@@ -83,6 +90,13 @@ interface Filesystem {
     ): ByteArray
 
     /**
+     * Backward-compatible overload for Java callers using positional args.
+     */
+    fun readByteArray(path: String, range: String?): ByteArray {
+        return readByteArray(path, range, null, null)
+    }
+
+    /**
      * Convenience overload for reading a file as a byte array.
      *
      * Equivalent to: `readByteArray(path, null)`
@@ -110,6 +124,13 @@ interface Filesystem {
         offset: Int? = null,
         limit: Int? = null,
     ): InputStream
+
+    /**
+     * Backward-compatible overload for Java callers using positional args.
+     */
+    fun readStream(path: String, range: String?): InputStream {
+        return readStream(path, range, null, null)
+    }
 
     /**
      * Convenience overload for opening a file stream.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -92,9 +92,11 @@ internal class FilesystemAdapter(
         path: String,
         encoding: String,
         range: String?,
+        offset: Int?,
+        limit: Int?,
     ): String {
         try {
-            val request = buildDownloadRequest(path, range)
+            val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     val errorBodyString = response.body?.string()
@@ -120,9 +122,11 @@ internal class FilesystemAdapter(
     override fun readByteArray(
         path: String,
         range: String?,
+        offset: Int?,
+        limit: Int?,
     ): ByteArray {
         try {
-            val request = buildDownloadRequest(path, range)
+            val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     val errorBodyString = response.body?.string()
@@ -146,9 +150,11 @@ internal class FilesystemAdapter(
     override fun readStream(
         path: String,
         range: String?,
+        offset: Int?,
+        limit: Int?,
     ): InputStream {
         try {
-            val request = buildDownloadRequest(path, range)
+            val request = buildDownloadRequest(path, range, offset, limit)
             val response = httpClientProvider.httpClient.newCall(request).execute()
 
             if (!response.isSuccessful) {
@@ -437,17 +443,25 @@ internal class FilesystemAdapter(
     private fun buildDownloadRequest(
         path: String,
         range: String?,
+        offset: Int? = null,
+        limit: Int? = null,
     ): Request {
         val baseUrlString = "${httpClientProvider.config.protocol}://${execdEndpoint.endpoint}$FILESYSTEM_DOWNLOAD_PATH"
-        val httpUrl =
+        val urlBuilder =
             baseUrlString.toHttpUrl()
                 .newBuilder()
                 .addQueryParameter("path", path)
-                .build()
+
+        if (offset != null) {
+            urlBuilder.addQueryParameter("offset", offset.toString())
+        }
+        if (limit != null) {
+            urlBuilder.addQueryParameter("limit", limit.toString())
+        }
 
         val requestBuilder =
             Request.Builder()
-                .url(httpUrl)
+                .url(urlBuilder.build())
                 .headers(execdEndpoint.headers.toHeaders())
                 .get()
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -136,9 +136,11 @@ class FilesystemAdapter(Filesystem):
         *,
         encoding: str = "utf-8",
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> str:
         """Read file content as string via HTTP API."""
-        content = await self.read_bytes(path, range_header=range_header)
+        content = await self.read_bytes(path, range_header=range_header, offset=offset, limit=limit)
         return content.decode(encoding)
 
     async def read_bytes(
@@ -146,12 +148,19 @@ class FilesystemAdapter(Filesystem):
         path: str,
         *,
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> bytes:
-        """Read file content as bytes with support for range requests.
+        """Read file content as bytes with support for range and line-based requests.
 
         Args:
             path: Path to the file to read
-            range_header: Optional range header for partial content requests
+            range_header: Optional range header for partial content requests.
+                Mutually exclusive with offset/limit.
+            offset: Starting line number (1-based) for line-based reading.
+                Mutually exclusive with range_header.
+            limit: Number of lines to return for line-based reading.
+                Mutually exclusive with range_header.
 
         Returns:
             File content as bytes
@@ -161,7 +170,7 @@ class FilesystemAdapter(Filesystem):
         """
         logger.debug(f"Reading file as bytes: {path}")
         try:
-            request_data = self._build_download_request(path, range_header)
+            request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
             client = await self._get_httpx_client()
 
             if request_data["params"] is None:
@@ -187,11 +196,13 @@ class FilesystemAdapter(Filesystem):
             *,
             chunk_size: int = 64 * 1024,
             range_header: str | None = None,
+            offset: int | None = None,
+            limit: int | None = None,
     ) -> AsyncIterator[bytes]:
         """Stream file content as bytes chunks via HTTP (true streaming)."""
         logger.debug(f"Streaming file as bytes: {path} (chunk_size={chunk_size})")
         try:
-            request_data = self._build_download_request(path, range_header)
+            request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
             client = await self._get_httpx_client()
 
             url = request_data["url"]
@@ -537,13 +548,20 @@ class FilesystemAdapter(Filesystem):
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def _build_download_request(
-            self, path: str, range_header: str | None = None
+            self,
+            path: str,
+            range_header: str | None = None,
+            *,
+            offset: int | None = None,
+            limit: int | None = None,
     ) -> _DownloadRequest:
         """Build HTTP request for file download operations.
 
         Args:
             path: File path to download
             range_header: Optional range header for partial downloads
+            offset: Starting line number (1-based) for line-based reading
+            limit: Number of lines to return for line-based reading
 
         Returns:
             Dictionary containing URL, parameters, and headers for the request
@@ -551,12 +569,20 @@ class FilesystemAdapter(Filesystem):
         encoded_path = quote(path, safe="/")
         url = f"{self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)}?path={encoded_path}"
         headers: dict[str, str] = {}
+        params: dict[str, str] | None = None
 
         if range_header:
             headers["Range"] = range_header
 
+        if offset is not None or limit is not None:
+            params = {}
+            if offset is not None:
+                params["offset"] = str(offset)
+            if limit is not None:
+                params["limit"] = str(limit)
+
         return {
             "url": url,
-            "params": None,
+            "params": params,
             "headers": headers,
         }

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 class _DownloadRequest(TypedDict):
     url: str
-    params: dict[str, str] | None
+    params: dict[str, str]
     headers: dict[str, str]
 
 
@@ -173,17 +173,11 @@ class FilesystemAdapter(Filesystem):
             request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
             client = await self._get_httpx_client()
 
-            if request_data["params"] is None:
-                response = await client.get(
-                    request_data["url"],
-                    headers=request_data["headers"],
-                )
-            else:
-                response = await client.get(
-                    request_data["url"],
-                    headers=request_data["headers"],
-                    params=request_data["params"],
-                )
+            response = await client.get(
+                request_data["url"],
+                headers=request_data["headers"],
+                params=request_data["params"],
+            )
             response.raise_for_status()
             return response.content
         except Exception as e:
@@ -209,15 +203,12 @@ class FilesystemAdapter(Filesystem):
             params = request_data["params"]
             headers = request_data["headers"]
 
-            if params is None:
-                request = client.build_request("GET", url, headers=headers)
-            else:
-                request = client.build_request(
-                    "GET",
-                    url,
-                    headers=headers,
-                    params=params,
-                )
+            request = client.build_request(
+                "GET",
+                url,
+                headers=headers,
+                params=params,
+            )
 
             response = await client.send(request, stream=True)
 
@@ -566,20 +557,17 @@ class FilesystemAdapter(Filesystem):
         Returns:
             Dictionary containing URL, parameters, and headers for the request
         """
-        encoded_path = quote(path, safe="/")
-        url = f"{self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)}?path={encoded_path}"
+        url = self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)
         headers: dict[str, str] = {}
-        params: dict[str, str] | None = None
+        params: dict[str, str] = {"path": path}
 
         if range_header:
             headers["Range"] = range_header
 
-        if offset is not None or limit is not None:
-            params = {}
-            if offset is not None:
-                params["offset"] = str(offset)
-            if limit is not None:
-                params["limit"] = str(limit)
+        if offset is not None:
+            params["offset"] = str(offset)
+        if limit is not None:
+            params["limit"] = str(limit)
 
         return {
             "url": url,

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -25,7 +25,6 @@ import logging
 from collections.abc import AsyncIterator
 from io import IOBase, TextIOBase
 from typing import TypedDict
-from urllib.parse import quote
 
 import httpx
 

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/download_file.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/download_file.py
@@ -29,6 +29,8 @@ from ...types import UNSET, File, Response, Unset
 def _get_kwargs(
     *,
     path: str,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
     range_: str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
@@ -38,6 +40,10 @@ def _get_kwargs(
     params: dict[str, Any] = {}
 
     params["path"] = path
+
+    params["offset"] = offset
+
+    params["limit"] = limit
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -103,6 +109,8 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     path: str,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
     range_: str | Unset = UNSET,
 ) -> Response[ErrorResponse | File]:
     """Download file from sandbox
@@ -111,8 +119,14 @@ def sync_detailed(
     range requests for resumable downloads and partial content retrieval.
     Returns file as octet-stream with appropriate headers.
 
+    When offset/limit query parameters are provided, the endpoint performs
+    line-based reading and returns text/plain content instead. Line-based
+    parameters are mutually exclusive with the Range header.
+
     Args:
         path (str):
+        offset (int | Unset):
+        limit (int | Unset):
         range_ (str | Unset):
 
     Raises:
@@ -125,6 +139,8 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         path=path,
+        offset=offset,
+        limit=limit,
         range_=range_,
     )
 
@@ -139,6 +155,8 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     path: str,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
     range_: str | Unset = UNSET,
 ) -> ErrorResponse | File | None:
     """Download file from sandbox
@@ -147,8 +165,14 @@ def sync(
     range requests for resumable downloads and partial content retrieval.
     Returns file as octet-stream with appropriate headers.
 
+    When offset/limit query parameters are provided, the endpoint performs
+    line-based reading and returns text/plain content instead. Line-based
+    parameters are mutually exclusive with the Range header.
+
     Args:
         path (str):
+        offset (int | Unset):
+        limit (int | Unset):
         range_ (str | Unset):
 
     Raises:
@@ -162,6 +186,8 @@ def sync(
     return sync_detailed(
         client=client,
         path=path,
+        offset=offset,
+        limit=limit,
         range_=range_,
     ).parsed
 
@@ -170,6 +196,8 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     path: str,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
     range_: str | Unset = UNSET,
 ) -> Response[ErrorResponse | File]:
     """Download file from sandbox
@@ -178,8 +206,14 @@ async def asyncio_detailed(
     range requests for resumable downloads and partial content retrieval.
     Returns file as octet-stream with appropriate headers.
 
+    When offset/limit query parameters are provided, the endpoint performs
+    line-based reading and returns text/plain content instead. Line-based
+    parameters are mutually exclusive with the Range header.
+
     Args:
         path (str):
+        offset (int | Unset):
+        limit (int | Unset):
         range_ (str | Unset):
 
     Raises:
@@ -192,6 +226,8 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         path=path,
+        offset=offset,
+        limit=limit,
         range_=range_,
     )
 
@@ -204,6 +240,8 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     path: str,
+    offset: int | Unset = UNSET,
+    limit: int | Unset = UNSET,
     range_: str | Unset = UNSET,
 ) -> ErrorResponse | File | None:
     """Download file from sandbox
@@ -212,8 +250,14 @@ async def asyncio(
     range requests for resumable downloads and partial content retrieval.
     Returns file as octet-stream with appropriate headers.
 
+    When offset/limit query parameters are provided, the endpoint performs
+    line-based reading and returns text/plain content instead. Line-based
+    parameters are mutually exclusive with the Range header.
+
     Args:
         path (str):
+        offset (int | Unset):
+        limit (int | Unset):
         range_ (str | Unset):
 
     Raises:
@@ -228,6 +272,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             path=path,
+            offset=offset,
+            limit=limit,
             range_=range_,
         )
     ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/list_directory.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/filesystem/list_directory.py
@@ -106,6 +106,17 @@ def sync_detailed(
     value to include descendants up to that many levels below `path`. The
     root directory itself is not included in the response.
 
+    Symbolic links are reported with `type=symlink` and are not traversed:
+    the listing never descends into a link target, even when `depth` would
+    otherwise allow it. For the same reason, when `path` itself resolves to
+    a symbolic link the request is rejected with `400`; callers must pass
+    the real directory path they want listed.
+
+    Entries are returned in lexical order by entry name within each
+    directory. Descendants reported via `depth>1` follow their parent in
+    the same lexical order, so a depth-2 listing yields stable, predictable
+    output for file-browser style clients.
+
     Args:
         path (str):
         depth (int | Unset):  Default: 1.
@@ -143,6 +154,17 @@ def sync(
     value to include descendants up to that many levels below `path`. The
     root directory itself is not included in the response.
 
+    Symbolic links are reported with `type=symlink` and are not traversed:
+    the listing never descends into a link target, even when `depth` would
+    otherwise allow it. For the same reason, when `path` itself resolves to
+    a symbolic link the request is rejected with `400`; callers must pass
+    the real directory path they want listed.
+
+    Entries are returned in lexical order by entry name within each
+    directory. Descendants reported via `depth>1` follow their parent in
+    the same lexical order, so a depth-2 listing yields stable, predictable
+    output for file-browser style clients.
+
     Args:
         path (str):
         depth (int | Unset):  Default: 1.
@@ -174,6 +196,17 @@ async def asyncio_detailed(
     only immediate children are returned (`depth=1`). Set `depth` to a larger
     value to include descendants up to that many levels below `path`. The
     root directory itself is not included in the response.
+
+    Symbolic links are reported with `type=symlink` and are not traversed:
+    the listing never descends into a link target, even when `depth` would
+    otherwise allow it. For the same reason, when `path` itself resolves to
+    a symbolic link the request is rejected with `400`; callers must pass
+    the real directory path they want listed.
+
+    Entries are returned in lexical order by entry name within each
+    directory. Descendants reported via `depth>1` follow their parent in
+    the same lexical order, so a depth-2 listing yields stable, predictable
+    output for file-browser style clients.
 
     Args:
         path (str):
@@ -209,6 +242,17 @@ async def asyncio(
     only immediate children are returned (`depth=1`). Set `depth` to a larger
     value to include descendants up to that many levels below `path`. The
     root directory itself is not included in the response.
+
+    Symbolic links are reported with `type=symlink` and are not traversed:
+    the listing never descends into a link target, even when `depth` would
+    otherwise allow it. For the same reason, when `path` itself resolves to
+    a symbolic link the request is rejected with `400`; callers must pass
+    the real directory path they want listed.
+
+    Entries are returned in lexical order by entry name within each
+    directory. Descendants reported via `depth>1` follow their parent in
+    the same lexical order, so a depth-2 listing yields stable, predictable
+    output for file-browser style clients.
 
     Args:
         path (str):

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_file_content_item.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/replace_file_content_item.py
@@ -30,7 +30,7 @@ class ReplaceFileContentItem:
     """Content replacement operation
 
     Attributes:
-        old (str): String to be replaced Example: localhost.
+        old (str): String to be replaced (must not be empty) Example: localhost.
         new (str): Replacement string Example: 0.0.0.0.
     """
 

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
@@ -26,9 +26,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.create_sandbox_request_env import CreateSandboxRequestEnv
-    from ..models.create_sandbox_request_extensions import (
-        CreateSandboxRequestExtensions,
-    )
+    from ..models.create_sandbox_request_extensions import CreateSandboxRequestExtensions
     from ..models.create_sandbox_request_metadata import CreateSandboxRequestMetadata
     from ..models.credential_proxy_config import CredentialProxyConfig
     from ..models.image_spec import ImageSpec
@@ -121,7 +119,10 @@ class CreateSandboxRequest:
             network_policy (NetworkPolicy | Unset): Egress network policy matching the sidecar `/policy` request body.
                 If `defaultAction` is omitted, the sidecar defaults to "deny"; passing an empty
                 object or null results in allow-all behavior at startup.
-            credential_proxy (CredentialProxyConfig | Unset): Credential Vault proxy startup settings.
+            credential_proxy (CredentialProxyConfig | Unset): Credential Vault proxy startup settings. This is an explicit
+                opt-in for
+                transparent MITM support used by credential injection; plain egress
+                network policy remains DNS/FQDN policy enforcement only.
             secure_access (bool | Unset): Opts the sandbox into secured access for endpoint access.
                 This is currently supported only for Kubernetes sandboxes exposed
                 through ingress gateway mode. When enabled, the server provisions
@@ -256,12 +257,8 @@ class CreateSandboxRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.create_sandbox_request_env import CreateSandboxRequestEnv
-        from ..models.create_sandbox_request_extensions import (
-            CreateSandboxRequestExtensions,
-        )
-        from ..models.create_sandbox_request_metadata import (
-            CreateSandboxRequestMetadata,
-        )
+        from ..models.create_sandbox_request_extensions import CreateSandboxRequestExtensions
+        from ..models.create_sandbox_request_metadata import CreateSandboxRequestMetadata
         from ..models.credential_proxy_config import CredentialProxyConfig
         from ..models.image_spec import ImageSpec
         from ..models.network_policy import NetworkPolicy

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
@@ -20,7 +20,6 @@ from collections.abc import Mapping
 from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -29,20 +28,24 @@ T = TypeVar("T", bound="CredentialProxyConfig")
 
 @_attrs_define
 class CredentialProxyConfig:
-    """Credential Vault proxy startup settings.
+    """Credential Vault proxy startup settings. This is an explicit opt-in for
+    transparent MITM support used by credential injection; plain egress
+    network policy remains DNS/FQDN policy enforcement only.
 
-    Attributes:
-        enabled (bool | Unset): Enable transparent MITM support required by Credential Vault injection. Default: False.
+        Attributes:
+            enabled (bool | Unset): When true, the server starts the egress sidecar with transparent
+                MITM enabled and installs the runtime-managed MITM CA bundle into
+                the sandbox container. Requires `networkPolicy`.
+                 Default: False.
     """
 
     enabled: bool | Unset = False
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         enabled = self.enabled
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update({})
         if enabled is not UNSET:
             field_dict["enabled"] = enabled
@@ -58,24 +61,4 @@ class CredentialProxyConfig:
             enabled=enabled,
         )
 
-        credential_proxy_config.additional_properties = d
         return credential_proxy_config
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties
-
-    def get(self, key: str, default: Any | None = None) -> Any:
-        return self.additional_properties.get(key, default)

--- a/sdks/sandbox/python/src/opensandbox/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/services/filesystem.py
@@ -49,6 +49,8 @@ class Filesystem(Protocol):
         *,
         encoding: str = "utf-8",
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> str:
         """
         Read the content of a file as a string with specified encoding.
@@ -56,7 +58,12 @@ class Filesystem(Protocol):
         Args:
             path: The absolute or relative path to the file to read
             encoding: Character encoding for the file content (default: UTF-8)
-            range_header: HTTP byte range to read (e.g., "bytes=0-1023")
+            range_header: HTTP byte range to read (e.g., "bytes=0-1023").
+                Mutually exclusive with offset/limit.
+            offset: Starting line number (1-based) for line-based reading.
+                Mutually exclusive with range_header.
+            limit: Number of lines to return for line-based reading.
+                Mutually exclusive with range_header.
 
         Returns:
             The file content as a string
@@ -71,13 +78,20 @@ class Filesystem(Protocol):
         path: str,
         *,
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> bytes:
         """
         Read the content of a file as bytes.
 
         Args:
             path: The absolute or relative path to the file to read
-            range_header: HTTP byte range to read (e.g., "bytes=0-1023")
+            range_header: HTTP byte range to read (e.g., "bytes=0-1023").
+                Mutually exclusive with offset/limit.
+            offset: Starting line number (1-based) for line-based reading.
+                Mutually exclusive with range_header.
+            limit: Number of lines to return for line-based reading.
+                Mutually exclusive with range_header.
 
         Returns:
             The file content as bytes
@@ -93,6 +107,8 @@ class Filesystem(Protocol):
         *,
         chunk_size: int = 64 * 1024,
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> AsyncIterator[bytes]:
         """
         Stream file content as bytes chunks (read_* naming).

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -92,13 +92,27 @@ class FilesystemAdapterSync(FilesystemSync):
     def _get_execd_url(self, path: str) -> str:
         return f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
 
-    def _build_download_request(self, path: str, range_header: str | None = None) -> _DownloadRequest:
+    def _build_download_request(
+        self,
+        path: str,
+        range_header: str | None = None,
+        *,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> _DownloadRequest:
         encoded_path = quote(path, safe="/")
         url = f"{self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)}?path={encoded_path}"
         headers: dict[str, str] = {}
+        params: dict[str, str] | None = None
         if range_header:
             headers["Range"] = range_header
-        return {"url": url, "params": None, "headers": headers}
+        if offset is not None or limit is not None:
+            params = {}
+            if offset is not None:
+                params["offset"] = str(offset)
+            if limit is not None:
+                params["limit"] = str(limit)
+        return {"url": url, "params": params, "headers": headers}
 
     def read_file(
         self,
@@ -106,14 +120,23 @@ class FilesystemAdapterSync(FilesystemSync):
         *,
         encoding: str = "utf-8",
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> str:
-        content = self.read_bytes(path, range_header=range_header)
+        content = self.read_bytes(path, range_header=range_header, offset=offset, limit=limit)
         return content.decode(encoding)
 
-    def read_bytes(self, path: str, *, range_header: str | None = None) -> bytes:
+    def read_bytes(
+        self,
+        path: str,
+        *,
+        range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> bytes:
         logger.debug("Reading file as bytes: %s", path)
         try:
-            request_data = self._build_download_request(path, range_header)
+            request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
             if request_data["params"] is None:
                 response = self._httpx_client.get(
                     request_data["url"],
@@ -132,10 +155,16 @@ class FilesystemAdapterSync(FilesystemSync):
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def read_bytes_stream(
-        self, path: str, *, chunk_size: int = 64 * 1024, range_header: str | None = None
+        self,
+        path: str,
+        *,
+        chunk_size: int = 64 * 1024,
+        range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> Iterator[bytes]:
         logger.debug("Streaming file as bytes: %s (chunk_size=%s)", path, chunk_size)
-        request_data = self._build_download_request(path, range_header)
+        request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
         url = request_data["url"]
         params = request_data["params"]
         headers = request_data["headers"]

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 
 class _DownloadRequest(TypedDict):
     url: str
-    params: dict[str, str] | None
+    params: dict[str, str]
     headers: dict[str, str]
 
 
@@ -100,18 +100,15 @@ class FilesystemAdapterSync(FilesystemSync):
         offset: int | None = None,
         limit: int | None = None,
     ) -> _DownloadRequest:
-        encoded_path = quote(path, safe="/")
-        url = f"{self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)}?path={encoded_path}"
+        url = self._get_execd_url(self.FILESYSTEM_DOWNLOAD_PATH)
         headers: dict[str, str] = {}
-        params: dict[str, str] | None = None
+        params: dict[str, str] = {"path": path}
         if range_header:
             headers["Range"] = range_header
-        if offset is not None or limit is not None:
-            params = {}
-            if offset is not None:
-                params["offset"] = str(offset)
-            if limit is not None:
-                params["limit"] = str(limit)
+        if offset is not None:
+            params["offset"] = str(offset)
+        if limit is not None:
+            params["limit"] = str(limit)
         return {"url": url, "params": params, "headers": headers}
 
     def read_file(
@@ -137,17 +134,11 @@ class FilesystemAdapterSync(FilesystemSync):
         logger.debug("Reading file as bytes: %s", path)
         try:
             request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
-            if request_data["params"] is None:
-                response = self._httpx_client.get(
-                    request_data["url"],
-                    headers=request_data["headers"],
-                )
-            else:
-                response = self._httpx_client.get(
-                    request_data["url"],
-                    headers=request_data["headers"],
-                    params=request_data["params"],
-                )
+            response = self._httpx_client.get(
+                request_data["url"],
+                headers=request_data["headers"],
+                params=request_data["params"],
+            )
             response.raise_for_status()
             return response.content
         except Exception as e:
@@ -169,15 +160,12 @@ class FilesystemAdapterSync(FilesystemSync):
         params = request_data["params"]
         headers = request_data["headers"]
 
-        if params is None:
-            request = self._httpx_client.build_request("GET", url, headers=headers)
-        else:
-            request = self._httpx_client.build_request(
-                "GET",
-                url,
-                headers=headers,
-                params=params,
-            )
+        request = self._httpx_client.build_request(
+            "GET",
+            url,
+            headers=headers,
+            params=params,
+        )
         response = self._httpx_client.send(request, stream=True)
 
         if response.status_code >= 300:

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -22,7 +22,6 @@ import logging
 from collections.abc import Iterator
 from io import IOBase, TextIOBase
 from typing import TypedDict
-from urllib.parse import quote
 
 import httpx
 

--- a/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/filesystem.py
@@ -54,6 +54,8 @@ class FilesystemSync(Protocol):
         *,
         encoding: str = "utf-8",
         range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> str:
         """
         Read the content of a file as a string with specified encoding.
@@ -62,6 +64,11 @@ class FilesystemSync(Protocol):
             path: The absolute or relative path to the file to read.
             encoding: Character encoding for the file content (default: UTF-8).
             range_header: HTTP byte range to read (e.g., "bytes=0-1023").
+                Mutually exclusive with offset/limit.
+            offset: Starting line number (1-based) for line-based reading.
+                Mutually exclusive with range_header.
+            limit: Number of lines to return for line-based reading.
+                Mutually exclusive with range_header.
 
         Returns:
             The file content as a string.
@@ -71,13 +78,25 @@ class FilesystemSync(Protocol):
         """
         ...
 
-    def read_bytes(self, path: str, *, range_header: str | None = None) -> bytes:
+    def read_bytes(
+        self,
+        path: str,
+        *,
+        range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> bytes:
         """
         Read the content of a file as bytes.
 
         Args:
             path: The absolute or relative path to the file to read.
             range_header: HTTP byte range to read (e.g., "bytes=0-1023").
+                Mutually exclusive with offset/limit.
+            offset: Starting line number (1-based) for line-based reading.
+                Mutually exclusive with range_header.
+            limit: Number of lines to return for line-based reading.
+                Mutually exclusive with range_header.
 
         Returns:
             The file content as bytes.
@@ -88,7 +107,13 @@ class FilesystemSync(Protocol):
         ...
 
     def read_bytes_stream(
-        self, path: str, *, chunk_size: int = 64 * 1024, range_header: str | None = None
+        self,
+        path: str,
+        *,
+        chunk_size: int = 64 * 1024,
+        range_header: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> Iterator[bytes]:
         """
         Stream file content as bytes chunks (blocking iterator).

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -852,10 +852,30 @@ paths:
           schema:
             type: string
           example: /workspace/data.csv
+        - name: offset
+          in: query
+          required: false
+          description: >
+            Starting line number (1-based) for line-based reading.
+            Mutually exclusive with the Range header.
+          schema:
+            type: integer
+            minimum: 1
+          example: 100
+        - name: limit
+          in: query
+          required: false
+          description: >
+            Number of lines to return for line-based reading.
+            Mutually exclusive with the Range header.
+          schema:
+            type: integer
+            minimum: 1
+          example: 20
         - name: Range
           in: header
           required: false
-          description: HTTP Range header for partial content requests
+          description: HTTP Range header for partial content requests. Mutually exclusive with offset/limit.
           schema:
             type: string
           example: "bytes=0-1023"

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -841,6 +841,10 @@ paths:
         Downloads a file from the specified path within the sandbox. Supports HTTP
         range requests for resumable downloads and partial content retrieval.
         Returns file as octet-stream with appropriate headers.
+
+        When offset/limit query parameters are provided, the endpoint performs
+        line-based reading and returns text/plain content instead. Line-based
+        parameters are mutually exclusive with the Range header.
       operationId: downloadFile
       tags:
         - Filesystem
@@ -881,21 +885,27 @@ paths:
           example: "bytes=0-1023"
       responses:
         "200":
-          description: File content
+          description: |
+            File content. Returns application/octet-stream for full or byte-range
+            downloads, or text/plain for line-based reads (when offset/limit are provided).
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
+            text/plain:
+              schema:
+                type: string
+                description: Line-based content returned when offset/limit parameters are used
           headers:
             Content-Disposition:
               schema:
                 type: string
-              description: Attachment header with filename
+              description: Attachment header with filename (byte-range mode only)
             Content-Length:
               schema:
                 type: integer
-              description: File size in bytes
+              description: File size in bytes (byte-range mode only)
         "206":
           description: Partial file content (when Range header is provided)
           content:

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -937,6 +937,36 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         Assert.Equal("OK", verify.Logs.Stdout[0].Text);
     }
 
+    [Fact(Timeout = 60 * 1000)]
+    public async Task Filesystem_LineBasedReading()
+    {
+        var sandbox = _fixture.Sandbox;
+
+        var testPath = "/tmp/line-read-e2e.txt";
+        var content = "line1\nline2\nline3\nline4\nline5";
+        await sandbox.Files.WriteFilesAsync(new[]
+        {
+            new WriteEntry { Path = testPath, Data = content }
+        });
+
+        // offset=2, limit=2 → lines 2-3
+        var result1 = await sandbox.Files.ReadFileAsync(
+            testPath, new ReadFileOptions { Offset = 2, Limit = 2 });
+        Assert.Equal("line2\nline3", result1);
+
+        // offset=4, no limit → lines 4-5
+        var result2 = await sandbox.Files.ReadFileAsync(
+            testPath, new ReadFileOptions { Offset = 4 });
+        Assert.Equal("line4\nline5", result2);
+
+        // limit=2, no offset → lines 1-2
+        var result3 = await sandbox.Files.ReadFileAsync(
+            testPath, new ReadFileOptions { Limit = 2 });
+        Assert.Equal("line1\nline2", result3);
+
+        await sandbox.Files.DeleteFilesAsync(new[] { testPath });
+    }
+
     [Fact(Timeout = 2 * 60 * 1000)]
     public async Task Command_Interrupt()
     {

--- a/tests/go/filesystem_e2e_test.go
+++ b/tests/go/filesystem_e2e_test.go
@@ -206,3 +206,36 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestFilesystem_DownloadFileLineReading(t *testing.T) {
+	ctx, sb := createTestSandbox(t)
+
+	remotePath := "/tmp/line-read-e2e.txt"
+	_, err := sb.RunCommand(ctx, `printf "line1\nline2\nline3\nline4\nline5" > `+remotePath, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{remotePath}) })
+
+	// offset=2, limit=2 → lines 2-3
+	rc, err := sb.DownloadFile(ctx, remotePath, "", opensandbox.DownloadFileOptions{Offset: 2, Limit: 2})
+	require.NoError(t, err)
+	data, err := io.ReadAll(rc)
+	rc.Close()
+	require.NoError(t, err)
+	require.Equal(t, "line2\nline3", string(data))
+
+	// offset=4, no limit → lines 4-5
+	rc, err = sb.DownloadFile(ctx, remotePath, "", opensandbox.DownloadFileOptions{Offset: 4})
+	require.NoError(t, err)
+	data, err = io.ReadAll(rc)
+	rc.Close()
+	require.NoError(t, err)
+	require.Equal(t, "line4\nline5", string(data))
+
+	// limit=2, no offset → lines 1-2
+	rc, err = sb.DownloadFile(ctx, remotePath, "", opensandbox.DownloadFileOptions{Limit: 2})
+	require.NoError(t, err)
+	data, err = io.ReadAll(rc)
+	rc.Close()
+	require.NoError(t, err)
+	require.Equal(t, "line1\nline2", string(data))
+}

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1443,6 +1443,38 @@ public class SandboxE2ETest extends BaseE2ETest {
     }
 
     @Test
+    @Order(5)
+    @DisplayName("Line-based file reading with offset and limit")
+    @Timeout(value = 1, unit = TimeUnit.MINUTES)
+    void testLineBasedFileReading() throws Exception {
+        assertNotNull(sandbox);
+
+        String testPath = "/tmp/line-read-e2e.txt";
+        String content = "line1\nline2\nline3\nline4\nline5";
+        sandbox.files()
+                .write(
+                        List.of(
+                                WriteEntry.builder()
+                                        .path(testPath)
+                                        .data(content)
+                                        .build()));
+
+        // offset=2, limit=2 → lines 2-3
+        String result1 = sandbox.files().readFile(testPath, "UTF-8", null, 2, 2);
+        assertEquals("line2\nline3", result1);
+
+        // offset=4, no limit → lines 4-5
+        String result2 = sandbox.files().readFile(testPath, "UTF-8", null, 4, null);
+        assertEquals("line4\nline5", result2);
+
+        // limit=2, no offset → lines 1-2
+        String result3 = sandbox.files().readFile(testPath, "UTF-8", null, null, 2);
+        assertEquals("line1\nline2", result3);
+
+        sandbox.files().deleteFiles(List.of(testPath));
+    }
+
+    @Test
     @Order(6)
     @DisplayName("Interrupt command")
     @Timeout(value = 2, unit = TimeUnit.MINUTES)

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -987,6 +987,28 @@ test("03 filesystem operations: CRUD + replace/move/delete + range + stream", as
   expect(verify.logs.stdout[0]?.text).toBe("OK");
 });
 
+test("03a line-based file reading with offset and limit", async () => {
+  if (!sandbox) throw new Error("sandbox not created");
+
+  const testPath = "/tmp/line-read-e2e.txt";
+  const content = "line1\nline2\nline3\nline4\nline5";
+  await sandbox.files.writeFiles([{ path: testPath, data: content }]);
+
+  // offset=2, limit=2 → lines 2-3
+  const result1 = await sandbox.files.readFile(testPath, { offset: 2, limit: 2 });
+  expect(result1).toBe("line2\nline3");
+
+  // offset=4, no limit → lines 4-5
+  const result2 = await sandbox.files.readFile(testPath, { offset: 4 });
+  expect(result2).toBe("line4\nline5");
+
+  // limit=2, no offset → lines 1-2
+  const result3 = await sandbox.files.readFile(testPath, { limit: 2 });
+  expect(result3).toBe("line1\nline2");
+
+  await sandbox.files.deleteFiles([testPath]);
+});
+
 test("04 interrupt command", async () => {
   if (!sandbox) throw new Error("sandbox not created");
 

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -1586,6 +1586,32 @@ class TestSandboxE2E:
 
         logger.info("TEST 3 PASSED: Basic filesystem operations test completed successfully")
 
+    @pytest.mark.timeout(60)
+    @pytest.mark.order(4)
+    async def test_03a_line_based_file_reading(self):
+        """Test line-based file reading with offset and limit."""
+        await self._ensure_sandbox_created()
+        sandbox = TestSandboxE2E.sandbox
+
+        test_path = "/tmp/line-read-e2e.txt"
+        content = "line1\nline2\nline3\nline4\nline5"
+        sandbox_files = sandbox.files
+        await sandbox_files.write_files([WriteEntry(path=test_path, data=content)])
+
+        # offset=2, limit=2 → lines 2-3
+        result = await sandbox_files.read_file(test_path, offset=2, limit=2)
+        assert result == "line2\nline3"
+
+        # offset=4, no limit → lines 4-5
+        result = await sandbox_files.read_file(test_path, offset=4)
+        assert result == "line4\nline5"
+
+        # limit=2, no offset → lines 1-2
+        result = await sandbox_files.read_file(test_path, limit=2)
+        assert result == "line1\nline2"
+
+        await sandbox.files.delete_files([test_path])
+
     @pytest.mark.timeout(120)
     @pytest.mark.order(5)
     async def test_04_interrupt_command(self):

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -1275,6 +1275,32 @@ class TestSandboxE2ESync:
         assert len(verify_dirs_deleted.logs.stdout) == 1
         assert verify_dirs_deleted.logs.stdout[0].text == "OK"
 
+    @pytest.mark.timeout(60)
+    @pytest.mark.order(4)
+    def test_03a_line_based_file_reading(self) -> None:
+        """Test line-based file reading with offset and limit."""
+        TestSandboxE2ESync._ensure_sandbox_created()
+        sandbox = TestSandboxE2ESync.sandbox
+        assert sandbox is not None
+
+        test_path = "/tmp/line-read-e2e.txt"
+        content = "line1\nline2\nline3\nline4\nline5"
+        sandbox.files.write_files([WriteEntry(path=test_path, data=content)])
+
+        # offset=2, limit=2 → lines 2-3
+        result = sandbox.files.read_file(test_path, offset=2, limit=2)
+        assert result == "line2\nline3"
+
+        # offset=4, no limit → lines 4-5
+        result = sandbox.files.read_file(test_path, offset=4)
+        assert result == "line4\nline5"
+
+        # limit=2, no offset → lines 1-2
+        result = sandbox.files.read_file(test_path, limit=2)
+        assert result == "line1\nline2"
+
+        sandbox.files.delete_files([test_path])
+
     @pytest.mark.timeout(360)
     @pytest.mark.order(5)
     def test_04_interrupt_command(self) -> None:


### PR DESCRIPTION
## Summary

- Add `offset` (1-based line number) and `limit` (line count) query parameters to `GET /files/download` for line-based reading, mutually exclusive with the existing `Range` header
- Uses `bufio.Scanner` for streaming line reads without buffering the entire file
- Updates across all layers: execd handler, OpenAPI spec, and all five SDKs (Python async/sync, JavaScript, Kotlin, C#, Go)

Closes #1003

## Test plan

- [x] Unit tests for offset+limit, offset-only, limit-only, offset beyond EOF, limit beyond remaining, Range conflict, invalid offset, invalid limit
- [x] Full execd test suite passes (`go test ./...`)
- [x] Go SDK compiles and existing download tests pass
- [ ] E2e test with live sandbox (requires sandbox environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)