### PR TITLE
Return sandbox extensions in lifecycle responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,4 @@ bin/
 obj/
 
 .qoder/
+/.vs

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
@@ -277,6 +277,13 @@ internal sealed class SandboxesAdapter : ISandboxes
         return element.ValueKind == JsonValueKind.Null ? null : ParseIsoDate(fieldName, element);
     }
 
+    private static IReadOnlyDictionary<string, string>? ParseStringMap(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.Object
+            ? property.EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString() ?? string.Empty)
+            : null;
+    }
+
     private static SandboxInfo ParseSandboxInfo(JsonElement element)
     {
         var status = element.GetProperty("status");
@@ -300,9 +307,8 @@ internal sealed class SandboxesAdapter : ISandboxes
                 ? JsonSerializer.Deserialize<PlatformSpec>(platform.GetRawText(), JsonOptions)
                 : null,
             Entrypoint = element.GetProperty("entrypoint").EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList(),
-            Metadata = element.TryGetProperty("metadata", out var metadata) && metadata.ValueKind == JsonValueKind.Object
-                ? metadata.EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString() ?? string.Empty)
-                : null,
+            Metadata = ParseStringMap(element, "metadata"),
+            Extensions = ParseStringMap(element, "extensions"),
             Status = new SandboxStatus
             {
                 State = status.GetProperty("state").GetString() ?? throw new SandboxApiException("Missing status.state in response"),
@@ -332,9 +338,8 @@ internal sealed class SandboxesAdapter : ISandboxes
             Platform = element.TryGetProperty("platform", out var platform) && platform.ValueKind == JsonValueKind.Object
                 ? JsonSerializer.Deserialize<PlatformSpec>(platform.GetRawText(), JsonOptions)
                 : null,
-            Metadata = element.TryGetProperty("metadata", out var metadata) && metadata.ValueKind == JsonValueKind.Object
-                ? metadata.EnumerateObject().ToDictionary(p => p.Name, p => p.Value.GetString() ?? string.Empty)
-                : null,
+            Metadata = ParseStringMap(element, "metadata"),
+            Extensions = ParseStringMap(element, "extensions"),
             CreatedAt = ParseIsoDate("createdAt", element.GetProperty("createdAt")),
             ExpiresAt = element.TryGetProperty("expiresAt", out var expiresAtElement)
                 ? ParseOptionalIsoDate("expiresAt", expiresAtElement)

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -716,6 +716,12 @@ public class SandboxInfo
     public IReadOnlyDictionary<string, string>? Metadata { get; set; }
 
     /// <summary>
+    /// Gets or sets opaque extension data returned by the server.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, string>? Extensions { get; set; }
+
+    /// <summary>
     /// Gets or sets the sandbox status.
     /// </summary>
     [JsonPropertyName("status")]
@@ -873,6 +879,12 @@ public class CreateSandboxResponse
     /// </summary>
     [JsonPropertyName("metadata")]
     public IReadOnlyDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets opaque extension data returned by the server.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, string>? Extensions { get; set; }
 
     /// <summary>
     /// Gets or sets the sandbox expiration time.

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxesAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxesAdapterTests.cs
@@ -69,6 +69,7 @@ public class SandboxesAdapterTests
           "image": { "uri": "python:3.11" },
           "platform": { "os": "linux", "arch": "amd64" },
           "entrypoint": ["python"],
+          "extensions": { "opensandbox.extensions.custom-label": "中文数据" },
           "status": { "state": "Running" },
           "createdAt": "2026-03-14T12:00:00Z"
         }
@@ -80,6 +81,8 @@ public class SandboxesAdapterTests
         sandbox.ExpiresAt.Should().BeNull();
         sandbox.Platform.Should().NotBeNull();
         sandbox.Platform!.Arch.Should().Be("amd64");
+        sandbox.Extensions.Should().ContainKey("opensandbox.extensions.custom-label")
+            .WhoseValue.Should().Be("中文数据");
     }
 
     [Fact]
@@ -90,6 +93,7 @@ public class SandboxesAdapterTests
           "id": "sbx-2",
           "status": { "state": "Pending" },
           "platform": { "os": "linux", "arch": "arm64" },
+          "extensions": { "opensandbox.extensions.custom-label": "中文数据" },
           "createdAt": "2026-03-14T12:00:00Z",
           "entrypoint": ["python"]
         }
@@ -106,6 +110,8 @@ public class SandboxesAdapterTests
         response.ExpiresAt.Should().BeNull();
         response.Platform.Should().NotBeNull();
         response.Platform!.Arch.Should().Be("arm64");
+        response.Extensions.Should().ContainKey("opensandbox.extensions.custom-label")
+            .WhoseValue.Should().Be("中文数据");
     }
 
     [Fact]

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1318,7 +1318,7 @@ func TestSandboxManager_GetSandboxInfo(t *testing.T) {
 	if got.ID != "sbx-get" {
 		assert.Fail(t, fmt.Sprintf("ID = %q, want %q", got.ID, "sbx-get"))
 	}
-	assert.Equal(t, "中文数据", got.Extensions["opensandbox.extensions.custom-label"])
+	require.Equal(t, "中文数据", got.Extensions["opensandbox.extensions.custom-label"])
 }
 
 func TestSandboxManager_KillSandbox(t *testing.T) {

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -1296,9 +1296,10 @@ func TestSandboxManager_ListMultipleStates(t *testing.T) {
 
 func TestSandboxManager_GetSandboxInfo(t *testing.T) {
 	want := SandboxInfo{
-		ID:        "sbx-get",
-		Status:    SandboxStatus{State: StateRunning},
-		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		ID:         "sbx-get",
+		Status:     SandboxStatus{State: StateRunning},
+		Extensions: map[string]string{"opensandbox.extensions.custom-label": "中文数据"},
+		CreatedAt:  time.Now().UTC().Truncate(time.Second),
 	}
 
 	_, client := newLifecycleServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1317,6 +1318,7 @@ func TestSandboxManager_GetSandboxInfo(t *testing.T) {
 	if got.ID != "sbx-get" {
 		assert.Fail(t, fmt.Sprintf("ID = %q, want %q", got.ID, "sbx-get"))
 	}
+	assert.Equal(t, "中文数据", got.Extensions["opensandbox.extensions.custom-label"])
 }
 
 func TestSandboxManager_KillSandbox(t *testing.T) {

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -173,6 +173,7 @@ type SandboxInfo struct {
 	SnapshotID string            `json:"snapshotId,omitempty"`
 	Status     SandboxStatus     `json:"status"`
 	Metadata   map[string]string `json:"metadata,omitempty"`
+	Extensions map[string]string `json:"extensions,omitempty"`
 	Entrypoint []string          `json:"entrypoint"`
 	ExpiresAt  *time.Time        `json:"expiresAt,omitempty"`
 	CreatedAt  time.Time         `json:"createdAt"`

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -775,6 +775,10 @@ export interface components {
             metadata?: {
                 [key: string]: string;
             };
+            /** @description Opaque extension data restored from provider-specific storage */
+            extensions?: {
+                [key: string]: string;
+            };
             /**
              * @description Platform constraint echoed from request or workload template.
              *     Null when no scheduling constraint is provided.
@@ -873,6 +877,10 @@ export interface components {
             status: components["schemas"]["SandboxStatus"];
             /** @description Custom metadata from creation request */
             metadata?: {
+                [key: string]: string;
+            };
+            /** @description Opaque extension data restored from provider-specific storage */
+            extensions?: {
                 [key: string]: string;
             };
             /**

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -408,6 +408,7 @@ export interface SandboxInfo extends Record<string, unknown> {
   platform?: PlatformSpec;
   entrypoint: string[];
   metadata?: Record<string, string>;
+  extensions?: Record<string, string>;
   status: SandboxStatus;
   /**
    * Sandbox creation time.
@@ -456,6 +457,7 @@ export interface CreateSandboxResponse extends Record<string, unknown> {
   status: SandboxStatus;
   platform?: PlatformSpec;
   metadata?: Record<string, string>;
+  extensions?: Record<string, string>;
   /**
    * Sandbox expiration time after creation.
    */

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -714,6 +714,7 @@ class Volume private constructor(
  * @property image Image specification used to create this sandbox
  * @property platform Effective platform used for sandbox provisioning
  * @property metadata Custom metadata attached to the sandbox
+ * @property extensions Opaque extension data returned by the server
  */
 class SandboxInfo(
     val id: String,
@@ -725,6 +726,7 @@ class SandboxInfo(
     val snapshotId: String? = null,
     val platform: PlatformSpec? = null,
     val metadata: Map<String, String>? = null,
+    val extensions: Map<String, String>? = null,
 )
 
 /**
@@ -747,10 +749,12 @@ class SandboxStatus(
  *
  * @property id Unique identifier of the newly created sandbox
  * @property platform Effective platform used for sandbox provisioning
+ * @property extensions Opaque extension data returned by the server
  */
 class SandboxCreateResponse(
     val id: String,
     val platform: PlatformSpec? = null,
+    val extensions: Map<String, String>? = null,
 )
 
 class SnapshotStatus(

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -323,6 +323,7 @@ internal object SandboxModelConverter {
             platform = this.platform?.toDomainPlatformSpec(),
             status = this.status.toSandboxStatus(),
             metadata = metadata,
+            extensions = extensions,
         )
     }
 
@@ -372,6 +373,7 @@ internal object SandboxModelConverter {
         return SandboxCreateResponse(
             id = this.id,
             platform = this.platform?.toDomainPlatformSpec(),
+            extensions = this.extensions,
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -553,7 +553,10 @@ class SandboxesAdapterTest {
                 "image": {
                     "uri": "ubuntu:latest"
                 },
-                "metadata": {}
+                "metadata": {},
+                "extensions": {
+                    "opensandbox.extensions.custom-label": "中文数据"
+                }
             }
             """.trimIndent()
 
@@ -564,6 +567,7 @@ class SandboxesAdapterTest {
         assertEquals(sandboxId, result.id)
         assertEquals(SandboxState.RUNNING, result.status.state)
         assertEquals("ubuntu:latest", result.image!!.image)
+        assertEquals("中文数据", result.extensions!!["opensandbox.extensions.custom-label"])
 
         val request = mockWebServer.takeRequest()
         assertEquals("/v1/sandboxes/$sandboxId", request.path)

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -46,6 +46,7 @@ from opensandbox.api.lifecycle.models import (
 )
 from opensandbox.api.lifecycle.models.create_sandbox_request import CreateSandboxRequest
 from opensandbox.api.lifecycle.models.image_spec import ImageSpec
+from opensandbox.api.lifecycle.types import Unset
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
     CredentialProxyConfig,
@@ -80,8 +81,6 @@ class SandboxModelConverter:
 
     @staticmethod
     def _additional_properties_to_dict(value: object) -> dict[str, str] | None:
-        from opensandbox.api.lifecycle.types import Unset
-
         if isinstance(value, Unset):
             return None
         if hasattr(value, "additional_properties"):
@@ -478,8 +477,11 @@ class SandboxModelConverter:
                 auth=auth,
             )
 
-        metadata = SandboxModelConverter._additional_properties_to_dict(
-            getattr(api_sandbox, "metadata", None)
+        metadata = (
+            SandboxModelConverter._additional_properties_to_dict(
+                getattr(api_sandbox, "metadata", None)
+            )
+            or {}
         )
         extensions = SandboxModelConverter._additional_properties_to_dict(
             getattr(api_sandbox, "extensions", None)

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -79,6 +79,20 @@ class SandboxModelConverter:
     """
 
     @staticmethod
+    def _additional_properties_to_dict(value: object) -> dict[str, str] | None:
+        from opensandbox.api.lifecycle.types import Unset
+
+        if isinstance(value, Unset):
+            return None
+        if hasattr(value, "additional_properties"):
+            props = getattr(value, "additional_properties", None)
+            if isinstance(props, dict):
+                return dict(props)
+        if isinstance(value, dict):
+            return value
+        return None
+
+    @staticmethod
     def to_api_image_spec(spec: SandboxImageSpec) -> ImageSpec:
         """Convert domain SandboxImageSpec to API ImageSpec."""
         from opensandbox.api.lifecycle.models.image_spec import ImageSpec
@@ -433,6 +447,9 @@ class SandboxModelConverter:
         return SandboxCreateResponse(
             id=str(api_response.id),
             platform=platform,
+            extensions=SandboxModelConverter._additional_properties_to_dict(
+                getattr(api_response, "extensions", None)
+            ),
         )
 
     @staticmethod
@@ -461,17 +478,12 @@ class SandboxModelConverter:
                 auth=auth,
             )
 
-        metadata: dict[str, str] = {}
-        if hasattr(api_sandbox, "metadata") and not isinstance(api_sandbox.metadata, Unset):
-            metadata_obj = api_sandbox.metadata
-            if hasattr(metadata_obj, "additional_properties") and not isinstance(
-                getattr(metadata_obj, "additional_properties", None), Unset
-            ):
-                props = metadata_obj.additional_properties
-                if isinstance(props, dict):
-                    metadata = dict(props)
-            elif isinstance(metadata_obj, dict):
-                metadata = metadata_obj
+        metadata = SandboxModelConverter._additional_properties_to_dict(
+            getattr(api_sandbox, "metadata", None)
+        )
+        extensions = SandboxModelConverter._additional_properties_to_dict(
+            getattr(api_sandbox, "extensions", None)
+        )
 
         expires_at = api_sandbox.expires_at
         if isinstance(expires_at, Unset):
@@ -500,6 +512,7 @@ class SandboxModelConverter:
             expires_at=expires_at,
             entrypoint=api_sandbox.entrypoint,
             metadata=metadata,
+            extensions=extensions,
         )
 
     @staticmethod

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
@@ -21,6 +21,7 @@ from .create_sandbox_request_env import CreateSandboxRequestEnv
 from .create_sandbox_request_extensions import CreateSandboxRequestExtensions
 from .create_sandbox_request_metadata import CreateSandboxRequestMetadata
 from .create_sandbox_response import CreateSandboxResponse
+from .create_sandbox_response_extensions import CreateSandboxResponseExtensions
 from .create_sandbox_response_metadata import CreateSandboxResponseMetadata
 from .create_snapshot_request import CreateSnapshotRequest
 from .credential_proxy_config import CredentialProxyConfig
@@ -48,6 +49,7 @@ from .renew_sandbox_expiration_request import RenewSandboxExpirationRequest
 from .renew_sandbox_expiration_response import RenewSandboxExpirationResponse
 from .resource_limits import ResourceLimits
 from .sandbox import Sandbox
+from .sandbox_extensions import SandboxExtensions
 from .sandbox_metadata import SandboxMetadata
 from .sandbox_status import SandboxStatus
 from .snapshot import Snapshot
@@ -60,6 +62,7 @@ __all__ = (
     "CreateSandboxRequestExtensions",
     "CreateSandboxRequestMetadata",
     "CreateSandboxResponse",
+    "CreateSandboxResponseExtensions",
     "CreateSandboxResponseMetadata",
     "CreateSnapshotRequest",
     "CredentialProxyConfig",
@@ -87,6 +90,7 @@ __all__ = (
     "RenewSandboxExpirationResponse",
     "ResourceLimits",
     "Sandbox",
+    "SandboxExtensions",
     "SandboxMetadata",
     "SandboxStatus",
     "Snapshot",

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_response.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_response.py
@@ -27,6 +27,7 @@ from dateutil.parser import isoparse
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.create_sandbox_response_extensions import CreateSandboxResponseExtensions
     from ..models.create_sandbox_response_metadata import CreateSandboxResponseMetadata
     from ..models.platform_spec import PlatformSpec
     from ..models.sandbox_status import SandboxStatus
@@ -47,6 +48,8 @@ class CreateSandboxResponse:
             this is copied from the creation request. For snapshot-created sandboxes,
             this is restored from the snapshot.
         metadata (CreateSandboxResponseMetadata | Unset): Custom metadata from creation request
+        extensions (CreateSandboxResponseExtensions | Unset): Opaque extension data restored from provider-specific
+            storage
         platform (PlatformSpec | Unset): Runtime platform constraint used for scheduling/provisioning.
 
             This field is independent from `image` and expresses the expected target
@@ -68,6 +71,7 @@ class CreateSandboxResponse:
     created_at: datetime.datetime
     entrypoint: list[str]
     metadata: CreateSandboxResponseMetadata | Unset = UNSET
+    extensions: CreateSandboxResponseExtensions | Unset = UNSET
     platform: PlatformSpec | Unset = UNSET
     expires_at: datetime.datetime | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -84,6 +88,10 @@ class CreateSandboxResponse:
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
             metadata = self.metadata.to_dict()
+
+        extensions: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.extensions, Unset):
+            extensions = self.extensions.to_dict()
 
         platform: dict[str, Any] | Unset = UNSET
         if not isinstance(self.platform, Unset):
@@ -105,6 +113,8 @@ class CreateSandboxResponse:
         )
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if extensions is not UNSET:
+            field_dict["extensions"] = extensions
         if platform is not UNSET:
             field_dict["platform"] = platform
         if expires_at is not UNSET:
@@ -114,6 +124,7 @@ class CreateSandboxResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.create_sandbox_response_extensions import CreateSandboxResponseExtensions
         from ..models.create_sandbox_response_metadata import CreateSandboxResponseMetadata
         from ..models.platform_spec import PlatformSpec
         from ..models.sandbox_status import SandboxStatus
@@ -133,6 +144,13 @@ class CreateSandboxResponse:
             metadata = UNSET
         else:
             metadata = CreateSandboxResponseMetadata.from_dict(_metadata)
+
+        _extensions = d.pop("extensions", UNSET)
+        extensions: CreateSandboxResponseExtensions | Unset
+        if isinstance(_extensions, Unset):
+            extensions = UNSET
+        else:
+            extensions = CreateSandboxResponseExtensions.from_dict(_extensions)
 
         _platform = d.pop("platform", UNSET)
         platform: PlatformSpec | Unset
@@ -154,6 +172,7 @@ class CreateSandboxResponse:
             created_at=created_at,
             entrypoint=entrypoint,
             metadata=metadata,
+            extensions=extensions,
             platform=platform,
             expires_at=expires_at,
         )

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_response_extensions.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_response_extensions.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="CreateSandboxResponseExtensions")
+
+
+@_attrs_define
+class CreateSandboxResponseExtensions:
+    """Opaque extension data restored from provider-specific storage"""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        create_sandbox_response_extensions = cls()
+
+        create_sandbox_response_extensions.additional_properties = d
+        return create_sandbox_response_extensions
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox.py
@@ -29,6 +29,7 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
     from ..models.image_spec import ImageSpec
     from ..models.platform_spec import PlatformSpec
+    from ..models.sandbox_extensions import SandboxExtensions
     from ..models.sandbox_metadata import SandboxMetadata
     from ..models.sandbox_status import SandboxStatus
 
@@ -67,6 +68,7 @@ class Sandbox:
             - If provided and cannot be satisfied by runtime/template/pool constraints,
               request must fail explicitly.
         metadata (SandboxMetadata | Unset): Custom metadata from creation request
+        extensions (SandboxExtensions | Unset): Opaque extension data restored from provider-specific storage
         expires_at (datetime.datetime | Unset): Timestamp when sandbox will auto-terminate. Omitted when manual cleanup
             is enabled.
     """
@@ -79,6 +81,7 @@ class Sandbox:
     snapshot_id: str | Unset = UNSET
     platform: PlatformSpec | Unset = UNSET
     metadata: SandboxMetadata | Unset = UNSET
+    extensions: SandboxExtensions | Unset = UNSET
     expires_at: datetime.datetime | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -105,6 +108,10 @@ class Sandbox:
         if not isinstance(self.metadata, Unset):
             metadata = self.metadata.to_dict()
 
+        extensions: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.extensions, Unset):
+            extensions = self.extensions.to_dict()
+
         expires_at: str | Unset = UNSET
         if not isinstance(self.expires_at, Unset):
             expires_at = self.expires_at.isoformat()
@@ -127,6 +134,8 @@ class Sandbox:
             field_dict["platform"] = platform
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if extensions is not UNSET:
+            field_dict["extensions"] = extensions
         if expires_at is not UNSET:
             field_dict["expiresAt"] = expires_at
 
@@ -136,6 +145,7 @@ class Sandbox:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.image_spec import ImageSpec
         from ..models.platform_spec import PlatformSpec
+        from ..models.sandbox_extensions import SandboxExtensions
         from ..models.sandbox_metadata import SandboxMetadata
         from ..models.sandbox_status import SandboxStatus
 
@@ -171,6 +181,13 @@ class Sandbox:
         else:
             metadata = SandboxMetadata.from_dict(_metadata)
 
+        _extensions = d.pop("extensions", UNSET)
+        extensions: SandboxExtensions | Unset
+        if isinstance(_extensions, Unset):
+            extensions = UNSET
+        else:
+            extensions = SandboxExtensions.from_dict(_extensions)
+
         _expires_at = d.pop("expiresAt", UNSET)
         expires_at: datetime.datetime | Unset
         if isinstance(_expires_at, Unset):
@@ -187,6 +204,7 @@ class Sandbox:
             snapshot_id=snapshot_id,
             platform=platform,
             metadata=metadata,
+            extensions=extensions,
             expires_at=expires_at,
         )
 

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox_extensions.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox_extensions.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SandboxExtensions")
+
+
+@_attrs_define
+class SandboxExtensions:
+    """Opaque extension data restored from provider-specific storage"""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        sandbox_extensions = cls()
+
+        sandbox_extensions.additional_properties = d
+        return sandbox_extensions
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -638,6 +638,9 @@ class SandboxInfo(BaseModel):
         default=None, description="Effective platform used for sandbox provisioning."
     )
     metadata: dict[str, str] | None = Field(default=None, description="Custom metadata")
+    extensions: dict[str, str] | None = Field(
+        default=None, description="Opaque extension data returned by the server"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -650,6 +653,9 @@ class SandboxCreateResponse(BaseModel):
     id: str = Field(description="Unique identifier of the newly created sandbox")
     platform: PlatformSpec | None = Field(
         default=None, description="Effective platform used for sandbox provisioning."
+    )
+    extensions: dict[str, str] | None = Field(
+        default=None, description="Opaque extension data returned by the server"
     )
 
 

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -341,6 +341,22 @@ def test_sandbox_model_converter_maps_platform_from_create_response() -> None:
     assert converted.extensions == {"opensandbox.extensions.custom-label": "中文数据"}
 
 
+def test_sandbox_model_converter_preserves_missing_metadata_default() -> None:
+    from opensandbox.api.lifecycle.models.sandbox import Sandbox
+    from opensandbox.api.lifecycle.models.sandbox_status import SandboxStatus
+
+    api_sandbox = Sandbox(
+        id="sbx-1",
+        status=SandboxStatus(state="Running"),
+        created_at=datetime(2025, 1, 1),
+        entrypoint=["/bin/sh"],
+    )
+
+    converted = SandboxModelConverter.to_sandbox_info(api_sandbox)
+    assert converted.metadata == {}
+    assert converted.extensions is None
+
+
 def test_sandbox_model_converter_supports_windows_platform_request() -> None:
     req = SandboxModelConverter.to_api_create_sandbox_request(
         spec=SandboxImageSpec("dockurr/windows:latest"),

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -316,6 +316,9 @@ def test_sandbox_model_converter_maps_platform_from_create_response() -> None:
     from opensandbox.api.lifecycle.models.create_sandbox_response import (
         CreateSandboxResponse,
     )
+    from opensandbox.api.lifecycle.models.create_sandbox_response_extensions import (
+        CreateSandboxResponseExtensions,
+    )
     from opensandbox.api.lifecycle.models.platform_spec import (
         PlatformSpec as ApiPlatformSpec,
     )
@@ -325,6 +328,9 @@ def test_sandbox_model_converter_maps_platform_from_create_response() -> None:
         id="sbx-1",
         status=SandboxStatus(state="Running"),
         platform=ApiPlatformSpec(os="linux", arch="arm64"),
+        extensions=CreateSandboxResponseExtensions.from_dict(
+            {"opensandbox.extensions.custom-label": "中文数据"}
+        ),
         created_at=datetime(2025, 1, 1),
         entrypoint=["/bin/sh"],
     )
@@ -332,6 +338,7 @@ def test_sandbox_model_converter_maps_platform_from_create_response() -> None:
     converted = SandboxModelConverter.to_sandbox_create_response(api_response)
     assert converted.platform is not None
     assert converted.platform.arch == "arm64"
+    assert converted.extensions == {"opensandbox.extensions.custom-label": "中文数据"}
 
 
 def test_sandbox_model_converter_supports_windows_platform_request() -> None:

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -543,6 +543,10 @@ class CreateSandboxResponse(BaseModel):
     id: str = Field(..., description="Unique sandbox identifier")
     status: SandboxStatus = Field(..., description="Current lifecycle status and detailed state information")
     metadata: Optional[Dict[str, str]] = Field(None, description="Custom metadata from creation request")
+    extensions: Optional[Dict[str, str]] = Field(
+        None,
+        description="Opaque extension data restored from provider-specific storage",
+    )
     platform: Optional[PlatformSpec] = Field(
         None,
         description=(
@@ -584,6 +588,10 @@ class Sandbox(BaseModel):
     )
     status: SandboxStatus = Field(..., description="Current lifecycle status and detailed state information")
     metadata: Optional[Dict[str, str]] = Field(None, description="Custom metadata from creation request")
+    extensions: Optional[Dict[str, str]] = Field(
+        None,
+        description="Opaque extension data restored from provider-specific storage",
+    )
     entrypoint: Optional[List[str]] = Field(None, description="The command to execute as the sandbox's entry process")
     expires_at: Optional[datetime] = Field(
         None,

--- a/server/opensandbox_server/extensions/__init__.py
+++ b/server/opensandbox_server/extensions/__init__.py
@@ -19,6 +19,7 @@ CreateSandbox ``extensions`` shared logic: well-known keys, HTTP validation, wor
 from opensandbox_server.extensions.codec import (
     apply_access_renew_extend_seconds_to_mapping,
     apply_extensions_to_annotations,
+    extract_extensions_from_annotations,
 )
 from opensandbox_server.extensions.keys import (
     ACCESS_RENEW_EXTEND_SECONDS_KEY,
@@ -40,6 +41,7 @@ __all__ = [
     "validate_extensions",
     "apply_access_renew_extend_seconds_to_mapping",
     "apply_extensions_to_annotations",
+    "extract_extensions_from_annotations",
     "EXTENSIONS_ANNOTATION_PREFIX",
     "ANNOTATION_METADATA_PREFIX",
 ]

--- a/server/opensandbox_server/extensions/codec.py
+++ b/server/opensandbox_server/extensions/codec.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, MutableMapping, Optional
+from typing import Dict, Mapping, MutableMapping, Optional
 
 from opensandbox_server.extensions.keys import (
     ACCESS_RENEW_EXTEND_SECONDS_KEY,
@@ -68,3 +68,23 @@ def apply_extensions_to_annotations(
             suffix = key[len(EXTENSIONS_ANNOTATION_PREFIX):]
             annotation_key = ANNOTATION_METADATA_PREFIX + suffix
             annotations[annotation_key] = value
+
+
+def extract_extensions_from_annotations(
+    annotations: Optional[Mapping[str, str]],
+) -> Optional[Dict[str, str]]:
+    """
+    Restore extension keys previously propagated to Pod annotations.
+
+    For each annotation key starting with ANNOTATION_METADATA_PREFIX, the value is
+    copied to extensions with EXTENSIONS_ANNOTATION_PREFIX prefix.
+    """
+    if not annotations:
+        return None
+
+    extensions = {
+        EXTENSIONS_ANNOTATION_PREFIX + key[len(ANNOTATION_METADATA_PREFIX):]: value
+        for key, value in annotations.items()
+        if key.startswith(ANNOTATION_METADATA_PREFIX)
+    }
+    return extensions or None

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -495,8 +495,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 if isinstance(workload, dict):
                     annotations = workload.get("metadata", {}).get("annotations") or {}
                 else:
-                    metadata = getattr(workload, "metadata", None)
-                    annotations = getattr(metadata, "annotations", None) or {}
+                    md = getattr(workload, "metadata", None)
+                    raw_ann = getattr(md, "annotations", None) if md else None
+                    annotations = raw_ann if isinstance(raw_ann, dict) else {}
 
                 return CreateSandboxResponse(
                     id=sandbox_id,

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -30,6 +30,7 @@ from fastapi import HTTPException, status
 from opensandbox_server.extensions import (
     apply_access_renew_extend_seconds_to_mapping,
     apply_extensions_to_annotations,
+    extract_extensions_from_annotations,
 )
 from opensandbox_server.extensions.keys import ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY
 from opensandbox_server.api.schema import (
@@ -491,6 +492,11 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     self.workload_provider.get_status(workload)
                 )
                 effective_platform = _extract_platform_from_workload(workload)
+                if isinstance(workload, dict):
+                    annotations = workload.get("metadata", {}).get("annotations") or {}
+                else:
+                    metadata = getattr(workload, "metadata", None)
+                    annotations = getattr(metadata, "annotations", None) or {}
 
                 return CreateSandboxResponse(
                     id=sandbox_id,
@@ -503,6 +509,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     created_at=created_at,
                     expires_at=context.expires_at,
                     metadata=request.metadata,
+                    extensions=extract_extensions_from_annotations(annotations),
                     entrypoint=request.entrypoint,
                     platform=effective_platform or request.platform,
                 )

--- a/server/opensandbox_server/services/k8s/workload_mapper.py
+++ b/server/opensandbox_server/services/k8s/workload_mapper.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from opensandbox_server.api.schema import ImageSpec, PlatformSpec, Sandbox, SandboxStatus
+from opensandbox_server.extensions import extract_extensions_from_annotations
 from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SANDBOX_SNAPSHOT_ID_LABEL
 
 
@@ -29,11 +30,13 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
         metadata = workload.get("metadata", {})
         spec = workload.get("spec", {})
         labels = metadata.get("labels", {})
+        annotations = metadata.get("annotations", {})
         creation_timestamp = metadata.get("creationTimestamp")
     else:
         metadata = workload.metadata
         spec = workload.spec
         labels = metadata.labels or {}
+        annotations = metadata.annotations or {}
         creation_timestamp = metadata.creation_timestamp
 
     sandbox_id = labels.get(SANDBOX_ID_LABEL, "")
@@ -75,6 +78,7 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
         created_at=creation_timestamp,
         expires_at=expires_at,
         metadata=user_metadata if user_metadata else None,
+        extensions=extract_extensions_from_annotations(annotations),
         image=image_spec,
         snapshotId=snapshot_id,
         entrypoint=entrypoint,

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
@@ -135,6 +136,30 @@ class TestKubernetesSandboxServiceCreate:
         assert response.extensions == {
             "opensandbox.extensions.custom-label": "中文数据",
         }
+
+    @pytest.mark.asyncio
+    async def test_create_sandbox_response_ignores_non_dict_workload_annotations(
+        self, k8s_service, create_sandbox_request
+    ):
+        workload = SimpleNamespace(
+            metadata=SimpleNamespace(annotations=["not", "a", "mapping"]),
+            spec=SimpleNamespace(),
+        )
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-123",
+            "uid": "abc-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Pod is running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+
+        response = await k8s_service.create_sandbox(create_sandbox_request)
+
+        assert response.extensions is None
 
     def test_list_sandboxes_restores_extensions_from_workloads(self, k8s_service, mock_workload):
         mock_workload["metadata"]["annotations"] = {

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -108,6 +108,56 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.create_workload.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_create_sandbox_response_restores_extensions_from_workload(
+        self, k8s_service, create_sandbox_request, mock_workload
+    ):
+        create_sandbox_request.extensions = {
+            "opensandbox.extensions.custom-label": "中文数据",
+        }
+        mock_workload["metadata"]["annotations"] = {
+            "opensandbox.io/extensions.custom-label": "中文数据",
+        }
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-123",
+            "uid": "abc-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Pod is running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+        k8s_service.workload_provider.get_expiration.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        response = await k8s_service.create_sandbox(create_sandbox_request)
+
+        assert response.extensions == {
+            "opensandbox.extensions.custom-label": "中文数据",
+        }
+
+    def test_list_sandboxes_restores_extensions_from_workloads(self, k8s_service, mock_workload):
+        mock_workload["metadata"]["annotations"] = {
+            "opensandbox.io/extensions.custom-label": "中文数据",
+        }
+        k8s_service.workload_provider.list_workloads.return_value = [mock_workload]
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+        k8s_service.workload_provider.get_expiration.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        from opensandbox_server.api.schema import PaginationRequest
+        request = ListSandboxesRequest(pagination=PaginationRequest(page=1, page_size=20))
+        response = k8s_service.list_sandboxes(request)
+
+        assert response.items[0].extensions == {
+            "opensandbox.extensions.custom-label": "中文数据",
+        }
+
+    @pytest.mark.asyncio
     async def test_create_sandbox_normalizes_allocated_status_to_running(
         self, k8s_service, create_sandbox_request, mock_workload
     ):

--- a/server/tests/k8s/test_workload_mapper.py
+++ b/server/tests/k8s/test_workload_mapper.py
@@ -13,8 +13,43 @@
 # limitations under the License.
 
 from opensandbox_server.services.k8s.workload_mapper import (
+    _build_sandbox_from_workload,
     _extract_platform_from_workload,
 )
+
+
+class _WorkloadProvider:
+    @staticmethod
+    def get_expiration(_workload):
+        return None
+
+    @staticmethod
+    def get_status(_workload):
+        return {
+            "state": "Running",
+            "reason": "",
+            "message": "Running",
+            "last_transition_at": None,
+        }
+
+
+class TestBuildSandboxFromWorkload:
+    def test_restores_extensions_from_annotations(self):
+        workload = {
+            "metadata": {
+                "labels": {"opensandbox.io/id": "sandbox-1"},
+                "annotations": {
+                    "opensandbox.io/extensions.custom-label": "中文数据",
+                    "opensandbox.io/access-renew-extend-seconds": "1800",
+                },
+                "creationTimestamp": "2026-06-22T00:00:00Z",
+            },
+            "spec": {"template": {"spec": {"containers": [{"image": "python:3.11", "command": ["python"]}]}}},
+        }
+
+        sandbox = _build_sandbox_from_workload(workload, _WorkloadProvider())
+
+        assert sandbox.extensions == {"opensandbox.extensions.custom-label": "中文数据"}
 
 
 class TestExtractPlatformFromWorkload:

--- a/server/tests/test_extensions.py
+++ b/server/tests/test_extensions.py
@@ -22,6 +22,7 @@ from opensandbox_server.extensions import (
     ACCESS_RENEW_EXTEND_SECONDS_MIN,
     apply_access_renew_extend_seconds_to_mapping,
     apply_extensions_to_annotations,
+    extract_extensions_from_annotations,
     validate_extensions
 )
 
@@ -156,3 +157,28 @@ class TestExtensionsToAnnotations:
             "existing": "value",
             "opensandbox.io/extensions.new-key": "new-value",
         }
+
+
+class TestExtensionsFromAnnotations:
+    def test_restores_prefixed_annotations(self):
+        annotations = {
+            "opensandbox.io/extensions.custom-key": "custom-value",
+            "opensandbox.io/extensions.localized": "中文数据",
+        }
+
+        assert extract_extensions_from_annotations(annotations) == {
+            "opensandbox.extensions.custom-key": "custom-value",
+            "opensandbox.extensions.localized": "中文数据",
+        }
+
+    def test_ignores_non_extension_annotations(self):
+        annotations = {
+            "opensandbox.io/access-renew-extend-seconds": "1800",
+            "other": "value",
+        }
+
+        assert extract_extensions_from_annotations(annotations) is None
+
+    def test_empty_annotations_return_none(self):
+        assert extract_extensions_from_annotations({}) is None
+        assert extract_extensions_from_annotations(None) is None

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -846,6 +846,12 @@ components:
             type: string
           description: Custom metadata from creation request
 
+        extensions:
+          type: object
+          additionalProperties:
+            type: string
+          description: Opaque extension data restored from provider-specific storage
+
         platform:
           $ref: '#/components/schemas/PlatformSpec'
           description: |
@@ -996,6 +1002,12 @@ components:
           additionalProperties:
             type: string
           description: Custom metadata from creation request
+
+        extensions:
+          type: object
+          additionalProperties:
+            type: string
+          description: Opaque extension data restored from provider-specific storage
 
         entrypoint:
           type: array


### PR DESCRIPTION
## Summary

- Add `extensions` to lifecycle `CreateSandboxResponse` and `Sandbox` response models
- Restore Kubernetes `opensandbox.io/extensions.*` annotations as `opensandbox.extensions.*` response data
- Update the OpenAPI lifecycle contract and regenerated Python/TypeScript lifecycle clients
- Expose response extensions in high-level Python, JavaScript, C#, Go, and Kotlin SDK models/converters
- Add regression coverage for create/get/list response extension round-tripping
- Ignore local Visual Studio `.vs` workspace files

Fixes #1060

## Validation

- `cd server && uv run pytest tests/test_extensions.py tests/k8s/test_workload_mapper.py tests/k8s/test_kubernetes_service.py -q` => 92 passed
- `cd server && uv run pytest` => 1172 passed, 1 skipped
- `cd sdks/sandbox/python && uv run ruff check && uv run pytest tests/ -q` => passed
- `cd sdks/sandbox/csharp && dotnet test OpenSandbox.sln` => 116 passed
- `cd sdks/sandbox/javascript && corepack pnpm run typecheck && corepack pnpm run lint` => passed
- `cd sdks/sandbox/javascript && node --test tests/*.test.mjs` => 36 passed

## Not Run Locally

- Go SDK tests: local `go` / `gofmt` toolchain unavailable in PATH
- Kotlin SDK tests: local environment uses JDK 11, while Gradle 9.2.1 requires JVM 17+

## Notes

This change restores only extension data stored via `opensandbox.io/extensions.*` annotations back to `opensandbox.extensions.*` keys. It does not expose other internal annotations such as `opensandbox.io/access-renew-extend-seconds` through the response `extensions` map.