### PR TITLE
docs: add component version requirements to credential-vault

### DIFF
--- a/docs/credential-vault.md
+++ b/docs/credential-vault.md
@@ -2,6 +2,19 @@
 
 Credential Vault is OpenSandbox's outbound credential broker for sandboxed agents and developer tools. Real credentials are written to the egress sidecar by the host-side SDK, while the sandbox process only receives fake or empty credential values. When tools such as Claude Code, Git, curl, package managers, or model API clients make allowed outbound HTTPS requests, the sidecar matches the request against Credential Vault bindings and injects the required authentication headers on the way out. This lets existing tools keep their normal workflows while keeping real secrets out of the sandbox environment, command line, filesystem, and logs, reducing credential exfiltration risk from prompt injection or untrusted code.
 
+## Requirements
+
+- `opensandbox-server` >= 0.2.0
+- `egress` >= 1.1.1
+- Python SDK >= 0.1.11
+- JavaScript/TypeScript SDK >= 0.1.9
+- Kotlin SDK >= 1.0.13
+- Go SDK >= 1.0.3
+- C# SDK >= 0.1.3
+- Server config sets `[egress].image`.
+- Sandbox create request includes an outbound network policy.
+- Sandbox create request enables Credential Proxy.
+
 ## How It Works
 
 ![Credential Vault request flow](assets/credential-vault.png)
@@ -81,14 +94,6 @@ auth={
 X-Client-Id: <client-id>
 X-Client-Secret: <client-secret>
 ```
-
-## Requirements
-
-- Server config sets `[egress].image`.
-- Sandbox create request includes an outbound network policy.
-- Sandbox create request enables Credential Proxy.
-- The sandbox image has the tools you want to run. For Claude Code, use an image
-  with Node.js and npm, such as the OpenSandbox code-interpreter image.
 
 ## SDK Quick Reference
 

--- a/docs/credential-vault_zh.md
+++ b/docs/credential-vault_zh.md
@@ -2,6 +2,19 @@
 
 Credential Vault 是 OpenSandbox 为沙箱内 Agent 和开发工具提供的出站凭证代理能力。真实凭证由宿主侧 SDK 写入 egress sidecar，沙箱进程只拿到假的或空的凭证值。当 Claude Code、Git、curl、包管理器或模型 API 客户端等工具发起被允许的 HTTPS 出站请求时，sidecar 会根据 Credential Vault binding 匹配请求，并在出站链路上注入所需的认证 header。这样工具可以保持原有使用方式，同时真实密钥不会进入沙箱环境变量、命令行、文件系统或日志，从而降低 prompt injection 或不可信代码导致的凭证外泄风险。
 
+## 前置条件
+
+- `opensandbox-server` >= 0.2.0
+- `egress` >= 1.1.1
+- Python SDK >= 0.1.11
+- JavaScript/TypeScript SDK >= 0.1.9
+- Go SDK >= 1.0.3
+- Kotlin SDK >= 1.0.13
+- C# SDK >= 0.1.3
+- Server 配置中设置了 `[egress].image`。
+- 创建沙箱时传入出站网络策略。
+- 创建沙箱时启用 Credential Proxy。
+
 ## 原理
 
 ![Credential Vault 请求流程](assets/credential-vault.png)
@@ -70,13 +83,6 @@ auth={
 X-Client-Id: <client-id>
 X-Client-Secret: <client-secret>
 ```
-
-## 前置条件
-
-- Server 配置中设置了 `[egress].image`。
-- 创建沙箱时传入出站网络策略。
-- 创建沙箱时启用 Credential Proxy。
-- 沙箱镜像包含要运行的工具。运行 Claude Code 时，可以使用包含 Node.js 和 npm 的 OpenSandbox code-interpreter 镜像。
 
 ## SDK 快速对照
 


### PR DESCRIPTION
## Summary
- Add minimum version requirements (server, egress, all SDKs) to credential-vault docs
- Move Requirements section before How It Works for better visibility
- Remove outdated sandbox image note
- Sync changes to both English and Chinese versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)