### PR TITLE
fix(proxy): strip content-length when streaming request body

### DIFF
--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -38,8 +38,11 @@ def apply_volumes_to_pod_spec(
     mounts = main_container.get("volumeMounts", [])
     pod_volumes = pod_spec.get("volumes", [])
 
-    existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
-    pvc_to_volume_name: Dict[str, str] = {}
+    existing_volume_names = {
+        v.get("name") for v in pod_volumes if isinstance(v, dict)
+    }
+    # Key: (claim_name, read_only) so the same PVC can be mounted both RO and RW.
+    pvc_to_volume_name: Dict[tuple, str] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -52,19 +55,23 @@ def apply_volumes_to_pod_spec(
 
         if vol.pvc is not None:
             pvc_claim_name = vol.pvc.claim_name
+            pvc_key = (pvc_claim_name, vol.read_only)
 
-            if pvc_claim_name not in pvc_to_volume_name:
+            if pvc_key not in pvc_to_volume_name:
+                pvc_volume: Dict[str, Any] = {
+                    "claimName": pvc_claim_name,
+                }
+                if vol.read_only:
+                    pvc_volume["readOnly"] = True
                 pod_volumes.append({
                     "name": vol_name,
-                    "persistentVolumeClaim": {
-                        "claimName": pvc_claim_name,
-                    },
+                    "persistentVolumeClaim": pvc_volume,
                 })
-                pvc_to_volume_name[pvc_claim_name] = vol_name
+                pvc_to_volume_name[pvc_key] = vol_name
                 existing_volume_names.add(vol_name)
 
             mount = {
-                "name": pvc_to_volume_name[pvc_claim_name],
+                "name": pvc_to_volume_name[pvc_key],
                 "mountPath": vol.mount_path,
                 "readOnly": vol.read_only,
             }
@@ -73,7 +80,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added PVC volume '{vol_name}' (claim: {pvc_claim_name}) mounted at '{vol.mount_path}' for sandbox"
+                "Added PVC volume '%s' (claim: %s, readOnly: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, pvc_claim_name, vol.read_only, vol.mount_path,
             )
         elif vol.host is not None:
             host_path = vol.host.path
@@ -96,7 +105,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added hostPath volume '{vol_name}' (path: {host_path}) mounted at '{vol.mount_path}' for sandbox"
+                "Added hostPath volume '%s' (path: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, host_path, vol.mount_path,
             )
         else:
             raise ValueError(

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -2675,6 +2675,16 @@ spec:
         assert models_mount is not None
         assert models_mount["readOnly"] is True
 
+        pvc_vol = next(
+            (
+                v for v in pod_spec["volumes"]
+                if v.get("persistentVolumeClaim", {}).get("claimName") == "models-pvc"
+            ),
+            None,
+        )
+        assert pvc_vol is not None
+        assert pvc_vol["persistentVolumeClaim"].get("readOnly") is True
+
     def test_create_workload_with_pvc_volume_subpath(self, mock_k8s_client):
         """
         Test creating workload with PVC volume mount with subPath.

--- a/server/tests/k8s/test_volume_helper.py
+++ b/server/tests/k8s/test_volume_helper.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from opensandbox_server.api.schema import Host, PVC, Volume
+from opensandbox_server.services.k8s.volume_helper import apply_volumes_to_pod_spec
+
+
+def _empty_pod_spec():
+    return {
+        "containers": [{"name": "main", "volumeMounts": []}],
+        "volumes": [],
+    }
+
+
+def _get_pvc_volume_spec(pod_spec, claim_name):
+    for v in pod_spec["volumes"]:
+        pvc = v.get("persistentVolumeClaim", {})
+        if pvc.get("claimName") == claim_name:
+            return v
+    return None
+
+
+def _get_mount(pod_spec, mount_path):
+    mounts = pod_spec["containers"][0].get("volumeMounts", [])
+    return next((m for m in mounts if m["mountPath"] == mount_path), None)
+
+
+class TestApplyVolumesToPodSpec:
+    def test_pvc_rw_no_readonly_in_volume_spec(self):
+        """Read-write PVC must not set readOnly on the PVC volume spec."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="data-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+                read_only=False,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "my-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert "readOnly" not in pvc_src
+
+        mount = _get_mount(pod_spec, "/mnt/data")
+        assert mount is not None
+        assert mount["readOnly"] is False
+
+    def test_pvc_readonly_sets_readonly_on_volume_spec_and_mount(self):
+        """readOnly=True must propagate to both PVC volume spec and VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="models-vol",
+                pvc=PVC(claim_name="models-pvc"),
+                mount_path="/mnt/models",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "models-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert pvc_src.get("readOnly") is True
+
+        mount = _get_mount(pod_spec, "/mnt/models")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_same_pvc_ro_and_rw_gets_separate_volume_entries(self):
+        """Same PVC mounted RO and RW must produce separate pod volume entries."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="vol-ro",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/ro",
+                read_only=True,
+            ),
+            Volume(
+                name="vol-rw",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/rw",
+                read_only=False,
+            ),
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_entries = [
+            v for v in pod_spec["volumes"]
+            if v.get("persistentVolumeClaim", {}).get("claimName") == "shared-pvc"
+        ]
+        assert len(pvc_entries) == 2
+
+        ro_entry = next(
+            v for v in pvc_entries
+            if v["persistentVolumeClaim"].get("readOnly") is True
+        )
+        rw_entry = next(
+            v for v in pvc_entries
+            if "readOnly" not in v["persistentVolumeClaim"]
+        )
+
+        ro_mount = _get_mount(pod_spec, "/mnt/ro")
+        rw_mount = _get_mount(pod_spec, "/mnt/rw")
+
+        assert ro_mount["name"] == ro_entry["name"]
+        assert ro_mount["readOnly"] is True
+        assert rw_mount["name"] == rw_entry["name"]
+        assert rw_mount["readOnly"] is False
+
+    def test_host_volume_readonly_sets_readonly_on_mount(self):
+        """readOnly=True on a host volume sets the VolumeMount readOnly flag."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="host-vol",
+                host=Host(path="/data/shared"),
+                mount_path="/mnt/shared",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/shared")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_conflicts_with_existing_volume_name(self):
+        """Volume name that collides with an existing pod volume raises ValueError."""
+        pod_spec = _empty_pod_spec()
+        pod_spec["volumes"].append({"name": "existing-vol"})
+        volumes = [
+            Volume(
+                name="existing-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+            )
+        ]
+        with pytest.raises(ValueError, match="conflicts with an internal volume"):
+            apply_volumes_to_pod_spec(pod_spec, volumes)
+
+    def test_pvc_with_subpath(self):
+        """subPath is forwarded to the VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="sub-vol",
+                pvc=PVC(claim_name="big-pvc"),
+                mount_path="/mnt/sub",
+                sub_path="tenant-a",
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/sub")
+        assert mount is not None
+        assert mount["subPath"] == "tenant-a"


### PR DESCRIPTION
## Summary

- When proxying POST/PUT/PATCH/DELETE requests the body is forwarded as an async generator, which httpx encodes with `Transfer-Encoding: chunked`.
- The original `Content-Length` header was still forwarded unchanged, causing Go's `net/http` on execd to read exactly `Content-Length` bytes and discard the rest of the chunked stream.
- Files larger than ~18 KB appeared to succeed (HTTP 200) but were silently truncated on the sandbox filesystem.
- Fix: pop `content-length` from forwarded headers whenever `stream_body=True` so httpx drives chunk framing without a conflicting length constraint.

Fixes #1016

## Files changed

- `server/opensandbox_server/api/proxy.py` — strip `content-length` before building the proxied request when streaming
- `server/tests/test_routes_proxy.py` — three new tests: POST/PUT/PATCH strip content-length, DELETE strips content-length, GET preserves content-length (not streamed)

## Test plan

- [ ] `pytest server/tests/test_routes_proxy.py` — all existing tests pass; three new tests cover the fix
- [ ] Manual end-to-end: upload a file > 18 KB via `sandbox.files.write_file` or `osb file upload` and confirm the file is present and complete in the sandbox filesystem