### PR TITLE
fix(docs): redirect legacy /zh and overview URLs after #1090 refactor

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -10,7 +10,6 @@ const router = useRouter();
 // The #1090 refactor removed the Chinese i18n locale and the legacy
 // `overview/*` / `*/readme` URL scheme. Old bookmarks and search results
 // still point at those paths, so map them to the new structure on 404.
-// Anything we can't map falls back to the home page.
 const EXACT: Record<string, string> = {
   "/overview/home": "/",
   "/overview/architecture": "/architecture/",
@@ -20,20 +19,29 @@ const EXACT: Record<string, string> = {
   "/kubernetes/development": "/kubernetes/deployment",
 };
 
+// Returns a base-relative best-effort target for a 404 path. The result may
+// itself not exist; the caller falls back to the home page only once a fully
+// cleaned path still 404s, so legacy URLs that match a current page (e.g.
+// /zh/community/contributing) reach it instead of collapsing to home.
 function resolveLegacy(rawPath: string): string {
-  let p = rawPath.replace(/\.html$/, "").replace(/\/$/, "").toLowerCase();
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  let p = rawPath.slice(base.length).replace(/\.html$/, "").replace(/\/$/, "").toLowerCase();
   p = p.replace(/^\/zh(?=\/|$)/, "");
   if (p === "" || p === "/") return "/";
   if (EXACT[p]) return EXACT[p];
   if (p.startsWith("/oseps/")) return "/community/oseps";
-  const stripped = p.replace(/\/(readme|development)$/, "");
-  if (stripped !== p) return stripped;
-  return "/";
+  p = p.replace("/sdks/sandbox/", "/sdks/").replace(/\/(readme|development)$/, "");
+  return p || "/";
 }
 
 function maybeRedirect() {
   if (!page.value.isNotFound) return;
   const target = resolveLegacy(window.location.pathname);
+  // Avoid looping when an already-clean path still 404s; send it home.
+  if (withBase(target) === window.location.pathname) {
+    if (target !== "/") router.go(withBase("/"));
+    return;
+  }
   router.go(withBase(target));
 }
 

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -20,6 +20,7 @@ const EXACT: Record<string, string> = {
   "/single_host_network": "/architecture/single-host-network",
   "/kubernetes/development": "/kubernetes/deployment",
   "/server/readme": "/components/server",
+  "/server/development": "/components/server",
   "/specs/readme": "/api/",
   "/secure-container": "/guides/secure-container",
   "/pause-resume": "/guides/pause-resume",
@@ -37,8 +38,14 @@ function resolveLegacy(rawPath: string): string {
   if (p === "" || p === "/") return "/";
   if (EXACT[p]) return EXACT[p];
   if (p.startsWith("/oseps/")) return "/community/oseps";
-  // Collapse any nested legacy SDK route (incl. the old /sdks/sandbox/* and
-  // /sdks/mcp/* variants) to its top-level page, e.g. /sdks/kotlin, /sdks/mcp.
+  // Nested Kubernetes pages (charts, examples) all consolidated under /kubernetes/.
+  if (p.startsWith("/kubernetes/")) return "/kubernetes/";
+  // Code-interpreter SDKs keep a per-language page; just drop the leaf suffix.
+  if (p.startsWith("/sdks/code-interpreter/")) {
+    return p.replace(/\/(readme|development)$/, "");
+  }
+  // Collapse other nested legacy SDK routes (incl. old /sdks/sandbox/* and
+  // /sdks/mcp/* variants) to their top-level page, e.g. /sdks/kotlin, /sdks/mcp.
   const sdk = p.match(/^\/sdks\/(?:sandbox\/)?([^/]+)\//);
   if (sdk) return `/sdks/${sdk[1]}`;
   p = p.replace("/sdks/sandbox/", "/sdks/").replace(/\/(readme|development)$/, "");

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -37,6 +37,10 @@ function resolveLegacy(rawPath: string): string {
   if (p === "" || p === "/") return "/";
   if (EXACT[p]) return EXACT[p];
   if (p.startsWith("/oseps/")) return "/community/oseps";
+  // Collapse any nested legacy SDK route (incl. the old /sdks/sandbox/* and
+  // /sdks/mcp/* variants) to its top-level page, e.g. /sdks/kotlin, /sdks/mcp.
+  const sdk = p.match(/^\/sdks\/(?:sandbox\/)?([^/]+)\//);
+  if (sdk) return `/sdks/${sdk[1]}`;
   p = p.replace("/sdks/sandbox/", "/sdks/").replace(/\/(readme|development)$/, "");
   return p || "/";
 }

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import DefaultTheme from "vitepress/theme";
+import { useData, useRouter, withBase } from "vitepress";
+import { onMounted, watch } from "vue";
+
+const { Layout } = DefaultTheme;
+const { page } = useData();
+const router = useRouter();
+
+// The #1090 refactor removed the Chinese i18n locale and the legacy
+// `overview/*` / `*/readme` URL scheme. Old bookmarks and search results
+// still point at those paths, so map them to the new structure on 404.
+// Anything we can't map falls back to the home page.
+const EXACT: Record<string, string> = {
+  "/overview/home": "/",
+  "/overview/architecture": "/architecture/",
+  "/overview/credential-vault": "/guides/credential-vault",
+  "/overview/release-verification": "/community/release-verification",
+  "/design/single-host-network": "/architecture/single-host-network",
+  "/kubernetes/development": "/kubernetes/deployment",
+};
+
+function resolveLegacy(rawPath: string): string {
+  let p = rawPath.replace(/\.html$/, "").replace(/\/$/, "").toLowerCase();
+  p = p.replace(/^\/zh(?=\/|$)/, "");
+  if (p === "" || p === "/") return "/";
+  if (EXACT[p]) return EXACT[p];
+  if (p.startsWith("/oseps/")) return "/community/oseps";
+  const stripped = p.replace(/\/(readme|development)$/, "");
+  if (stripped !== p) return stripped;
+  return "/";
+}
+
+function maybeRedirect() {
+  if (!page.value.isNotFound) return;
+  const target = resolveLegacy(window.location.pathname);
+  router.go(withBase(target));
+}
+
+onMounted(maybeRedirect);
+watch(() => page.value.isNotFound, maybeRedirect);
+</script>
+
+<template>
+  <Layout />
+</template>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
-import { useData, useRouter, withBase } from "vitepress";
+import { useData, useRoute, useRouter, withBase } from "vitepress";
 import { onMounted, watch } from "vue";
 
 const { Layout } = DefaultTheme;
 const { page } = useData();
+const route = useRoute();
 const router = useRouter();
 
 // The #1090 refactor removed the Chinese i18n locale and the legacy
@@ -16,7 +17,13 @@ const EXACT: Record<string, string> = {
   "/overview/credential-vault": "/guides/credential-vault",
   "/overview/release-verification": "/community/release-verification",
   "/design/single-host-network": "/architecture/single-host-network",
+  "/single_host_network": "/architecture/single-host-network",
   "/kubernetes/development": "/kubernetes/deployment",
+  "/server/readme": "/components/server",
+  "/specs/readme": "/api/",
+  "/secure-container": "/guides/secure-container",
+  "/pause-resume": "/guides/pause-resume",
+  "/execd-path-migration": "/reference/execd-path-migration",
 };
 
 // Returns a base-relative best-effort target for a 404 path. The result may
@@ -46,7 +53,9 @@ function maybeRedirect() {
 }
 
 onMounted(maybeRedirect);
-watch(() => page.value.isNotFound, maybeRedirect);
+// Watch the path (not just isNotFound) so a redirect that lands on another
+// missing route re-evaluates and reaches the home fallback instead of sticking.
+watch(() => route.path, maybeRedirect);
 </script>
 
 <template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,10 @@
 import DefaultTheme from "vitepress/theme";
+import Layout from "./Layout.vue";
 import "./styles.css";
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  // Layout.vue redirects legacy /zh/* and overview/* URLs to the post-#1090
+  // structure before the default 404 renders.
+  Layout,
+};


### PR DESCRIPTION
# Summary
- The #1090 docs refactor removed the Chinese i18n locale and the legacy `overview/*` / `*/readme` URL scheme, moving the home page to root `/`. Old bookmarks and search-engine results (e.g. `/zh/overview/home`) now hit a dead 404 with no path forward.
- Adds `docs/.vitepress/theme/Layout.vue`: a wrapper around the default Layout that, on 404, maps legacy paths to the new structure and redirects; unmapped paths fall back to the home page. Real pages are untouched.

# Testing
- [x] e2e / manual verification — built with `pnpm docs:build`, served via `pnpm docs:preview`, and verified in a browser:
  - `/zh/overview/home` → `/`
  - `/zh/overview/architecture` → `/architecture/`
  - `/components/execd/readme` → `/components/execd`
  - `/oseps/0001-...` → `/community/oseps`
  - `/totally/bogus/path` → `/` (fallback)
  - `/getting-started/installation` → unchanged (no false positive)

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed) — N/A, docs-only redirect shim
- [x] Security impact considered
- [x] Backward compatibility considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)