### PR TITLE
Add Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
   <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox">
     <img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4?style=flat-square" alt="CNCF Landscape" />
   </a>
+  <a href="https://discord.gg/g7FuPs8YeD">
+    <img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" />
+  </a>
   <a href="https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11">
-    <img src="https://img.shields.io/badge/DingTalk-Join-0089FF?style=flat-square&logo=dingtalk&logoColor=white" alt="DingTalk" />
+    <img src="https://img.shields.io/badge/DingTalk-Join-0089FF?style=flat-square" alt="DingTalk" />
   </a>
   <a href="https://github.com/alibaba/OpenSandbox/actions">
     <img src="https://img.shields.io/github/actions/workflow/status/opensandbox-group/OpenSandbox/real-e2e.yml?branch=main&label=TEST&style=flat-square&logo=github&logoColor=white" alt="E2E Status" />
@@ -304,6 +307,7 @@ and how roadmap items are managed.
 ## Contact and Discussion
 
 - Issues: Submit bugs, feature requests, or design discussions through GitHub Issues
+- Discord: Join the [OpenSandbox Discord community](https://discord.gg/g7FuPs8YeD)
 - DingTalk: Join the [OpenSandbox technical discussion group](https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11)
 
 ## Star History


### PR DESCRIPTION
## Summary

- add a Discord community badge before the DingTalk badge in the README
- add the Discord invite to the Contact and Discussion section
- keep the DingTalk badge text-only after removing the unsupported logo parameter

## Validation

- Not run; README-only change.