### PR TITLE
Bump code-interpreter Kotlin SDK to 1.0.15

### DIFF
--- a/sdks/code-interpreter/kotlin/gradle.properties
+++ b/sdks/code-interpreter/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.14
+project.version=1.0.15
 project.description=A Kotlin SDK for Code Interpreter

--- a/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
+++ b/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 jackson = "2.18.2"
-sandbox = "1.0.14"
+sandbox = "1.0.15"
 junit-platform = "1.13.4"
 
 [libraries]


### PR DESCRIPTION
## Summary
- bump the Kotlin code-interpreter SDK artifact version to 1.0.15
- align its OpenSandbox sandbox dependency with 1.0.15

## Verification
- ./gradlew --no-configuration-cache -PuseMavenLocal publishToMavenLocal
- ./gradlew --no-configuration-cache -PuseMavenLocal :code-interpreter:test