### PR TITLE
fix(python-sdk): Handle large file uploads via direct execd

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -57,6 +57,20 @@ from opensandbox.services.filesystem import Filesystem
 
 logger = logging.getLogger(__name__)
 
+
+def _multipart_header_filename(filename: str) -> str:
+    return (
+        filename.replace("\\", "\\\\")
+        .replace('"', r'\"')
+        .replace("\r", "_")
+        .replace("\n", "_")
+    )
+
+
+def _rewind_seekable_stream(stream: IOBase) -> None:
+    if not stream.seekable():
+        return
+    stream.seek(0)
 class _DownloadRequest(TypedDict):
     url: str
     params: dict[str, str]
@@ -355,6 +369,7 @@ class FilesystemAdapter(Filesystem):
                             "File stream must be binary (opened with 'rb'). Text streams are not supported."
                         )
                     content = entry.data
+                    _rewind_seekable_stream(content)
                     content_type = "application/octet-stream"
                 else:
                     raise InvalidArgumentException(
@@ -367,7 +382,7 @@ class FilesystemAdapter(Filesystem):
                 yield metadata_json.encode()
                 yield b"\r\n"
 
-                filename = os.path.basename(entry.path) or "file"
+                filename = _multipart_header_filename(os.path.basename(entry.path) or "file")
                 yield f"--{boundary}\r\n".encode()
                 yield (
                     f'Content-Disposition: form-data; name="file"; '

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -308,7 +308,7 @@ class FilesystemAdapter(Filesystem):
                 content_type = "application/octet-stream"
             elif isinstance(entry.data, str):
                 encoding = entry.encoding or "utf-8"
-                content = entry.data
+                content = entry.data.encode(encoding)
                 content_type = f"text/plain; charset={encoding}"
             elif isinstance(entry.data, IOBase):
                 if isinstance(entry.data, TextIOBase):
@@ -361,7 +361,7 @@ class FilesystemAdapter(Filesystem):
                     content_type = "application/octet-stream"
                 elif isinstance(entry.data, str):
                     encoding = entry.encoding or "utf-8"
-                    content = entry.data
+                    content = entry.data.encode(encoding)
                     content_type = f"text/plain; charset={encoding}"
                 elif isinstance(entry.data, IOBase):
                     if isinstance(entry.data, TextIOBase):
@@ -392,8 +392,6 @@ class FilesystemAdapter(Filesystem):
 
                 if isinstance(content, bytes):
                     yield content
-                elif isinstance(content, str):
-                    yield content.encode("utf-8")
                 else:
                     while True:
                         chunk = content.read(64 * 1024)

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -362,7 +362,7 @@ class FilesystemAdapter(Filesystem):
                     )
 
                 yield f"--{boundary}\r\n".encode()
-                yield b'Content-Disposition: form-data; name="metadata"\r\n'
+                yield b'Content-Disposition: form-data; name="metadata"; filename="metadata"\r\n'
                 yield b"Content-Type: application/json\r\n\r\n"
                 yield metadata_json.encode()
                 yield b"\r\n"

--- a/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/filesystem_adapter.py
@@ -22,6 +22,8 @@ This adapter handles file operations within sandboxes using the auto-generated A
 
 import json
 import logging
+import os
+import time
 from collections.abc import AsyncIterator
 from io import IOBase, TextIOBase
 from typing import TypedDict
@@ -230,7 +232,9 @@ class FilesystemAdapter(Filesystem):
     async def write_files(self, entries: list[WriteEntry]) -> None:
         """Write multiple files in a single operation using multipart upload.
 
-        Aligned with Kotlin SDK implementation.
+        Uses chunked transfer encoding for direct execd access to bypass
+        ingress proxy body size limits. Uses Content-Length when going
+        through the server proxy, which does not support chunked multipart.
         """
         if not entries:
             return
@@ -239,8 +243,88 @@ class FilesystemAdapter(Filesystem):
 
         try:
             client = await self._get_httpx_client()
-            multipart_parts = []
+            url = self._get_execd_url(self.FILESYSTEM_UPLOAD_PATH)
 
+            if self.connection_config.use_server_proxy:
+                response = await self._write_files_with_content_length(
+                    url, client, entries
+                )
+            else:
+                response = await self._write_files_chunked(url, client, entries)
+
+            response.raise_for_status()
+        except Exception as e:
+            logger.error(f"Failed to write {len(entries)} files", exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def _write_files_with_content_length(
+        self,
+        url: str,
+        client: httpx.AsyncClient,
+        entries: list[WriteEntry],
+    ) -> httpx.Response:
+        """Upload via httpx ``files=`` parameter with Content-Length.
+
+        Used when going through the server proxy, which requires Content-Length
+        for multipart requests.
+        """
+        multipart_parts = []
+        for entry in entries:
+            if not entry.path:
+                raise InvalidArgumentException("File path cannot be null")
+            if entry.data is None:
+                raise InvalidArgumentException("File data cannot be null")
+
+            metadata = {
+                "path": entry.path,
+                "owner": entry.owner,
+                "group": entry.group,
+                "mode": entry.mode,
+            }
+            metadata_json = json.dumps(metadata)
+            multipart_parts.append(
+                ("metadata", ("metadata", metadata_json, "application/json"))
+            )
+
+            content: bytes | str | IOBase
+            content_type: str
+
+            if isinstance(entry.data, bytes):
+                content = entry.data
+                content_type = "application/octet-stream"
+            elif isinstance(entry.data, str):
+                encoding = entry.encoding or "utf-8"
+                content = entry.data
+                content_type = f"text/plain; charset={encoding}"
+            elif isinstance(entry.data, IOBase):
+                if isinstance(entry.data, TextIOBase):
+                    raise InvalidArgumentException(
+                        "File stream must be binary (opened with 'rb'). Text streams are not supported."
+                    )
+                content = entry.data
+                content_type = "application/octet-stream"
+            else:
+                raise InvalidArgumentException(
+                    f"Unsupported file data type: {type(entry.data)}"
+                )
+
+            multipart_parts.append(("file", (entry.path, content, content_type)))
+
+        return await client.post(url, files=multipart_parts)
+
+    async def _write_files_chunked(
+        self,
+        url: str,
+        client: httpx.AsyncClient,
+        entries: list[WriteEntry],
+    ) -> httpx.Response:
+        """Upload via chunked transfer encoding.
+
+        Used for direct execd access to bypass ingress proxy body size limits.
+        """
+        boundary = f"opensandbox_{os.urandom(8).hex()}_{int(time.time())}"
+
+        async def _body() -> AsyncIterator[bytes]:
             for entry in entries:
                 if not entry.path:
                     raise InvalidArgumentException("File path cannot be null")
@@ -255,42 +339,64 @@ class FilesystemAdapter(Filesystem):
                 }
                 metadata_json = json.dumps(metadata)
 
-                multipart_parts.append(
-                    ("metadata", ("metadata", metadata_json, "application/json"))
-                )
-
                 content: bytes | str | IOBase
                 content_type: str
 
                 if isinstance(entry.data, bytes):
                     content = entry.data
                     content_type = "application/octet-stream"
-
                 elif isinstance(entry.data, str):
                     encoding = entry.encoding or "utf-8"
                     content = entry.data
                     content_type = f"text/plain; charset={encoding}"
-
                 elif isinstance(entry.data, IOBase):
                     if isinstance(entry.data, TextIOBase):
                         raise InvalidArgumentException(
                             "File stream must be binary (opened with 'rb'). Text streams are not supported."
                         )
-                    else:
-                        content = entry.data
-                        content_type = "application/octet-stream"
+                    content = entry.data
+                    content_type = "application/octet-stream"
                 else:
                     raise InvalidArgumentException(
                         f"Unsupported file data type: {type(entry.data)}"
                     )
-                multipart_parts.append(("file", (entry.path, content, content_type)))
 
-            url = self._get_execd_url(self.FILESYSTEM_UPLOAD_PATH)
-            response = await client.post(url, files=multipart_parts)
-            response.raise_for_status()
-        except Exception as e:
-            logger.error(f"Failed to write {len(entries)} files", exc_info=e)
-            raise ExceptionConverter.to_sandbox_exception(e) from e
+                yield f"--{boundary}\r\n".encode()
+                yield b'Content-Disposition: form-data; name="metadata"\r\n'
+                yield b"Content-Type: application/json\r\n\r\n"
+                yield metadata_json.encode()
+                yield b"\r\n"
+
+                filename = os.path.basename(entry.path) or "file"
+                yield f"--{boundary}\r\n".encode()
+                yield (
+                    f'Content-Disposition: form-data; name="file"; '
+                    f'filename="{filename}"\r\n'
+                ).encode()
+                yield f"Content-Type: {content_type}\r\n\r\n".encode()
+
+                if isinstance(content, bytes):
+                    yield content
+                elif isinstance(content, str):
+                    yield content.encode("utf-8")
+                else:
+                    while True:
+                        chunk = content.read(64 * 1024)
+                        if not chunk:
+                            break
+                        if isinstance(chunk, str):
+                            yield chunk.encode()
+                        else:
+                            yield chunk
+                yield b"\r\n"
+
+            yield f"--{boundary}--\r\n".encode()
+
+        return await client.post(
+            url,
+            content=_body(),
+            headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        )
 
     async def write_file(
         self,

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -259,7 +259,7 @@ class FilesystemAdapterSync(FilesystemSync):
                 content_type = "application/octet-stream"
             elif isinstance(entry.data, str):
                 encoding = entry.encoding or "utf-8"
-                content = entry.data
+                content = entry.data.encode(encoding)
                 content_type = f"text/plain; charset={encoding}"
             elif isinstance(entry.data, IOBase):
                 if isinstance(entry.data, TextIOBase):
@@ -310,7 +310,7 @@ class FilesystemAdapterSync(FilesystemSync):
                     content_type = "application/octet-stream"
                 elif isinstance(entry.data, str):
                     encoding = entry.encoding or "utf-8"
-                    content = entry.data
+                    content = entry.data.encode(encoding)
                     content_type = f"text/plain; charset={encoding}"
                 elif isinstance(entry.data, IOBase):
                     if isinstance(entry.data, TextIOBase):
@@ -341,8 +341,6 @@ class FilesystemAdapterSync(FilesystemSync):
 
                 if isinstance(content, bytes):
                     yield content
-                elif isinstance(content, str):
-                    yield content.encode("utf-8")
                 else:
                     while True:
                         chunk = content.read(64 * 1024)

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -311,7 +311,7 @@ class FilesystemAdapterSync(FilesystemSync):
                     )
 
                 yield f"--{boundary}\r\n".encode()
-                yield b'Content-Disposition: form-data; name="metadata"\r\n'
+                yield b'Content-Disposition: form-data; name="metadata"; filename="metadata"\r\n'
                 yield b"Content-Type: application/json\r\n\r\n"
                 yield metadata_json.encode()
                 yield b"\r\n"

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -54,6 +54,20 @@ from opensandbox.sync.services.filesystem import FilesystemSync
 
 logger = logging.getLogger(__name__)
 
+
+def _multipart_header_filename(filename: str) -> str:
+    return (
+        filename.replace("\\", "\\\\")
+        .replace('"', r'\"')
+        .replace("\r", "_")
+        .replace("\n", "_")
+    )
+
+
+def _rewind_seekable_stream(stream: IOBase) -> None:
+    if not stream.seekable():
+        return
+    stream.seek(0)
 class _DownloadRequest(TypedDict):
     url: str
     params: dict[str, str]
@@ -304,6 +318,7 @@ class FilesystemAdapterSync(FilesystemSync):
                             "File stream must be binary (opened with 'rb'). Text streams are not supported."
                         )
                     content = entry.data
+                    _rewind_seekable_stream(content)
                     content_type = "application/octet-stream"
                 else:
                     raise InvalidArgumentException(
@@ -316,7 +331,7 @@ class FilesystemAdapterSync(FilesystemSync):
                 yield metadata_json.encode()
                 yield b"\r\n"
 
-                filename = os.path.basename(entry.path) or "file"
+                filename = _multipart_header_filename(os.path.basename(entry.path) or "file")
                 yield f"--{boundary}\r\n".encode()
                 yield (
                     f'Content-Disposition: form-data; name="file"; '

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -19,6 +19,8 @@ Synchronous filesystem service adapter implementation.
 
 import json
 import logging
+import os
+import time
 from collections.abc import Iterator
 from io import IOBase, TextIOBase
 from typing import TypedDict
@@ -187,11 +189,92 @@ class FilesystemAdapterSync(FilesystemSync):
         return _iter()
 
     def write_files(self, entries: list[WriteEntry]) -> None:
+        """Write multiple files in a single operation using multipart upload.
+
+        Uses chunked transfer encoding for direct execd access to bypass
+        ingress proxy body size limits. Uses Content-Length when going
+        through the server proxy, which does not support chunked multipart.
+        """
         if not entries:
             return
         logger.debug("Writing %s files", len(entries))
         try:
-            multipart_parts = []
+            url = self._get_execd_url(self.FILESYSTEM_UPLOAD_PATH)
+
+            if self.connection_config.use_server_proxy:
+                response = self._write_files_with_content_length(url, entries)
+            else:
+                response = self._write_files_chunked(url, entries)
+
+            response.raise_for_status()
+        except Exception as e:
+            logger.error("Failed to write %s files", len(entries), exc_info=e)
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def _write_files_with_content_length(
+        self,
+        url: str,
+        entries: list[WriteEntry],
+    ) -> httpx.Response:
+        """Upload via httpx ``files=`` parameter with Content-Length.
+
+        Used when going through the server proxy, which requires Content-Length
+        for multipart requests.
+        """
+        multipart_parts = []
+        for entry in entries:
+            if not entry.path:
+                raise InvalidArgumentException("File path cannot be null")
+            if entry.data is None:
+                raise InvalidArgumentException("File data cannot be null")
+
+            metadata = {
+                "path": entry.path,
+                "owner": entry.owner,
+                "group": entry.group,
+                "mode": entry.mode,
+            }
+            multipart_parts.append(
+                ("metadata", ("metadata", json.dumps(metadata), "application/json"))
+            )
+
+            content: bytes | str | IOBase
+            content_type: str
+            if isinstance(entry.data, bytes):
+                content = entry.data
+                content_type = "application/octet-stream"
+            elif isinstance(entry.data, str):
+                encoding = entry.encoding or "utf-8"
+                content = entry.data
+                content_type = f"text/plain; charset={encoding}"
+            elif isinstance(entry.data, IOBase):
+                if isinstance(entry.data, TextIOBase):
+                    raise InvalidArgumentException(
+                        "File stream must be binary (opened with 'rb'). Text streams are not supported."
+                    )
+                content = entry.data
+                content_type = "application/octet-stream"
+            else:
+                raise InvalidArgumentException(
+                    f"Unsupported file data type: {type(entry.data)}"
+                )
+
+            multipart_parts.append(("file", (entry.path, content, content_type)))
+
+        return self._httpx_client.post(url, files=multipart_parts)
+
+    def _write_files_chunked(
+        self,
+        url: str,
+        entries: list[WriteEntry],
+    ) -> httpx.Response:
+        """Upload via chunked transfer encoding.
+
+        Used for direct execd access to bypass ingress proxy body size limits.
+        """
+        boundary = f"opensandbox_{os.urandom(8).hex()}_{int(time.time())}"
+
+        def _body() -> Iterator[bytes]:
             for entry in entries:
                 if not entry.path:
                     raise InvalidArgumentException("File path cannot be null")
@@ -204,7 +287,7 @@ class FilesystemAdapterSync(FilesystemSync):
                     "group": entry.group,
                     "mode": entry.mode,
                 }
-                multipart_parts.append(("metadata", ("metadata", json.dumps(metadata), "application/json")))
+                metadata_json = json.dumps(metadata)
 
                 content: bytes | str | IOBase
                 content_type: str
@@ -223,16 +306,46 @@ class FilesystemAdapterSync(FilesystemSync):
                     content = entry.data
                     content_type = "application/octet-stream"
                 else:
-                    raise InvalidArgumentException(f"Unsupported file data type: {type(entry.data)}")
+                    raise InvalidArgumentException(
+                        f"Unsupported file data type: {type(entry.data)}"
+                    )
 
-                multipart_parts.append(("file", (entry.path, content, content_type)))
+                yield f"--{boundary}\r\n".encode()
+                yield b'Content-Disposition: form-data; name="metadata"\r\n'
+                yield b"Content-Type: application/json\r\n\r\n"
+                yield metadata_json.encode()
+                yield b"\r\n"
 
-            url = self._get_execd_url(self.FILESYSTEM_UPLOAD_PATH)
-            response = self._httpx_client.post(url, files=multipart_parts)
-            response.raise_for_status()
-        except Exception as e:
-            logger.error("Failed to write %s files", len(entries), exc_info=e)
-            raise ExceptionConverter.to_sandbox_exception(e) from e
+                filename = os.path.basename(entry.path) or "file"
+                yield f"--{boundary}\r\n".encode()
+                yield (
+                    f'Content-Disposition: form-data; name="file"; '
+                    f'filename="{filename}"\r\n'
+                ).encode()
+                yield f"Content-Type: {content_type}\r\n\r\n".encode()
+
+                if isinstance(content, bytes):
+                    yield content
+                elif isinstance(content, str):
+                    yield content.encode("utf-8")
+                else:
+                    while True:
+                        chunk = content.read(64 * 1024)
+                        if not chunk:
+                            break
+                        if isinstance(chunk, str):
+                            yield chunk.encode()
+                        else:
+                            yield chunk
+                yield b"\r\n"
+
+            yield f"--{boundary}--\r\n".encode()
+
+        return self._httpx_client.post(
+            url,
+            content=_body(),
+            headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        )
 
     def write_file(
         self,

--- a/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
+++ b/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
@@ -138,6 +138,26 @@ async def test_async_write_files_server_proxy_uses_content_length_and_preserves_
     await adapter._httpx_client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_async_write_files_direct_execd_encodes_strings_with_entry_encoding() -> None:
+    transport = _CaptureAsyncTransport()
+    adapter = FilesystemAdapter(
+        ConnectionConfig(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    await adapter.write_files([
+        WriteEntry(path="/tmp/latin1.txt", data="olá", encoding="latin-1"),
+    ])
+
+    assert transport.request is not None
+    assert b"text/plain; charset=latin-1" in transport.body
+    assert "olá".encode("latin-1") in transport.body
+    assert "olá".encode() not in transport.body
+
+    await adapter._httpx_client.aclose()
+
+
 def test_sync_write_files_direct_execd_uses_chunked_upload() -> None:
     transport = _CaptureSyncTransport()
     adapter = FilesystemAdapterSync(

--- a/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
+++ b/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
@@ -1,0 +1,142 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from opensandbox.adapters.filesystem_adapter import FilesystemAdapter
+from opensandbox.config import ConnectionConfig
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.models.filesystem import WriteEntry
+from opensandbox.models.sandboxes import SandboxEndpoint
+from opensandbox.sync.adapters.filesystem_adapter import FilesystemAdapterSync
+
+LARGE_PAYLOAD = b"x" * (20 * 1024)
+
+
+class _CaptureAsyncTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.request: httpx.Request | None = None
+        self.body: bytes = b""
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.request = request
+        self.body = await request.aread()
+        return httpx.Response(200, request=request, content=b"{}")
+
+
+class _CaptureSyncTransport(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.request: httpx.Request | None = None
+        self.body: bytes = b""
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.request = request
+        self.body = request.read()
+        return httpx.Response(200, request=request, content=b"{}")
+
+
+def _headers(request: httpx.Request) -> dict[str, str]:
+    return {k.lower(): v for k, v in request.headers.items()}
+
+
+@pytest.mark.asyncio
+async def test_async_write_files_direct_execd_uses_chunked_upload() -> None:
+    transport = _CaptureAsyncTransport()
+    adapter = FilesystemAdapter(
+        ConnectionConfig(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    await adapter.write_files([WriteEntry(path="/tmp/large.bin", data=LARGE_PAYLOAD)])
+
+    assert transport.request is not None
+    headers = _headers(transport.request)
+    assert headers["transfer-encoding"] == "chunked"
+    assert "content-length" not in headers
+    assert headers["content-type"].startswith("multipart/form-data; boundary=opensandbox_")
+    assert b'name="file"; filename="large.bin"' in transport.body
+    assert LARGE_PAYLOAD in transport.body
+
+    await adapter._httpx_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_write_files_server_proxy_uses_content_length_and_preserves_charset() -> None:
+    transport = _CaptureAsyncTransport()
+    adapter = FilesystemAdapter(
+        ConnectionConfig(protocol="http", transport=transport, use_server_proxy=True),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    await adapter.write_files([
+        WriteEntry(path="/tmp/large.txt", data="hello", encoding="latin-1"),
+        WriteEntry(path="/tmp/large.bin", data=LARGE_PAYLOAD),
+    ])
+
+    assert transport.request is not None
+    headers = _headers(transport.request)
+    assert "transfer-encoding" not in headers
+    assert headers["content-length"] == str(len(transport.body))
+    assert headers["content-type"].startswith("multipart/form-data; boundary=")
+    assert b"text/plain; charset=latin-1" in transport.body
+    assert LARGE_PAYLOAD in transport.body
+
+    await adapter._httpx_client.aclose()
+
+
+def test_sync_write_files_direct_execd_uses_chunked_upload() -> None:
+    transport = _CaptureSyncTransport()
+    adapter = FilesystemAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    adapter.write_files([WriteEntry(path="/tmp/large.bin", data=LARGE_PAYLOAD)])
+
+    assert transport.request is not None
+    headers = _headers(transport.request)
+    assert headers["transfer-encoding"] == "chunked"
+    assert "content-length" not in headers
+    assert headers["content-type"].startswith("multipart/form-data; boundary=opensandbox_")
+    assert b'name="file"; filename="large.bin"' in transport.body
+    assert LARGE_PAYLOAD in transport.body
+
+    adapter._httpx_client.close()
+
+
+def test_sync_write_files_server_proxy_uses_content_length_and_preserves_charset() -> None:
+    transport = _CaptureSyncTransport()
+    adapter = FilesystemAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport, use_server_proxy=True),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    adapter.write_files([
+        WriteEntry(path="/tmp/large.txt", data="hello", encoding="latin-1"),
+        WriteEntry(path="/tmp/large.bin", data=LARGE_PAYLOAD),
+    ])
+
+    assert transport.request is not None
+    headers = _headers(transport.request)
+    assert "transfer-encoding" not in headers
+    assert headers["content-length"] == str(len(transport.body))
+    assert headers["content-type"].startswith("multipart/form-data; boundary=")
+    assert b"text/plain; charset=latin-1" in transport.body
+    assert LARGE_PAYLOAD in transport.body
+
+    adapter._httpx_client.close()

--- a/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
+++ b/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from io import BytesIO
+
 import httpx
 import pytest
 
@@ -77,6 +79,42 @@ async def test_async_write_files_direct_execd_uses_chunked_upload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_write_files_direct_execd_rewinds_seekable_streams() -> None:
+    transport = _CaptureAsyncTransport()
+    adapter = FilesystemAdapter(
+        ConnectionConfig(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    stream = BytesIO(LARGE_PAYLOAD)
+    stream.read(7)
+
+    await adapter.write_files([WriteEntry(path="/tmp/stream.bin", data=stream)])
+
+    assert transport.request is not None
+    assert LARGE_PAYLOAD in transport.body
+
+    await adapter._httpx_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_write_files_direct_execd_escapes_filename_header() -> None:
+    transport = _CaptureAsyncTransport()
+    adapter = FilesystemAdapter(
+        ConnectionConfig(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    await adapter.write_files([WriteEntry(path='/tmp/weird"name\r\n.txt', data='hello')])
+
+    assert transport.request is not None
+    assert b'filename="weird\\"name__.txt"' in transport.body
+    assert b'filename="weird"name' not in transport.body
+
+    await adapter._httpx_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_async_write_files_server_proxy_uses_content_length_and_preserves_charset() -> None:
     transport = _CaptureAsyncTransport()
     adapter = FilesystemAdapter(
@@ -117,6 +155,40 @@ def test_sync_write_files_direct_execd_uses_chunked_upload() -> None:
     assert b'name="metadata"; filename="metadata"' in transport.body
     assert b'name="file"; filename="large.bin"' in transport.body
     assert LARGE_PAYLOAD in transport.body
+
+    adapter._httpx_client.close()
+
+
+def test_sync_write_files_direct_execd_rewinds_seekable_streams() -> None:
+    transport = _CaptureSyncTransport()
+    adapter = FilesystemAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    stream = BytesIO(LARGE_PAYLOAD)
+    stream.read(7)
+
+    adapter.write_files([WriteEntry(path="/tmp/stream.bin", data=stream)])
+
+    assert transport.request is not None
+    assert LARGE_PAYLOAD in transport.body
+
+    adapter._httpx_client.close()
+
+
+def test_sync_write_files_direct_execd_escapes_filename_header() -> None:
+    transport = _CaptureSyncTransport()
+    adapter = FilesystemAdapterSync(
+        ConnectionConfigSync(protocol="http", transport=transport, use_server_proxy=False),
+        SandboxEndpoint(endpoint="localhost:44772"),
+    )
+
+    adapter.write_files([WriteEntry(path='/tmp/weird"name\r\n.txt', data='hello')])
+
+    assert transport.request is not None
+    assert b'filename="weird\\"name__.txt"' in transport.body
+    assert b'filename="weird"name' not in transport.body
 
     adapter._httpx_client.close()
 

--- a/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
+++ b/sdks/sandbox/python/tests/test_filesystem_upload_transport.py
@@ -69,6 +69,7 @@ async def test_async_write_files_direct_execd_uses_chunked_upload() -> None:
     assert headers["transfer-encoding"] == "chunked"
     assert "content-length" not in headers
     assert headers["content-type"].startswith("multipart/form-data; boundary=opensandbox_")
+    assert b'name="metadata"; filename="metadata"' in transport.body
     assert b'name="file"; filename="large.bin"' in transport.body
     assert LARGE_PAYLOAD in transport.body
 
@@ -113,6 +114,7 @@ def test_sync_write_files_direct_execd_uses_chunked_upload() -> None:
     assert headers["transfer-encoding"] == "chunked"
     assert "content-length" not in headers
     assert headers["content-type"].startswith("multipart/form-data; boundary=opensandbox_")
+    assert b'name="metadata"; filename="metadata"' in transport.body
     assert b'name="file"; filename="large.bin"' in transport.body
     assert LARGE_PAYLOAD in transport.body
 


### PR DESCRIPTION
# Summary
- Fix Python SDK file uploads so large writes use chunked multipart on direct execd and Content-Length multipart through the server proxy.
- Preserve per-entry text encoding handling in both upload paths.
- Add async/sync regression tests that assert the request framing and headers for both modes.

# Testing
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:
- `uv run pytest tests/test_filesystem_upload_transport.py tests/test_filesystem_search_error_handling.py -q`
- `uv run ruff check src/opensandbox/adapters/filesystem_adapter.py src/opensandbox/sync/adapters/filesystem_adapter.py tests/test_filesystem_upload_transport.py`
- `uv run pyright tests/test_filesystem_upload_transport.py src/opensandbox/adapters/filesystem_adapter.py src/opensandbox/sync/adapters/filesystem_adapter.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

Fixes #1016
