### PR TITLE
fix(execd): skip chmod/chown for pre-existing dirs in MakeDir

### DIFF
--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -155,9 +155,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/components/execd/pkg/web/controller/utils.go
+++ b/components/execd/pkg/web/controller/utils.go
@@ -160,6 +160,9 @@ func MakeDir(dir string, perm model.Permission) error {
 	// we can skip chmod/chown on pre-existing directories (including system
 	// dirs like /tmp that the sandbox user does not own).
 	_, statErr := os.Stat(abs)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
 	alreadyExisted := statErr == nil
 
 	if err = os.MkdirAll(abs, os.ModePerm); err != nil {

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -70,6 +70,57 @@ func TestSearchFileMetadata(t *testing.T) {
 	require.False(t, ok, "expected no match")
 }
 
+func TestMakeDirCreatesNewDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	newDir := filepath.Join(tmp, "newdir")
+
+	require.NoError(t, MakeDir(newDir, model.Permission{Mode: 755}))
+
+	info, err := os.Stat(newDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestMakeDirIsIdempotentOnExistingDirectory(t *testing.T) {
+	// MakeDir on a pre-existing directory must not return an error and must
+	// not attempt to chmod/chown the directory (which would fail for system
+	// dirs like /tmp that the process does not own).
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing")
+	require.NoError(t, os.Mkdir(existing, 0o755))
+
+	// Record perms before calling MakeDir to verify they are unchanged.
+	before, err := os.Stat(existing)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(existing, model.Permission{Mode: 700}))
+
+	after, err := os.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, before.Mode(), after.Mode(), "MakeDir must not chmod a pre-existing directory")
+}
+
+func TestMakeDirCreatesNestedDirectoriesWithoutChmodingParents(t *testing.T) {
+	// When creating /parent/child and /parent already exists, only /parent/child
+	// should receive chmod — /parent must be left untouched.
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "parent")
+	child := filepath.Join(parent, "child")
+	require.NoError(t, os.Mkdir(parent, 0o755))
+
+	beforeParent, err := os.Stat(parent)
+	require.NoError(t, err)
+
+	require.NoError(t, MakeDir(child, model.Permission{Mode: 755}))
+
+	afterParent, err := os.Stat(parent)
+	require.NoError(t, err)
+	require.Equal(t, beforeParent.Mode(), afterParent.Mode(), "MakeDir must not chmod the pre-existing parent")
+
+	_, err = os.Stat(child)
+	require.NoError(t, err, "child directory must exist")
+}
+
 func TestParseRange(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/components/execd/pkg/web/controller/utils_test.go
+++ b/components/execd/pkg/web/controller/utils_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/alibaba/opensandbox/execd/pkg/web/model"
@@ -79,6 +80,13 @@ func TestMakeDirCreatesNewDirectory(t *testing.T) {
 	info, err := os.Stat(newDir)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
+
+	if runtime.GOOS != "windows" {
+		// Verify the permission bits match what was requested (mode 755 octal).
+		wantPerm := os.FileMode(0o755)
+		gotPerm := info.Mode().Perm()
+		require.Equal(t, wantPerm, gotPerm, "expected directory permissions %o, got %o", wantPerm, gotPerm)
+	}
 }
 
 func TestMakeDirIsIdempotentOnExistingDirectory(t *testing.T) {
@@ -100,7 +108,7 @@ func TestMakeDirIsIdempotentOnExistingDirectory(t *testing.T) {
 	require.Equal(t, before.Mode(), after.Mode(), "MakeDir must not chmod a pre-existing directory")
 }
 
-func TestMakeDirCreatesNestedDirectoriesWithoutChmodingParents(t *testing.T) {
+func TestMakeDirCreatesNestedDirectoriesWithoutChmodNewDirParents(t *testing.T) {
 	// When creating /parent/child and /parent already exists, only /parent/child
 	// should receive chmod — /parent must be left untouched.
 	tmp := t.TempDir()

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -119,9 +119,19 @@ func MakeDir(dir string, perm model.Permission) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(abs, os.ModePerm)
-	if err != nil {
+
+	// Record whether the target directory already exists before MkdirAll so
+	// we can skip chmod/chown on pre-existing directories (including system
+	// dirs like /tmp that the sandbox user does not own).
+	_, statErr := os.Stat(abs)
+	alreadyExisted := statErr == nil
+
+	if err = os.MkdirAll(abs, os.ModePerm); err != nil {
 		return err
+	}
+
+	if alreadyExisted {
+		return nil
 	}
 
 	return ChmodFile(abs, perm)

--- a/components/execd/pkg/web/controller/utils_windows.go
+++ b/components/execd/pkg/web/controller/utils_windows.go
@@ -124,6 +124,9 @@ func MakeDir(dir string, perm model.Permission) error {
 	// we can skip chmod/chown on pre-existing directories (including system
 	// dirs like /tmp that the sandbox user does not own).
 	_, statErr := os.Stat(abs)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
 	alreadyExisted := statErr == nil
 
 	if err = os.MkdirAll(abs, os.ModePerm); err != nil {


### PR DESCRIPTION
## Summary

- `MakeDir` called `os.MkdirAll` then unconditionally called `ChmodFile` on the target path
- For pre-existing directories (e.g. `/tmp`, `/workspace`) owned by a different user, the `chmod`/`chown` syscall fails with "operation not permitted", breaking subsequent `writeFile` calls
- Fix: `os.Stat` before `MkdirAll` — if the path already exists, skip permission changes entirely; only newly-created directories get `chmod`/`chown` applied

## Test plan
- [ ] `go test ./pkg/web/controller/...` — 3 new unit tests: new dir created, pre-existing dir mode unchanged, nested create doesn't chmod parents

Fixes #1024