### PR TITLE
test/fix: add replaceContent e2e coverage and fix SDK empty body handling

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -40,8 +40,6 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.isFileN
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -330,7 +328,13 @@ internal class FilesystemAdapter(
     override fun replaceContents(entries: List<ContentReplaceEntry>) {
         try {
             val replaceMap = entries.toApiReplaceFileContentMap()
-            api.replaceContent(replaceMap)
+            try {
+                api.replaceContent(replaceMap)
+            } catch (_: NullPointerException) {
+                // Older execd versions return an empty body for verbose=false,
+                // which the generated client cannot deserialize. The replacement
+                // itself succeeded if no HTTP error was thrown.
+            }
         } catch (e: Exception) {
             logger.error("Failed to replace contents", e)
             throw e.toSandboxException()
@@ -340,50 +344,12 @@ internal class FilesystemAdapter(
     override fun replaceContentsDetailed(entries: List<ContentReplaceEntry>): List<ContentReplaceResult> {
         return try {
             val replaceMap = entries.toApiReplaceFileContentMap()
-            val jsonBody =
-                buildJsonObject {
-                    replaceMap.forEach { (path, item) ->
-                        put(
-                            path,
-                            buildJsonObject {
-                                put("old", item.old)
-                                put("new", item.new)
-                            },
-                        )
-                    }
-                }.toString()
-
-            val baseUrl = "${httpClientProvider.config.protocol}://${execdEndpoint.endpoint}"
-            val request =
-                Request.Builder()
-                    .url("$baseUrl/files/replace?verbose=true")
-                    .post(jsonBody.toRequestBody("application/json".toMediaType()))
-                    .apply { execdEndpoint.headers.forEach { (k, v) -> header(k, v) } }
-                    .build()
-
-            httpClientProvider.httpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    val errorBody = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBody)
-                    throw SandboxApiException(
-                        message = "Failed to replace contents. Status: ${response.code}, Body: $errorBody",
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
-                }
-                val body = response.body?.string()
-                if (body.isNullOrBlank()) {
-                    emptyList()
-                } else {
-                    val parsed = kotlinx.serialization.json.Json.decodeFromString<Map<String, kotlinx.serialization.json.JsonObject>>(body)
-                    parsed.map { (path, result) ->
-                        ContentReplaceResult(
-                            path = path,
-                            replacedCount = result["replacedCount"]?.jsonPrimitive?.intOrNull ?: 0,
-                        )
-                    }
-                }
+            val response = api.replaceContent(replaceMap, verbose = true)
+            response.map { (path, result) ->
+                ContentReplaceResult(
+                    path = path,
+                    replacedCount = result.replacedCount,
+                )
             }
         } catch (e: Exception) {
             logger.error("Failed to replace contents", e)

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Text;
 using OpenSandbox.Config;
 using OpenSandbox.Core;
@@ -902,6 +903,37 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         });
         Assert.Single(multiResults);
         Assert.Equal(3, multiResults[0].ReplacedCount);
+
+        // Batch replace across multiple files
+        var batchA = $"{testDir1}/batch_a.txt";
+        var batchB = $"{testDir1}/batch_b.txt";
+        await sandbox.Files.WriteFilesAsync(new[]
+        {
+            new WriteEntry { Path = batchA, Data = "hello world" },
+            new WriteEntry { Path = batchB, Data = "hello hello" }
+        });
+        var batchResults = await sandbox.Files.ReplaceContentsDetailedAsync(new[]
+        {
+            new ContentReplaceEntry { Path = batchA, OldContent = "hello", NewContent = "hi" },
+            new ContentReplaceEntry { Path = batchB, OldContent = "hello", NewContent = "hi" }
+        });
+        Assert.Equal(2, batchResults.Count);
+        var resultsByPath = batchResults.ToDictionary(r => r.Path, r => r.ReplacedCount);
+        Assert.Equal(1, resultsByPath[batchA]);
+        Assert.Equal(2, resultsByPath[batchB]);
+        Assert.Equal("hi world", await sandbox.Files.ReadFileAsync(batchA, new ReadFileOptions { Encoding = "utf-8" }));
+        Assert.Equal("hi hi", await sandbox.Files.ReadFileAsync(batchB, new ReadFileOptions { Encoding = "utf-8" }));
+
+        // Verify original ReplaceContentsAsync (verbose=false, void return) still works
+        await sandbox.Files.ReplaceContentsAsync(new[]
+        {
+            new ContentReplaceEntry { Path = testFile1, OldContent = "Replaced line.", NewContent = "Final line." }
+        });
+        var finalContent = await sandbox.Files.ReadFileAsync(testFile1, new ReadFileOptions { Encoding = "utf-8" });
+        Assert.Contains("Final line.", finalContent, StringComparison.Ordinal);
+        Assert.DoesNotContain("Replaced line.", finalContent, StringComparison.Ordinal);
+
+        await sandbox.Files.DeleteFilesAsync(new[] { $"{testDir1}/multi.txt", batchA, batchB });
 
         var movedPath = $"{testDir2}/moved_file3.txt";
         await sandbox.Files.MoveFilesAsync(new[] { new MoveEntry { Src = testFile3, Dest = movedPath } });

--- a/tests/go/filesystem_e2e_test.go
+++ b/tests/go/filesystem_e2e_test.go
@@ -200,11 +200,39 @@ func TestFilesystem_ReplaceInFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, resp["/tmp/replace-multi.txt"].ReplacedCount)
 
-	// Verify original ReplaceInFiles (error-only) still works
+	// Batch replace across multiple files
+	_, err = sb.RunCommand(ctx, `echo "hello world" > /tmp/replace-batch-a.txt`, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-batch-a.txt"}) })
+	_, err = sb.RunCommand(ctx, `echo "hello hello" > /tmp/replace-batch-b.txt`, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sb.DeleteFiles(context.Background(), []string{"/tmp/replace-batch-b.txt"}) })
+
+	resp, err = sb.ReplaceInFilesDetailed(ctx, opensandbox.ReplaceRequest{
+		"/tmp/replace-batch-a.txt": {Old: "hello", New: "hi"},
+		"/tmp/replace-batch-b.txt": {Old: "hello", New: "hi"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp["/tmp/replace-batch-a.txt"].ReplacedCount)
+	require.Equal(t, 2, resp["/tmp/replace-batch-b.txt"].ReplacedCount)
+
+	execA, err := sb.RunCommand(ctx, "cat /tmp/replace-batch-a.txt", nil)
+	require.NoError(t, err)
+	require.Contains(t, execA.Text(), "hi world")
+
+	execB, err := sb.RunCommand(ctx, "cat /tmp/replace-batch-b.txt", nil)
+	require.NoError(t, err)
+	require.Contains(t, execB.Text(), "hi hi")
+
+	// Verify original ReplaceInFiles (verbose=false, error-only return) still works
 	err = sb.ReplaceInFiles(ctx, opensandbox.ReplaceRequest{
 		"/tmp/replace-multi.txt": {Old: "qux", New: "done"},
 	})
 	require.NoError(t, err)
+	execDone, err := sb.RunCommand(ctx, "cat /tmp/replace-multi.txt", nil)
+	require.NoError(t, err)
+	require.Contains(t, execDone.Text(), "done")
+	require.NotContains(t, execDone.Text(), "qux")
 }
 
 func TestFilesystem_DownloadFileLineReading(t *testing.T) {

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -1380,7 +1380,36 @@ public class SandboxE2ETest extends BaseE2ETest {
         assertEquals(1, multiResults.size());
         assertEquals(3, multiResults.get(0).getReplacedCount());
 
-        sandbox.files().deleteFiles(List.of(testDir1 + "/multi.txt"));
+        // Batch replace across multiple files
+        String batchFileA = testDir1 + "/batch_a.txt";
+        String batchFileB = testDir1 + "/batch_b.txt";
+        sandbox.files().write(List.of(
+                WriteEntry.builder().path(batchFileA).data("hello world").build(),
+                WriteEntry.builder().path(batchFileB).data("hello hello").build()));
+        var batchResults = sandbox.files().replaceContentsDetailed(List.of(
+                ContentReplaceEntry.builder().path(batchFileA).oldContent("hello").newContent("hi").build(),
+                ContentReplaceEntry.builder().path(batchFileB).oldContent("hello").newContent("hi").build()));
+        assertEquals(2, batchResults.size());
+        var resultsByPath = batchResults.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        ContentReplaceResult::getPath, ContentReplaceResult::getReplacedCount));
+        assertEquals(1, resultsByPath.get(batchFileA));
+        assertEquals(2, resultsByPath.get(batchFileB));
+        assertEquals("hi world", sandbox.files().readFile(batchFileA, "UTF-8", null));
+        assertEquals("hi hi", sandbox.files().readFile(batchFileB, "UTF-8", null));
+
+        // Verify original replaceContents (verbose=false, void return) still works
+        sandbox.files().replaceContents(List.of(
+                ContentReplaceEntry.builder()
+                        .path(testFile1)
+                        .oldContent("Replaced line in file1")
+                        .newContent("Final line in file1")
+                        .build()));
+        String finalContent = sandbox.files().readFile(testFile1, "UTF-8", null);
+        assertTrue(finalContent.contains("Final line in file1"));
+        assertFalse(finalContent.contains("Replaced line in file1"));
+
+        sandbox.files().deleteFiles(List.of(testDir1 + "/multi.txt", batchFileA, batchFileB));
 
         // Move file3
         String movedPath = testDir2 + "/moved_file3.txt";


### PR DESCRIPTION
## Summary

- **Go/Java/C# e2e tests** were missing batch multi-file `replaceContent` (verbose=true) and `replaceContent` (verbose=false) test coverage that Python/JS already had. Added matching test cases.
- **Kotlin SDK bug**: `replaceContents()` (verbose=false) threw `NullPointerException` because the generated OpenAPI client couldn't parse the empty HTTP response body returned by execd.
- **Kotlin SDK cleanup**: `replaceContentsDetailed()` was using hand-rolled HTTP instead of the generated API client. Refactored to use `api.replaceContent(replaceMap, verbose = true)`.

### Root cause

When `verbose=false` (default), execd returns HTTP 200 with an **empty body** (`RespondSuccess(nil)`). Generated API clients (Kotlin `openapi-generator`, Python `openapi-python-client`) unconditionally deserialize the 200 response body, failing on empty input:
- Kotlin: `NullPointerException` on unchecked cast
- Python: `JSONDecodeError` on `response.json()`

JS/Go/C# SDKs are unaffected because they either use non-codegen HTTP clients or don't read the response body for the non-verbose path.

### Fix approach

Handle the empty body at the **SDK adapter layer** rather than changing execd, to maintain backward compatibility with older execd versions:
- **Kotlin**: catch `NullPointerException` from generated client — the replacement itself succeeded if no HTTP error was thrown
- **Python**: `except JSONDecodeError: pass` (was already present, restored after exploration)

## Test plan
- [ ] Run Go e2e: `TestFilesystem_ReplaceInFiles` — batch replace + verbose=false content verification
- [ ] Run Java e2e: filesystem CRUD test — batch replace + `replaceContents` (verbose=false)
- [ ] Run C# e2e: `Filesystem_Operations_CRUD_Replace_Move_Delete` — batch replace + `ReplaceContentsAsync`
- [ ] Run Python/JS e2e: verify existing tests still pass
- [ ] Verify Kotlin SDK compiles: `./gradlew :sandbox:compileKotlin` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)