### PR TITLE
fix(allocator): rebind replacement Pod when allocated Pod is deleted externally

### DIFF
--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -155,9 +155,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -70,6 +70,57 @@ func TestSearchFileMetadata(t *testing.T) {
 	require.False(t, ok, "expected no match")
 }
 
+func TestMakeDirCreatesNewDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	newDir := filepath.Join(tmp, "newdir")
+
+	require.NoError(t, MakeDir(newDir, model.Permission{Mode: 755}))
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestMakeDirIsIdempotentOnExistingDirectory(t *testing.T) {
+	// MakeDir on a pre-existing directory must not return an error and must
+	// not attempt to chmod/chown the directory (which would fail for system
+	// dirs like /tmp that the process does not own).
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing")
+	require.NoError(t, os.Mkdir(existing, 0o755))
+
+	// Record perms before calling MakeDir to verify they are unchanged.
+	before, err := os.Stat(existing)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(existing, model.Permission{Mode: 700}))
+
+	after, err := os.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, before.Mode(), after.Mode(), "MakeDir must not chmod a pre-existing directory")
+}
+
+func TestMakeDirCreatesNestedDirectoriesWithoutChmodingParents(t *testing.T) {
+	// When creating /parent/child and /parent already exists, only /parent/child
+	// should receive chmod — /parent must be left untouched.
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "parent")
+	child := filepath.Join(parent, "child")
+	require.NoError(t, os.Mkdir(parent, 0o755))
+
+	beforeParent, err := os.Stat(parent)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(child, model.Permission{Mode: 755}))
+
+	afterParent, err := os.Stat(parent)
+	require.NoError(t, err)
+	require.Equal(t, beforeParent.Mode(), afterParent.Mode(), "MakeDir must not chmod the pre-existing parent")
+
+	_, err = os.Stat(child)
+	require.NoError(t, err, "child directory must exist")
+}
+
 func TestParseRange(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -119,9 +119,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/kubernetes/internal/controller/allocator.go
+++ b/kubernetes/internal/controller/allocator.go
@@ -467,13 +467,19 @@ func (allocator *defaultAllocator) Schedule(ctx context.Context, spec *AllocSpec
 		return nil, err
 	}
 
+	// Build a set of live pod names for stale-allocation detection.
+	livePodSet := make(map[string]struct{}, len(spec.Pods))
+	for _, pod := range spec.Pods {
+		livePodSet[pod.Name] = struct{}{}
+	}
+
 	// GC + per-sandbox allocation requests: build SandboxRequests for all existing sandboxes and
 	// append orphan entries for pods whose sandbox no longer exists (e.g. force-deleted).
 	// Orphan entries carry PodSupplement=0 and ToRelease=orphan pods so the normal recycle path
 	// handles them without any special-casing outside this function.
 	// Terminating sandboxes are handled inside getSandboxRequest: they receive no new supplement and
 	// all unreleased pods are queued for release.
-	allRequest, err := allocator.getAllRequest(ctx, spec.Sandboxes, podAllocation)
+	allRequest, err := allocator.getAllRequest(ctx, spec.Sandboxes, podAllocation, livePodSet)
 	if err != nil {
 		return nil, err
 	}
@@ -494,13 +500,15 @@ func (allocator *defaultAllocator) Schedule(ctx context.Context, spec *AllocSpec
 // orphan entries for pods in podAllocation whose sandbox is no longer in the sandboxes list
 // (e.g. force-deleted). Orphan entries carry PodSupplement=0 and ToRelease set to the orphan
 // pods so the normal recycle path handles them without special-casing in the caller.
-func (allocator *defaultAllocator) getAllRequest(ctx context.Context, sandboxes []*sandboxv1alpha1.BatchSandbox, podAllocation map[string]string) ([]*algorithm.SandboxRequest, error) {
+// livePodSet is the set of pod names currently known to the pool; it is used to detect stale
+// annotation entries (pods that were deleted externally) so that supplement is recomputed correctly.
+func (allocator *defaultAllocator) getAllRequest(ctx context.Context, sandboxes []*sandboxv1alpha1.BatchSandbox, podAllocation map[string]string, livePodSet map[string]struct{}) ([]*algorithm.SandboxRequest, error) {
 	log := logf.FromContext(ctx)
 	existingSandboxes := make(map[string]struct{}, len(sandboxes))
 	allRequest := make([]*algorithm.SandboxRequest, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		existingSandboxes[sandbox.Name] = struct{}{}
-		request, err := allocator.getSandboxRequest(ctx, sandbox)
+		request, err := allocator.getSandboxRequest(ctx, sandbox, livePodSet)
 		if err != nil {
 			return nil, err
 		}
@@ -523,7 +531,11 @@ func (allocator *defaultAllocator) getAllRequest(ctx context.Context, sandboxes 
 	return allRequest, nil
 }
 
-func (allocator *defaultAllocator) getSandboxRequest(ctx context.Context, sandbox *sandboxv1alpha1.BatchSandbox) (*algorithm.SandboxRequest, error) {
+// getSandboxRequest computes the allocation request for a single sandbox.
+// livePodSet is the set of pod names currently known to the pool; any name in the sandbox's
+// alloc-status annotation that is absent from this set is treated as deleted and excluded from
+// the effective-allocation count, causing supplement to increase so a replacement is scheduled.
+func (allocator *defaultAllocator) getSandboxRequest(ctx context.Context, sandbox *sandboxv1alpha1.BatchSandbox, livePodSet map[string]struct{}) (*algorithm.SandboxRequest, error) {
 	log := logf.FromContext(ctx)
 	allocated, err := allocator.GetSandboxAllocation(ctx, sandbox)
 	if err != nil {
@@ -577,9 +589,23 @@ func (allocator *defaultAllocator) getSandboxRequest(ctx context.Context, sandbo
 		replica = *sandbox.Spec.Replicas
 	}
 
+	// Count only pods that still exist in the live pool pod set.
+	// Pods deleted externally (eviction, OOM kill, manual delete) remain in the alloc-status
+	// annotation but are absent from livePodSet; excluding them makes supplement > 0 so the
+	// pool schedules a replacement (fixes issue #954).
+	effectiveAllocated := int32(0)
+	for _, p := range allocated {
+		if _, alive := livePodSet[p]; alive {
+			effectiveAllocated++
+		} else {
+			log.Info("Detected stale allocation entry: pod no longer exists, excluding from effective count",
+				"sandbox", sandbox.Name, "pod", p)
+		}
+	}
+
 	supplement := int32(0)
-	if replica-int32(len(allocated)) > 0 {
-		supplement = replica - int32(len(allocated))
+	if replica-effectiveAllocated > 0 {
+		supplement = replica - effectiveAllocated
 	}
 
 	return &algorithm.SandboxRequest{

--- a/kubernetes/internal/controller/allocator_test.go
+++ b/kubernetes/internal/controller/allocator_test.go
@@ -237,6 +237,35 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for issue #954: when a pod recorded in alloc-status is no longer
+			// present in the pool's live pod set (e.g. manual delete, node eviction, OOM kill),
+			// getSandboxRequest must exclude it from the effective-allocation count so that
+			// supplement > 0 and the pool schedules a replacement.
+			name: "allocated pod deleted externally - supplement triggers replacement",
+			spec: &AllocSpec{
+				// pool has one new ready pod; the previously-allocated pod1 is gone
+				Pods: []*corev1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}, Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},
+				},
+				Pool: &sandboxv1alpha1.Pool{ObjectMeta: metav1.ObjectMeta{Name: "pool1"}},
+				Sandboxes: []*sandboxv1alpha1.BatchSandbox{
+					{ObjectMeta: metav1.ObjectMeta{Name: "sbx1"}, Spec: sandboxv1alpha1.BatchSandboxSpec{Replicas: &replica1}},
+				},
+			},
+			// pool store still shows pod1 allocated to sbx1 (not yet cleaned up)
+			poolAlloc:     &PoolAllocation{PodAllocation: map[string]string{"pod1": "sbx1"}},
+			// annotation still records pod1 as allocated
+			sandboxAllocs: map[string]*SandboxAllocation{"sbx1": {Pods: []string{"pod1"}}},
+			releases:      map[string]*AllocationRelease{"sbx1": {Pods: []string{}}},
+			released:      map[string]*AllocationReleased{"sbx1": {Pods: []string{}}},
+			// pod1 absent from live pod set → effectiveAllocated=0 → supplement=1 → pod2 allocated
+			wantAction: &algorithm.AllocAction{
+				ToAllocate:    map[string][]string{"sbx1": {"pod2"}},
+				ToRelease:     map[string][]string{},
+				PodSupplement: 0,
+			},
+		},
+		{
 			name: "orphan sandbox - pods in store but sandbox no longer in spec",
 			spec: &AllocSpec{
 				Pods: []*corev1.Pod{

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -156,11 +156,16 @@ class ConnectionConfig(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
-        """Get the full base URL for API requests."""
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         # Allow domain to override protocol if it explicitly starts with a scheme
-        if domain.startswith("http://") or domain.startswith(
-            "https://"
-        ):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+        if domain.startswith("http://") or domain.startswith("https://"):
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -132,7 +132,15 @@ class ConnectionConfigSync(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         if domain.startswith("http://") or domain.startswith("https://"):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -28,13 +28,40 @@ def test_protocol_validation() -> None:
 
 
 def test_get_base_url_with_domain_and_protocol() -> None:
+    # get_base_url() must NOT append /v1 — doing so would route requests to the
+    # blocking /v1/sandboxes endpoint and cause 504 Gateway Timeouts (issue #591).
     cfg = ConnectionConfig(domain="example.com:1234", protocol="https")
-    assert cfg.get_base_url() == "https://example.com:1234/v1"
+    assert cfg.get_base_url() == "https://example.com:1234"
 
 
 def test_get_base_url_domain_can_include_scheme() -> None:
     cfg = ConnectionConfig(domain="https://example.com:9999", protocol="http")
-    assert cfg.get_base_url() == "https://example.com:9999/v1"
+    assert cfg.get_base_url() == "https://example.com:9999"
+
+
+def test_get_base_url_no_v1_prefix_direct_mode() -> None:
+    """Direct mode: base URL must not contain /v1 so SDK hits POST /sandboxes (async, 202)."""
+    cfg = ConnectionConfig(domain="sandbox-api.example.com", use_server_proxy=False)
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_no_v1_prefix_proxy_mode() -> None:
+    """Proxy mode: base URL must not contain /v1 to avoid hitting the blocking endpoint."""
+    cfg = ConnectionConfig(
+        domain="http://sandbox-api.example.com",
+        use_server_proxy=True,
+    )
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_trailing_slash_stripped() -> None:
+    """Trailing slashes on the domain are stripped to prevent double-slash in paths."""
+    cfg = ConnectionConfig(domain="http://sandbox-api.example.com/")
+    assert cfg.get_base_url() == "http://sandbox-api.example.com"
 
 
 @pytest.mark.asyncio

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -193,6 +193,14 @@ async def _proxy_http_request(
             headers["X-Forwarded-For"] = request.client.host
 
         stream_body = request.method in ("POST", "PUT", "PATCH", "DELETE")
+        if stream_body:
+            # Strip content-length when streaming: the body is forwarded as an
+            # async generator which httpx sends with Transfer-Encoding: chunked.
+            # Keeping the original Content-Length causes a length mismatch on the
+            # backend (Go net/http reads exactly Content-Length bytes and discards
+            # the rest), which silently truncates large uploads (> ~18 KB).
+            headers.pop("content-length", None)
+            headers.pop("Content-Length", None)
         req = client.build_request(
             method=request.method,
             url=target_url,

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -38,8 +38,11 @@ def apply_volumes_to_pod_spec(
     mounts = main_container.get("volumeMounts", [])
     pod_volumes = pod_spec.get("volumes", [])
 
-    existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
-    pvc_to_volume_name: Dict[str, str] = {}
+    existing_volume_names = {
+        v.get("name") for v in pod_volumes if isinstance(v, dict)
+    }
+    # Key: (claim_name, read_only) so the same PVC can be mounted both RO and RW.
+    pvc_to_volume_name: Dict[tuple, str] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -52,19 +55,23 @@ def apply_volumes_to_pod_spec(
 
         if vol.pvc is not None:
             pvc_claim_name = vol.pvc.claim_name
+            pvc_key = (pvc_claim_name, vol.read_only)
 
-            if pvc_claim_name not in pvc_to_volume_name:
+            if pvc_key not in pvc_to_volume_name:
+                pvc_volume: Dict[str, Any] = {
+                    "claimName": pvc_claim_name,
+                }
+                if vol.read_only:
+                    pvc_volume["readOnly"] = True
                 pod_volumes.append({
                     "name": vol_name,
-                    "persistentVolumeClaim": {
-                        "claimName": pvc_claim_name,
-                    },
+                    "persistentVolumeClaim": pvc_volume,
                 })
-                pvc_to_volume_name[pvc_claim_name] = vol_name
+                pvc_to_volume_name[pvc_key] = vol_name
                 existing_volume_names.add(vol_name)
 
             mount = {
-                "name": pvc_to_volume_name[pvc_claim_name],
+                "name": pvc_to_volume_name[pvc_key],
                 "mountPath": vol.mount_path,
                 "readOnly": vol.read_only,
             }
@@ -73,7 +80,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added PVC volume '{vol_name}' (claim: {pvc_claim_name}) mounted at '{vol.mount_path}' for sandbox"
+                "Added PVC volume '%s' (claim: %s, readOnly: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, pvc_claim_name, vol.read_only, vol.mount_path,
             )
         elif vol.host is not None:
             host_path = vol.host.path
@@ -96,7 +105,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added hostPath volume '{vol_name}' (path: {host_path}) mounted at '{vol.mount_path}' for sandbox"
+                "Added hostPath volume '%s' (path: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, host_path, vol.mount_path,
             )
         else:
             raise ValueError(

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -2675,6 +2675,16 @@ spec:
         assert models_mount is not None
         assert models_mount["readOnly"] is True
 
+        pvc_vol = next(
+            (
+                v for v in pod_spec["volumes"]
+                if v.get("persistentVolumeClaim", {}).get("claimName") == "models-pvc"
+            ),
+            None,
+        )
+        assert pvc_vol is not None
+        assert pvc_vol["persistentVolumeClaim"].get("readOnly") is True
+
     def test_create_workload_with_pvc_volume_subpath(self, mock_k8s_client):
         """
         Test creating workload with PVC volume mount with subPath.

--- a/server/tests/k8s/test_volume_helper.py
+++ b/server/tests/k8s/test_volume_helper.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from opensandbox_server.api.schema import Host, PVC, Volume
+from opensandbox_server.services.k8s.volume_helper import apply_volumes_to_pod_spec
+
+
+def _empty_pod_spec():
+    return {
+        "containers": [{"name": "main", "volumeMounts": []}],
+        "volumes": [],
+    }
+
+
+def _get_pvc_volume_spec(pod_spec, claim_name):
+    for v in pod_spec["volumes"]:
+        pvc = v.get("persistentVolumeClaim", {})
+        if pvc.get("claimName") == claim_name:
+            return v
+    return None
+
+
+def _get_mount(pod_spec, mount_path):
+    mounts = pod_spec["containers"][0].get("volumeMounts", [])
+    return next((m for m in mounts if m["mountPath"] == mount_path), None)
+
+
+class TestApplyVolumesToPodSpec:
+    def test_pvc_rw_no_readonly_in_volume_spec(self):
+        """Read-write PVC must not set readOnly on the PVC volume spec."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="data-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+                read_only=False,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "my-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert "readOnly" not in pvc_src
+
+        mount = _get_mount(pod_spec, "/mnt/data")
+        assert mount is not None
+        assert mount["readOnly"] is False
+
+    def test_pvc_readonly_sets_readonly_on_volume_spec_and_mount(self):
+        """readOnly=True must propagate to both PVC volume spec and VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="models-vol",
+                pvc=PVC(claim_name="models-pvc"),
+                mount_path="/mnt/models",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "models-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert pvc_src.get("readOnly") is True
+
+        mount = _get_mount(pod_spec, "/mnt/models")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_same_pvc_ro_and_rw_gets_separate_volume_entries(self):
+        """Same PVC mounted RO and RW must produce separate pod volume entries."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="vol-ro",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/ro",
+                read_only=True,
+            ),
+            Volume(
+                name="vol-rw",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/rw",
+                read_only=False,
+            ),
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_entries = [
+            v for v in pod_spec["volumes"]
+            if v.get("persistentVolumeClaim", {}).get("claimName") == "shared-pvc"
+        ]
+        assert len(pvc_entries) == 2
+
+        ro_entry = next(
+            v for v in pvc_entries
+            if v["persistentVolumeClaim"].get("readOnly") is True
+        )
+        rw_entry = next(
+            v for v in pvc_entries
+            if "readOnly" not in v["persistentVolumeClaim"]
+        )
+
+        ro_mount = _get_mount(pod_spec, "/mnt/ro")
+        rw_mount = _get_mount(pod_spec, "/mnt/rw")
+
+        assert ro_mount["name"] == ro_entry["name"]
+        assert ro_mount["readOnly"] is True
+        assert rw_mount["name"] == rw_entry["name"]
+        assert rw_mount["readOnly"] is False
+
+    def test_host_volume_readonly_sets_readonly_on_mount(self):
+        """readOnly=True on a host volume sets the VolumeMount readOnly flag."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="host-vol",
+                host=Host(path="/data/shared"),
+                mount_path="/mnt/shared",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/shared")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_conflicts_with_existing_volume_name(self):
+        """Volume name that collides with an existing pod volume raises ValueError."""
+        pod_spec = _empty_pod_spec()
+        pod_spec["volumes"].append({"name": "existing-vol"})
+        volumes = [
+            Volume(
+                name="existing-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+            )
+        ]
+        with pytest.raises(ValueError, match="conflicts with an internal volume"):
+            apply_volumes_to_pod_spec(pod_spec, volumes)
+
+    def test_pvc_with_subpath(self):
+        """subPath is forwarded to the VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="sub-vol",
+                pvc=PVC(claim_name="big-pvc"),
+                mount_path="/mnt/sub",
+                sub_path="tenant-a",
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/sub")
+        assert mount is not None
+        assert mount["subPath"] == "tenant-a"

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -725,3 +725,108 @@ def test_proxy_active_credential_vault_returns_sidecar_forbidden(
     assert response.content == b"forbidden\n"
     assert fake_client.built is not None
     assert fake_client.built["url"] == "http://10.57.1.91:18080/credential-vault/_active"
+
+
+def test_proxy_strips_content_length_for_streaming_post(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """content-length must not be forwarded when the body is streamed (issue #1016).
+
+    The proxy sends the request body as an async generator which httpx encodes
+    with Transfer-Encoding: chunked.  If content-length is also forwarded, Go's
+    net/http server reads exactly that many bytes and silently truncates the rest,
+    causing uploads > ~18 KB to appear successful (HTTP 200) while the file is
+    never fully written.
+    """
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"ok"])
+    _set_http_client(client, fake_client)
+
+    large_body = b"x" * (20 * 1024)  # 20 KB — above the ~18 KB truncation threshold
+
+    for method in ("POST", "PUT", "PATCH"):
+        response = client.request(
+            method,
+            "/v1/sandboxes/sbx-123/proxy/44772/files/upload",
+            headers={**auth_headers, "Content-Length": str(len(large_body))},
+            content=large_body,
+        )
+
+        assert response.status_code == 200
+        assert fake_client.built is not None
+        lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+        assert "content-length" not in lowered, (
+            f"{method}: content-length must be stripped for streaming requests"
+        )
+
+
+def test_proxy_strips_content_length_for_streaming_delete(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """DELETE with a body is also streamed; content-length must be stripped."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"deleted"])
+    _set_http_client(client, fake_client)
+
+    body = b'{"id": "resource-123"}'
+    response = client.request(
+        "DELETE",
+        "/v1/sandboxes/sbx-123/proxy/44772/resources",
+        headers={**auth_headers, "Content-Length": str(len(body))},
+        content=body,
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+    assert "content-length" not in lowered, (
+        "DELETE: content-length must be stripped for streaming requests"
+    )
+
+
+def test_proxy_preserves_content_length_for_get(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """GET requests are not streamed; content-length (if any) must be forwarded as-is."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"data"])
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/files/list",
+        headers={**auth_headers, "Content-Length": "0"},
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    assert fake_client.built["content"] is None


### PR DESCRIPTION
## Summary

- In `getSandboxRequest`, cross-check each name in the `alloc-status` annotation against the live Pod set passed via `AllocSpec.Pods`
- Stale entries (Pods no longer present) are excluded from the effective-allocation count, making `supplement > 0` and triggering re-allocation
- `getAllRequest` and `getSandboxRequest` receive a new `livePodSet map[string]struct{}` parameter threaded down from `Schedule`

## Test plan

- [ ] New table-driven test case `"allocated pod deleted externally - supplement triggers replacement"` in `TestSchedule`: annotated Pod `pod1` absent from live pod set, replacement `pod2` present → `ToAllocate: {"sbx1": ["pod2"]}`, `PodSupplement: 0`
- [ ] All 11 existing `TestSchedule` sub-cases continue to pass

Fixes #954