### PR TITLE
docs(egress): clarify intra-cluster service allow rules

### DIFF
--- a/docs/architecture/network-isolation.md
+++ b/docs/architecture/network-isolation.md
@@ -109,6 +109,31 @@ After this configuration is applied, all newly created sandboxes will use the eg
 - **Forced access path**: legitimate cross-sandbox communication must go through the `GetEndpoint()` API, which returns an external access endpoint proxied by OpenSandbox Ingress with authentication and authorization.
 - **Transparent to users**: users do not need to declare any additional parameters in SDK calls. Isolation is enforced automatically at the platform level.
 
+## Allowing Legitimate In-Cluster Services
+
+When `defaultAction: deny` is enabled, allowing a sandbox to reach a Kubernetes Service requires **both** layers of the egress sidecar to agree:
+
+1. **DNS layer**: allow the service hostname so the DNS proxy does not return `NXDOMAIN`.
+2. **Network layer** (`dns+nft` mode): allow the Service CIDR (or a narrower ClusterIP range) so nftables does not drop the resolved TCP connection.
+
+For example, if a sandbox should reach `postgres.opensandbox.svc.cluster.local`, this is not enough by itself:
+
+```json
+{ "action": "allow", "target": "postgres.opensandbox.svc.cluster.local" }
+```
+
+The request can still fail after DNS resolution if the Service ClusterIP falls inside a denied CIDR such as `10.96.0.0/12`. In `dns+nft` mode you must also allow the Service CIDR (or the specific ClusterIP range you want exposed):
+
+```json
+{ "action": "allow", "target": "10.96.0.0/12" }
+```
+
+### Recommended Patterns
+
+- **Platform-managed allowlist**: if many sandboxes need the same internal services, keep the Service CIDR allowance in `allow.always` and let users request only the DNS names they should reach.
+- **Per-sandbox allowlist**: if access should be tightly scoped, include both the service FQDN and the required Service CIDR in the sandbox's `network_policy` / `networkPolicy`.
+- **Avoid assuming CoreDNS exemptions are enough**: the sidecar automatically allows nameserver IPs so DNS forwarding works, but it does **not** automatically allow arbitrary Service ClusterIPs for application traffic.
+
 ## Approach 2: On-Demand Isolation via Per-Sandbox NetworkPolicy
 
 If global enforced isolation is not desired, or if specific sandboxes need more permissive access, you can explicitly deny internal network access at sandbox creation time via the `network_policy` parameter:

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -35,6 +35,17 @@ The egress control is implemented as a **Sidecar** that shares the network names
     - Uses `nftables` to enforce IP-level allow/deny. Resolved IPs for allowed domains are added to dynamic allow sets with TTL (dynamic DNS).
     - At startup, the sidecar whitelists **127.0.0.1** (redirect target for the proxy) and **nameserver IPs** from `/etc/resolv.conf` so DNS resolution and proxy upstream work (including private DNS). Nameserver count is capped and invalid IPs are filtered.
 
+### Kubernetes Service Access Under `defaultAction: deny`
+
+In Kubernetes deployments that use `defaultAction: deny`, reaching an in-cluster Service usually needs two separate allowances:
+
+- allow the Service DNS name so the DNS proxy resolves it
+- allow the Service CIDR (or a narrower ClusterIP range) so `dns+nft` does not drop the TCP connection after resolution
+
+Allowing only `postgres.opensandbox.svc.cluster.local` is not sufficient if the resolved ClusterIP still belongs to a denied range such as `10.96.0.0/12`. Likewise, allowing only the CIDR is not sufficient if the DNS proxy still denies the hostname.
+
+See [Network Isolation](/architecture/network-isolation#allowing-legitimate-in-cluster-services) for operator guidance and examples.
+
 ## Requirements
 
 - **Runtime**: Docker or Kubernetes.


### PR DESCRIPTION
Fixes #1091

Summary: Document the allow-side behavior of Kubernetes in-cluster service access when OpenSandbox egress runs with `defaultAction: deny`, including the requirement to allow both the service DNS name and the Service CIDR, and add concrete operator guidance for platform-managed and per-sandbox allowlists.

Validation: `pnpm docs:build` passed in `docs/`. The updated docs now explain why allowing only `*.svc.cluster.local` or only the Service CIDR is insufficient in `dns+nft` mode and show where to document those two layers.
