### PR TITLE
feat(egress): make credential vault TLS transport check configurable

### DIFF
--- a/components/egress/credential_vault_handler_test.go
+++ b/components/egress/credential_vault_handler_test.go
@@ -199,7 +199,7 @@ func TestCredentialVaultWriteRequiresTLSOrLoopback(t *testing.T) {
 	initial := testCredentialVaultPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)
 	srv := &policyServer{
 		proxy:                     &stubProxy{updated: initial},
-		credentialVault:            credentialvault.NewStore(nil, func() bool { return true }),
+		credentialVault:           credentialvault.NewStore(nil, func() bool { return true }),
 		credentialVaultRequireTLS: true,
 	}
 
@@ -237,7 +237,7 @@ func TestCredentialVaultWriteAllowsForwardedProto(t *testing.T) {
 	initial := testCredentialVaultPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)
 	srv := &policyServer{
 		proxy:                     &stubProxy{updated: initial},
-		credentialVault:            credentialvault.NewStore(nil, func() bool { return true }),
+		credentialVault:           credentialvault.NewStore(nil, func() bool { return true }),
 		credentialVaultRequireTLS: true,
 	}
 

--- a/components/egress/credential_vault_handler_test.go
+++ b/components/egress/credential_vault_handler_test.go
@@ -198,8 +198,9 @@ func TestCredentialVaultWriteRequiresTLSOrLoopback(t *testing.T) {
 	t.Setenv(constants.EnvMitmproxyTransparent, "true")
 	initial := testCredentialVaultPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)
 	srv := &policyServer{
-		proxy:           &stubProxy{updated: initial},
-		credentialVault: credentialvault.NewStore(nil, func() bool { return true }),
+		proxy:                     &stubProxy{updated: initial},
+		credentialVault:            credentialvault.NewStore(nil, func() bool { return true }),
+		credentialVaultRequireTLS: true,
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/credential-vault", strings.NewReader(`{"credentials":[],"bindings":[]}`))
@@ -229,4 +230,38 @@ func TestCredentialVaultWriteRequiresTLSOrLoopback(t *testing.T) {
 	srv.handleCredentialVault(w, req)
 
 	require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+}
+
+func TestCredentialVaultWriteAllowsForwardedProto(t *testing.T) {
+	t.Setenv(constants.EnvMitmproxyTransparent, "true")
+	initial := testCredentialVaultPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)
+	srv := &policyServer{
+		proxy:                     &stubProxy{updated: initial},
+		credentialVault:            credentialvault.NewStore(nil, func() bool { return true }),
+		credentialVaultRequireTLS: true,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/credential-vault", strings.NewReader(`{"credentials":[],"bindings":[]}`))
+	req.RemoteAddr = "198.51.100.10:1234"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	srv.handleCredentialVault(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Result().StatusCode)
+}
+
+func TestCredentialVaultWriteSkipsTLSCheckByDefault(t *testing.T) {
+	t.Setenv(constants.EnvMitmproxyTransparent, "true")
+	initial := testCredentialVaultPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)
+	srv := &policyServer{
+		proxy:           &stubProxy{updated: initial},
+		credentialVault: credentialvault.NewStore(nil, func() bool { return true }),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/credential-vault", strings.NewReader(`{"credentials":[],"bindings":[]}`))
+	req.RemoteAddr = "198.51.100.10:1234"
+	w := httptest.NewRecorder()
+	srv.handleCredentialVault(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Result().StatusCode)
 }

--- a/components/egress/pkg/constants/configuration.go
+++ b/components/egress/pkg/constants/configuration.go
@@ -21,21 +21,21 @@ import (
 )
 
 const (
-	EnvBlockDoH443             = "OPENSANDBOX_EGRESS_BLOCK_DOH_443"
-	EnvDoHBlocklist            = "OPENSANDBOX_EGRESS_DOH_BLOCKLIST"
-	EnvEgressMode              = "OPENSANDBOX_EGRESS_MODE"
-	EnvEgressHTTPAddr          = "OPENSANDBOX_EGRESS_HTTP_ADDR"
-	EnvEgressToken             = "OPENSANDBOX_EGRESS_TOKEN"
-	EnvCredentialProxySocket   = "OPENSANDBOX_CREDENTIAL_PROXY_SOCKET"
-	EnvEgressRules             = "OPENSANDBOX_EGRESS_RULES"
-	EnvEgressPolicyFile        = "OPENSANDBOX_EGRESS_POLICY_FILE"
-	EnvEgressLogLevel          = "OPENSANDBOX_EGRESS_LOG_LEVEL"
-	EnvMaxEgressRules          = "OPENSANDBOX_EGRESS_MAX_RULES"
-	EnvBlockedWebhook          = "OPENSANDBOX_EGRESS_DENY_WEBHOOK"
-	EnvSandboxID               = "OPENSANDBOX_EGRESS_SANDBOX_ID"
-	EnvEgressMetricsExtraAttrs = "OPENSANDBOX_EGRESS_METRICS_EXTRA_ATTRS"
-	EnvNameserverExempt            = "OPENSANDBOX_EGRESS_NAMESERVER_EXEMPT"
-	EnvCredentialVaultRequireTLS   = "OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS"
+	EnvBlockDoH443               = "OPENSANDBOX_EGRESS_BLOCK_DOH_443"
+	EnvDoHBlocklist              = "OPENSANDBOX_EGRESS_DOH_BLOCKLIST"
+	EnvEgressMode                = "OPENSANDBOX_EGRESS_MODE"
+	EnvEgressHTTPAddr            = "OPENSANDBOX_EGRESS_HTTP_ADDR"
+	EnvEgressToken               = "OPENSANDBOX_EGRESS_TOKEN"
+	EnvCredentialProxySocket     = "OPENSANDBOX_CREDENTIAL_PROXY_SOCKET"
+	EnvEgressRules               = "OPENSANDBOX_EGRESS_RULES"
+	EnvEgressPolicyFile          = "OPENSANDBOX_EGRESS_POLICY_FILE"
+	EnvEgressLogLevel            = "OPENSANDBOX_EGRESS_LOG_LEVEL"
+	EnvMaxEgressRules            = "OPENSANDBOX_EGRESS_MAX_RULES"
+	EnvBlockedWebhook            = "OPENSANDBOX_EGRESS_DENY_WEBHOOK"
+	EnvSandboxID                 = "OPENSANDBOX_EGRESS_SANDBOX_ID"
+	EnvEgressMetricsExtraAttrs   = "OPENSANDBOX_EGRESS_METRICS_EXTRA_ATTRS"
+	EnvNameserverExempt          = "OPENSANDBOX_EGRESS_NAMESERVER_EXEMPT"
+	EnvCredentialVaultRequireTLS = "OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS"
 
 	// MITM: mitmdump transparent; Linux + CAP_NET_ADMIN, runs as a dedicated user.
 	// Static mitm options (mode, connection_strategy, listen_host, stream_large_bodies,

--- a/components/egress/pkg/constants/configuration.go
+++ b/components/egress/pkg/constants/configuration.go
@@ -34,7 +34,8 @@ const (
 	EnvBlockedWebhook          = "OPENSANDBOX_EGRESS_DENY_WEBHOOK"
 	EnvSandboxID               = "OPENSANDBOX_EGRESS_SANDBOX_ID"
 	EnvEgressMetricsExtraAttrs = "OPENSANDBOX_EGRESS_METRICS_EXTRA_ATTRS"
-	EnvNameserverExempt        = "OPENSANDBOX_EGRESS_NAMESERVER_EXEMPT"
+	EnvNameserverExempt            = "OPENSANDBOX_EGRESS_NAMESERVER_EXEMPT"
+	EnvCredentialVaultRequireTLS   = "OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS"
 
 	// MITM: mitmdump transparent; Linux + CAP_NET_ADMIN, runs as a dedicated user.
 	// Static mitm options (mode, connection_strategy, listen_host, stream_large_bodies,

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -175,11 +175,11 @@ type policyServer struct {
 	alwaysLoader     *policy.AlwaysRuleLoader
 	stopAlwaysReload chan struct{}
 
-	lastAlwaysFP    uint64
-	lastAlwaysFPSet bool
-	credentialVault            *credentialvault.Store
-	mitmGate                   *mitmproxy.HealthGate
-	credentialVaultRequireTLS  bool
+	lastAlwaysFP              uint64
+	lastAlwaysFPSet           bool
+	credentialVault           *credentialvault.Store
+	mitmGate                  *mitmproxy.HealthGate
+	credentialVaultRequireTLS bool
 }
 
 type policyStatusResponse struct {

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -85,6 +85,7 @@ func startPolicyServer(
 		mitmGate:         mitmGate,
 	}
 	handler.credentialVault = credentialvault.NewStore(mitmGate, func() bool { return strings.TrimSpace(token) != "" })
+	handler.credentialVaultRequireTLS = constants.IsTruthy(os.Getenv(constants.EnvCredentialVaultRequireTLS))
 	handler.setAlwaysRules(alwaysDeny, alwaysAllow)
 
 	mux.HandleFunc("/policy", handler.handlePolicy)
@@ -176,8 +177,9 @@ type policyServer struct {
 
 	lastAlwaysFP    uint64
 	lastAlwaysFPSet bool
-	credentialVault *credentialvault.Store
-	mitmGate        *mitmproxy.HealthGate
+	credentialVault            *credentialvault.Store
+	mitmGate                   *mitmproxy.HealthGate
+	credentialVaultRequireTLS  bool
 }
 
 type policyStatusResponse struct {
@@ -294,7 +296,7 @@ func (s *policyServer) handleCredentialVaultPost(w http.ResponseWriter, r *http.
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	if !credentialVaultWriteTransportAllowed(r) {
+	if s.credentialVaultRequireTLS && !credentialVaultWriteTransportAllowed(r) {
 		http.Error(w, "credential vault writes require TLS or loopback transport", http.StatusUpgradeRequired)
 		return
 	}
@@ -316,7 +318,7 @@ func (s *policyServer) handleCredentialVaultPatch(w http.ResponseWriter, r *http
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	if !credentialVaultWriteTransportAllowed(r) {
+	if s.credentialVaultRequireTLS && !credentialVaultWriteTransportAllowed(r) {
 		http.Error(w, "credential vault writes require TLS or loopback transport", http.StatusUpgradeRequired)
 		return
 	}
@@ -338,7 +340,7 @@ func (s *policyServer) handleCredentialVaultDelete(w http.ResponseWriter, r *htt
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
-	if !credentialVaultWriteTransportAllowed(r) {
+	if s.credentialVaultRequireTLS && !credentialVaultWriteTransportAllowed(r) {
 		http.Error(w, "credential vault writes require TLS or loopback transport", http.StatusUpgradeRequired)
 		return
 	}
@@ -760,7 +762,7 @@ func (s *policyServer) authorize(r *http.Request) bool {
 }
 
 func credentialVaultWriteTransportAllowed(r *http.Request) bool {
-	return r.TLS != nil || isLoopbackRequest(r)
+	return r.TLS != nil || isLoopbackRequest(r) || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }
 
 func isLoopbackRequest(r *http.Request) bool {

--- a/docs/credential-vault.md
+++ b/docs/credential-vault.md
@@ -90,6 +90,12 @@ X-Client-Secret: <client-secret>
 - The sandbox image has the tools you want to run. For Claude Code, use an image
   with Node.js and npm, such as the OpenSandbox code-interpreter image.
 
+## Egress Sidecar Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS` | off | When enabled (`true`/`1`/`on`), credential vault write operations (create, patch, delete) require the request to arrive over TLS, from a loopback address, or with `X-Forwarded-Proto: https`. When disabled (default), any authenticated request is accepted regardless of transport. Enable this in deployments where the egress sidecar is directly reachable from untrusted networks without a TLS-terminating reverse proxy. |
+
 ## SDK Quick Reference
 
 All sandbox SDKs use the same wire contract. The main differences are naming and

--- a/docs/credential-vault_zh.md
+++ b/docs/credential-vault_zh.md
@@ -78,6 +78,12 @@ X-Client-Secret: <client-secret>
 - 创建沙箱时启用 Credential Proxy。
 - 沙箱镜像包含要运行的工具。运行 Claude Code 时，可以使用包含 Node.js 和 npm 的 OpenSandbox code-interpreter 镜像。
 
+## Egress Sidecar 配置
+
+| 环境变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS` | 关闭 | 启用后（`true`/`1`/`on`），credential vault 写操作（create、patch、delete）要求请求通过 TLS 到达、来自 loopback 地址、或携带 `X-Forwarded-Proto: https` 头。关闭时（默认），只要通过认证的请求均被接受，不校验传输层安全。在 egress sidecar 可从非信任网络直接访问且没有 TLS 终止反向代理的部署中应启用此选项。 |
+
 ## SDK 快速对照
 
 所有 sandbox SDK 使用同一套 wire contract，主要差异是命名和语言风格：


### PR DESCRIPTION
## Summary
- Add `OPENSANDBOX_EGRESS_CREDENTIAL_VAULT_REQUIRE_TLS` env var to control whether credential vault write operations require TLS/loopback transport (default: off)
- When enabled, also trust `X-Forwarded-Proto: https` header for requests arriving through TLS-terminating reverse proxies
- Fixes HTTP 426 when credential vault writes go through ingress gateways that terminate TLS (e.g. tengine-ingress)

## Test plan
- [x] `TestCredentialVaultWriteSkipsTLSCheckByDefault` — default off, non-TLS non-loopback writes succeed
- [x] `TestCredentialVaultWriteRequiresTLSOrLoopback` — enabled, non-TLS non-loopback rejected with 426
- [x] `TestCredentialVaultWriteAllowsForwardedProto` — enabled, `X-Forwarded-Proto: https` accepted
- [x] All existing credential vault tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)