### PR TITLE
docs(egress): clarify service mesh sidecar conflict

### DIFF
--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -153,6 +153,8 @@ If you need both gVisor's syscall isolation and FQDN egress control:
 - Use `kata-qemu` instead — it provides comparable security isolation and supports the egress sidecar.
 - Alternatively, use a CNI-level FQDN policy (e.g., Cilium `toFQDNs`) for network isolation alongside gVisor.
 
+The same architectural constraint applies to transparent service meshes such as Istio/Envoy sidecar injection: OpenSandbox egress expects to own outbound interception inside the pod network namespace. If a mesh sidecar also rewrites outbound traffic in that namespace, egress-sidecar features such as per-sandbox network policy, transparent MITM, and Credential Vault are not currently supported together. Prefer excluding sandbox pods from mesh injection or enforcing outbound policy at the platform network layer instead.
+
 See the [Compatibility Matrix](../guides/secure-container.md#compatibility-matrix) in the Secure Container Runtime Guide for the full feature support table.
 
 ## Recommendations

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -40,6 +40,7 @@ The egress control is implemented as a **Sidecar** that shares the network names
 - **Runtime**: Docker or Kubernetes.
 - **Capabilities**: `CAP_NET_ADMIN` (for the sidecar container only).
 - **Kernel**: Linux kernel with `iptables` support.
+- **Service mesh**: OpenSandbox egress is not currently supported inside pods that already have a transparent service-mesh sidecar (for example Istio/Envoy injection). Both layers rewrite outbound traffic in the same network namespace and can conflict.
 
 ## Configuration
 
@@ -82,6 +83,32 @@ Format: one domain per line (supports wildcards like `*.example.com`). Lines sta
 Rule precedence: `deny.always` > `allow.always` > user policy (API/env).
 
 Always-rules are hot-reloaded: the sidecar polls the files once per minute and applies changes without restart.
+
+### Service Mesh Compatibility
+
+::: warning Not Supported with Transparent Mesh Sidecars
+OpenSandbox egress is designed to be the only transparent outbound interception layer inside the sandbox pod. Deployments that automatically inject a service-mesh sidecar such as Istio/Envoy into the same pod are not currently supported for egress-sidecar features.
+:::
+
+Why this conflicts today:
+
+- OpenSandbox egress installs `iptables`/`nft` redirect rules in the shared pod network namespace so DNS and optional HTTPS MITM traffic flow through the egress sidecar.
+- Service meshes such as Istio also redirect outbound traffic in that same namespace, usually to Envoy.
+- When both are present, the redirect order becomes deployment-dependent and can produce double interception, broken TLS, or traffic that bypasses the expected Credential Vault / egress-policy path.
+
+This matters for:
+
+- per-sandbox `networkPolicy` / `network_policy` enforcement
+- transparent mitmproxy mode
+- Credential Vault / Credential Proxy
+
+Recommended operator choices today:
+
+1. Exclude OpenSandbox sandbox pods from automatic mesh sidecar injection when they need the egress sidecar.
+2. If mesh injection is mandatory, do not rely on the OpenSandbox egress sidecar for outbound control in those pods; instead use a platform-level mechanism such as a CNI/network-policy solution.
+3. Treat mesh-injected sandboxes as a separate runtime profile and document that Credential Vault and transparent egress interception are unavailable there until first-class coexistence support is implemented.
+
+See also [Credential Vault](/guides/credential-vault) and [Network Isolation](/architecture/network-isolation).
 
 ### Runtime HTTP API
 

--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -19,6 +19,7 @@ Credential Vault is OpenSandbox's outbound credential broker for sandboxed agent
 - Server config sets `[egress].image`.
 - Sandbox create request includes an outbound network policy.
 - Sandbox create request enables Credential Proxy.
+- Sandbox pods are not running with an additional transparent service-mesh sidecar (for example Istio/Envoy injection) in the same network namespace. Credential Vault currently assumes the OpenSandbox egress sidecar is the only transparent outbound interception layer in the pod.
 - The sandbox image has the tools you want to run. For Claude Code, use an image
   with Node.js and npm, such as the OpenSandbox code-interpreter image.
 
@@ -45,6 +46,18 @@ At a high level:
 The active vault used by the MITM process is served over a local Unix domain
 socket inside the sidecar. The sandbox workload cannot fetch this active state
 over the normal server proxy path.
+
+## Service Mesh Compatibility
+
+Credential Vault depends on the egress sidecar's transparent redirect and MITM path. If the sandbox pod is also injected with a transparent service-mesh sidecar such as Istio/Envoy, both layers will try to intercept outbound traffic in the same network namespace. OpenSandbox does not currently support that combination for Credential Vault.
+
+Use one of these operator patterns instead:
+
+- disable mesh sidecar injection for sandbox pods that need Credential Vault
+- keep mesh injection enabled, but do not enable `credentialProxy` / Credential Vault for those pods
+- move outbound policy and credential handling to a platform mechanism outside the sandbox pod if mesh injection is mandatory
+
+For the underlying egress-sidecar limitation, see [Egress](/components/egress#service-mesh-compatibility).
 
 Credential bindings are intentionally precise. Prefer a default-deny egress
 policy and a narrow path match, for example `/v1/*` for Anthropic API calls.


### PR DESCRIPTION
Fixes #1106

Summary: Document that OpenSandbox egress-sidecar features are not currently supported when a transparent service-mesh sidecar such as Istio or Envoy is injected into the same sandbox pod, explain the shared-network-namespace interception conflict, and point operators to safe deployment patterns in the egress, Credential Vault, and network-isolation docs.

Validation: `pnpm docs:build` passed in `docs/`. The updated pages now explicitly warn that per-sandbox network policy, transparent MITM, and Credential Vault rely on the OpenSandbox egress sidecar being the only transparent outbound interception layer in the pod.
