### PR TITLE
feat(execd):add optional command field to pty session creation

### DIFF
--- a/components/execd/pkg/runtime/pty_session.go
+++ b/components/execd/pkg/runtime/pty_session.go
@@ -73,8 +73,9 @@ func NewPTYSessionID() string {
 //  4. The bash process exits → Done() closes → exit frame sent.
 //  5. Call close() to terminate an early session and release resources.
 type ptySession struct {
-	id  string
-	cwd string
+	id      string
+	cwd     string
+	command string // optional custom command; defaults to bash if empty
 
 	mu      sync.Mutex
 	closing bool
@@ -113,10 +114,11 @@ type ptySession struct {
 	stderrW *io.PipeWriter // nil in PTY mode
 }
 
-func newPTYSession(id, cwd string) *ptySession {
+func newPTYSession(id, cwd, command string) *ptySession {
 	return &ptySession{
 		id:           id,
 		cwd:          cwd,
+		command:      command,
 		replay:       newReplayBuffer(),
 		lastExitCode: -1,
 	}
@@ -230,7 +232,11 @@ func (s *ptySession) StartPTY() error {
 		return errors.New("pty session is closing")
 	}
 
-	cmd := exec.Command("bash", "--norc", "--noprofile")
+	cmdArgs := []string{"--norc", "--noprofile"}
+	if s.command != "" {
+		cmdArgs = append(cmdArgs, "-c", s.command)
+	}
+	cmd := exec.Command("bash", cmdArgs...)
 	cmd.Env = os.Environ()
 	if s.cwd != "" {
 		cmd.Dir = s.cwd
@@ -287,7 +293,11 @@ func (s *ptySession) StartPipe() error {
 		return fmt.Errorf("stderr pipe: %w", err)
 	}
 
-	cmd := exec.Command("bash", "--norc", "--noprofile")
+	cmdArgs := []string{"--norc", "--noprofile"}
+	if s.command != "" {
+		cmdArgs = append(cmdArgs, "-c", s.command)
+	}
+	cmd := exec.Command("bash", cmdArgs...)
 	cmd.Env = os.Environ()
 	if s.cwd != "" {
 		cmd.Dir = s.cwd
@@ -608,7 +618,7 @@ func (s *ptySession) close() {
 }
 
 // CreatePTYSession creates a new PTY session and stores it in the map.
-func (c *Controller) CreatePTYSession(id, cwd string) (PTYSession, error) {
+func (c *Controller) CreatePTYSession(id, cwd, command string) (PTYSession, error) {
 	resolvedCwd, err := pathutil.ExpandPath(cwd)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving PTY session work directory: %w", err)
@@ -619,7 +629,7 @@ func (c *Controller) CreatePTYSession(id, cwd string) (PTYSession, error) {
 			return nil, fmt.Errorf("error creating PTY session work directory: %w", err)
 		}
 	}
-	s := newPTYSession(id, resolvedCwd)
+	s := newPTYSession(id, resolvedCwd, command)
 	c.ptySessionMap.Store(id, s)
 	log.Info("created pty session %s", id)
 	return s, nil

--- a/components/execd/pkg/runtime/pty_session_test.go
+++ b/components/execd/pkg/runtime/pty_session_test.go
@@ -50,7 +50,7 @@ func TestPTYSession_BasicExecution(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
 
@@ -70,7 +70,7 @@ func TestPTYSession_IsRunning(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.False(t, s.IsRunning())
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
@@ -82,7 +82,7 @@ func TestPTYSession_ResizeWinsize(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
 
@@ -109,7 +109,7 @@ func TestPTYSession_ANSISequences(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
 
@@ -135,7 +135,7 @@ func TestPTYSession_PipeMode(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPipe())
 	t.Cleanup(func() { s.close() })
 
@@ -175,7 +175,7 @@ func TestPTYSession_ReconnectReplay(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
 
@@ -224,7 +224,7 @@ func TestPTYSession_SendSIGINT(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 	t.Cleanup(func() { s.close() })
 
@@ -251,7 +251,7 @@ func TestPTYSession_CloseTerminatesProcess(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 
 	require.True(t, s.IsRunning())
@@ -272,7 +272,7 @@ func TestPTYSession_ExitCode(t *testing.T) {
 		t.Skip("bash not found")
 	}
 
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.NoError(t, s.StartPTY())
 
 	stdoutR, _, detach := s.AttachOutput()
@@ -293,7 +293,7 @@ func TestPTYSession_ExitCode(t *testing.T) {
 }
 
 func TestPTYSession_LockWS(t *testing.T) {
-	s := newPTYSession(uuidString(), "")
+	s := newPTYSession(uuidString(), "", "")
 	require.True(t, s.LockWS(), "first lock should succeed")
 	require.False(t, s.LockWS(), "second lock should fail")
 	s.UnlockWS()
@@ -301,11 +301,41 @@ func TestPTYSession_LockWS(t *testing.T) {
 	s.UnlockWS()
 }
 
+func TestPTYSession_CustomCommand(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found")
+	}
+
+	s := newPTYSession(uuidString(), "", "echo hello_command")
+	require.NoError(t, s.StartPipe())
+	t.Cleanup(func() { s.close() })
+
+	stdoutR, stderrR, detach := s.AttachOutput()
+	defer detach()
+	require.NotNil(t, stderrR)
+
+	stdoutCh := make(chan string, 32)
+	safego.Go(func() {
+		sc := bufio.NewScanner(stdoutR)
+		for sc.Scan() {
+			stdoutCh <- sc.Text()
+		}
+	})
+
+	require.True(t, waitForLine(stdoutCh, "hello_command", 5*time.Second),
+		"expected 'hello_command' from custom command on stdout")
+
+	// After the command exits, the session should no longer be running.
+	require.Eventually(t, func() bool {
+		return !s.IsRunning()
+	}, 3*time.Second, 50*time.Millisecond, "session should exit after custom command completes")
+}
+
 func TestPTYSession_ControllerCRUD(t *testing.T) {
 	c := NewController("", "")
 	id := uuidString()
 
-	sess, _ := c.CreatePTYSession(id, "")
+	sess, _ := c.CreatePTYSession(id, "", "")
 	require.NotNil(t, sess)
 
 	got := c.GetPTYSession(id)

--- a/components/execd/pkg/runtime/pty_session_windows.go
+++ b/components/execd/pkg/runtime/pty_session_windows.go
@@ -58,7 +58,7 @@ func IsPTYSessionSupported() bool { return false }
 func NewPTYSessionID() string { return "" }
 
 // CreatePTYSession is not supported on Windows.
-func (c *Controller) CreatePTYSession(id, cwd string) (PTYSession, error) { return nil, nil } //nolint:revive
+func (c *Controller) CreatePTYSession(id, cwd, command string) (PTYSession, error) { return nil, nil } //nolint:revive
 
 // GetPTYSession is not supported on Windows.
 func (c *Controller) GetPTYSession(id string) PTYSession { return nil } //nolint:revive

--- a/components/execd/pkg/web/controller/codeinterpreting.go
+++ b/components/execd/pkg/web/controller/codeinterpreting.go
@@ -59,7 +59,7 @@ type codeExecutionRunner interface {
 	SeekBackgroundCommandOutput(session string, cursor int64) ([]byte, int64, error)
 	DeleteBashSession(sessionID string) error
 	Interrupt(sessionID string) error
-	CreatePTYSession(id, cwd string) (runtime.PTYSession, error)
+	CreatePTYSession(id, cwd, command string) (runtime.PTYSession, error)
 	GetPTYSession(id string) runtime.PTYSession
 	DeletePTYSession(id string) error
 	GetPTYSessionStatus(id string) (bool, int64, error)

--- a/components/execd/pkg/web/controller/codeinterpreting_test.go
+++ b/components/execd/pkg/web/controller/codeinterpreting_test.go
@@ -90,7 +90,7 @@ func (f *fakeCodeRunner) Interrupt(_ string) error {
 	return nil
 }
 
-func (f *fakeCodeRunner) CreatePTYSession(_ string, _ string) (runtime.PTYSession, error) {
+func (f *fakeCodeRunner) CreatePTYSession(_ string, _ string, _ string) (runtime.PTYSession, error) {
 	return nil, nil
 }
 func (f *fakeCodeRunner) GetPTYSession(_ string) runtime.PTYSession         { return nil }

--- a/components/execd/pkg/web/controller/pty_controller.go
+++ b/components/execd/pkg/web/controller/pty_controller.go
@@ -59,7 +59,7 @@ func (c *PTYController) CreatePTYSession() {
 	}
 
 	id := runtime.NewPTYSessionID()
-	_, err := codeRunner.CreatePTYSession(id, req.Cwd)
+	_, err := codeRunner.CreatePTYSession(id, req.Cwd, req.Command)
 	if err != nil {
 		c.RespondError(
 			http.StatusInternalServerError,

--- a/components/execd/pkg/web/model/pty.go
+++ b/components/execd/pkg/web/model/pty.go
@@ -16,7 +16,8 @@ package model
 
 // CreatePTYSessionRequest is the request body for POST /pty.
 type CreatePTYSessionRequest struct {
-	Cwd string `json:"cwd,omitempty"`
+	Cwd     string `json:"cwd,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 // CreatePTYSessionResponse is the response for POST /pty.


### PR DESCRIPTION
## Summary
- What is changing and why?

Add an optional `command` field to PTY session creation (`POST /pty`). Currently, PTY sessions always start an interactive bash shell (`bash --norc --noprofile`). This change allows clients to specify a custom command via `bash -c <command>`, enabling one-shot command execution within a PTY session (e.g., running a script or CLI tool with terminal I/O support). When `command` is empty, behavior is unchanged — an interactive bash shell starts as before.

## Testing
- [x] Unit tests
  - Added `TestPTYSession_CustomCommand` — verifies `bash -c` execution via pipe mode, checks stdout output and session exit after command completes
  - Updated all existing `newPTYSession` and `CreatePTYSession` calls with the new third `command` parameter
  - Updated `fakeCodeRunner.CreatePTYSession` signature in `codeinterpreting_test.go`
- [ ] Integration tests — Not run (no integration test harness for PTY REST API in this repo)
- [ ] e2e / manual verification — Tested manually in sandbox: PTY session created with `command` field executes the command and exits; without `command` field, interactive shell works as before

## Breaking Changes
- [x] None
  - `command` is optional (`omitempty` JSON tag) — clients that don't send it get the same interactive bash behavior
  - `CreatePTYSession(id, cwd, command)` signature change is internal to execd; the REST API request body is additive only
  - Windows stub updated to match the new signature (returns nil as before)

## Checklist
- [x] Linked Issue or clearly described motivation — Enables running targeted commands in PTY sessions for SDK/CLI integrations that need terminal I/O but don't want a persistent shell
- [ ] Added/updated docs — Not needed (internal execd API, no public spec change)
- [x] Added/updated tests — `TestPTYSession_CustomCommand` + signature updates in existing tests
- [x] Security impact considered — `command` runs via `bash -c` with the same security posture as existing stdin-based execution; no new privilege escalation path
- [x] Backward compatibility considered — `command` defaults to empty string; empty = interactive bash, unchanged behavior