### PR TITLE
fix(recycle): delete pod on release when NoopRecycler is used

### DIFF
--- a/kubernetes/internal/controller/recycle/noop.go
+++ b/kubernetes/internal/controller/recycle/noop.go
@@ -22,8 +22,9 @@ import (
 	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
 )
 
-// NoopRecycler is a RecycleHandler that does nothing.
-// The pod is immediately available for reallocation after being returned to the pool.
+// NoopRecycler is a RecycleHandler that skips any in-pod cleanup (no exec, no restart)
+// but still deletes the pod so that a fresh replacement is created by the pool controller.
+// This ensures no data from a previous sandbox run persists in a recycled pod.
 type NoopRecycler struct{}
 
 // NewNoopRecycler creates a new NoopRecycler.
@@ -31,11 +32,21 @@ func NewNoopRecycler() *NoopRecycler {
 	return &NoopRecycler{}
 }
 
-// TryRecycle does nothing and returns Succeeded status immediately.
-// A nil pod (already deleted) is also considered succeeded since there is nothing to do.
+// TryRecycle drives the delete recycle state machine without any in-pod cleanup.
+// When the pod still exists, it returns Recycling with NeedDelete=true so the caller
+// deletes the pod and the pool controller creates a fresh replacement.
+// When the pod is already gone, it returns Succeeded.
+// A nil pod is considered succeeded since there is nothing to do.
 func (n *NoopRecycler) TryRecycle(ctx context.Context, pool *sandboxv1alpha1.Pool, pod *corev1.Pod, spec *Spec) (*Status, error) {
+	if pod == nil || pod.DeletionTimestamp != nil {
+		return &Status{
+			State:   StateSucceeded,
+			Message: "noop recycler: pod is deleted",
+		}, nil
+	}
 	return &Status{
-		State:   StateSucceeded,
-		Message: "noop recycler: no action needed",
+		State:      StateRecycling,
+		Message:    "noop recycler: pod marked for deletion",
+		NeedDelete: true,
 	}, nil
 }

--- a/kubernetes/internal/controller/recycle/noop.go
+++ b/kubernetes/internal/controller/recycle/noop.go
@@ -38,10 +38,18 @@ func NewNoopRecycler() *NoopRecycler {
 // When the pod is already gone, it returns Succeeded.
 // A nil pod is considered succeeded since there is nothing to do.
 func (n *NoopRecycler) TryRecycle(ctx context.Context, pool *sandboxv1alpha1.Pool, pod *corev1.Pod, spec *Spec) (*Status, error) {
-	if pod == nil || pod.DeletionTimestamp != nil {
+	if pod == nil {
 		return &Status{
 			State:   StateSucceeded,
-			Message: "noop recycler: pod is deleted",
+			Message: "noop recycler: pod is gone",
+		}, nil
+	}
+	// Pod still exists but deletion has been requested; wait for it to disappear
+	// before reporting success so the pool does not re-allocate a terminating pod.
+	if pod.DeletionTimestamp != nil {
+		return &Status{
+			State:   StateRecycling,
+			Message: "noop recycler: waiting for pod termination",
 		}, nil
 	}
 	return &Status{

--- a/kubernetes/internal/controller/recycle/noop_test.go
+++ b/kubernetes/internal/controller/recycle/noop_test.go
@@ -19,27 +19,49 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 
 	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
 )
 
+// TestNoopRecycler verifies that NoopRecycler deletes the pod on release (NeedDelete=true)
+// so that a fresh replacement is created by the pool controller and no stale data persists.
 func TestNoopRecycler(t *testing.T) {
+	now := metav1.Now()
 	tests := []struct {
-		name string
-		pod  *corev1.Pod
+		name           string
+		pod            *corev1.Pod
+		wantState      string
+		wantNeedDelete bool
 	}{
-		{name: "NilPod", pod: nil},
-		{name: "WithPod", pod: &corev1.Pod{}},
+		{
+			name:           "NilPod_Succeeded",
+			pod:            nil,
+			wantState:      StateSucceeded,
+			wantNeedDelete: false,
+		},
+		{
+			name:           "PodWithDeletionTimestamp_Succeeded",
+			pod:            &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}},
+			wantState:      StateSucceeded,
+			wantNeedDelete: false,
+		},
+		{
+			name:           "PodStillExists_NeedDelete",
+			pod:            &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}},
+			wantState:      StateRecycling,
+			wantNeedDelete: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := NewNoopRecycler()
 			status, err := n.TryRecycle(context.Background(), &sandboxv1alpha1.Pool{}, tt.pod, &Spec{ID: "sbx1"})
 			assert.NoError(t, err)
-			assert.Equal(t, StateSucceeded, status.State)
-			assert.False(t, status.NeedDelete)
+			assert.Equal(t, tt.wantState, status.State)
+			assert.Equal(t, tt.wantNeedDelete, status.NeedDelete)
 		})
 	}
 }

--- a/kubernetes/internal/controller/recycle/noop_test.go
+++ b/kubernetes/internal/controller/recycle/noop_test.go
@@ -43,9 +43,11 @@ func TestNoopRecycler(t *testing.T) {
 			wantNeedDelete: false,
 		},
 		{
-			name:           "PodWithDeletionTimestamp_Succeeded",
+			// Pod is terminating but not yet gone; report Recycling so the pool
+			// does not re-allocate it before it fully disappears.
+			name:           "PodWithDeletionTimestamp_Recycling",
 			pod:            &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}},
-			wantState:      StateSucceeded,
+			wantState:      StateRecycling,
 			wantNeedDelete: false,
 		},
 		{


### PR DESCRIPTION
## Summary

- `NoopRecycler.TryRecycle` returned `StateSucceeded + NeedDelete: false` for any pod, including live ones
- `collectRecycleResults` treated `StateSucceeded` as "recycling complete → return pod to pool", so the pod re-entered the pool carrying all state from the previous sandbox run
- Fix: return `StateRecycling + NeedDelete: true` for live pods (matching `DeleteRecycler` semantics); the pool controller deletes the pod and scales up a fresh replacement

## Test plan
- [ ] `go test ./internal/controller/recycle/...` — 3 cases: nil pod → Succeeded; pod with DeletionTimestamp → Succeeded; live pod → Recycling + NeedDelete

Fixes #743