### PR TITLE
fix(server): honor internal k8s proxy endpoint

### DIFF
--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -20,6 +20,7 @@ using Kubernetes resources for sandbox lifecycle management.
 """
 
 import asyncio
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -1313,6 +1314,20 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
             if expires is not None:
                 endpoint = self._build_signed_endpoint(sandbox_id, port, expires)
+            elif resolve_internal:
+                annotations = workload.get("metadata", {}).get("annotations", {})
+                raw_endpoints = annotations.get("sandbox.opensandbox.io/endpoints")
+                pod_ip = None
+                if raw_endpoints:
+                    try:
+                        endpoints = json.loads(raw_endpoints)
+                        if isinstance(endpoints, list) and endpoints:
+                            first_endpoint = endpoints[0]
+                            if isinstance(first_endpoint, str) and first_endpoint:
+                                pod_ip = first_endpoint
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        pod_ip = None
+                endpoint = Endpoint(endpoint=f"{pod_ip}:{port}") if pod_ip else None
             else:
                 endpoint = self.workload_provider.get_endpoint_info(workload, port, sandbox_id)
 

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -444,6 +444,27 @@ class TestKubernetesSandboxServiceCreate:
         assert response.platform.os == "linux"
         assert response.platform.arch == "arm64"
 
+    def test_get_endpoint_resolve_internal_uses_pod_ip_even_in_gateway_mode(
+        self, k8s_service
+    ):
+        k8s_service.workload_provider.get_workload.return_value = {
+            "metadata": {
+                "annotations": {
+                    "sandbox.opensandbox.io/endpoints": '["10.0.0.1"]',
+                }
+            }
+        }
+        k8s_service.workload_provider.get_endpoint_info.return_value = Endpoint(
+            endpoint="gateway.example.com",
+            headers={"OpenSandbox-Ingress-To": "sbx-123-44772"},
+        )
+
+        endpoint = k8s_service.get_endpoint("sbx-123", 44772, resolve_internal=True)
+
+        assert endpoint.endpoint == "10.0.0.1:44772"
+        assert endpoint.headers is None
+
+
     def test_get_endpoint_keeps_instance_egress_auth_header_private_for_workload_ports(
         self, k8s_service
     ):


### PR DESCRIPTION
## Summary
- honor `resolve_internal=True` for Kubernetes server-proxy endpoint resolution
- bypass gateway ingress formatting in that path and return the sandbox pod IP instead
- add focused regression coverage for the internal-endpoint lookup case

## Testing
- `.venv/bin/python -m pytest tests/k8s/test_kubernetes_service.py -k "resolve_internal_uses_pod_ip_even_in_gateway_mode or get_endpoint_keeps_instance_egress_auth_header_private_for_workload_ports"`
- `git diff --check`
