### PR TITLE
feat(egress): support multiple user mitm addon scripts

### DIFF
--- a/components/egress/docs/mitmproxy-transparent.md
+++ b/components/egress/docs/mitmproxy-transparent.md
@@ -30,8 +30,8 @@ By default, mitmproxy listens on `18081` and transparent redirect rules are set 
 # Optional: change listening port (default: 18081)
 export OPENSANDBOX_EGRESS_MITMPROXY_PORT=18081
 
-# Optional: load an additional user-defined mitm addon (loaded after the system addon)
-export OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT=/path/to/your/addon.py
+# Optional: load user-defined mitm addons (loaded after the system addon, comma-separated)
+export OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT=/path/to/your/addon.py,/path/to/another.py
 ```
 
 To bypass decryption for selected domains, edit the baked-in
@@ -46,7 +46,7 @@ To bypass decryption for selected domains, edit the baked-in
 |------|----------|------|--------|
 | `OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT` | Yes | Enable transparent mitmproxy (`1/true/on`, etc.) | Disabled |
 | `OPENSANDBOX_EGRESS_MITMPROXY_PORT` | No | mitmdump listen port; `iptables` redirects `80/443` here | `18081` |
-| `OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT` | No | Additional user mitm addon script path (`-s`); loaded after the system addon | Empty |
+| `OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT` | No | User mitm addon script paths (comma-separated); each is passed as `-s` and loaded after the system addon in order | Empty |
 | `OPENSANDBOX_EGRESS_MITMPROXY_UPSTREAM_TRUST_DIR` | No | Trust directory for upstream TLS verification (OpenSSL style); overrides the config.yaml default | `/etc/ssl/certs` |
 | `OPENSANDBOX_EGRESS_MITMPROXY_SSL_INSECURE` | No | Skip upstream TLS verification (`1/true/on`); use when clients connect by IP and SNI is unavailable | Disabled |
 
@@ -124,16 +124,21 @@ The bundled system addon at `/var/egress/mitmscripts/system.py` is shipped in th
 - Forces streaming (`flow.response.stream = True`) for SSE (`text/event-stream`) and chunked responses, so each chunk is forwarded immediately instead of being buffered up to the `stream_large_bodies=1m` threshold (critical for LLM streaming UX).
 - Redacts credential values from response headers. Response bodies are not rewritten by default.
 
-The system addon is always loaded and cannot be disabled via configuration. To override its behavior, supply a user addon via `OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT`; user addons are loaded after the system addon and may observe or override its hooks.
+The system addon is always loaded and cannot be disabled via configuration. To override its behavior, supply user addons via `OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT` (comma-separated for multiple scripts); user addons are loaded after the system addon in the order given and may observe or override its hooks.
 
-### 3) Add a User Addon Alongside the System Addon
+### 3) Add User Addons Alongside the System Addon
 
 ```bash
 export OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT=true
+
+# Single addon
 export OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT=/path/to/your/addon.py
+
+# Multiple addons (comma-separated)
+export OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT=/path/to/auth.py,/path/to/logging.py
 ```
 
-The user addon is loaded after the system addon (`-s system.py -s user.py`), so user hooks observe and may override system behavior.
+User addons are loaded after the system addon (`-s system.py -s auth.py -s logging.py`), in the order given. Later addons observe and may override hooks from earlier ones.
 
 ### 4) Bypass Decryption for Specific Domains (e.g. log upload)
 

--- a/components/egress/mitmproxy_transparent.go
+++ b/components/egress/mitmproxy_transparent.go
@@ -104,9 +104,9 @@ func startMitmproxyTransparentIfEnabled() (*mitmTransparent, error) {
 	}
 
 	cfg := mitmproxy.Config{
-		ListenPort: mpPort,
-		UserName:   mitmproxy.RunAsUser,
-		ScriptPath: strings.TrimSpace(os.Getenv(constants.EnvMitmproxyScript)),
+		ListenPort:  mpPort,
+		UserName:    mitmproxy.RunAsUser,
+		ScriptPaths: parseScriptPaths(os.Getenv(constants.EnvMitmproxyScript)),
 	}
 	// Buffer absorbs OnExit events from a retry storm so OnExit goroutines
 	// don't all park waiting for the watcher to drain. Correctness does not
@@ -240,4 +240,18 @@ func (m *mitmTransparent) restartWithBackoff(ctx context.Context, gate *mitmprox
 			}
 		}
 	}
+}
+
+func parseScriptPaths(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -35,7 +35,7 @@
 #      found, ensuring domain-based TLS pass-through works reliably.
 #
 # User-defined addons can be loaded alongside this script via
-# OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT.
+# OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT (comma-separated for multiple scripts).
 from __future__ import annotations
 
 import http.client as http_client

--- a/components/egress/pkg/mitmproxy/launch.go
+++ b/components/egress/pkg/mitmproxy/launch.go
@@ -49,8 +49,9 @@ const systemScriptPath = "/var/egress/mitmscripts/system.py"
 type Config struct {
 	ListenPort int
 	UserName   string
-	// ScriptPath is an optional user-supplied addon, loaded after the system addon.
-	ScriptPath string
+	// ScriptPaths are optional user-supplied addons, loaded after the system addon
+	// in the order given. Parsed from the comma-separated OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT env var.
+	ScriptPaths []string
 	// OnExit is called (if non-nil) when mitmdump exits. Called from a background goroutine.
 	OnExit func(error)
 }
@@ -98,35 +99,7 @@ func Launch(cfg Config) (*Running, error) {
 		return nil, fmt.Errorf("mitmproxy: lookup user %q: %w", uname, err)
 	}
 
-	// Only per-launch dynamic values are passed on the command line. Static
-	// options (mode, listen_host, connection_strategy, stream_large_bodies,
-	// http2, ignore_hosts, ssl_verify_upstream_trusted_confdir) come from
-	// /var/lib/mitmproxy/.mitmproxy/config.yaml shipped in the egress image.
-	// `--set` overrides config.yaml, so the env-driven overrides below take
-	// precedence at runtime without rebuilding the image.
-	args := []string{
-		"--listen-port", strconv.Itoa(cfg.ListenPort),
-	}
-
-	// Upstream cert trust path override. Default in config.yaml is /etc/ssl/certs;
-	// override per-deployment when the upstream uses a private CA bundle.
-	if trustDir := strings.TrimSpace(os.Getenv(constants.EnvMitmproxyUpstreamTrustDir)); trustDir != "" {
-		args = append(args, "--set", "ssl_verify_upstream_trusted_confdir="+trustDir)
-	}
-
-	// Transparent mode redirects TCP to IP addresses. Clients connecting to IPs
-	// do not send SNI, so upstream TLS cert hostname verification fails with
-	// "IP address mismatch". Set OPENSANDBOX_EGRESS_MITMPROXY_SSL_INSECURE=true
-	// to skip upstream verification when clients connect by IP.
-	if constants.IsTruthy(os.Getenv(constants.EnvMitmproxySslInsecure)) {
-		args = append(args, "--set", "ssl_insecure=true")
-	}
-
-	// Load the system addon first so user addons can observe / override its hooks.
-	args = append(args, "-s", systemScriptPath)
-	if user := strings.TrimSpace(cfg.ScriptPath); user != "" {
-		args = append(args, "-s", user)
-	}
+	args := buildMitmdumpArgs(cfg)
 
 	cmd := exec.Command("mitmdump", args...)
 	cmd.Stdout = os.Stdout
@@ -153,6 +126,28 @@ func Launch(cfg Config) (*Running, error) {
 
 	log.Infof("[mitmproxy] mitmdump started (pid %d, transparent on %s:%d)", cmd.Process.Pid, listenHostLoopback, cfg.ListenPort)
 	return &Running{Cmd: cmd, done: done}, nil
+}
+
+func buildMitmdumpArgs(cfg Config) []string {
+	args := []string{
+		"--listen-port", strconv.Itoa(cfg.ListenPort),
+	}
+
+	if trustDir := strings.TrimSpace(os.Getenv(constants.EnvMitmproxyUpstreamTrustDir)); trustDir != "" {
+		args = append(args, "--set", "ssl_verify_upstream_trusted_confdir="+trustDir)
+	}
+
+	if constants.IsTruthy(os.Getenv(constants.EnvMitmproxySslInsecure)) {
+		args = append(args, "--set", "ssl_insecure=true")
+	}
+
+	args = append(args, "-s", systemScriptPath)
+	for _, p := range cfg.ScriptPaths {
+		if s := strings.TrimSpace(p); s != "" {
+			args = append(args, "-s", s)
+		}
+	}
+	return args
 }
 
 func buildMitmdumpEnv(base []string, home string) []string {

--- a/components/egress/pkg/mitmproxy/launch_test.go
+++ b/components/egress/pkg/mitmproxy/launch_test.go
@@ -20,6 +20,73 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildMitmdumpArgsNoUserScripts(t *testing.T) {
+	args := buildMitmdumpArgs(Config{ListenPort: 18081})
+	require.Contains(t, args, "--listen-port")
+	require.Contains(t, args, "18081")
+	require.Contains(t, args, "-s")
+	require.Contains(t, args, systemScriptPath)
+	// Only one -s (system addon)
+	count := 0
+	for _, a := range args {
+		if a == "-s" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}
+
+func TestBuildMitmdumpArgsSingleUserScript(t *testing.T) {
+	args := buildMitmdumpArgs(Config{
+		ListenPort:  18081,
+		ScriptPaths: []string{"/scripts/auth.py"},
+	})
+	count := 0
+	for _, a := range args {
+		if a == "-s" {
+			count++
+		}
+	}
+	require.Equal(t, 2, count)
+	require.Equal(t, "/scripts/auth.py", args[len(args)-1])
+}
+
+func TestBuildMitmdumpArgsMultipleUserScripts(t *testing.T) {
+	args := buildMitmdumpArgs(Config{
+		ListenPort:  18081,
+		ScriptPaths: []string{"/scripts/auth.py", "/scripts/logging.py"},
+	})
+	count := 0
+	for _, a := range args {
+		if a == "-s" {
+			count++
+		}
+	}
+	require.Equal(t, 3, count)
+	// Order: system, auth, logging
+	scripts := []string{}
+	for i, a := range args {
+		if a == "-s" {
+			scripts = append(scripts, args[i+1])
+		}
+	}
+	require.Equal(t, []string{systemScriptPath, "/scripts/auth.py", "/scripts/logging.py"}, scripts)
+}
+
+func TestBuildMitmdumpArgsSkipsEmptyScriptPaths(t *testing.T) {
+	args := buildMitmdumpArgs(Config{
+		ListenPort:  18081,
+		ScriptPaths: []string{"  ", "/scripts/auth.py", "", "  /scripts/logging.py  "},
+	})
+	scripts := []string{}
+	for i, a := range args {
+		if a == "-s" {
+			scripts = append(scripts, args[i+1])
+		}
+	}
+	require.Equal(t, []string{systemScriptPath, "/scripts/auth.py", "/scripts/logging.py"}, scripts)
+}
+
 func TestBuildMitmdumpEnvSetsMitmproxyHome(t *testing.T) {
 	env := buildMitmdumpEnv(
 		[]string{


### PR DESCRIPTION
## Summary

- `OPENSANDBOX_EGRESS_MITMPROXY_SCRIPT` now accepts comma-separated paths (e.g. `/a.py,/b.py`), each passed as a separate `-s` flag to mitmdump after the system addon
- `Config.ScriptPath string` → `ScriptPaths []string`，extract `buildMitmdumpArgs()` for testability
- Add `parseScriptPaths()` for comma-separated env parsing, 4 unit tests covering single/multiple/empty cases
- Fully backward compatible — single path and empty value still work as before

## Test plan

- [ ] Unit tests pass: `go test ./components/egress/pkg/mitmproxy/...`
- [ ] Verify single script env value still works (backward compat)
- [ ] Verify comma-separated value loads multiple addons in order
- [ ] Verify empty/whitespace-only entries are skipped
- [ ] Server-side env passthrough unaffected (no parsing on server side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)