### PR TITLE
fix: include SandboxError details in exception string representation

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
@@ -35,6 +35,17 @@ open class SandboxException(
         cause: Throwable?,
         error: SandboxError,
     ) : this(message = message, cause = cause, error = error, requestId = null)
+
+    override fun toString(): String {
+        val parts = mutableListOf(super.toString())
+        if (!error.message.isNullOrBlank()) {
+            parts += "[${error.code}] ${error.message}"
+        }
+        if (!requestId.isNullOrBlank()) {
+            parts += "request_id=$requestId"
+        }
+        return parts.joinToString(" | ")
+    }
 }
 
 /**

--- a/sdks/sandbox/python/src/opensandbox/exceptions/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/exceptions/sandbox.py
@@ -62,6 +62,14 @@ class SandboxException(Exception):
         self.error = error or SandboxError(SandboxError.INTERNAL_UNKNOWN_ERROR)
         self.request_id = request_id
 
+    def __str__(self) -> str:
+        parts = [super().__str__()]
+        if self.error and self.error.message:
+            parts.append(f"[{self.error.code}] {self.error.message}")
+        if self.request_id:
+            parts.append(f"request_id={self.request_id}")
+        return " | ".join(parts)
+
 
 class SandboxApiException(SandboxException):
     """


### PR DESCRIPTION
## Summary
- `SandboxException.toString()` (Kotlin) and `__str__()` (Python) only showed generic message like `"API error: HTTP 500"`, silently dropping the parsed server error in `self.error`
- Override `toString`/`__str__` in both SDKs to append `[error.code] error.message` and `request_id` when present
- JS/C#/Go SDKs not affected — JS and C# already put error details in the message field, Go uses a different design

## Example output after fix
```
API error: HTTP 500 | [UNEXPECTED_RESPONSE] file upload failed: disk full | request_id=abc123
```

## Test plan
- [x] Python: all 218 tests pass
- [x] Kotlin: `SandboxExceptionCompatibilityTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)