### PR TITLE
fix(egress): wait for mitmproxy ready instead of rejecting credential vault writes

### DIFF
--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -15,6 +15,7 @@
 package credentialvault
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -366,7 +367,7 @@ func (v *Store) ValidateActiveAgainstPolicy(pol *policy.NetworkPolicy) error {
 	return v.validateCandidate(v.credentials, v.bindings, pol)
 }
 
-func (v *Store) Ready() error {
+func (v *Store) Ready(ctx context.Context) error {
 	if v.requireToken != nil && !v.requireToken() {
 		return fmt.Errorf("credential vault requires egress API auth token")
 	}
@@ -376,7 +377,7 @@ func (v *Store) Ready() error {
 	if constants.IsTruthy(os.Getenv(constants.EnvMitmproxySslInsecure)) {
 		return fmt.Errorf("credential vault rejects insecure upstream TLS mode")
 	}
-	if v.mitmGate != nil && v.mitmGate.MitmPending() {
+	if v.mitmGate != nil && !v.mitmGate.WaitReady(ctx) {
 		return fmt.Errorf("credential proxy is not ready")
 	}
 	return nil

--- a/components/egress/pkg/mitmproxy/health_gate.go
+++ b/components/egress/pkg/mitmproxy/health_gate.go
@@ -55,11 +55,14 @@ func (g *HealthGate) MitmPending() bool {
 	return g.required && !g.ready.Load()
 }
 
-// WaitReady polls until the gate is ready or ctx is cancelled.
+// WaitReady polls until the gate is ready, ctx is cancelled, or 30s elapses.
 func (g *HealthGate) WaitReady(ctx context.Context) bool {
+	deadline := time.After(30 * time.Second)
 	for g.MitmPending() {
 		select {
 		case <-ctx.Done():
+			return false
+		case <-deadline:
 			return false
 		case <-time.After(100 * time.Millisecond):
 		}

--- a/components/egress/pkg/mitmproxy/health_gate.go
+++ b/components/egress/pkg/mitmproxy/health_gate.go
@@ -15,8 +15,10 @@
 package mitmproxy
 
 import (
+	"context"
 	"os"
 	"sync/atomic"
+	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 )
@@ -51,4 +53,16 @@ func (g *HealthGate) MitmPending() bool {
 		return false
 	}
 	return g.required && !g.ready.Load()
+}
+
+// WaitReady polls until the gate is ready or ctx is cancelled.
+func (g *HealthGate) WaitReady(ctx context.Context) bool {
+	for g.MitmPending() {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return true
 }

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -292,7 +292,7 @@ func (s *policyServer) handleCredentialVaultGet(w http.ResponseWriter) {
 }
 
 func (s *policyServer) handleCredentialVaultPost(w http.ResponseWriter, r *http.Request) {
-	if err := s.credentialVault.Ready(); err != nil {
+	if err := s.credentialVault.Ready(r.Context()); err != nil {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
@@ -314,7 +314,7 @@ func (s *policyServer) handleCredentialVaultPost(w http.ResponseWriter, r *http.
 }
 
 func (s *policyServer) handleCredentialVaultPatch(w http.ResponseWriter, r *http.Request) {
-	if err := s.credentialVault.Ready(); err != nil {
+	if err := s.credentialVault.Ready(r.Context()); err != nil {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}
@@ -336,7 +336,7 @@ func (s *policyServer) handleCredentialVaultPatch(w http.ResponseWriter, r *http
 }
 
 func (s *policyServer) handleCredentialVaultDelete(w http.ResponseWriter, r *http.Request) {
-	if err := s.credentialVault.Ready(); err != nil {
+	if err := s.credentialVault.Ready(r.Context()); err != nil {
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
 	}


### PR DESCRIPTION
## Summary
- Credential vault write handlers (POST/PATCH/DELETE) returned HTTP 412 immediately when mitmproxy had not finished starting, causing race condition on sandbox startup
- Add `HealthGate.WaitReady(ctx)` that polls until mitmproxy is ready or request context is cancelled
- Change `Store.Ready()` to accept context and block briefly during startup instead of failing

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all egress packages)
- [ ] Deploy egress with credential proxy enabled, create sandbox, immediately call create credential — should succeed without 412

🤖 Generated with [Claude Code](https://claude.com/claude-code)