### PR TITLE
chore: bump Kotlin SDK to v1.0.14 and Python SDK to v0.1.12

### DIFF
--- a/sdks/code-interpreter/kotlin/gradle.properties
+++ b/sdks/code-interpreter/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.13
+project.version=1.0.14
 project.description=A Kotlin SDK for Code Interpreter

--- a/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
+++ b/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 jackson = "2.18.2"
-sandbox = "1.0.13"
+sandbox = "1.0.14"
 junit-platform = "1.13.4"
 
 [libraries]

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.13
+project.version=1.0.14
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -71,7 +71,7 @@ class ConnectionConfig private constructor(
         private const val ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.13"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.14"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -67,7 +67,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.11"
+fallback_version = "0.1.12"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -65,7 +65,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.11", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.12", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -53,7 +53,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.11", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.12", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 


### PR DESCRIPTION
## Summary
- Bump Kotlin SDK (sandbox + code-interpreter) version from v1.0.13 to v1.0.14
- Bump Python SDK (sandbox) version from v0.1.11 to v0.1.12
- Update User-Agent strings accordingly

## Test plan
- [ ] Verify Kotlin SDK builds successfully
- [ ] Verify Python SDK builds successfully
- [ ] Confirm User-Agent headers reflect new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)