### PR TITLE
fix(proxy): strip content-length when streaming request body

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -192,6 +192,10 @@ async def _proxy_http_request(
         if request.client and "x-forwarded-for" not in existing_lower:
             headers["X-Forwarded-For"] = request.client.host
 
+        # Normalize header keys to lowercase so subsequent lookups are
+        # case-insensitive regardless of what the upstream client sent.
+        headers = {k.lower(): v for k, v in headers.items()}
+
         stream_body = request.method in ("POST", "PUT", "PATCH", "DELETE")
         if stream_body:
             # Strip content-length when streaming: the body is forwarded as an
@@ -200,7 +204,6 @@ async def _proxy_http_request(
             # backend (Go net/http reads exactly Content-Length bytes and discards
             # the rest), which silently truncates large uploads (> ~18 KB).
             headers.pop("content-length", None)
-            headers.pop("Content-Length", None)
         req = client.build_request(
             method=request.method,
             url=target_url,

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -193,6 +193,14 @@ async def _proxy_http_request(
             headers["X-Forwarded-For"] = request.client.host
 
         stream_body = request.method in ("POST", "PUT", "PATCH", "DELETE")
+        if stream_body:
+            # Strip content-length when streaming: the body is forwarded as an
+            # async generator which httpx sends with Transfer-Encoding: chunked.
+            # Keeping the original Content-Length causes a length mismatch on the
+            # backend (Go net/http reads exactly Content-Length bytes and discards
+            # the rest), which silently truncates large uploads (> ~18 KB).
+            headers.pop("content-length", None)
+            headers.pop("Content-Length", None)
         req = client.build_request(
             method=request.method,
             url=target_url,

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -727,6 +727,18 @@ def test_proxy_active_credential_vault_returns_sidecar_forbidden(
     assert fake_client.built["url"] == "http://10.57.1.91:18080/credential-vault/_active"
 
 
+class _StubServiceSimple:
+    """Minimal sandbox service stub that returns a fixed endpoint.
+
+    Shared by the content-length stripping/preservation tests so that the
+    identical three-line inner class is not repeated in each test body.
+    """
+
+    @staticmethod
+    def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+        return Endpoint(endpoint="10.57.1.91:40109")
+
+
 def test_proxy_strips_content_length_for_streaming_post(
     client: TestClient,
     auth_headers: dict,
@@ -740,13 +752,7 @@ def test_proxy_strips_content_length_for_streaming_post(
     causing uploads > ~18 KB to appear successful (HTTP 200) while the file is
     never fully written.
     """
-
-    class StubService:
-        @staticmethod
-        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
-            return Endpoint(endpoint="10.57.1.91:40109")
-
-    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(lifecycle, "sandbox_service", _StubServiceSimple())
 
     fake_client = _FakeAsyncClient()
     fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"ok"])
@@ -776,13 +782,7 @@ def test_proxy_strips_content_length_for_streaming_delete(
     monkeypatch,
 ) -> None:
     """DELETE with a body is also streamed; content-length must be stripped."""
-
-    class StubService:
-        @staticmethod
-        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
-            return Endpoint(endpoint="10.57.1.91:40109")
-
-    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(lifecycle, "sandbox_service", _StubServiceSimple())
 
     fake_client = _FakeAsyncClient()
     fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"deleted"])
@@ -810,13 +810,7 @@ def test_proxy_preserves_content_length_for_get(
     monkeypatch,
 ) -> None:
     """GET requests are not streamed; content-length (if any) must be forwarded as-is."""
-
-    class StubService:
-        @staticmethod
-        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
-            return Endpoint(endpoint="10.57.1.91:40109")
-
-    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(lifecycle, "sandbox_service", _StubServiceSimple())
 
     fake_client = _FakeAsyncClient()
     fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"data"])
@@ -830,3 +824,7 @@ def test_proxy_preserves_content_length_for_get(
     assert response.status_code == 200
     assert fake_client.built is not None
     assert fake_client.built["content"] is None
+    lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+    assert "content-length" in lowered, (
+        "GET: content-length must be forwarded as-is (not streamed)"
+    )

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -725,3 +725,108 @@ def test_proxy_active_credential_vault_returns_sidecar_forbidden(
     assert response.content == b"forbidden\n"
     assert fake_client.built is not None
     assert fake_client.built["url"] == "http://10.57.1.91:18080/credential-vault/_active"
+
+
+def test_proxy_strips_content_length_for_streaming_post(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """content-length must not be forwarded when the body is streamed (issue #1016).
+
+    The proxy sends the request body as an async generator which httpx encodes
+    with Transfer-Encoding: chunked.  If content-length is also forwarded, Go's
+    net/http server reads exactly that many bytes and silently truncates the rest,
+    causing uploads > ~18 KB to appear successful (HTTP 200) while the file is
+    never fully written.
+    """
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"ok"])
+    _set_http_client(client, fake_client)
+
+    large_body = b"x" * (20 * 1024)  # 20 KB — above the ~18 KB truncation threshold
+
+    for method in ("POST", "PUT", "PATCH"):
+        response = client.request(
+            method,
+            "/v1/sandboxes/sbx-123/proxy/44772/files/upload",
+            headers={**auth_headers, "Content-Length": str(len(large_body))},
+            content=large_body,
+        )
+
+        assert response.status_code == 200
+        assert fake_client.built is not None
+        lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+        assert "content-length" not in lowered, (
+            f"{method}: content-length must be stripped for streaming requests"
+        )
+
+
+def test_proxy_strips_content_length_for_streaming_delete(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """DELETE with a body is also streamed; content-length must be stripped."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"deleted"])
+    _set_http_client(client, fake_client)
+
+    body = b'{"id": "resource-123"}'
+    response = client.request(
+        "DELETE",
+        "/v1/sandboxes/sbx-123/proxy/44772/resources",
+        headers={**auth_headers, "Content-Length": str(len(body))},
+        content=body,
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    lowered = {k.lower(): v for k, v in fake_client.built["headers"].items()}
+    assert "content-length" not in lowered, (
+        "DELETE: content-length must be stripped for streaming requests"
+    )
+
+
+def test_proxy_preserves_content_length_for_get(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """GET requests are not streamed; content-length (if any) must be forwarded as-is."""
+
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            return Endpoint(endpoint="10.57.1.91:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(status_code=200, chunks=[b"data"])
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/files/list",
+        headers={**auth_headers, "Content-Length": "0"},
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+    assert fake_client.built["content"] is None


### PR DESCRIPTION
## Summary

- The server proxy (`_proxy_http_request`) forwarded the original `Content-Length` header while sending the body as a chunked async generator via `content=request.stream()`
- Go's `net/http` server on execd read exactly `Content-Length` bytes and stopped, silently truncating uploads larger than ~18 KB
- Fix: pop `content-length` (case-insensitive) from forwarded headers when `stream_body=True` so Go switches to chunked-transfer mode and reads the full body

## Test plan
- [ ] `uv run pytest server/tests/test_routes_proxy.py -k content_length` — 3 new tests pass (POST/PUT/PATCH strip header; GET preserves it)

Fixes #1016