### PR TITLE
chore: bump SDK release versions

### DIFF
--- a/sdks/Directory.Build.props
+++ b/sdks/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Shared C# SDK packaging metadata -->
-    <OpenSandboxPackageVersion>0.1.2</OpenSandboxPackageVersion>
+    <OpenSandboxPackageVersion>0.1.3</OpenSandboxPackageVersion>
     <OpenSandboxCodeInterpreterPackageVersion>0.1.1</OpenSandboxCodeInterpreterPackageVersion>
     <OpenSandboxDependencyVersionRange>[$(OpenSandboxPackageVersion),0.2.0)</OpenSandboxDependencyVersionRange>
   </PropertyGroup>

--- a/sdks/code-interpreter/kotlin/gradle.properties
+++ b/sdks/code-interpreter/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.12
+project.version=1.0.13
 project.description=A Kotlin SDK for Code Interpreter

--- a/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
+++ b/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 jackson = "2.18.2"
-sandbox = "1.0.12"
+sandbox = "1.0.13"
 junit-platform = "1.13.4"
 
 [libraries]

--- a/sdks/sandbox/javascript/package.json
+++ b/sdks/sandbox/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alibaba-group/opensandbox",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "OpenSandbox TypeScript/JavaScript SDK (sandbox lifecycle + execd APIs)",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.12
+project.version=1.0.13
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -71,7 +71,7 @@ class ConnectionConfig private constructor(
         private const val ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.12"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.13"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -67,7 +67,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.10"
+fallback_version = "0.1.11"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -65,7 +65,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.10", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.11", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -53,7 +53,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.10", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.11", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 


### PR DESCRIPTION
## Summary
- bump sandbox SDK release versions for JavaScript, Python, Kotlin, and C#
- bump Kotlin code-interpreter release version and sandbox dependency
- sync Python and Kotlin default User-Agent versions

## Verification
- git diff --check
- rg scan for old release version strings