### PR TITLE
fix(sdk): remove /v1 prefix from ConnectionConfig.get_base_url()

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -156,11 +156,16 @@ class ConnectionConfig(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
-        """Get the full base URL for API requests."""
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         # Allow domain to override protocol if it explicitly starts with a scheme
-        if domain.startswith("http://") or domain.startswith(
-            "https://"
-        ):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+        if domain.startswith("http://") or domain.startswith("https://"):
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -164,8 +164,8 @@ class ConnectionConfig(BaseModel):
         ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
         server-side proxy has a short idle timeout (see issue #591).
         """
-        domain = self.get_domain()
+        domain = self.get_domain().rstrip("/")
         # Allow domain to override protocol if it explicitly starts with a scheme
         if domain.startswith("http://") or domain.startswith("https://"):
-            return domain.rstrip("/")
+            return domain
         return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -132,7 +132,15 @@ class ConnectionConfigSync(BaseModel):
         return self.domain or os.getenv(self._ENV_DOMAIN, self._DEFAULT_DOMAIN)
 
     def get_base_url(self) -> str:
+        """Get the full base URL for API requests.
+
+        Returns the base URL without a version prefix. The generated API client
+        appends versioned paths (e.g. ``/sandboxes``) relative to this URL.
+        Appending ``/v1`` here would route all requests to the blocking
+        ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
+        server-side proxy has a short idle timeout (see issue #591).
+        """
         domain = self.get_domain()
         if domain.startswith("http://") or domain.startswith("https://"):
-            return f"{domain}/{self._API_VERSION}"
-        return f"{self.protocol}://{domain}/{self._API_VERSION}"
+            return domain.rstrip("/")
+        return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -140,7 +140,7 @@ class ConnectionConfigSync(BaseModel):
         ``/v1/sandboxes`` endpoint and cause 504 Gateway Timeouts when the
         server-side proxy has a short idle timeout (see issue #591).
         """
-        domain = self.get_domain()
+        domain = self.get_domain().rstrip("/")
         if domain.startswith("http://") or domain.startswith("https://"):
-            return domain.rstrip("/")
+            return domain
         return f"{self.protocol}://{domain}"

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -28,13 +28,40 @@ def test_protocol_validation() -> None:
 
 
 def test_get_base_url_with_domain_and_protocol() -> None:
+    # get_base_url() must NOT append /v1 — doing so would route requests to the
+    # blocking /v1/sandboxes endpoint and cause 504 Gateway Timeouts (issue #591).
     cfg = ConnectionConfig(domain="example.com:1234", protocol="https")
-    assert cfg.get_base_url() == "https://example.com:1234/v1"
+    assert cfg.get_base_url() == "https://example.com:1234"
 
 
 def test_get_base_url_domain_can_include_scheme() -> None:
     cfg = ConnectionConfig(domain="https://example.com:9999", protocol="http")
-    assert cfg.get_base_url() == "https://example.com:9999/v1"
+    assert cfg.get_base_url() == "https://example.com:9999"
+
+
+def test_get_base_url_no_v1_prefix_direct_mode() -> None:
+    """Direct mode: base URL must not contain /v1 so SDK hits POST /sandboxes (async, 202)."""
+    cfg = ConnectionConfig(domain="sandbox-api.example.com", use_server_proxy=False)
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_no_v1_prefix_proxy_mode() -> None:
+    """Proxy mode: base URL must not contain /v1 to avoid hitting the blocking endpoint."""
+    cfg = ConnectionConfig(
+        domain="http://sandbox-api.example.com",
+        use_server_proxy=True,
+    )
+    url = cfg.get_base_url()
+    assert "/v1" not in url
+    assert url == "http://sandbox-api.example.com"
+
+
+def test_get_base_url_trailing_slash_stripped() -> None:
+    """Trailing slashes on the domain are stripped to prevent double-slash in paths."""
+    cfg = ConnectionConfig(domain="http://sandbox-api.example.com/")
+    assert cfg.get_base_url() == "http://sandbox-api.example.com"
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -64,6 +64,12 @@ def test_get_base_url_trailing_slash_stripped() -> None:
     assert cfg.get_base_url() == "http://sandbox-api.example.com"
 
 
+def test_get_base_url_no_scheme_trailing_slash_stripped() -> None:
+    """Trailing slash is stripped even when domain has no explicit scheme."""
+    cfg = ConnectionConfig(domain="sandbox-api.example.com/")
+    assert cfg.get_base_url() == "http://sandbox-api.example.com"
+
+
 @pytest.mark.asyncio
 async def test_close_transport_if_owned_default_transport() -> None:
     cfg = ConnectionConfig().with_transport_if_missing()


### PR DESCRIPTION
## Summary

- `ConnectionConfig.get_base_url()` (async and sync) appended `/v1` to the domain, so all SDK requests went to `/v1/sandboxes/...`
- In certain gateway deployments the `/v1/` prefix routes through a blocking path — when sandbox startup exceeds the gateway idle timeout (~60 s), the connection is dropped with a 504
- Fix: return the bare domain without any version prefix; the generated API client paths already include the correct resource paths

## Test plan
- [ ] `uv run pytest sdks/sandbox/python/tests/test_connection_config.py` — updated + 3 new tests verify no `/v1` in base URL for both proxy and direct modes

Fixes #591