### PR TITLE
fix(egress): increase upstream DNS UDP buffer

### DIFF
--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -234,11 +234,16 @@ func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
 	list := p.forwardUpstreams()
 	var lastErr error
 	for _, upstream := range list {
+		query := r.Copy()
+		if query.IsEdns0() == nil {
+			query.SetEdns0(4096, false)
+		}
 		c := &dns.Client{
 			Timeout: p.upstreamExchangeTimeout,
 			Dialer:  p.dialerForUpstream(upstream),
+			UDPSize: 4096,
 		}
-		resp, _, err := c.Exchange(r, upstream)
+		resp, _, err := c.Exchange(query, upstream)
 		if err != nil {
 			lastErr = err
 			log.Warnf("[dns] upstream %s exchange error: %v", upstream, err)

--- a/components/egress/pkg/dnsproxy/proxy.go
+++ b/components/egress/pkg/dnsproxy/proxy.go
@@ -234,14 +234,15 @@ func (p *Proxy) forward(r *dns.Msg) (*dns.Msg, error) {
 	list := p.forwardUpstreams()
 	var lastErr error
 	for _, upstream := range list {
+		const upstreamUDPSize = 4096
 		query := r.Copy()
 		if query.IsEdns0() == nil {
-			query.SetEdns0(4096, false)
+			query.SetEdns0(upstreamUDPSize, false)
 		}
 		c := &dns.Client{
 			Timeout: p.upstreamExchangeTimeout,
 			Dialer:  p.dialerForUpstream(upstream),
-			UDPSize: 4096,
+			UDPSize: upstreamUDPSize,
 		}
 		resp, _, err := c.Exchange(query, upstream)
 		if err != nil {

--- a/components/egress/pkg/dnsproxy/proxy_test.go
+++ b/components/egress/pkg/dnsproxy/proxy_test.go
@@ -82,6 +82,44 @@ func TestExtractResolvedIPs_EmptyOrNil(t *testing.T) {
 	require.Nil(t, extractResolvedIPs(msg), "CNAME only: expected nil")
 }
 
+func TestForwardAddsEDNS0BufferSize(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	seen := make(chan uint16, 1)
+	server := &dns.Server{
+		PacketConn: conn,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			opt := r.IsEdns0()
+			require.NotNil(t, opt)
+			seen <- opt.UDPSize()
+
+			resp := new(dns.Msg)
+			resp.SetReply(r)
+			resp.Answer = []dns.RR{
+				&dns.A{Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: net.ParseIP("1.2.3.4")},
+			}
+			_ = w.WriteMsg(resp)
+		}),
+	}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	proxy := &Proxy{
+		upstreams:               []string{conn.LocalAddr().String()},
+		activeUpstreams:         []string{conn.LocalAddr().String()},
+		upstreamExchangeTimeout: time.Second,
+	}
+	query := new(dns.Msg)
+	query.SetQuestion("example.com.", dns.TypeA)
+
+	resp, err := proxy.forward(query)
+	require.NoError(t, err)
+	require.Len(t, resp.Answer, 1)
+	require.Equal(t, uint16(4096), <-seen)
+}
+
 func TestSetOnResolved(t *testing.T) {
 	proxy, err := New(policy.DefaultDenyPolicy(), "", nil, nil)
 	require.NoError(t, err)

--- a/components/egress/pkg/dnsproxy/proxy_test.go
+++ b/components/egress/pkg/dnsproxy/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/nftables"
 	"github.com/alibaba/opensandbox/egress/pkg/policy"
 )
@@ -83,6 +84,10 @@ func TestExtractResolvedIPs_EmptyOrNil(t *testing.T) {
 }
 
 func TestForwardAddsEDNS0BufferSize(t *testing.T) {
+	t.Cleanup(func() { resetNameserverExemptCache(t) })
+	t.Setenv(constants.EnvNameserverExempt, "127.0.0.1")
+	resetNameserverExemptCache(t)
+
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })


### PR DESCRIPTION
## Summary

Increase the egress DNS proxy upstream UDP buffer handling by:

- adding EDNS0 with UDP payload size `4096` when forwarding DNS queries upstream if the client query does not already include EDNS0
- setting `dns.Client.UDPSize` to `4096`
- adding regression coverage that verifies forwarded upstream queries include EDNS0 size `4096`

This follows the same miekg/dns fix pattern used by:

- https://github.com/netbirdio/netbird/pull/3441
- https://github.com/nange/easyss/pull/23

## Context

While running OpenSandbox egress with `dns+nft` mode in Kubernetes, package-manager traffic through `packages.microsoft.com` intermittently failed. The sandbox-side symptom was `tdnf` reporting `Error(1208): Could not connect to server` during metadata refresh or package downloads.

The egress sidecar logged DNS upstream failures from CoreDNS:

```text
[dns] upstream 10.0.0.10:53 exchange error: dns: buffer size too small
```

The current proxy forwards upstream DNS with `miekg/dns.Client.Exchange` using default UDP sizing. When CoreDNS returns a response larger than the default UDP read buffer, miekg/dns can surface `buffer size too small`, causing the proxy to return `SERVFAIL` to the workload.

## Reproduction

The easiest reproduction we found was repeated Azure Linux metadata refreshes from a sandbox with egress policy allowing `packages.microsoft.com`:

```sh
for i in $(seq 1 20); do
  tdnf clean metadata >/dev/null 2>&1 || true
  tdnf makecache || exit 1
done
```

With `opensandbox/egress:v1.1.1`, this intermittently reproduced the error above. After building this patch into an egress image and configuring the server to use it, the same 20-iteration loop completed successfully and egress logs contained normal `packages.microsoft.com` DNS outbound entries without `buffer size too small`.

A non-`tdnf` way to see the size condition is querying CoreDNS directly. In our cluster, the same host response is below 512 bytes without EDNS, but with EDNS the response can exceed the classic DNS UDP payload size:

```sh
dig @10.0.0.10 packages.microsoft.com A +noedns +stats +comments +nocmd
# MSG SIZE rcvd: 268

dig @10.0.0.10 packages.microsoft.com A +bufsize=4096 +stats +comments +nocmd
# MSG SIZE rcvd: 540
```

## Validation

```sh
cd components/egress
go test ./...
```

Also validated in a Kubernetes OpenSandbox deployment by publishing a patched egress image and rerunning the `tdnf makecache` reproduction loop.
