### PR TITLE
fix(execd): avoid global signal to fix false command failures

### DIFF
--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -37,6 +37,16 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
+var forwardSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGHUP,
+	syscall.SIGQUIT,
+	syscall.SIGUSR1,
+	syscall.SIGUSR2,
+	syscall.SIGWINCH,
+}
+
 // getShell returns the preferred shell, falling back to sh if bash is not available.
 // This is needed for Alpine-based Docker images that only have sh by default.
 func getShell() string {
@@ -90,10 +100,10 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest) error {
 	session := c.newContextID()
 
-	signals := make(chan os.Signal, 1)
+	signals := make(chan os.Signal, len(forwardSignals)+1)
 	defer close(signals)
-	signal.Notify(signals)
-	defer signal.Reset()
+	signal.Notify(signals, forwardSignals...)
+	defer signal.Stop(signals)
 
 	stdout, stderr, err := c.stdLogDescriptor(session)
 	if err != nil {
@@ -259,10 +269,10 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	stdoutPath := c.combinedOutputFileName(session)
 	stderrPath := c.combinedOutputFileName(session)
 
-	signals := make(chan os.Signal, 1)
+	signals := make(chan os.Signal, len(forwardSignals)+1)
 	defer close(signals)
-	signal.Notify(signals)
-	defer signal.Reset()
+	signal.Notify(signals, forwardSignals...)
+	defer signal.Stop(signals)
 
 	startAt := time.Now()
 	log.Info("received command: %v", log.SanitizeCommand(request.Code))


### PR DESCRIPTION
# Summary
Fixes #1041.

`execd` could report a successfully-executed command as a failure (`CommandExecError`) when `cmd.Wait()` returned a spurious `ECHILD` ("waitid: no child processes"). 
The root cause was global signal handling in `runCommand` / `runBackgroundCommand`: they called `signal.Notify(signals)` with no signal list (capturing ALL signals, including SIGCHLD and SIGURG) and `defer signal.Reset()` (a process-global reset). This interfered with the Go runtime's use of SIGCHLD/SIGURG (child reaping and async preemption) and raced across concurrent/sequential commands, occasionally leaving `Wait()` unable to reap its own child.

This change:
1. Replaces `signal.Notify(signals)` + `signal.Reset()` with `signal.Notify(signals, forwardSignals...)` + `signal.Stop(signals)`, so only an explicit set of signals is forwarded and cleanup is scoped to this channel instead of resetting global handlers.
2. Ignores spurious `ECHILD` from `cmd.Wait()` (child already reaped) so a command that ran to completion is reported as success instead of a false failure.

# Testing
- [ ] Unit tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
