### PR TITLE
fix: honor internal endpoint resolution on Kubernetes

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -17,6 +17,7 @@ HTTP and WebSocket proxy routes for reaching services inside sandboxes via the l
 """
 
 import logging
+import secrets
 from collections.abc import AsyncIterator, Mapping
 from typing import Optional
 
@@ -132,6 +133,34 @@ def _filter_proxy_headers(
     return forwarded
 
 
+def _validate_secure_access_header(
+    request_headers: Mapping[str, str],
+    endpoint_headers: Optional[dict[str, str]],
+) -> None:
+    expected = next(
+        (
+            value
+            for key, value in (endpoint_headers or {}).items()
+            if key.lower() == OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower()
+        ),
+        None,
+    )
+    if not expected:
+        return
+
+    actual = request_headers.get(OPEN_SANDBOX_SECURE_ACCESS_HEADER)
+    if actual and secrets.compare_digest(actual, expected):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail={
+            "code": "UNAUTHORIZED",
+            "message": f"Missing or invalid {OPEN_SANDBOX_SECURE_ACCESS_HEADER} header.",
+        },
+    )
+
+
 def _schedule_proxy_renew(request: Request | WebSocket, sandbox_id: str) -> None:
     proxy_renew = getattr(request.app.state, "proxy_renew_coordinator", None)
     if proxy_renew is not None:
@@ -159,8 +188,9 @@ async def _proxy_http_request(
     port: int,
     full_path: str,
 ) -> StreamingResponse:
-    _schedule_proxy_renew(request, sandbox_id)
     endpoint = lifecycle.sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
+    _validate_secure_access_header(request.headers, endpoint.headers)
+    _schedule_proxy_renew(request, sandbox_id)
     query_string = request.url.query
     target_url = _build_proxy_target_url(endpoint, full_path, query_string, websocket=False)
     client: httpx.AsyncClient = request.app.state.http_client
@@ -307,10 +337,10 @@ async def _proxy_websocket_request(
     port: int,
     full_path: str,
 ) -> None:
-    _schedule_proxy_renew(websocket, sandbox_id)
-
     try:
         endpoint = lifecycle.sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
+        _validate_secure_access_header(websocket.headers, endpoint.headers)
+        _schedule_proxy_renew(websocket, sandbox_id)
     except HTTPException as exc:
         logger.warning(
             "Rejecting websocket proxy request for sandbox=%s port=%s: %s",

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -507,8 +507,16 @@ class AgentSandboxProvider(WorkloadProvider):
 
         return None
 
-    def get_endpoint_info(self, workload: Dict[str, Any], port: int, sandbox_id: str) -> Optional[Endpoint]:
-        ingress_endpoint = format_ingress_endpoint(self.ingress_config, sandbox_id, port)
+    def get_endpoint_info(
+        self,
+        workload: Dict[str, Any],
+        port: int,
+        sandbox_id: str,
+        resolve_internal: bool = False,
+    ) -> Optional[Endpoint]:
+        ingress_endpoint = None
+        if not resolve_internal:
+            ingress_endpoint = format_ingress_endpoint(self.ingress_config, sandbox_id, port)
         if ingress_endpoint:
             return ingress_endpoint
 

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -811,9 +811,19 @@ class BatchSandboxProvider(WorkloadProvider):
             "last_transition_at": creation_timestamp,
         }
     
-    def get_endpoint_info(self, workload: Dict[str, Any], port: int, sandbox_id: str) -> Optional[Endpoint]:
+    def get_endpoint_info(
+        self,
+        workload: Dict[str, Any],
+        port: int,
+        sandbox_id: str,
+        resolve_internal: bool = False,
+    ) -> Optional[Endpoint]:
         """Resolve endpoint using gateway ingress or parsed pod IP."""
-        if self.ingress_config and self.ingress_config.mode == INGRESS_MODE_GATEWAY:
+        if (
+            not resolve_internal
+            and self.ingress_config
+            and self.ingress_config.mode == INGRESS_MODE_GATEWAY
+        ):
             return format_ingress_endpoint(self.ingress_config, sandbox_id, port)
 
         pod_ip = self._parse_pod_ip(workload)

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -20,6 +20,7 @@ using Kubernetes resources for sandbox lifecycle management.
 """
 
 import asyncio
+import inspect
 import logging
 import time
 from datetime import datetime, timezone
@@ -89,6 +90,14 @@ from opensandbox_server.services.k8s.provider_factory import create_workload_pro
 from opensandbox_server.services.snapshot_restore import resolve_sandbox_image_from_request
 
 logger = logging.getLogger(__name__)
+
+
+def _provider_supports_internal_endpoint_resolution(provider: Any) -> bool:
+    signature = inspect.signature(provider.get_endpoint_info)
+    return "resolve_internal" in signature.parameters or any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    )
 
 
 class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionService):
@@ -882,12 +891,33 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             if expires is not None:
                 endpoint = self._build_signed_endpoint(sandbox_id, port, expires)
             else:
-                endpoint = self.workload_provider.get_endpoint_info(
-                    workload,
-                    port,
-                    sandbox_id,
-                    resolve_internal=resolve_internal,
+                supports_internal_resolution = _provider_supports_internal_endpoint_resolution(
+                    self.workload_provider
                 )
+                if resolve_internal and not supports_internal_resolution:
+                    raise HTTPException(
+                        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                        detail={
+                            "code": SandboxErrorCodes.API_NOT_SUPPORTED,
+                            "message": (
+                                "The configured Kubernetes workload provider does not "
+                                "support internal endpoint resolution required by server proxy."
+                            ),
+                        },
+                    )
+                if supports_internal_resolution:
+                    endpoint = self.workload_provider.get_endpoint_info(
+                        workload,
+                        port,
+                        sandbox_id,
+                        resolve_internal=resolve_internal,
+                    )
+                else:
+                    endpoint = self.workload_provider.get_endpoint_info(
+                        workload,
+                        port,
+                        sandbox_id,
+                    )
 
             if not endpoint:
                 raise HTTPException(

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -833,7 +833,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         Args:
             sandbox_id: Unique sandbox identifier
             port: Port number
-            resolve_internal: Ignored for Kubernetes (always returns Pod IP)
+            resolve_internal: If True, return an internal endpoint for server proxy backends.
             expires: Unix epoch seconds for a signed route token.
                 Requires ingress gateway mode with secure_access keys configured.
 
@@ -882,7 +882,12 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             if expires is not None:
                 endpoint = self._build_signed_endpoint(sandbox_id, port, expires)
             else:
-                endpoint = self.workload_provider.get_endpoint_info(workload, port, sandbox_id)
+                endpoint = self.workload_provider.get_endpoint_info(
+                    workload,
+                    port,
+                    sandbox_id,
+                    resolve_internal=resolve_internal,
+                )
 
             if not endpoint:
                 raise HTTPException(

--- a/server/opensandbox_server/services/k8s/workload_provider.py
+++ b/server/opensandbox_server/services/k8s/workload_provider.py
@@ -170,7 +170,13 @@ class WorkloadProvider(ABC):
         pass
     
     @abstractmethod
-    def get_endpoint_info(self, workload: Any, port: int, sandbox_id: str) -> Optional[Endpoint]:
+    def get_endpoint_info(
+        self,
+        workload: Any,
+        port: int,
+        sandbox_id: str,
+        resolve_internal: bool = False,
+    ) -> Optional[Endpoint]:
         """
         Get endpoint information from workload.
 
@@ -178,6 +184,7 @@ class WorkloadProvider(ABC):
             workload: Workload object
             port: Port number
             sandbox_id: Sandbox identifier for ingress-based endpoints
+            resolve_internal: If True, bypass client-facing ingress endpoints.
 
         Returns:
             Endpoint object (including optional headers) or None if not available

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -28,6 +28,9 @@ from opensandbox_server.config import (
     EGRESS_MODE_DNS_NFT,
     EgressConfig,
     ExecdInitResources,
+    GatewayConfig,
+    GatewayRouteModeConfig,
+    IngressConfig,
     KubernetesRuntimeConfig,
     RuntimeConfig,
 )
@@ -669,6 +672,58 @@ spec:
         }
 
         endpoint = provider.get_endpoint_info(workload, 8080, "sandbox-123")
+
+        assert endpoint.endpoint == "10.0.0.9:8080"
+        assert endpoint.headers is None
+
+    def test_get_endpoint_info_gateway_mode_returns_gateway_endpoint_by_default(self, mock_k8s_client):
+        app_config = _app_config()
+        app_config.ingress = IngressConfig(
+            mode="gateway",
+            gateway=GatewayConfig(
+                address="127.0.0.1:8081",
+                route=GatewayRouteModeConfig(mode="header"),
+            ),
+        )
+        provider = AgentSandboxProvider(mock_k8s_client, app_config)
+        mock_k8s_client.list_pods.return_value = [
+            SimpleNamespace(status=SimpleNamespace(phase="Running", pod_ip="10.0.0.9"))
+        ]
+        workload = {
+            "status": {"selector": "app=sandbox"},
+            "metadata": {"namespace": "test-ns"},
+        }
+
+        endpoint = provider.get_endpoint_info(workload, 8080, "sandbox-123")
+
+        assert endpoint.endpoint == "127.0.0.1:8081"
+        assert endpoint.headers == {"OpenSandbox-Ingress-To": "sandbox-123-8080"}
+        mock_k8s_client.list_pods.assert_not_called()
+
+    def test_get_endpoint_info_resolve_internal_skips_gateway_endpoint(self, mock_k8s_client):
+        app_config = _app_config()
+        app_config.ingress = IngressConfig(
+            mode="gateway",
+            gateway=GatewayConfig(
+                address="127.0.0.1:8081",
+                route=GatewayRouteModeConfig(mode="header"),
+            ),
+        )
+        provider = AgentSandboxProvider(mock_k8s_client, app_config)
+        mock_k8s_client.list_pods.return_value = [
+            SimpleNamespace(status=SimpleNamespace(phase="Running", pod_ip="10.0.0.9"))
+        ]
+        workload = {
+            "status": {"selector": "app=sandbox"},
+            "metadata": {"namespace": "test-ns"},
+        }
+
+        endpoint = provider.get_endpoint_info(
+            workload,
+            8080,
+            "sandbox-123",
+            resolve_internal=True,
+        )
 
         assert endpoint.endpoint == "10.0.0.9:8080"
         assert endpoint.headers is None

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -32,6 +32,9 @@ from opensandbox_server.config import (
     EGRESS_MODE_DNS_NFT,
     EgressConfig,
     ExecdInitResources,
+    GatewayConfig,
+    GatewayRouteModeConfig,
+    IngressConfig,
     KubernetesRuntimeConfig,
     RuntimeConfig,
 )
@@ -1265,6 +1268,59 @@ spec:
         }
 
         result = provider.get_endpoint_info(workload, 8080, "sandbox-123")
+
+        assert result.endpoint == "10.0.0.1:8080"
+        assert result.headers is None
+
+    def test_get_endpoint_info_gateway_mode_returns_gateway_endpoint_by_default(self):
+        app_config = AppConfig(
+            runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+            kubernetes=KubernetesRuntimeConfig(namespace="test-ns"),
+            ingress=IngressConfig(
+                mode="gateway",
+                gateway=GatewayConfig(
+                    address="127.0.0.1:8081",
+                    route=GatewayRouteModeConfig(mode="header"),
+                ),
+            ),
+        )
+        provider = BatchSandboxProvider(MagicMock(), app_config)
+        workload = {
+            "metadata": {
+                "annotations": {"sandbox.opensandbox.io/endpoints": '["10.0.0.1"]'}
+            }
+        }
+
+        result = provider.get_endpoint_info(workload, 8080, "sandbox-123")
+
+        assert result.endpoint == "127.0.0.1:8081"
+        assert result.headers == {"OpenSandbox-Ingress-To": "sandbox-123-8080"}
+
+    def test_get_endpoint_info_resolve_internal_skips_gateway_endpoint(self):
+        app_config = AppConfig(
+            runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+            kubernetes=KubernetesRuntimeConfig(namespace="test-ns"),
+            ingress=IngressConfig(
+                mode="gateway",
+                gateway=GatewayConfig(
+                    address="127.0.0.1:8081",
+                    route=GatewayRouteModeConfig(mode="header"),
+                ),
+            ),
+        )
+        provider = BatchSandboxProvider(MagicMock(), app_config)
+        workload = {
+            "metadata": {
+                "annotations": {"sandbox.opensandbox.io/endpoints": '["10.0.0.1"]'}
+            }
+        }
+
+        result = provider.get_endpoint_info(
+            workload,
+            8080,
+            "sandbox-123",
+            resolve_internal=True,
+        )
 
         assert result.endpoint == "10.0.0.1:8080"
         assert result.headers is None

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -464,6 +464,28 @@ class TestKubernetesSandboxServiceCreate:
             "OpenSandbox-Ingress-To": "sbx-123-44772",
         }
 
+    def test_get_endpoint_passes_resolve_internal_to_provider(self, k8s_service):
+        k8s_service.workload_provider.get_workload.return_value = {
+            "metadata": {"annotations": {}}
+        }
+        k8s_service.workload_provider.get_endpoint_info.return_value = Endpoint(
+            endpoint="10.244.0.5:44772",
+        )
+
+        endpoint = k8s_service.get_endpoint(
+            "sbx-123",
+            44772,
+            resolve_internal=True,
+        )
+
+        assert endpoint.endpoint == "10.244.0.5:44772"
+        k8s_service.workload_provider.get_endpoint_info.assert_called_once_with(
+            k8s_service.workload_provider.get_workload.return_value,
+            44772,
+            "sbx-123",
+            resolve_internal=True,
+        )
+
     def test_get_endpoint_merges_egress_auth_header_for_egress_api_port(
         self, k8s_service
     ):

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -465,12 +465,24 @@ class TestKubernetesSandboxServiceCreate:
         }
 
     def test_get_endpoint_passes_resolve_internal_to_provider(self, k8s_service):
-        k8s_service.workload_provider.get_workload.return_value = {
-            "metadata": {"annotations": {}}
-        }
-        k8s_service.workload_provider.get_endpoint_info.return_value = Endpoint(
-            endpoint="10.244.0.5:44772",
-        )
+        calls = []
+
+        class InternalProvider:
+            @staticmethod
+            def get_workload(sandbox_id, namespace):
+                return {"metadata": {"annotations": {}}}
+
+            @staticmethod
+            def get_endpoint_info(
+                workload,
+                port,
+                sandbox_id,
+                resolve_internal=False,
+            ):
+                calls.append((workload, port, sandbox_id, resolve_internal))
+                return Endpoint(endpoint="10.244.0.5:44772")
+
+        k8s_service.workload_provider = InternalProvider()
 
         endpoint = k8s_service.get_endpoint(
             "sbx-123",
@@ -479,12 +491,67 @@ class TestKubernetesSandboxServiceCreate:
         )
 
         assert endpoint.endpoint == "10.244.0.5:44772"
-        k8s_service.workload_provider.get_endpoint_info.assert_called_once_with(
-            k8s_service.workload_provider.get_workload.return_value,
-            44772,
-            "sbx-123",
-            resolve_internal=True,
-        )
+        assert calls == [({"metadata": {"annotations": {}}}, 44772, "sbx-123", True)]
+
+    def test_get_endpoint_supports_legacy_provider_without_internal_resolution(
+        self, k8s_service
+    ):
+        class LegacyProvider:
+            @staticmethod
+            def get_workload(sandbox_id, namespace):
+                return {"metadata": {"annotations": {}}}
+
+            @staticmethod
+            def get_endpoint_info(workload, port, sandbox_id):
+                return Endpoint(endpoint="gateway.example.com")
+
+        k8s_service.workload_provider = LegacyProvider()
+
+        endpoint = k8s_service.get_endpoint("sbx-123", 44772)
+
+        assert endpoint.endpoint == "gateway.example.com"
+
+    def test_get_endpoint_rejects_legacy_provider_for_internal_resolution(
+        self, k8s_service
+    ):
+        class LegacyProvider:
+            @staticmethod
+            def get_workload(sandbox_id, namespace):
+                return {"metadata": {"annotations": {}}}
+
+            @staticmethod
+            def get_endpoint_info(workload, port, sandbox_id):
+                return Endpoint(endpoint="gateway.example.com")
+
+        k8s_service.workload_provider = LegacyProvider()
+
+        with pytest.raises(HTTPException) as exc_info:
+            k8s_service.get_endpoint("sbx-123", 44772, resolve_internal=True)
+
+        assert exc_info.value.status_code == 501
+        assert exc_info.value.detail["code"] == SandboxErrorCodes.API_NOT_SUPPORTED
+
+    def test_get_endpoint_treats_kwargs_provider_as_internal_resolution_capable(
+        self, k8s_service
+    ):
+        calls = []
+
+        class KwargsProvider:
+            @staticmethod
+            def get_workload(sandbox_id, namespace):
+                return {"metadata": {"annotations": {}}}
+
+            @staticmethod
+            def get_endpoint_info(workload, port, sandbox_id, **kwargs):
+                calls.append(kwargs)
+                return Endpoint(endpoint="10.244.0.5:44772")
+
+        k8s_service.workload_provider = KwargsProvider()
+
+        endpoint = k8s_service.get_endpoint("sbx-123", 44772, resolve_internal=True)
+
+        assert endpoint.endpoint == "10.244.0.5:44772"
+        assert calls == [{"resolve_internal": True}]
 
     def test_get_endpoint_merges_egress_auth_header_for_egress_api_port(
         self, k8s_service

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -238,7 +238,7 @@ def test_proxy_root_path_forwards_endpoint_headers_and_query(
     assert lowered_headers["x-trace"] == "trace-root"
 
 
-def test_proxy_does_not_auto_inject_secure_access_header(
+def test_proxy_does_not_replace_client_secure_access_header(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -266,7 +266,11 @@ def test_proxy_does_not_auto_inject_secure_access_header(
     response = client.get(
         "/v1/sandboxes/sbx-123/proxy/44772",
         params={"q": "search"},
-        headers={**auth_headers, "X-Trace": "trace-root"},
+        headers={
+            **auth_headers,
+            "X-Trace": "trace-root",
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token",
+        },
     )
 
     assert response.status_code == 200
@@ -274,7 +278,133 @@ def test_proxy_does_not_auto_inject_secure_access_header(
         key.lower(): value for key, value in fake_client.built["headers"].items()
     }
     assert lowered_headers["opensandbox-ingress-to"] == "sbx-123-44772"
-    assert OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower() not in lowered_headers
+    assert lowered_headers[OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower()] == "secure-token"
+
+
+def test_proxy_rejects_missing_secure_access_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/base",
+                headers={OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token"},
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 401
+    assert fake_client.built is None
+
+
+def test_proxy_rejects_invalid_secure_access_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/base",
+                headers={OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token"},
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        headers={
+            **auth_headers,
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "wrong-token",
+        },
+    )
+
+    assert response.status_code == 401
+    assert fake_client.built is None
+
+
+def test_proxy_validates_secure_access_endpoint_header_case_insensitively(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/base",
+                headers={OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower(): "secure-token"},
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        headers={
+            **auth_headers,
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token",
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_client.built is not None
+
+
+def test_proxy_does_not_schedule_renew_before_secure_access_validation(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/base",
+                headers={OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token"},
+            )
+
+    class StubRenew:
+        def __init__(self):
+            self.scheduled: list[str] = []
+
+        def schedule(self, sandbox_id: str) -> None:
+            self.scheduled.append(sandbox_id)
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    fake_client = _FakeAsyncClient()
+    _set_http_client(client, fake_client)
+    renew = StubRenew()
+    client.app.state.proxy_renew_coordinator = renew
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 401
+    assert renew.scheduled == []
 
 
 def test_proxy_forwards_client_supplied_secure_access_header(
@@ -306,7 +436,7 @@ def test_proxy_forwards_client_supplied_secure_access_header(
         "/v1/sandboxes/sbx-123/proxy/44772",
         headers={
             **auth_headers,
-            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "client-token",
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "server-side-token",
         },
     )
 
@@ -314,7 +444,7 @@ def test_proxy_forwards_client_supplied_secure_access_header(
     lowered_headers = {
         key.lower(): value for key, value in fake_client.built["headers"].items()
     }
-    assert lowered_headers[OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower()] == "client-token"
+    assert lowered_headers[OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower()] == "server-side-token"
 
 
 def test_proxy_forwards_get_request_with_query_params(
@@ -574,6 +704,35 @@ def test_proxy_websocket_relays_messages_and_forwards_safe_headers(
     assert "origin" not in lowered_headers
     assert lowered_headers["opensandbox-ingress-to"] == "sbx-123-44772"
     assert lowered_headers["x-trace"] == "trace-ws"
+
+
+def test_proxy_websocket_rejects_missing_secure_access_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/proxy/44772",
+                headers={OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token"},
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    backend = _FakeBackendWebSocket()
+    connector = _FakeWebSocketConnector(backend)
+    monkeypatch.setattr(proxy_api.websockets, "connect", connector)
+
+    with client.websocket_connect(
+        "/v1/sandboxes/sbx-123/proxy/44772/ws",
+        headers=auth_headers,
+    ) as websocket:
+        message = websocket.receive()
+
+    assert message["type"] == "websocket.close"
+    assert connector.calls == []
 
 
 def test_proxy_maps_connect_error_to_502(


### PR DESCRIPTION
## Summary
- thread resolve_internal through Kubernetes workload endpoint providers
- keep gateway ingress endpoints as the default public endpoint in gateway mode
- bypass gateway formatting for server-proxy backend resolution so BatchSandbox and agent-sandbox use internal pod/service endpoints

Fixes #1096

## Tests
- uv run pytest tests/k8s/test_kubernetes_service.py tests/k8s/test_batchsandbox_provider.py tests/k8s/test_agent_sandbox_provider.py
- uv run ruff check opensandbox_server/services/k8s/workload_provider.py opensandbox_server/services/k8s/kubernetes_service.py opensandbox_server/services/k8s/batchsandbox_provider.py opensandbox_server/services/k8s/agent_sandbox_provider.py tests/k8s/test_kubernetes_service.py tests/k8s/test_batchsandbox_provider.py tests/k8s/test_agent_sandbox_provider.py
- git diff --check