### PR TITLE
fix(k8s): validate shardTaskPatches early and unblock finalizer on deletion

### DIFF
--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -155,9 +155,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -70,6 +70,57 @@ func TestSearchFileMetadata(t *testing.T) {
 	require.False(t, ok, "expected no match")
 }
 
+func TestMakeDirCreatesNewDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	newDir := filepath.Join(tmp, "newdir")
+
+	require.NoError(t, MakeDir(newDir, model.Permission{Mode: 755}))
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestMakeDirIsIdempotentOnExistingDirectory(t *testing.T) {
+	// MakeDir on a pre-existing directory must not return an error and must
+	// not attempt to chmod/chown the directory (which would fail for system
+	// dirs like /tmp that the process does not own).
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing")
+	require.NoError(t, os.Mkdir(existing, 0o755))
+
+	// Record perms before calling MakeDir to verify they are unchanged.
+	before, err := os.Stat(existing)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(existing, model.Permission{Mode: 700}))
+
+	after, err := os.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, before.Mode(), after.Mode(), "MakeDir must not chmod a pre-existing directory")
+}
+
+func TestMakeDirCreatesNestedDirectoriesWithoutChmodingParents(t *testing.T) {
+	// When creating /parent/child and /parent already exists, only /parent/child
+	// should receive chmod — /parent must be left untouched.
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "parent")
+	child := filepath.Join(parent, "child")
+	require.NoError(t, os.Mkdir(parent, 0o755))
+
+	beforeParent, err := os.Stat(parent)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(child, model.Permission{Mode: 755}))
+
+	afterParent, err := os.Stat(parent)
+	require.NoError(t, err)
+	require.Equal(t, beforeParent.Mode(), afterParent.Mode(), "MakeDir must not chmod the pre-existing parent")
+
+	_, err = os.Stat(child)
+	require.NoError(t, err, "child directory must exist")
+}
+
 func TestParseRange(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -119,9 +119,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/kubernetes/apis/sandbox/v1alpha1/batchsandbox_types.go
+++ b/kubernetes/apis/sandbox/v1alpha1/batchsandbox_types.go
@@ -41,7 +41,7 @@ const (
 )
 
 // BatchSandboxConditionType represents the type of BatchSandbox condition.
-// +kubebuilder:validation:Enum=Ready;Progressing;Paused;PauseFailed;ResumeFailed;PodFailed
+// +kubebuilder:validation:Enum=Ready;Progressing;Paused;PauseFailed;ResumeFailed;PodFailed;InvalidShardPatch
 type BatchSandboxConditionType string
 
 const (
@@ -57,6 +57,9 @@ const (
 	BatchSandboxConditionResumeFailed BatchSandboxConditionType = "ResumeFailed"
 	// BatchSandboxConditionPodFailed is set when the sandbox pod enters a failed state.
 	BatchSandboxConditionPodFailed BatchSandboxConditionType = "PodFailed"
+	// BatchSandboxConditionInvalidShardPatch is set when a shardTaskPatch cannot be merged
+	// into TaskTemplateSpec due to a type mismatch or invalid JSON structure.
+	BatchSandboxConditionInvalidShardPatch BatchSandboxConditionType = "InvalidShardPatch"
 )
 
 // BatchSandboxCondition represents a condition of a BatchSandbox

--- a/kubernetes/internal/controller/batchsandbox_controller.go
+++ b/kubernetes/internal/controller/batchsandbox_controller.go
@@ -146,6 +146,19 @@ func (r *BatchSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// handle finalizers
 	if batchSbx.DeletionTimestamp == nil {
 		if taskStrategy.NeedTaskScheduling() {
+			// Validate shardTaskPatches early so that a type-mismatch is surfaced
+			// immediately as a status condition rather than causing a silent merge
+			// failure deep in the reconcile loop.
+			if patchErr := taskStrategy.ValidateShardTaskPatches(); patchErr != nil {
+				log.Error(patchErr, "invalid shardTaskPatches detected, updating status condition")
+				statusCopy := batchSbx.Status.DeepCopy()
+				setConditionInStatus(statusCopy, sandboxv1alpha1.BatchSandboxConditionInvalidShardPatch,
+					sandboxv1alpha1.ConditionTrue, "InvalidShardPatch", patchErr.Error())
+				_ = r.updateStatus(ctx, batchSbx, statusCopy)
+				// Return without error so the controller does not keep requeueing;
+				// the resource must be corrected by the user.
+				return ctrl.Result{}, nil
+			}
 			if !controllerutil.ContainsFinalizer(batchSbx, FinalizerTaskCleanup) {
 				err := utils.UpdateFinalizer(r.Client, batchSbx, utils.AddFinalizerOpType, FinalizerTaskCleanup)
 				if err != nil {
@@ -158,6 +171,27 @@ func (r *BatchSandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	} else {
 		if !taskStrategy.NeedTaskScheduling() {
+			return ctrl.Result{}, nil
+		}
+		// If shardTaskPatches are invalid we cannot build task specs, but we must
+		// not leave the resource stuck in Terminating. Clear the finalizer now and
+		// record the error in status so the deletion can proceed.
+		if patchErr := taskStrategy.ValidateShardTaskPatches(); patchErr != nil {
+			log.Error(patchErr, "invalid shardTaskPatches on deletion path, clearing finalizer to unblock termination")
+			statusCopy := batchSbx.Status.DeepCopy()
+			setConditionInStatus(statusCopy, sandboxv1alpha1.BatchSandboxConditionInvalidShardPatch,
+				sandboxv1alpha1.ConditionTrue, "InvalidShardPatch", patchErr.Error())
+			_ = r.updateStatus(ctx, batchSbx, statusCopy)
+			if controllerutil.ContainsFinalizer(batchSbx, FinalizerTaskCleanup) {
+				if err := utils.UpdateFinalizer(r.Client, batchSbx, utils.RemoveFinalizerOpType, FinalizerTaskCleanup); err != nil {
+					if !errors.IsNotFound(err) {
+						log.Error(err, "failed to remove finalizer during invalid-patch deletion", "finalizer", FinalizerTaskCleanup)
+						return ctrl.Result{}, err
+					}
+				}
+				r.deleteTaskScheduler(ctx, batchSbx)
+				log.Info("removed finalizer due to invalid shardTaskPatches, resource can now be deleted")
+			}
 			return ctrl.Result{}, nil
 		}
 	}

--- a/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
+++ b/kubernetes/internal/controller/batchsandbox_pause_resume_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
 	taskscheduler "github.com/alibaba/OpenSandbox/sandbox-k8s/internal/scheduler"
@@ -2724,3 +2726,123 @@ func TestAckPauseWithPhase_DoesNotMutateSpecPause(t *testing.T) {
 
 // Ensure ctrl.Result type is used
 var _ = ctrl.Result{}
+
+// ---------- Issue 1019: shardTaskPatches validation and finalizer unblock ----------
+
+// TestReconcile_InvalidShardTaskPatches_SetsConditionAndDoesNotProceed verifies that when
+// a BatchSandbox has invalid shardTaskPatches (e.g. args as an integer instead of a string
+// array), the reconciler surfaces an InvalidShardPatch condition in status and returns
+// without adding a finalizer or progressing further.
+func TestReconcile_InvalidShardTaskPatches_SetsConditionAndDoesNotProceed(t *testing.T) {
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-bs-invalid-patch",
+			Namespace: "default",
+		},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "img"}},
+				},
+			},
+			TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{
+				Spec: sandboxv1alpha1.TaskSpec{
+					Process: &sandboxv1alpha1.ProcessTask{
+						Command: []string{"sleep"},
+						Args:    []string{"infinite"},
+					},
+				},
+			},
+			// args is an integer, not a string array — invalid against TaskSpec schema.
+			ShardTaskPatches: []runtime.RawExtension{
+				{Raw: []byte(`{"spec":{"process":{"args":3600}}}`)},
+			},
+		},
+	}
+	r := newTestReconciler(bs)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-bs-invalid-patch"},
+	})
+	require.NoError(t, err, "reconcile should not return an error for invalid user input")
+	assert.Equal(t, ctrl.Result{}, result, "reconcile should return an empty result (no requeue)")
+
+	// Verify InvalidShardPatch condition is set in status.
+	updated := &sandboxv1alpha1.BatchSandbox{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-bs-invalid-patch"}, updated))
+
+	var invalidPatchCond *sandboxv1alpha1.BatchSandboxCondition
+	for i := range updated.Status.Conditions {
+		if updated.Status.Conditions[i].Type == sandboxv1alpha1.BatchSandboxConditionInvalidShardPatch {
+			invalidPatchCond = &updated.Status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, invalidPatchCond, "InvalidShardPatch condition should be set")
+	assert.Equal(t, sandboxv1alpha1.ConditionTrue, invalidPatchCond.Status)
+	assert.Equal(t, "InvalidShardPatch", invalidPatchCond.Reason)
+
+	// Verify that the finalizer was NOT added (reconcile should have bailed before that).
+	assert.False(t, controllerutil.ContainsFinalizer(updated, FinalizerTaskCleanup),
+		"finalizer should not have been added when shardTaskPatches are invalid")
+}
+
+// TestReconcile_InvalidShardTaskPatches_OnDeletion_ClearsFinalizer verifies that when a
+// BatchSandbox with an invalid shardTaskPatch is being deleted, the reconciler clears the
+// finalizer so the resource is not stuck in Terminating forever.
+func TestReconcile_InvalidShardTaskPatches_OnDeletion_ClearsFinalizer(t *testing.T) {
+	now := metav1.Now()
+	bs := &sandboxv1alpha1.BatchSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-bs-delete-invalid",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			// fake client requires non-zero ResourceVersion for objects with DeletionTimestamp.
+			ResourceVersion: "1",
+			Finalizers:      []string{FinalizerTaskCleanup},
+		},
+		Spec: sandboxv1alpha1.BatchSandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "img"}},
+				},
+			},
+			TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{
+				Spec: sandboxv1alpha1.TaskSpec{
+					Process: &sandboxv1alpha1.ProcessTask{
+						Command: []string{"sleep"},
+						Args:    []string{"infinite"},
+					},
+				},
+			},
+			// args is an integer, not a string array — invalid against TaskSpec schema.
+			ShardTaskPatches: []runtime.RawExtension{
+				{Raw: []byte(`{"spec":{"process":{"args":3600}}}`)},
+			},
+		},
+	}
+	r := newTestReconciler(bs)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-bs-delete-invalid"},
+	})
+	require.NoError(t, err, "reconcile should not return an error on deletion with invalid patches")
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// After the finalizer is removed from a terminating object, the fake client
+	// garbage-collects the resource immediately (same behaviour as the real API server).
+	// A "not found" response confirms the finalizer was cleared and deletion unblocked.
+	updated := &sandboxv1alpha1.BatchSandbox{}
+	getErr := r.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-bs-delete-invalid"}, updated)
+	if getErr == nil {
+		// Resource still visible (e.g. fake client version differences) — confirm finalizer gone.
+		assert.False(t, controllerutil.ContainsFinalizer(updated, FinalizerTaskCleanup),
+			"finalizer should have been removed so the resource is no longer stuck in Terminating")
+	} else {
+		// Resource already garbage-collected — this is the expected happy path.
+		require.True(t, apierrors.IsNotFound(getErr),
+			"expected resource to be deleted after finalizer removal, got unexpected error: %v", getErr)
+	}
+}

--- a/kubernetes/internal/controller/strategy/task_scheduling_strategy.go
+++ b/kubernetes/internal/controller/strategy/task_scheduling_strategy.go
@@ -25,6 +25,10 @@ type TaskSchedulingStrategy interface {
 	// NeedTaskScheduling determines whether the BatchSandbox requires task scheduling.
 	NeedTaskScheduling() bool
 
+	// ValidateShardTaskPatches checks that all shardTaskPatches can be merged into
+	// a TaskTemplateSpec without type errors. Returns nil when all patches are valid.
+	ValidateShardTaskPatches() error
+
 	// GenerateTaskSpecs generates the complete list of task specifications for the BatchSandbox.
 	GenerateTaskSpecs() ([]*api.Task, error)
 }

--- a/kubernetes/internal/controller/strategy/task_scheduling_strategy_default.go
+++ b/kubernetes/internal/controller/strategy/task_scheduling_strategy_default.go
@@ -41,6 +41,26 @@ func (s *DefaultTaskSchedulingStrategy) NeedTaskScheduling() bool {
 	return s.Spec.TaskTemplate != nil
 }
 
+// ValidateShardTaskPatches checks that every shardTaskPatch can be successfully
+// merged into a zero-value TaskTemplateSpec. It returns the first error encountered,
+// including the patch index and the raw patch bytes to aid diagnosis.
+func (s *DefaultTaskSchedulingStrategy) ValidateShardTaskPatches() error {
+	if len(s.Spec.ShardTaskPatches) == 0 {
+		return nil
+	}
+	zeroBytes, _ := json.Marshal(&sandboxv1alpha1.TaskTemplateSpec{})
+	for i, patch := range s.Spec.ShardTaskPatches {
+		modified, err := strategicpatch.StrategicMergePatch(zeroBytes, patch.Raw, &sandboxv1alpha1.TaskTemplateSpec{})
+		if err != nil {
+			return fmt.Errorf("batchsandbox: shardTaskPatches[%d] failed schema validation: patch %s, err %w", i, patch.Raw, err)
+		}
+		if err = json.Unmarshal(modified, &sandboxv1alpha1.TaskTemplateSpec{}); err != nil {
+			return fmt.Errorf("batchsandbox: shardTaskPatches[%d] produced invalid TaskTemplateSpec: patch %s, err %w", i, patch.Raw, err)
+		}
+	}
+	return nil
+}
+
 // GenerateTaskSpecs generates task specifications for all replicas.
 func (s *DefaultTaskSchedulingStrategy) GenerateTaskSpecs() ([]*api.Task, error) {
 	ret := make([]*api.Task, *s.Spec.Replicas)

--- a/kubernetes/internal/controller/strategy/task_scheduling_strategy_default_test.go
+++ b/kubernetes/internal/controller/strategy/task_scheduling_strategy_default_test.go
@@ -25,6 +25,82 @@ import (
 	api "github.com/alibaba/OpenSandbox/sandbox-k8s/pkg/task-executor"
 )
 
+func TestDefaultTaskSchedulingStrategy_ValidateShardTaskPatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		batchSbx *sandboxv1alpha1.BatchSandbox
+		wantErr  bool
+	}{
+		{
+			name: "no shard task patches - valid",
+			batchSbx: &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{
+					TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid shard task patch with string args",
+			batchSbx: &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{
+					TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{},
+					ShardTaskPatches: []runtime.RawExtension{
+						{Raw: []byte(`{"spec":{"process":{"command":["sleep"],"args":["3600"]}}}`)},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid shard task patch - args as integer instead of string array",
+			batchSbx: &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{
+					TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{},
+					ShardTaskPatches: []runtime.RawExtension{
+						{Raw: []byte(`{"spec":{"process":{"args":3600}}}`)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid shard task patch - malformed JSON",
+			batchSbx: &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{
+					TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{},
+					ShardTaskPatches: []runtime.RawExtension{
+						{Raw: []byte(`{"invalid json`)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "second patch invalid - returns error with correct index",
+			batchSbx: &sandboxv1alpha1.BatchSandbox{
+				Spec: sandboxv1alpha1.BatchSandboxSpec{
+					TaskTemplate: &sandboxv1alpha1.TaskTemplateSpec{},
+					ShardTaskPatches: []runtime.RawExtension{
+						{Raw: []byte(`{"spec":{"process":{"args":["valid"]}}}`)},
+						{Raw: []byte(`{"spec":{"process":{"args":3600}}}`)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewDefaultTaskSchedulingStrategy(tt.batchSbx)
+			err := s.ValidateShardTaskPatches()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateShardTaskPatches() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestDefaultTaskSchedulingStrategy_NeedTaskScheduling(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -156,11 +156,16 @@ class ConnectionConfig(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
-        """Get the full base URL for API requests."""
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         # Allow domain to override protocol if it explicitly starts with a scheme
-        if domain.startswith("http://") or domain.startswith(
-            "https://"
-        ):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+        if domain.startswith("http://") or domain.startswith("https://"):
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -132,7 +132,15 @@ class ConnectionConfigSync(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         if domain.startswith("http://") or domain.startswith("https://"):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -28,13 +28,40 @@ def test_protocol_validation() -> None:
 
 
 def test_get_base_url_with_domain_and_protocol() -> None:
+    # get_base_url() must NOT append /v1 — doing so would route requests to the
+    # blocking /v1/sandboxes endpoint and cause 504 Gateway Timeouts (issue #591).
     cfg = ConnectionConfig(domain="example.com:1234", protocol="https")
-    assert cfg.get_base_url() == "https://example.com:1234/v1"
+    assert cfg.get_base_url() == "https://example.com:1234"
 
 
 def test_get_base_url_domain_can_include_scheme() -> None:
     cfg = ConnectionConfig(domain="https://example.com:9999", protocol="http")
-    assert cfg.get_base_url() == "https://example.com:9999/v1"
+    assert cfg.get_base_url() == "https://example.com:9999"
+
+
+def test_get_base_url_no_v1_prefix_direct_mode() -> None:
+    """Direct mode: base URL must not contain /v1 so SDK hits POST /sandboxes (async, 202)."""
+    cfg = ConnectionConfig(domain="sandbox-api.example.com", use_server_proxy=False)
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_no_v1_prefix_proxy_mode() -> None:
+    """Proxy mode: base URL must not contain /v1 to avoid hitting the blocking endpoint."""
+    cfg = ConnectionConfig(
+        domain="http://sandbox-api.example.com",
+        use_server_proxy=True,
+    )
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_trailing_slash_stripped() -> None:
+    """Trailing slashes on the domain are stripped to prevent double-slash in paths."""
+    cfg = ConnectionConfig(domain="http://sandbox-api.example.com/")
+    assert cfg.get_base_url() == "http://sandbox-api.example.com"
 
 
 @pytest.mark.asyncio

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -193,6 +193,14 @@ async def _proxy_http_request(
             headers["X-Forwarded-For"] = request.client.host
 
         stream_body = request.method in ("POST", "PUT", "PATCH", "DELETE")
+        if stream_body:
+            # Strip content-length when streaming: the body is forwarded as an
+            # async generator which httpx sends with Transfer-Encoding: chunked.
+            # Keeping the original Content-Length causes a length mismatch on the
+            # backend (Go net/http reads exactly Content-Length bytes and discards
+            # the rest), which silently truncates large uploads (> ~18 KB).
+            headers.pop("content-length", None)
+            headers.pop("Content-Length", None)
         req = client.build_request(
             method=request.method,
             url=target_url,

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -38,8 +38,11 @@ def apply_volumes_to_pod_spec(
     mounts = main_container.get("volumeMounts", [])
     pod_volumes = pod_spec.get("volumes", [])
 
-    existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
-    pvc_to_volume_name: Dict[str, str] = {}
+    existing_volume_names = {
+        v.get("name") for v in pod_volumes if isinstance(v, dict)
+    }
+    # Key: (claim_name, read_only) so the same PVC can be mounted both RO and RW.
+    pvc_to_volume_name: Dict[tuple, str] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -52,19 +55,23 @@ def apply_volumes_to_pod_spec(
 
         if vol.pvc is not None:
             pvc_claim_name = vol.pvc.claim_name
+            pvc_key = (pvc_claim_name, vol.read_only)
 
-            if pvc_claim_name not in pvc_to_volume_name:
+            if pvc_key not in pvc_to_volume_name:
+                pvc_volume: Dict[str, Any] = {
+                    "claimName": pvc_claim_name,
+                }
+                if vol.read_only:
+                    pvc_volume["readOnly"] = True
                 pod_volumes.append({
                     "name": vol_name,
-                    "persistentVolumeClaim": {
-                        "claimName": pvc_claim_name,
-                    },
+                    "persistentVolumeClaim": pvc_volume,
                 })
-                pvc_to_volume_name[pvc_claim_name] = vol_name
+                pvc_to_volume_name[pvc_key] = vol_name
                 existing_volume_names.add(vol_name)
 
             mount = {
-                "name": pvc_to_volume_name[pvc_claim_name],
+                "name": pvc_to_volume_name[pvc_key],
                 "mountPath": vol.mount_path,
                 "readOnly": vol.read_only,
             }
@@ -73,7 +80,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added PVC volume '{vol_name}' (claim: {pvc_claim_name}) mounted at '{vol.mount_path}' for sandbox"
+                "Added PVC volume '%s' (claim: %s, readOnly: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, pvc_claim_name, vol.read_only, vol.mount_path,
             )
         elif vol.host is not None:
             host_path = vol.host.path
@@ -96,7 +105,9 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added hostPath volume '{vol_name}' (path: {host_path}) mounted at '{vol.mount_path}' for sandbox"
+                "Added hostPath volume '%s' (path: %s) "
+                "mounted at '%s' for sandbox",
+                vol_name, host_path, vol.mount_path,
             )
         else:
             raise ValueError(

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -2675,6 +2675,16 @@ spec:
         assert models_mount is not None
         assert models_mount["readOnly"] is True
 
+        pvc_vol = next(
+            (
+                v for v in pod_spec["volumes"]
+                if v.get("persistentVolumeClaim", {}).get("claimName") == "models-pvc"
+            ),
+            None,
+        )
+        assert pvc_vol is not None
+        assert pvc_vol["persistentVolumeClaim"].get("readOnly") is True
+
     def test_create_workload_with_pvc_volume_subpath(self, mock_k8s_client):
         """
         Test creating workload with PVC volume mount with subPath.

--- a/server/tests/k8s/test_volume_helper.py
+++ b/server/tests/k8s/test_volume_helper.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from opensandbox_server.api.schema import Host, PVC, Volume
+from opensandbox_server.services.k8s.volume_helper import apply_volumes_to_pod_spec
+
+
+def _empty_pod_spec():
+    return {
+        "containers": [{"name": "main", "volumeMounts": []}],
+        "volumes": [],
+    }
+
+
+def _get_pvc_volume_spec(pod_spec, claim_name):
+    for v in pod_spec["volumes"]:
+        pvc = v.get("persistentVolumeClaim", {})
+        if pvc.get("claimName") == claim_name:
+            return v
+    return None
+
+
+def _get_mount(pod_spec, mount_path):
+    mounts = pod_spec["containers"][0].get("volumeMounts", [])
+    return next((m for m in mounts if m["mountPath"] == mount_path), None)
+
+
+class TestApplyVolumesToPodSpec:
+    def test_pvc_rw_no_readonly_in_volume_spec(self):
+        """Read-write PVC must not set readOnly on the PVC volume spec."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="data-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+                read_only=False,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "my-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert "readOnly" not in pvc_src
+
+        mount = _get_mount(pod_spec, "/mnt/data")
+        assert mount is not None
+        assert mount["readOnly"] is False
+
+    def test_pvc_readonly_sets_readonly_on_volume_spec_and_mount(self):
+        """readOnly=True must propagate to both PVC volume spec and VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="models-vol",
+                pvc=PVC(claim_name="models-pvc"),
+                mount_path="/mnt/models",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_vol = _get_pvc_volume_spec(pod_spec, "models-pvc")
+        assert pvc_vol is not None
+        pvc_src = pvc_vol["persistentVolumeClaim"]
+        assert pvc_src.get("readOnly") is True
+
+        mount = _get_mount(pod_spec, "/mnt/models")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_same_pvc_ro_and_rw_gets_separate_volume_entries(self):
+        """Same PVC mounted RO and RW must produce separate pod volume entries."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="vol-ro",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/ro",
+                read_only=True,
+            ),
+            Volume(
+                name="vol-rw",
+                pvc=PVC(claim_name="shared-pvc"),
+                mount_path="/mnt/rw",
+                read_only=False,
+            ),
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        pvc_entries = [
+            v for v in pod_spec["volumes"]
+            if v.get("persistentVolumeClaim", {}).get("claimName") == "shared-pvc"
+        ]
+        assert len(pvc_entries) == 2
+
+        ro_entry = next(
+            v for v in pvc_entries
+            if v["persistentVolumeClaim"].get("readOnly") is True
+        )
+        rw_entry = next(
+            v for v in pvc_entries
+            if "readOnly" not in v["persistentVolumeClaim"]
+        )
+
+        ro_mount = _get_mount(pod_spec, "/mnt/ro")
+        rw_mount = _get_mount(pod_spec, "/mnt/rw")
+
+        assert ro_mount["name"] == ro_entry["name"]
+        assert ro_mount["readOnly"] is True
+        assert rw_mount["name"] == rw_entry["name"]
+        assert rw_mount["readOnly"] is False
+
+    def test_host_volume_readonly_sets_readonly_on_mount(self):
+        """readOnly=True on a host volume sets the VolumeMount readOnly flag."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="host-vol",
+                host=Host(path="/data/shared"),
+                mount_path="/mnt/shared",
+                read_only=True,
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/shared")
+        assert mount is not None
+        assert mount["readOnly"] is True
+
+    def test_conflicts_with_existing_volume_name(self):
+        """Volume name that collides with an existing pod volume raises ValueError."""
+        pod_spec = _empty_pod_spec()
+        pod_spec["volumes"].append({"name": "existing-vol"})
+        volumes = [
+            Volume(
+                name="existing-vol",
+                pvc=PVC(claim_name="my-pvc"),
+                mount_path="/mnt/data",
+            )
+        ]
+        with pytest.raises(ValueError, match="conflicts with an internal volume"):
+            apply_volumes_to_pod_spec(pod_spec, volumes)
+
+    def test_pvc_with_subpath(self):
+        """subPath is forwarded to the VolumeMount."""
+        pod_spec = _empty_pod_spec()
+        volumes = [
+            Volume(
+                name="sub-vol",
+                pvc=PVC(claim_name="big-pvc"),
+                mount_path="/mnt/sub",
+                sub_path="tenant-a",
+            )
+        ]
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        mount = _get_mount(pod_spec, "/mnt/sub")
+        assert mount is not None
+        assert mount["subPath"] == "tenant-a"

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -725,3 +725,108 @@ def test_proxy_active_credential_vault_returns_sidecar_forbidden(
     assert response.content == b"forbidden\n"
     assert fake_client.built is not None
     assert fake_client.built["url"] == "http://10.57.1.91:18080/credential-vault/_active"
+
+
+def test_proxy_strips_content_length_for_streaming_post(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """content-length must not be forwarded when the body is streamed (issue #1016).
+
+    The proxy sends the request body as an async generator which httpx encodes
+    with Transfer-Encoding: chunked.  If content-length is also forwarded, Go's
+    net/http server reads exactly that many bytes and silently truncates the rest,
+    causing uploads > ~18 KB to appear successful (HTTP 200) while the file is
+    never fully written.
+    """
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"ok"])
+    _set_http_client(client, fake_client)
+
+    large_body = b"x" * (20 * 1024)  # 20 KB — above the ~18 KB truncation threshold
+
+    for method in ("POST", "PUT", "PATCH"):
+        response = client.request(
+            method,
+            "/v1/sandboxes/sbx-123/proxy/44772/files/upload",
+            headers={**auth_headers, "Content-Length": str(len(large_body))},
+            content=large_body,
+        )
+
+        assert response.status_code == 200
+        assert fake_client.built is not None
+        lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+        assert "content-length" not in lowered, (
+            f"{method}: content-length must be stripped for streaming requests"
+        )
+
+
+def test_proxy_strips_content_length_for_streaming_delete(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """DELETE with a body is also streamed; content-length must be stripped."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"deleted"])
+    _set_http_client(client, fake_client)
+
+    body = b'{"id": "resource-123"}'
+    response = client.request(
+        "DELETE",
+        "/v1/sandboxes/sbx-123/proxy/44772/resources",
+        headers={**auth_headers, "Content-Length": str(len(body))},
+        content=body,
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+    assert "content-length" not in lowered, (
+        "DELETE: content-length must be stripped for streaming requests"
+    )
+
+
+def test_proxy_preserves_content_length_for_get(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """GET requests are not streamed; content-length (if any) must be forwarded as-is."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"data"])
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/files/list",
+        headers={**auth_headers, "Content-Length": "0"},
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    assert fake_client.built["content"] is None


### PR DESCRIPTION
## Summary

Fixes #1019.

- **Fix 1 (schema validation)**: Add `ValidateShardTaskPatches()` to the `TaskSchedulingStrategy` interface and `DefaultTaskSchedulingStrategy`. Call it in the reconcile loop before adding the `FinalizerTaskCleanup` finalizer. If any patch cannot be merged into a zero-value `TaskTemplateSpec` (e.g. `args: 3600` instead of `args: [3600]`), write an `InvalidShardPatch` condition to status and return without error, so the controller stops requeueing until the user corrects the resource.
- **Fix 2 (finalizer deadlock)**: On the deletion path (`DeletionTimestamp != nil`), run the same validation first. If patches are invalid, remove `FinalizerTaskCleanup` immediately and record the error in status so the resource is no longer stuck in `Terminating`.
- **New condition type**: `BatchSandboxConditionInvalidShardPatch = InvalidShardPatch` added to `BatchSandboxConditionType`.

## Test plan

- [ ] `TestDefaultTaskSchedulingStrategy_ValidateShardTaskPatches` â€” 5 sub-cases covering no patches, valid string args, integer args (invalid), malformed JSON, and second-patch-invalid detection.
- [ ] `TestReconcile_InvalidShardTaskPatches_SetsConditionAndDoesNotProceed` â€” reconcile with invalid patches sets `InvalidShardPatch` condition, returns no error, and does not add finalizer.
- [ ] `TestReconcile_InvalidShardTaskPatches_OnDeletion_ClearsFinalizer` â€” reconcile of a terminating sandbox with invalid patches clears the finalizer so the resource is garbage-collected.
