### PR TITLE
docs(server): streamline AGENTS.md and DEVELOPMENT.md

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,96 +1,46 @@
 # Server AGENTS
 
-You are working on the OpenSandbox lifecycle server. Keep the route layer thin and put behavior in services, validators, repositories, or runtime helpers.
+OpenSandbox lifecycle server. Routes thin — logic in services/validators/repositories/runtime helpers.
 
 ## Scope
 
-- `opensandbox_server/**`
-- `tests/**`
-- `configuration.md`, `docker-compose.example.yaml`, and other server-facing docs/examples
+`opensandbox_server/**`, `tests/**`, `configuration.md`, `docker-compose.example.yaml`.
 
-If the task changes lifecycle API contracts in `../specs/sandbox-lifecycle.yml`, also read `../specs/AGENTS.md`.
-If the task changes Kubernetes runtime behavior, also read `../kubernetes/AGENTS.md`.
+Cross-cutting: specs changes → read `../specs/AGENTS.md`; K8s runtime → read `../kubernetes/AGENTS.md`.
 
 ## Key Paths
 
-- `opensandbox_server/cli.py`: `opensandbox-server` CLI entry point and config initialization
-- `opensandbox_server/main.py`: FastAPI app entry point and startup wiring
-- `opensandbox_server/api/`: FastAPI routes and request/response schemas
-- `opensandbox_server/services/`: business logic and runtime integration
-- `opensandbox_server/services/docker/`: Docker runtime, endpoints, port allocation, diagnostics, and snapshot runtime
-- `opensandbox_server/services/k8s/`: Kubernetes providers, templates, informer, egress, pool, diagnostics, and pause/resume runtime integration
-- `opensandbox_server/repositories/`: persistence backends, including snapshot metadata
-- `opensandbox_server/integrations/`: optional external integrations
-- `opensandbox_server/extensions/`: extension loading and optional behavior hooks
-- `opensandbox_server/middleware/`: authentication and request middleware
-- `opensandbox_server/config.py`: TOML config model, defaults, validation, and environment integration
-- `tests/`: unit, integration, smoke, and Kubernetes-focused tests
+| Path | Role |
+|------|------|
+| `opensandbox_server/cli.py` | CLI entry point, config init |
+| `opensandbox_server/main.py` | FastAPI app entry, startup wiring |
+| `opensandbox_server/config.py` | TOML config model, defaults, validation |
+| `opensandbox_server/api/` | Routes and request/response schemas |
+| `opensandbox_server/services/` | Business logic and runtime integration |
+| `opensandbox_server/services/docker/` | Docker runtime, endpoints, ports, diagnostics, snapshots |
+| `opensandbox_server/services/k8s/` | K8s providers, templates, informer, egress, pool, pause/resume |
+| `opensandbox_server/repositories/` | Persistence backends, snapshot metadata |
+| `opensandbox_server/integrations/` | Optional external integrations |
+| `opensandbox_server/extensions/` | Extension loading and behavior hooks |
+| `opensandbox_server/middleware/` | Auth and request middleware |
+| `tests/` | Unit, integration, smoke, K8s tests |
 
 ## Commands
 
-Setup and focused checks:
-
 ```bash
 cd server
-uv sync --all-groups
-uv run ruff check
-uv run pytest tests/test_docker_service.py
-uv run pytest tests/test_schema.py
-```
-
-Kubernetes-focused checks:
-
-```bash
-cd server
-uv run pytest tests/k8s
-uv run pytest tests/test_routes_pause_resume.py tests/test_routes_snapshots.py tests/test_snapshot_service.py
-```
-
-Typed or broader validation:
-
-```bash
-cd server
-uv run pyright
-uv run pytest
-```
-
-Local startup:
-
-```bash
-cd server
-uv run opensandbox-server init-config ~/.sandbox.toml --example docker
-uv run python -m opensandbox_server.main
-```
-
-Smoke path when Docker is available:
-
-```bash
-cd server
-chmod +x tests/smoke.sh
-./tests/smoke.sh
+uv sync --all-groups          # setup
+uv run ruff check             # lint
+uv run pytest tests/test_docker_service.py   # focused test
+uv run pytest tests/k8s       # k8s tests
+uv run pyright                # type check
+uv run pytest                 # full suite
 ```
 
 ## Guardrails
 
-Always:
+**Always:** routes thin, runtime-specific logic in docker/k8s modules, snapshot state coordinated across layers, config defaults/examples/docs aligned, extend existing fixtures, regression tests with every fix.
 
-- Keep FastAPI routes thin and delegate behavior to services, validators, or runtime helpers.
-- Keep runtime-specific behavior in Docker/Kubernetes service modules; shared API behavior belongs in common services or validators.
-- Keep snapshot state changes coordinated across route handlers, services, repositories, and runtime-specific snapshot implementations.
-- Keep TOML config defaults, config examples, README/configuration docs, and CLI `init-config` output aligned.
-- Extend existing fixtures and helpers before adding parallel abstractions.
-- Add focused regression tests with every bug fix or behavior change.
+**Ask first:** removing/renaming endpoints, config shape changes, new external deps, snapshot/pause/resume/egress/pool semantics changes, large reorgs.
 
-Ask first:
-
-- Removing or renaming public endpoints
-- Changing config shape or defaults in a user-visible way
-- Introducing new external service dependencies
-- Changing snapshot, pause/resume, renew-intent, ingress, egress, or pool semantics
-- Large reorganizations across `api/`, `services/`, and `tests/`
-
-Never:
-
-- Put business logic directly in route handlers.
-- Change public server behavior without tests.
-- Assume Docker-only behavior is harmless for Kubernetes paths.
+**Never:** business logic in route handlers, behavior changes without tests, assume Docker-only is safe for K8s paths.

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/server/DEVELOPMENT.md
+++ b/server/DEVELOPMENT.md
@@ -1,371 +1,95 @@
 # Development Guide
 
-This guide provides comprehensive information for developers working on OpenSandbox Server, including environment setup, architecture deep-dive, testing strategies, and contribution workflows.
+## Setup
 
-## 📋 Table of Contents
-
-- [Development Environment Setup](#development-environment-setup)
-- [Project Structure](#project-structure)
-- [Architecture Deep Dive](#architecture-deep-dive)
-- [Development Workflow](#development-workflow)
-- [Testing Guide](#testing-guide)
-- [Working with Docker Runtime](#working-with-docker-runtime)
-- [Working with Kubernetes Runtime](#working-with-kubernetes-runtime)
-- [Code Style and Standards](#code-style-and-standards)
-- [Debugging](#debugging)
-- [Performance Optimization](#performance-optimization)
-- [Contributing](#contributing)
-
-## Development Environment Setup
-
-### Prerequisites
-
-- **Python 3.10+**: Check version with `python --version`
-- **uv**: Install from [https://github.com/astral-sh/uv](https://github.com/astral-sh/uv)
-- **Docker**: For local development and testing
-- **Git**: Version control
-- **IDE**: VS Code, PyCharm, or Cursor (recommended for AI assistance)
-
-### Initial Setup
-
-1. **Clone and Navigate**
-   ```bash
-   git clone https://github.com/alibaba/OpenSandbox.git
-   cd OpenSandbox/server
-   ```
-
-2. **Install Dependencies**
-   ```bash
-   uv sync
-   ```
-
-3. **Verify Installation**
-   ```bash
-   uv run python -c "import fastapi; print(fastapi.__version__)"
-   ```
-
-4. **Configure Development Environment**
-   ```bash
-   cp opensandbox_server/examples/example.config.toml ~/.sandbox.toml
-   ```
-
-   Edit `~/.sandbox.toml` for local development:
-   ```toml
-   [server]
-   host = "0.0.0.0"
-   port = 8080
-   api_key = "your-secret-api-key-change-this"
-
-   [log]
-   level = "DEBUG"
-
-   [runtime]
-   type = "docker"
-   execd_image = "opensandbox/execd:v1.0.19"
-
-   [docker]
-   network_mode = "host"
-   ```
-
-5. **Run Development Server**
-   ```bash
-   uv run python -m opensandbox_server.main
-   ```
-
-### IDE Configuration
-
-#### VS Code / Cursor
-
-Create `.vscode/launch.json`:
-
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: FastAPI",
-            "type": "python",
-            "request": "launch",
-            "module": "opensandbox_server.main",
-            "justMyCode": false,
-            "env": {
-                "SANDBOX_CONFIG_PATH": "${workspaceFolder}/.sandbox.toml"
-            }
-        }
-    ]
-}
+```bash
+cd OpenSandbox/server
+uv sync --all-groups
+cp opensandbox_server/examples/example.config.toml ~/.sandbox.toml
+# Edit ~/.sandbox.toml as needed
+uv run python -m opensandbox_server.main
 ```
 
-#### PyCharm
+Example dev config:
 
-1. Open project in PyCharm
-2. Configure Python interpreter: **Settings → Project → Python Interpreter**
-3. Select the virtual environment created by `uv sync`
-4. Enable pytest: **Settings → Tools → Python Integrated Tools → Testing → pytest**
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+api_key = "your-secret-api-key-change-this"
 
-## Project Structure
+[log]
+level = "DEBUG"
 
-```
-server/
-├── opensandbox_server/           # Source code
-│   ├── main.py                   # FastAPI application entry point
-│   ├── config.py                 # Configuration management
-│   ├── api/                      # API layer
-│   │   ├── lifecycle.py          # Sandbox lifecycle routes
-│   │   └── schema.py             # Pydantic models
-│   ├── middleware/               # Middleware components
-│   │   └── auth.py               # API Key authentication
-│   └── services/                 # Business logic layer
-│       ├── sandbox_service.py    # Abstract base class
-│       ├── docker.py             # Docker implementation
-│       └── factory.py            # Service factory
-├── tests/                        # Test suite
-├── scripts/                      # Utility scripts
-├── pyproject.toml                # Project metadata and dependencies
-└── example.config.toml           # Example configuration
+[runtime]
+type = "docker"
+execd_image = "opensandbox/execd:v1.0.19"
+
+[docker]
+network_mode = "bridge"
 ```
 
-## Architecture Deep Dive
+## Testing
 
-### Layered Architecture
+Docker daemon required for integration tests.
 
-The server follows a clean layered architecture:
+```bash
+uv run pytest                                    # full suite
+uv run pytest tests/test_docker_service.py       # single file
+uv run pytest tests/k8s                          # k8s tests
+uv run ruff check                                # lint
+uv run pyright                                   # type check
+uv run pytest --cov=opensandbox_server --cov-report=term  # with coverage
+```
 
-1. **HTTP Layer** (FastAPI routes) - Request validation and response serialization
-2. **Middleware Layer** - Authentication and cross-cutting concerns
-3. **Service Layer** - Business logic abstraction
-4. **Runtime Implementation Layer** - Docker/Kubernetes specific code
+## Architecture
 
-### Request Flow
+Layered architecture:
 
-#### Create Sandbox (Async)
+1. **HTTP Layer** — FastAPI routes, request validation, response serialization
+2. **Middleware Layer** — authentication, cross-cutting concerns
+3. **Service Layer** — business logic abstraction (`sandbox_service.py`, `snapshot_service.py`, etc.)
+4. **Runtime Layer** — Docker (`services/docker/`) and Kubernetes (`services/k8s/`) implementations
+
+### Request Flow: Create Sandbox
 
 ```
 Client → POST /sandboxes
-  ↓
-Auth Middleware validates API key
-  ↓
-lifecycle.create_sandbox() receives CreateSandboxRequest
-  ↓
-sandbox_service.create_sandbox_async(request)
-  ↓
-Returns 202 Accepted with Pending status immediately
-  ↓
-Background thread provisions the sandbox
+  → Auth Middleware validates API key
+  → lifecycle.create_sandbox() receives CreateSandboxRequest
+  → sandbox_service.create_sandbox_async(request)
+  → Returns 202 Accepted with Pending status immediately
+  → Background thread provisions the sandbox
 ```
 
-### Internal Systems
+Async provisioning avoids blocking API requests during slow operations (image pull, container start). Sandbox stored in pending state first, transitions to running when ready.
 
-#### Expiration Timer System
+### Expiration System
 
-Tracks sandbox timeouts using in-memory data structures:
-- `_sandbox_expirations: Dict[str, datetime]` - Expiration times
-- `_expiration_timers: Dict[str, Timer]` - Active timer threads
-- `_expiration_lock: Lock` - Thread synchronization
+In-memory timer tracking per sandbox. On timeout, sandbox is cleaned up automatically. Timers synchronized via lock for thread safety.
 
-#### Async Provisioning System
-
-Avoids blocking API requests during slow operations by:
-1. Storing sandboxes in pending state
-2. Starting background provisioning thread
-3. Returning 202 Accepted immediately
-4. Transitioning to running state when ready
-
-## Development Workflow
-
-### Feature Development
-
-```bash
-git checkout -b feature/my-feature
-# Implement feature
-uv run pytest
-git commit -m "feat: add my feature"
-git push origin feature/my-feature
-```
-
-### Bug Fixes
-
-```bash
-git checkout -b fix/bug-description
-# Write failing test
-# Fix bug
-uv run pytest
-git commit -m "fix: resolve bug"
-```
-
-## Testing Guide
-
-### Running Tests
-> **Note**: A local Docker daemon is required to run the full test suite, as integration tests interact with the Docker Engine.
-
-```bash
-# All tests
-uv run pytest
-
-# Specific file
-uv run pytest tests/test_docker_service.py
-
-# With coverage
-uv run pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80
-```
-
-### Writing Tests
-
-Example unit test:
-
-```python
-@patch("opensandbox_server.services.docker.docker")
-def test_create_sandbox_validates_entrypoint(mock_docker):
-    service = DockerSandboxService(config=test_config())
-    request = CreateSandboxRequest(
-        image=ImageSpec(uri="python:3.11"),
-        timeout=120,
-        entrypoint=[]  # Invalid
-    )
-    with pytest.raises(HTTPException):
-        service.create_sandbox(request)
-```
-
-## Working with Docker Runtime
-
-### Local Development
-
-```bash
-# Use local Docker
-export DOCKER_HOST="unix:///var/run/docker.sock"
-uv run python -m opensandbox_server.main
-
-# Use remote Docker
-export DOCKER_HOST="ssh://user@remote-host"
-uv run python -m opensandbox_server.main
-```
+## Docker Runtime
 
 ### Network Modes
 
-**Host Mode (Default):**
-- Sandboxes share host network
-- Direct port access
-- Endpoint format: `http://{domain}/{sandbox_id}/{port}`
+**Bridge (recommended):** isolated networks, HTTP proxy for routing.
+- Endpoint: `http://{server}/route/{sandbox_id}/{port}/path`
 
-**Bridge Mode:**
-- Isolated networks
-- HTTP proxy required
-- Endpoint format: `http://{server}/route/{sandbox_id}/{port}/path`
-
-### Egress sidecar (bridge + `networkPolicy`)
-
-- Config: set `[egress].image`; sidecar starts only when the request carries `networkPolicy`. Requires Docker `network_mode="bridge"`.
-- Network & privileges: main container shares the sidecar netns (`network_mode=container:<sidecar>`); main container explicitly drops `NET_ADMIN`; sidecar keeps `NET_ADMIN` to manage iptables / DNS transparent redirect.
-- Ports: host port bindings live on the sidecar; main container labels record the mapped ports for upstream endpoint resolution.
-- Lifecycle: on create failure / delete / expiration / abnormal recovery, the sidecar is cleaned up; startup also removes orphaned sidecars.
-- Injection: `OPENSANDBOX_EGRESS_RULES` env passes the `networkPolicy` JSON; sidecar image is pulled/ensured before start.
-
-## Working with Kubernetes Runtime
-
-> **Status:** Planned / Configuration Ready
-
-Architecture will include:
-- Pod management with execd init container
-- Service/Ingress for networking
-- CronJob or operator for expiration handling
-
-## Code Style and Standards
-
-Follow PEP 8 with Ruff enforcement:
+**Host:** sandboxes share host network, direct port access. Not recommended — no network isolation.
+- Endpoint: `http://{domain}/{sandbox_id}/{port}`
 
 ```bash
-uv run ruff check opensandbox_server tests
+# Local Docker
+export DOCKER_HOST="unix:///var/run/docker.sock"
+
+# Remote Docker
+export DOCKER_HOST="ssh://user@remote-host"
 ```
 
-### Naming Conventions
+### Egress Sidecar (bridge + `networkPolicy`)
 
-- Functions: `snake_case`
-- Classes: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Private: `_leading_underscore`
-
-### Type Hints
-
-Always use type hints:
-
-```python
-def get_sandbox(self, sandbox_id: str) -> Sandbox:
-    pass
-```
-
-## Debugging
-
-### Enable Debug Logging
-
-```toml
-[log]
-level = "DEBUG"
-```
-
-### Interactive Debugging
-
-Use VS Code/Cursor breakpoints or:
-
-```python
-breakpoint()  # Python 3.7+
-```
-
-### Docker Debugging
-
-```python
-import logging
-logging.getLogger("docker").setLevel(logging.DEBUG)
-```
-
-## Performance Optimization
-
-### Profiling
-
-```bash
-python -m cProfile -o profile.stats -m opensandbox_server.main
-```
-
-### Optimization Tips
-
-1. **Async Operations**: Use async provisioning to avoid blocking
-2. **Connection Pooling**: Reuse Docker client connections
-3. **Caching**: Cache configuration and frequently accessed data
-4. **Resource Limits**: Set appropriate container resource limits
-5. **Monitoring**: Track container creation/deletion metrics
-
-## Contributing
-
-### Pull Request Process
-
-1. Fork the repository
-2. Create feature branch from `main`
-3. Write tests for new functionality
-4. Ensure all tests pass: `uv run pytest`
-5. Run linter: `uv run ruff check`
-6. Write clear commit messages
-7. Submit PR with description
-
-### Code Review Guidelines
-
-- Focus on readability and maintainability
-- Ensure test coverage for new code
-- Check for proper error handling
-- Verify documentation updates
-- Test Docker and potential Kubernetes compatibility
-
-### Commit Message Format
-
-```
-<type>: <description>
-
-Types: feat, fix, docs, style, refactor, test, chore
-```
-
-Examples:
-- `feat: add Kubernetes runtime support`
-- `fix: resolve expiration timer memory leak`
-- `docs: update API documentation`
-
----
-
-For questions or support, please open an issue on the project repository.
+- Config: set `[egress].image`; sidecar starts only when request carries `networkPolicy`. Requires `network_mode="bridge"`.
+- Network: main container shares sidecar netns (`network_mode=container:<sidecar>`); main drops `NET_ADMIN`; sidecar keeps `NET_ADMIN` for iptables/DNS redirect.
+- Ports: host port bindings on sidecar; main container labels record mapped ports for endpoint resolution.
+- Lifecycle: sidecar cleaned up on create failure / delete / expiration / abnormal recovery; startup removes orphaned sidecars.
+- Injection: `OPENSANDBOX_EGRESS_RULES` env passes `networkPolicy` JSON; sidecar image pulled before start.


### PR DESCRIPTION
## Summary

- Streamline `server/AGENTS.md`: convert key paths to table format, compress guardrails into dense paragraphs (97 → 46 lines)
- Streamline `server/DEVELOPMENT.md`: remove outdated project structure tree, stale "Planned" K8s roadmap, generic boilerplate (IDE config, naming conventions, debugging/profiling, contributing workflow), keep architecture overview and Docker runtime specifics (372 → 83 lines)
- Recommend bridge network mode over host mode in examples and docs
- Add `server/CLAUDE.md` symlink pointing to `AGENTS.md`

## Test plan

- [ ] Verify all paths listed in AGENTS.md still exist
- [ ] Verify CLAUDE.md symlink resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)