### PR TITLE
feat(egress): log full policy body on init and update

### DIFF
--- a/components/egress/pkg/policy/persist.go
+++ b/components/egress/pkg/policy/persist.go
@@ -48,6 +48,7 @@ func loadPolicyFromEnvWithSource(envName string) (*NetworkPolicy, PolicyInitialS
 	if raw == "" {
 		return p, PolicyFromDefault, nil
 	}
+	log.Infof("loaded egress policy from env %s: %s", envName, raw)
 	return p, PolicyFromEnv, nil
 }
 
@@ -82,7 +83,7 @@ func LoadInitialPolicyDetailed(policyFile, envName string) (*NetworkPolicy, Poli
 		return loadPolicyFromEnvWithSource(envName)
 	}
 
-	log.Infof("loaded egress policy from %s", policyFile)
+	log.Infof("loaded egress policy from %s: %s", policyFile, raw)
 	return pol, PolicyFromFile, nil
 }
 

--- a/components/egress/policy_utils.go
+++ b/components/egress/policy_utils.go
@@ -35,7 +35,9 @@ func readPolicyRequestBody(r *http.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(body)), nil
+	raw := strings.TrimSpace(string(body))
+	log.Infof("policy API: request body (%s %s): %s", r.Method, r.URL.Path, raw)
+	return raw, nil
 }
 
 func patchMergedPolicy(base *policy.NetworkPolicy, patchRules []policy.EgressRule) (*policy.NetworkPolicy, error) {


### PR DESCRIPTION
## Summary
- Add raw body logging to egress policy initialization (file and env sources) for debugging
- Add request body logging to policy API handlers (POST/PATCH/DELETE)
- Previously only logged a summary (action+target per rule), now logs complete JSON payload

## Test plan
- [ ] Verify egress component builds cleanly
- [ ] Deploy and confirm full policy body appears in logs on sandbox init
- [ ] Confirm POST/PATCH/DELETE policy API calls log raw request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)