### PR TITLE
docs(execd): fix outdated DEVELOPMENT.md and add missing env var

### DIFF
--- a/components/execd/DEVELOPMENT.md
+++ b/components/execd/DEVELOPMENT.md
@@ -1,227 +1,65 @@
 # Development Guide - execd
 
-This comprehensive guide explains how to work on `execd` as a contributor or maintainer. It covers environment setup,
-development workflows, testing strategies, architectural patterns, and subsystem-specific implementation details.
-
-## Table of Contents
-
-- [Getting Started](#getting-started)
-- [Project Structure](#project-structure)
-- [Coding Standards](#coding-standards)
-- [Testing Strategy](#testing-strategy)
-- [Subsystem Guides](#subsystem-guides)
-- [Common Development Tasks](#common-development-tasks)
-- [Debugging Techniques](#debugging-techniques)
-- [Performance Optimization](#performance-optimization)
-- [Contributing Guidelines](#contributing-guidelines)
-- [Additional Resources](#additional-resources)
-
 ## Getting Started
 
 ### Prerequisites
 
-#### Required Tools
+- **Go 1.24+** — match `go.mod`
+- **Make** — build automation
+- **Docker/Podman** — containerized testing (optional)
+- **Jupyter Server** — required for integration tests
 
-- **Go 1.24+** - Match the version declared in `go.mod`
-- **Git** - Version control
-- **Make** - Build automation (optional but recommended)
-
-#### Optional but Recommended
-
-- **golangci-lint** - For comprehensive linting
-- **Docker/Podman** - For containerized testing and deployment
-- **Jupyter Server** - Required for integration tests with real kernels
-- **VS Code/GoLand** - IDE with Go support
-
-### Initial Setup
+### Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/alibaba/OpenSandbox.git
-cd OpenSandbox/components/execd
-
-# Download dependencies
+cd components/execd
 go mod download
-
-# Verify setup
-go build -o bin/execd .
+make build        # → bin/execd
 ```
 
 ## Project Structure
 
-### Project Structure Deep Dive
-
 ```
 execd/
-├── main.go                 # Application entry point
-├── go.mod                  # Go module definition
-├── Makefile               # Build automation
-├── Dockerfile             # Container image definition
-│
-├── pkg/                   # Public packages
-│   ├── flag/              # CLI flag parsing
-│   ├── web/               # HTTP layer
-│   │   ├── router.go      # Route registration
-│   │   ├── controller/    # Request handlers
-│   │   └── model/         # API models
-│   ├── runtime/           # Execution engine
-│   │   ├── ctrl.go        # Main controller
-│   │   ├── jupyter.go     # Jupyter execution
-│   │   └── command.go     # Shell command execution
-│   ├── jupyter/           # Jupyter client
-│   │   ├── client.go      # HTTP/WebSocket client
-│   │   ├── session/       # Session management
-│   │   └── execute/       # Execution protocol
-│   └── util/              # Utilities
-│
-└── tests/                # Integration test scripts
+├── main.go                 # Entry point
+├── Makefile                # Build automation
+├── Dockerfile              # Container image
+├── pkg/
+│   ├── flag/               # CLI flag parsing
+│   ├── web/
+│   │   ├── router.go       # Gin route registration
+│   │   ├── controller/     # Request handlers
+│   │   └── model/          # API request/response models
+│   ├── runtime/            # Execution engine
+│   │   ├── ctrl.go         # Main controller
+│   │   ├── jupyter.go      # Jupyter kernel execution
+│   │   ├── command.go      # Shell command execution
+│   │   └── bash_session.go # Pipe-based bash sessions
+│   ├── jupyter/            # Jupyter HTTP/WebSocket client
+│   ├── telemetry/          # OTLP metrics
+│   ├── clone3compat/       # Linux clone3 seccomp workaround
+│   └── log/                # Structured logger wrapper
+└── tests/                  # Integration test scripts
 ```
 
-### Key Design Patterns
+### Key Patterns
 
-#### 1. Controller Pattern (pkg/web/controller)
+- **Controller pattern** (`pkg/web/controller`): thin Gin handlers that parse requests, validate, delegate to runtime, and stream responses via SSE.
+- **Runtime controller** (`pkg/runtime`): dispatches to Jupyter, Command, or SQL executors; manages session lifecycle.
+- **Hook-based streaming**: execution results flow through hooks, decoupling runtime events from SSE serialization.
 
-Controllers are thin HTTP handlers that parse requests, validate, delegate to runtime, and stream responses via SSE.
-
-#### 2. Runtime Controller Pattern (pkg/runtime)
-
-The runtime controller dispatches requests to appropriate executors (Jupyter, Command, SQL) and manages session
-lifecycle.
-
-#### 3. Hook Pattern for Streaming
-
-Execution results are streamed via hooks, allowing controllers to transform runtime events into SSE events without tight
-coupling.
-
-## Coding Standards
-
-### Go Conventions
-
-#### Formatting
-
-**Always use `gofmt`** before committing:
-
-```bash
-gofmt -w .
-# or
-make fmt
-```
-
-#### Import Organization
-
-Three groups separated by blank lines:
-
-```go
-import (
-    // Standard library
-    "context"
-    "fmt"
-    "net/http"
-
-    // Third-party
-    "github.com/gin-gonic/gin"
-
-    // Internal
-    "github.com/alibaba/opensandbox/execd/pkg/log"
-    "github.com/alibaba/opensandbox/execd/pkg/runtime"
-)
-```
-
-#### Error Handling
-
-Always handle errors explicitly:
-
-```go
-// Good
-result, err := someOperation()
-if err != nil {
-    log.Error("operation failed: %v", err)
-    return fmt.Errorf("failed to do something: %w", err)
-}
-
-// Bad - silent failure
-result, _ := someOperation()
-```
-
-#### Logging
-
-Use execd's package logger, which wraps the shared structured logger used by the Gin HTTP layer and runtime code:
-
-```go
-log.Info("starting execution: sessionID=%s", sessionID)
-log.Warning("session busy: sessionID=%s", sessionID)
-log.Error("execution failed: error=%v", err)
-log.Debug("received event: type=%s", eventType)
-```
-
-### Concurrency Best Practices
-
-#### Use safego for goroutines
-
-Always use `safego.Go` to prevent panics:
-
-```go
-import "github.com/alibaba/opensandbox/internal/safego"
-
-safego.Go(func() {
-    processInBackground()
-})
-```
-
-#### Context Propagation
-
-Always respect context cancellation:
-
-```go
-func (c *Controller) runCommand(ctx context.Context, req *ExecuteCodeRequest) error {
-    cmd := exec.CommandContext(ctx, "bash", "-c", req.Code)
-
-    go func() {
-        <-ctx.Done()
-        if cmd.Process != nil {
-            cmd.Process.Kill()
-        }
-    }()
-
-    return cmd.Run()
-}
-```
-
-## Testing Strategy
+## Testing
 
 ### Unit Tests
 
-Located in `*_test.go` files alongside source code.
-
-**Example:**
-
-```go
-func TestController_Execute_Python(t *testing.T) {
-    ctrl := NewController("http://jupyter:8888", "test-token")
-
-    req := &ExecuteCodeRequest{
-        Language: Python,
-        Code:     "print('hello')",
-    }
-
-    err := ctrl.Execute(req)
-    assert.NoError(t, err)
-}
-```
-
-**Running Unit Tests:**
-
 ```bash
 go test ./pkg/...
-# with coverage
 go test -v -cover ./pkg/...
 ```
 
 ### Integration Tests
 
-Located in `*_integration_test.go`, require real dependencies.
-
-**Running Integration Tests:**
+Require a running Jupyter server:
 
 ```bash
 export JUPYTER_URL=http://localhost:8888
@@ -229,369 +67,55 @@ export JUPYTER_TOKEN=your-token
 go test -v ./pkg/jupyter/...
 ```
 
-### Test Coverage
-
-Check coverage:
-
-```bash
-go test -coverprofile=coverage.out ./pkg/...
-go tool cover -html=coverage.out -o coverage.html
-```
-
-**Coverage Goals:**
-
-- Core packages (`pkg/runtime`, `pkg/jupyter`): > 80%
-- Controllers (`pkg/web/controller`): > 70%
-- Utilities (`pkg/util`): > 90%
-
-## Subsystem Guides
-
-### Working with Jupyter Integration
-
-#### Architecture
-
-```
-pkg/jupyter/
-├── client.go          # Main client
-├── transport.go       # Connection handling
-├── session/           # Session lifecycle
-├── execute/           # Execution protocol
-└── auth/              # Authentication
-```
-
-#### Adding New Kernel Support
-
-1. Define language in `pkg/runtime/language.go`:
-
-```go
-const Ruby Language = "ruby"
-```
-
-2. Map to kernel in `pkg/runtime/jupyter.go`
-
-3. Test with real kernel:
-
-```bash
-# Install Ruby kernel
-gem install iruby
-iruby register --force
-
-# Run test
-export JUPYTER_URL=http://localhost:8888
-go test -v ./pkg/jupyter/integration_test.go
-```
-
-#### Debugging Jupyter Communication
-
-Run debug integration test:
-
-```bash
-go test -v ./pkg/jupyter/debug_integration_test.go
-```
-
-This dumps complete HTTP request/response pairs.
-
-### Working with Command Execution
-
-#### Key Implementation Details
-
-**Process Group Management:**
-
-```go
-cmd.SysProcAttr = &syscall.SysProcAttr{
-    Setpgid: true,  // Create new process group
-}
-```
-
-This allows signal forwarding to all child processes:
-
-```go
-syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-```
-
-**Signal Forwarding:**
-
-```go
-signals := make(chan os.Signal, 1)
-signal.Notify(signals)
-
-go func() {
-    for sig := range signals {
-        if sig != syscall.SIGCHLD && sig != syscall.SIGURG {
-            syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
-        }
-    }
-}()
-```
-
-**Stdout/Stderr Streaming:**
-
-Commands write to temporary log files, which are tailed and streamed to hooks.
-
-## Common Development Tasks
+## Common Tasks
 
 ### Adding a New API Endpoint
 
-1. **Define model** in `pkg/web/model/`:
+1. Define request/response model in `pkg/web/model/`.
 
-```go
-type NewFeatureRequest struct {
-    Param1 string `json:"param1" validate:"required"`
-    Param2 int    `json:"param2"`
-}
-```
-
-2. **Add controller method** in `pkg/web/controller/`:
+2. Add controller method in `pkg/web/controller/`:
 
 ```go
 func (c *MyController) NewFeature() {
     var req model.NewFeatureRequest
-    json.Unmarshal(c.Ctx.Input.RequestBody, &req)
-
-    // Business logic
-    result := processNewFeature(req)
-
-    c.Data["json"] = result
-    c.ServeJSON()
-}
-```
-
-3. **Register route** in `pkg/web/router.go`:
-
-```go
-myNamespace := web.NewNamespace("/my-feature",
-    web.NSRouter("", &controller.MyController{}, "post:NewFeature"),
-)
-web.AddNamespace(myNamespace)
-```
-
-### Adding Configuration Flag
-
-1. **Declare in `pkg/flag/flags.go`:**
-
-```go
-var NewFeatureTimeout time.Duration
-```
-
-2. **Parse in `pkg/flag/parser.go`:**
-
-```go
-func InitFlags() {
-    flag.DurationVar(&NewFeatureTimeout, "new-feature-timeout", 30*time.Second, "Description")
-
-    // Parse environment variable
-    if env := os.Getenv("NEW_FEATURE_TIMEOUT"); env != "" {
-        if d, err := time.ParseDuration(env); err == nil {
-            NewFeatureTimeout = d
-        }
+    if err := c.Ctx.ShouldBindJSON(&req); err != nil {
+        c.Ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
     }
-
-    flag.Parse()
+    // ...
 }
 ```
 
-3. **Update README** with new flag documentation
+3. Register route in `pkg/web/router.go`:
 
-## Debugging Techniques
-
-### Local Debugging with Delve
-
-```bash
-# Install delve
-go install github.com/go-delve/delve/cmd/dlv@latest
-
-# Start debugging
-dlv debug . -- \
-  --jupyter-host=http://localhost:8888 \
-  --jupyter-token=test
-
-# Set breakpoint
-(dlv) break pkg/runtime/ctrl.go:57
-(dlv) continue
+```go
+myGroup := r.Group("/my-feature")
+{
+    myGroup.POST("", withMyController(func(c *controller.MyController) { c.NewFeature() }))
+}
 ```
+
+### Adding a Configuration Flag
+
+1. Declare variable in `pkg/flag/flags.go`.
+2. In `pkg/flag/parser.go`, read env var first, then register `flag.*Var` with current value as default — flag overrides env.
+3. Update `README.md` CLI Flags and Environment Variables tables.
 
 ### Debugging SSE Streams
 
-**Test with curl:**
-
 ```bash
-curl -N -H "x-access-token: dev" \
-  -H "Content-Type: application/json" \
+curl -N -H "Content-Type: application/json" \
   -d '{"language":"python","code":"print(\"test\")"}' \
   http://localhost:44772/code
 ```
 
-The `-N` flag disables buffering for real-time events.
+`-N` disables buffering for real-time events.
 
-**Debug in browser:**
-
-```javascript
-const eventSource = new EventSource('/code');
-
-eventSource.addEventListener('stdout', (e) => {
-    console.log('stdout:', e.data);
-});
-
-eventSource.addEventListener('error', (e) => {
-    console.error('error:', e.data);
-});
-```
-
-### Performance Profiling
-
-**CPU Profile:**
+## Useful Commands
 
 ```bash
-# Add to main.go
-import _ "net/http/pprof"
-
-go func() {
-    http.ListenAndServe("localhost:6060", nil)
-}()
-
-# Collect profile
-go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+make fmt      # gofmt
+make golint   # lint
+make test     # all tests
+make build    # binary → bin/execd
 ```
-
-**Memory Profile:**
-
-```bash
-go tool pprof http://localhost:6060/debug/pprof/heap
-```
-
-**Goroutine Inspection:**
-
-```bash
-curl http://localhost:6060/debug/pprof/goroutine?debug=2
-```
-
-## Performance Optimization
-
-### Optimization Guidelines
-
-1. **Profile before optimizing** - Use pprof to identify bottlenecks
-2. **Benchmark changes** - Measure impact of optimizations
-3. **Use `sync.Pool`** for frequently allocated objects
-4. **Minimize allocations** in hot paths
-5. **Buffer channels** appropriately
-
-### Example: Optimizing SSE Writer
-
-**Before:**
-
-```go
-func writeEvent(w http.ResponseWriter, event, data string) {
-    fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
-    w.(http.Flusher).Flush()
-}
-```
-
-**After:**
-
-```go
-var bufPool = sync.Pool{
-    New: func() interface{} { return new(bytes.Buffer) },
-}
-
-func writeEvent(w http.ResponseWriter, event, data string) {
-    buf := bufPool.Get().(*bytes.Buffer)
-    buf.Reset()
-    defer bufPool.Put(buf)
-
-    buf.WriteString("event: ")
-    buf.WriteString(event)
-    buf.WriteString("\ndata: ")
-    buf.WriteString(data)
-    buf.WriteString("\n\n")
-
-    w.Write(buf.Bytes())
-    w.(http.Flusher).Flush()
-}
-```
-
-**Benchmark:**
-
-```go
-func BenchmarkWriteEvent(b *testing.B) {
-    w := httptest.NewRecorder()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        writeEvent(w, "test", "data")
-    }
-}
-```
-
-## Contributing Guidelines
-
-### Pull Request Process
-
-1. **Fork and clone** the repository
-2. **Create feature branch** from `main`
-3. **Implement changes** following coding standards
-4. **Add tests** for new functionality
-5. **Run all tests** and ensure they pass
-6. **Update documentation** as needed
-7. **Submit PR** with clear description
-
-### Code Review Standards
-
-Reviewers check for:
-
-- [ ] Correctness and functionality
-- [ ] Test coverage
-- [ ] Code style and formatting
-- [ ] Documentation completeness
-- [ ] Performance implications
-- [ ] Security considerations
-- [ ] Error handling
-- [ ] Backwards compatibility
-
-### Release Checklist
-
-Before releasing:
-
-- [ ] All tests pass (unit, integration, e2e)
-- [ ] Documentation updated (README, DEVELOPMENT, API docs)
-- [ ] CHANGELOG updated with changes
-- [ ] Version bumped appropriately (semver)
-- [ ] Dependencies reviewed and updated
-- [ ] Security scan passed
-- [ ] Performance benchmarks run
-- [ ] Docker image built and tested
-
-## Additional Resources
-
-### Useful Commands
-
-```bash
-# Format all Go files
-make fmt
-
-# Run linter
-make golint
-
-# Run all tests
-make test
-
-# Build binary
-make build
-```
-
-### External Documentation
-
-- [Gin Documentation](https://gin-gonic.com/docs/)
-- [Jupyter Kernel Protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html)
-- [Go Best Practices](https://golang.org/doc/effective_go)
-- [Server-Sent Events Spec](https://html.spec.whatwg.org/multipage/server-sent-events.html)
-
-### Getting Help
-
-- **Issues**: Report bugs or request features on GitHub Issues
-- **Discussions**: Ask questions in GitHub Discussions
-- **Chat**: Join the OpenSandbox community chat
-- **Documentation**: Check the wiki for detailed guides
-
----
-
-**Happy hacking!** Feel free to augment this guide with tips you discover along the way. For questions or suggestions,
-open an issue or discussion on GitHub.

--- a/components/execd/README.md
+++ b/components/execd/README.md
@@ -64,6 +64,7 @@ curl -v http://localhost:44772/ping
 |---|---|
 | `JUPYTER_HOST` | Same as `--jupyter-host` (overridden by explicit flag). |
 | `JUPYTER_TOKEN` | Same as `--jupyter-token` (overridden by explicit flag). |
+| `EXECD_ACCESS_TOKEN` | Same as `--access-token` (overridden by explicit flag). |
 | `EXECD_API_GRACE_SHUTDOWN` | Same as `--graceful-shutdown-timeout`. |
 | `EXECD_JUPYTER_IDLE_POLL_INTERVAL` | Same as `--jupyter-idle-poll-interval`. |
 | `EXECD_CLONE3_COMPAT` | Linux clone3 compatibility switch (see below). |


### PR DESCRIPTION
## Summary
- **DEVELOPMENT.md**: 598→99 lines. Removed generic Go boilerplate (coding standards, performance optimization, contributing guidelines). Fixed all code examples from Beego to Gin to match current codebase (migrated in v1.0.3).
- **README.md**: Added missing `EXECD_ACCESS_TOKEN` environment variable that `parser.go` defines but was undocumented.

## Test plan
- [ ] Verify DEVELOPMENT.md code examples match `pkg/web/router.go` Gin patterns
- [ ] Verify README env var table matches `pkg/flag/parser.go` constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)