### PR TITLE
feat(sdk): add LRU+TTL endpoint cache with inflight dedup across all SDKs

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/SandboxesAdapter.cs
@@ -27,6 +27,7 @@ namespace OpenSandbox.Adapters;
 internal sealed class SandboxesAdapter : ISandboxes
 {
     private readonly HttpClientWrapper _client;
+    private readonly EndpointCache? _endpointCache;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -35,9 +36,10 @@ internal sealed class SandboxesAdapter : ISandboxes
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
 
-    public SandboxesAdapter(HttpClientWrapper client)
+    public SandboxesAdapter(HttpClientWrapper client, EndpointCache? endpointCache = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _endpointCache = endpointCache;
     }
 
     public async Task<CreateSandboxResponse> CreateSandboxAsync(
@@ -211,6 +213,26 @@ internal sealed class SandboxesAdapter : ISandboxes
         bool useServerProxy = false,
         CancellationToken cancellationToken = default)
     {
+        if (_endpointCache != null)
+        {
+            var key = new EndpointCacheKey(sandboxId, port, useServerProxy);
+            // Shared fetch uses CancellationToken.None so one caller's cancellation
+            // doesn't kill the request for all waiters. Per-caller cancellation is
+            // handled in GetOrFetchAsync via Task.WhenAny.
+            return await _endpointCache.GetOrFetchAsync(key,
+                () => FetchSandboxEndpointAsync(sandboxId, port, useServerProxy, CancellationToken.None),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return await FetchSandboxEndpointAsync(sandboxId, port, useServerProxy, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Endpoint> FetchSandboxEndpointAsync(
+        string sandboxId,
+        int port,
+        bool useServerProxy,
+        CancellationToken cancellationToken)
+    {
         var queryParams = new Dictionary<string, string?>
         {
             ["use_server_proxy"] = useServerProxy ? "true" : "false"
@@ -222,6 +244,11 @@ internal sealed class SandboxesAdapter : ISandboxes
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return ParseEndpointResponse(response);
+    }
+
+    public void InvalidateEndpointCache(string sandboxId)
+    {
+        _endpointCache?.Invalidate(sandboxId);
     }
 
     public async Task<Endpoint> GetSignedSandboxEndpointAsync(

--- a/sdks/sandbox/csharp/src/OpenSandbox/Config/ConnectionConfig.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Config/ConnectionConfig.cs
@@ -69,6 +69,21 @@ public class ConnectionConfigOptions
     /// Gets or sets whether to use server-proxied endpoint URLs.
     /// </summary>
     public bool? UseServerProxy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the endpoint cache TTL in seconds. Default: 600 (10 minutes).
+    /// </summary>
+    public int? EndpointCacheTtlSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of cached endpoint entries. Default: 1024.
+    /// </summary>
+    public int? EndpointCacheSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to disable endpoint caching entirely.
+    /// </summary>
+    public bool? EndpointCacheDisabled { get; set; }
 }
 
 /// <summary>
@@ -111,6 +126,21 @@ public sealed class ConnectionConfig
     public bool UseServerProxy { get; }
 
     /// <summary>
+    /// Gets the endpoint cache TTL in seconds.
+    /// </summary>
+    public int EndpointCacheTtlSeconds { get; }
+
+    /// <summary>
+    /// Gets the maximum number of cached endpoint entries.
+    /// </summary>
+    public int EndpointCacheSize { get; }
+
+    /// <summary>
+    /// Gets whether endpoint caching is disabled.
+    /// </summary>
+    public bool EndpointCacheDisabled { get; }
+
+    /// <summary>
     /// Gets the user agent string.
     /// </summary>
     public string UserAgent { get; } = Constants.DefaultUserAgent;
@@ -137,6 +167,9 @@ public sealed class ConnectionConfig
         ApiKey = options.ApiKey ?? envApiKey;
         RequestTimeoutSeconds = options.RequestTimeoutSeconds ?? Constants.DefaultRequestTimeoutSeconds;
         UseServerProxy = options.UseServerProxy ?? false;
+        EndpointCacheTtlSeconds = options.EndpointCacheTtlSeconds ?? 600;
+        EndpointCacheSize = options.EndpointCacheSize ?? 1024;
+        EndpointCacheDisabled = options.EndpointCacheDisabled ?? false;
 
         var headers = new Dictionary<string, string>(options.Headers ?? new Dictionary<string, string>());
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/Core/EndpointCache.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Core/EndpointCache.cs
@@ -1,0 +1,177 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenSandbox.Models;
+
+namespace OpenSandbox.Core;
+
+internal readonly record struct EndpointCacheKey(string SandboxId, int Port, bool UseServerProxy);
+
+/// <summary>
+/// Thread-safe LRU + TTL endpoint cache with inflight deduplication.
+/// </summary>
+internal sealed class EndpointCache
+{
+    private readonly int _maxSize;
+    private readonly TimeSpan _ttl;
+    private readonly object _lock = new();
+    private readonly Dictionary<EndpointCacheKey, LinkedListNode<CacheEntry>> _entries = new();
+    private readonly LinkedList<CacheEntry> _order = new();
+    private readonly ConcurrentDictionary<EndpointCacheKey, Lazy<Task<Endpoint>>> _inflight = new();
+    private long _generation;
+
+    private sealed record CacheEntry(EndpointCacheKey Key, Endpoint Endpoint, long ExpiresAtTimestamp);
+
+    public EndpointCache(int maxSize = 1024, int ttlSeconds = 600)
+    {
+        _maxSize = maxSize > 0 ? maxSize : 1024;
+        _ttl = TimeSpan.FromSeconds(ttlSeconds > 0 ? ttlSeconds : 600);
+    }
+
+    private static long GetTimestamp() => Stopwatch.GetTimestamp();
+
+    private long TtlInTicks => (long)(_ttl.TotalSeconds * Stopwatch.Frequency);
+
+    public Endpoint? Get(EndpointCacheKey key)
+    {
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(key, out var node))
+                return null;
+
+            if (GetTimestamp() >= node.Value.ExpiresAtTimestamp)
+            {
+                RemoveLocked(node);
+                return null;
+            }
+
+            _order.Remove(node);
+            _order.AddFirst(node);
+            return node.Value.Endpoint;
+        }
+    }
+
+    public void Put(EndpointCacheKey key, Endpoint endpoint)
+    {
+        lock (_lock)
+        {
+            PutLocked(key, endpoint);
+        }
+    }
+
+    private void PutLocked(EndpointCacheKey key, Endpoint endpoint)
+    {
+        if (_entries.TryGetValue(key, out var existing))
+        {
+            _order.Remove(existing);
+            _entries.Remove(key);
+        }
+
+        while (_order.Count >= _maxSize)
+        {
+            var last = _order.Last;
+            if (last == null) break;
+            RemoveLocked(last);
+        }
+
+        var entry = new CacheEntry(key, endpoint, GetTimestamp() + TtlInTicks);
+        var node = _order.AddFirst(entry);
+        _entries[key] = node;
+    }
+
+    public void Invalidate(string sandboxId)
+    {
+        lock (_lock)
+        {
+            _generation++;
+            var toRemove = new List<LinkedListNode<CacheEntry>>();
+            foreach (var kvp in _entries)
+            {
+                if (kvp.Key.SandboxId == sandboxId)
+                    toRemove.Add(kvp.Value);
+            }
+
+            foreach (var node in toRemove)
+                RemoveLocked(node);
+        }
+        foreach (var key in _inflight.Keys)
+        {
+            if (key.SandboxId == sandboxId)
+                _inflight.TryRemove(key, out _);
+        }
+    }
+
+    public async Task<Endpoint> GetOrFetchAsync(
+        EndpointCacheKey key,
+        Func<Task<Endpoint>> fetcher,
+        CancellationToken cancellationToken = default)
+    {
+        var cached = Get(key);
+        if (cached != null)
+            return cached;
+
+        long genBefore;
+        lock (_lock) { genBefore = _generation; }
+        var lazy = _inflight.GetOrAdd(key, _ => new Lazy<Task<Endpoint>>(() => FetchAndCache(key, fetcher, genBefore)));
+
+        try
+        {
+            var fetchTask = lazy.Value;
+            if (cancellationToken.CanBeCanceled)
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                using (cancellationToken.Register(() => tcs.TrySetResult(true)))
+                {
+                    if (await Task.WhenAny(fetchTask, tcs.Task).ConfigureAwait(false) == tcs.Task)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                }
+            }
+            return await fetchTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            _inflight.TryRemove(key, out _);
+        }
+    }
+
+    private async Task<Endpoint> FetchAndCache(EndpointCacheKey key, Func<Task<Endpoint>> fetcher, long genBefore)
+    {
+        var endpoint = await fetcher().ConfigureAwait(false);
+        lock (_lock)
+        {
+            if (_generation == genBefore)
+                PutLocked(key, endpoint);
+        }
+        return endpoint;
+    }
+
+    public int Count
+    {
+        get { lock (_lock) { return _order.Count; } }
+    }
+
+    private void RemoveLocked(LinkedListNode<CacheEntry> node)
+    {
+        _entries.Remove(node.Value.Key);
+        _order.Remove(node);
+    }
+}

--- a/sdks/sandbox/csharp/src/OpenSandbox/Factory/DefaultAdapterFactory.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Factory/DefaultAdapterFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using OpenSandbox.Adapters;
+using OpenSandbox.Core;
 using OpenSandbox.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -38,7 +39,15 @@ public sealed class DefaultAdapterFactory : IAdapterFactory
             options.ConnectionConfig.Headers,
             options.LoggerFactory.CreateLogger("OpenSandbox.HttpClientWrapper"));
 
-        var sandboxes = new SandboxesAdapter(clientWrapper);
+        EndpointCache? endpointCache = null;
+        if (!options.ConnectionConfig.EndpointCacheDisabled)
+        {
+            endpointCache = new EndpointCache(
+                options.ConnectionConfig.EndpointCacheSize,
+                options.ConnectionConfig.EndpointCacheTtlSeconds);
+        }
+
+        var sandboxes = new SandboxesAdapter(clientWrapper, endpointCache);
 
         return new LifecycleStack
         {

--- a/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
@@ -512,6 +512,7 @@ public sealed class Sandbox : IAsyncDisposable
     /// <exception cref="SandboxApiException">Thrown when the sandbox API returns an error.</exception>
     public Task PauseAsync(CancellationToken cancellationToken = default)
     {
+        (_sandboxes as Adapters.SandboxesAdapter)?.InvalidateEndpointCache(Id);
         return _sandboxes.PauseSandboxAsync(Id, cancellationToken);
     }
 
@@ -552,6 +553,7 @@ public sealed class Sandbox : IAsyncDisposable
     /// <exception cref="SandboxApiException">Thrown when the sandbox API returns an error.</exception>
     public Task KillAsync(CancellationToken cancellationToken = default)
     {
+        (_sandboxes as Adapters.SandboxesAdapter)?.InvalidateEndpointCache(Id);
         return _sandboxes.DeleteSandboxAsync(Id, cancellationToken);
     }
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/ISandboxes.cs
@@ -168,4 +168,5 @@ public interface ISandboxes
         long expires,
         bool useServerProxy = false,
         CancellationToken cancellationToken = default);
+
 }

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/EndpointCacheTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/EndpointCacheTests.cs
@@ -1,0 +1,127 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenSandbox.Core;
+using OpenSandbox.Models;
+using Xunit;
+
+namespace OpenSandbox.Tests;
+
+public class EndpointCacheTests
+{
+    private static Endpoint Ep(string addr) => new() { EndpointAddress = addr, Headers = new Dictionary<string, string>() };
+
+    [Fact]
+    public void Get_ReturnsNull_OnMiss()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        var key = new EndpointCacheKey("sb-1", 8080, false);
+        Assert.Null(cache.Get(key));
+    }
+
+    [Fact]
+    public void Get_ReturnsEndpoint_AfterPut()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        var key = new EndpointCacheKey("sb-1", 8080, false);
+        cache.Put(key, Ep("localhost:8080"));
+        Assert.Equal("localhost:8080", cache.Get(key)?.EndpointAddress);
+    }
+
+    [Fact]
+    public void Invalidate_RemovesAllEntriesForSandbox()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        cache.Put(new EndpointCacheKey("sb-1", 8080, false), Ep("a"));
+        cache.Put(new EndpointCacheKey("sb-1", 18080, false), Ep("b"));
+        cache.Put(new EndpointCacheKey("sb-2", 8080, false), Ep("c"));
+
+        cache.Invalidate("sb-1");
+
+        Assert.Null(cache.Get(new EndpointCacheKey("sb-1", 8080, false)));
+        Assert.Null(cache.Get(new EndpointCacheKey("sb-1", 18080, false)));
+        Assert.NotNull(cache.Get(new EndpointCacheKey("sb-2", 8080, false)));
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_DeduplicatesConcurrentRequests()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        var key = new EndpointCacheKey("sb-1", 8080, false);
+        var fetchCount = 0;
+
+        async Task<Endpoint> Fetcher()
+        {
+            Interlocked.Increment(ref fetchCount);
+            await Task.Delay(50);
+            return Ep("result");
+        }
+
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => cache.GetOrFetchAsync(key, Fetcher))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, fetchCount);
+        Assert.All(results, r => Assert.Equal("result", r.EndpointAddress));
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_ReturnsCachedValue_WithoutCallingFetcher()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        var key = new EndpointCacheKey("sb-1", 8080, false);
+        cache.Put(key, Ep("cached"));
+        var called = false;
+
+        var result = await cache.GetOrFetchAsync(key, () =>
+        {
+            called = true;
+            return Task.FromResult(Ep("fetched"));
+        });
+
+        Assert.Equal("cached", result.EndpointAddress);
+        Assert.False(called);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_DoesNotCache_OnError()
+    {
+        var cache = new EndpointCache(maxSize: 10, ttlSeconds: 60);
+        var key = new EndpointCacheKey("sb-1", 8080, false);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            cache.GetOrFetchAsync(key, () => throw new InvalidOperationException("network error")));
+
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void LruEviction_WhenAtCapacity()
+    {
+        var cache = new EndpointCache(maxSize: 3, ttlSeconds: 60);
+        cache.Put(new EndpointCacheKey("sb-0", 8080, false), Ep("h0"));
+        cache.Put(new EndpointCacheKey("sb-1", 8080, false), Ep("h1"));
+        cache.Put(new EndpointCacheKey("sb-2", 8080, false), Ep("h2"));
+
+        // Access sb-0 to make it recently used
+        cache.Get(new EndpointCacheKey("sb-0", 8080, false));
+        // Insert 4th — sb-1 should be evicted
+        cache.Put(new EndpointCacheKey("sb-3", 8080, false), Ep("h3"));
+
+        Assert.Null(cache.Get(new EndpointCacheKey("sb-1", 8080, false)));
+        Assert.NotNull(cache.Get(new EndpointCacheKey("sb-0", 8080, false)));
+    }
+}

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -343,6 +343,7 @@ public class SandboxEgressLifecycleTests
                 }
             });
         }
+
     }
 
     private sealed class StubEgress : IEgress

--- a/sdks/sandbox/go/config.go
+++ b/sdks/sandbox/go/config.go
@@ -72,6 +72,17 @@ type ConnectionConfig struct {
 	// resolvable from the host machine.
 	// Example: map[string]string{"host.docker.internal": "localhost"}
 	EndpointHostRewrite map[string]string
+
+	// EndpointCacheTTL is how long a cached endpoint stays valid.
+	// Zero means DefaultEndpointCacheTTL (600s).
+	EndpointCacheTTL time.Duration
+
+	// EndpointCacheSize is the maximum number of cached endpoints.
+	// Zero means DefaultEndpointCacheSize (1024).
+	EndpointCacheSize int
+
+	// EndpointCacheDisabled disables endpoint caching entirely.
+	EndpointCacheDisabled bool
 }
 
 // RewriteEndpointURL applies EndpointHostRewrite rules to an endpoint URL
@@ -174,7 +185,11 @@ func (c *ConnectionConfig) clientOpts(includeAuthHeader bool) []Option {
 // Appends the API version prefix (/v1) to the base URL, as required by
 // NewLifecycleClient and the OpenSandbox lifecycle API spec.
 func (c *ConnectionConfig) lifecycleClient() *LifecycleClient {
-	return NewLifecycleClient(c.GetBaseURL()+"/"+APIVersion, c.GetAPIKey(), c.clientOpts(true)...)
+	var cache *EndpointCache
+	if !c.EndpointCacheDisabled {
+		cache = NewEndpointCache(c.EndpointCacheSize, c.EndpointCacheTTL)
+	}
+	return NewLifecycleClientWithCache(c.GetBaseURL()+"/"+APIVersion, c.GetAPIKey(), cache, c.clientOpts(true)...)
 }
 
 // execdClient creates an ExecdClient for a resolved endpoint. All headers

--- a/sdks/sandbox/go/endpoint_cache.go
+++ b/sdks/sandbox/go/endpoint_cache.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	DefaultEndpointCacheTTL  = 600 * time.Second
+	DefaultEndpointCacheSize = 1024
+)
+
+type endpointCacheKey struct {
+	sandboxID      string
+	port           int
+	useServerProxy bool
+}
+
+func (k endpointCacheKey) String() string {
+	return fmt.Sprintf("%s:%d:%v", k.sandboxID, k.port, k.useServerProxy)
+}
+
+type endpointCacheEntry struct {
+	key       endpointCacheKey
+	endpoint  *Endpoint
+	expiresAt time.Time
+}
+
+func cloneEndpoint(ep *Endpoint) *Endpoint {
+	headers := make(map[string]string, len(ep.Headers))
+	for k, v := range ep.Headers {
+		headers[k] = v
+	}
+	return &Endpoint{Endpoint: ep.Endpoint, Headers: headers}
+}
+
+// EndpointCache is a thread-safe LRU+TTL cache for sandbox endpoints.
+type EndpointCache struct {
+	mu      sync.Mutex
+	entries map[endpointCacheKey]*list.Element
+	order   *list.List
+	maxSize int
+	ttl     time.Duration
+
+	group singleflight.Group
+}
+
+// NewEndpointCache creates a cache with the given max size and TTL.
+// If maxSize <= 0, DefaultEndpointCacheSize is used.
+// If ttl <= 0, DefaultEndpointCacheTTL is used.
+func NewEndpointCache(maxSize int, ttl time.Duration) *EndpointCache {
+	if maxSize <= 0 {
+		maxSize = DefaultEndpointCacheSize
+	}
+	if ttl <= 0 {
+		ttl = DefaultEndpointCacheTTL
+	}
+	return &EndpointCache{
+		entries: make(map[endpointCacheKey]*list.Element),
+		order:   list.New(),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+}
+
+// Get retrieves a cached endpoint. Returns nil, false on miss or expiry.
+func (c *EndpointCache) Get(key endpointCacheKey) (*Endpoint, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	entry := elem.Value.(*endpointCacheEntry)
+	if time.Now().After(entry.expiresAt) {
+		c.removeLocked(elem)
+		return nil, false
+	}
+	c.order.MoveToFront(elem)
+	return cloneEndpoint(entry.endpoint), true
+}
+
+// Put stores an endpoint in the cache, evicting LRU entries if at capacity.
+func (c *EndpointCache) Put(key endpointCacheKey, ep *Endpoint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.entries[key]; ok {
+		c.order.MoveToFront(elem)
+		entry := elem.Value.(*endpointCacheEntry)
+		entry.endpoint = cloneEndpoint(ep)
+		entry.expiresAt = time.Now().Add(c.ttl)
+		return
+	}
+
+	for c.order.Len() >= c.maxSize {
+		oldest := c.order.Back()
+		if oldest == nil {
+			break
+		}
+		c.removeLocked(oldest)
+	}
+
+	entry := &endpointCacheEntry{
+		key:       key,
+		endpoint:  cloneEndpoint(ep),
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	elem := c.order.PushFront(entry)
+	c.entries[key] = elem
+}
+
+// Invalidate removes all cached and inflight entries for the given sandbox ID.
+func (c *EndpointCache) Invalidate(sandboxID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, elem := range c.entries {
+		if key.sandboxID == sandboxID {
+			c.removeLocked(elem)
+			c.group.Forget(key.String())
+		}
+	}
+}
+
+// Len returns the number of entries in the cache.
+func (c *EndpointCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}
+
+func (c *EndpointCache) removeLocked(elem *list.Element) {
+	entry := elem.Value.(*endpointCacheEntry)
+	delete(c.entries, entry.key)
+	c.order.Remove(elem)
+}
+
+// GetOrFetch checks cache, deduplicates inflight requests via singleflight,
+// and calls fetch on miss. The caller's context is respected: if ctx is
+// cancelled while waiting for a shared inflight request, the caller returns
+// immediately with the context error (the shared fetch continues for other waiters).
+func (c *EndpointCache) GetOrFetch(ctx context.Context, key endpointCacheKey, fetch func() (*Endpoint, error)) (*Endpoint, error) {
+	if ep, ok := c.Get(key); ok {
+		return ep, nil
+	}
+
+	ch := c.group.DoChan(key.String(), func() (interface{}, error) {
+		if ep, ok := c.Get(key); ok {
+			return ep, nil
+		}
+		ep, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		c.Put(key, ep)
+		return ep, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-ch:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		return cloneEndpoint(result.Val.(*Endpoint)), nil
+	}
+}

--- a/sdks/sandbox/go/endpoint_cache_test.go
+++ b/sdks/sandbox/go/endpoint_cache_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEndpointCache_GetPut(t *testing.T) {
+	c := NewEndpointCache(10, time.Minute)
+
+	key := endpointCacheKey{sandboxID: "sb-1", port: 8080, useServerProxy: false}
+	ep := &Endpoint{Endpoint: "localhost:8080"}
+
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	c.Put(key, ep)
+
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected hit after put")
+	}
+	if got.Endpoint != ep.Endpoint {
+		t.Fatalf("got %q, want %q", got.Endpoint, ep.Endpoint)
+	}
+}
+
+func TestEndpointCache_TTLExpiry(t *testing.T) {
+	c := NewEndpointCache(10, 50*time.Millisecond)
+
+	key := endpointCacheKey{sandboxID: "sb-1", port: 8080}
+	c.Put(key, &Endpoint{Endpoint: "localhost:8080"})
+
+	if _, ok := c.Get(key); !ok {
+		t.Fatal("expected hit before TTL")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected miss after TTL")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("expected 0 entries after expiry, got %d", c.Len())
+	}
+}
+
+func TestEndpointCache_LRUEviction(t *testing.T) {
+	c := NewEndpointCache(3, time.Minute)
+
+	for i := 0; i < 3; i++ {
+		key := endpointCacheKey{sandboxID: fmt.Sprintf("sb-%d", i), port: 8080}
+		c.Put(key, &Endpoint{Endpoint: fmt.Sprintf("host-%d:8080", i)})
+	}
+
+	if c.Len() != 3 {
+		t.Fatalf("expected 3 entries, got %d", c.Len())
+	}
+
+	// Access sb-0 to make it recently used.
+	c.Get(endpointCacheKey{sandboxID: "sb-0", port: 8080})
+
+	// Insert 4th — should evict sb-1 (least recently used).
+	c.Put(endpointCacheKey{sandboxID: "sb-3", port: 8080}, &Endpoint{Endpoint: "host-3:8080"})
+
+	if c.Len() != 3 {
+		t.Fatalf("expected 3 entries after eviction, got %d", c.Len())
+	}
+
+	if _, ok := c.Get(endpointCacheKey{sandboxID: "sb-1", port: 8080}); ok {
+		t.Fatal("sb-1 should have been evicted")
+	}
+	if _, ok := c.Get(endpointCacheKey{sandboxID: "sb-0", port: 8080}); !ok {
+		t.Fatal("sb-0 should still be cached")
+	}
+}
+
+func TestEndpointCache_Invalidate(t *testing.T) {
+	c := NewEndpointCache(10, time.Minute)
+
+	c.Put(endpointCacheKey{sandboxID: "sb-1", port: 8080}, &Endpoint{Endpoint: "a"})
+	c.Put(endpointCacheKey{sandboxID: "sb-1", port: 18080}, &Endpoint{Endpoint: "b"})
+	c.Put(endpointCacheKey{sandboxID: "sb-2", port: 8080}, &Endpoint{Endpoint: "c"})
+
+	c.Invalidate("sb-1")
+
+	if c.Len() != 1 {
+		t.Fatalf("expected 1 entry after invalidate, got %d", c.Len())
+	}
+	if _, ok := c.Get(endpointCacheKey{sandboxID: "sb-2", port: 8080}); !ok {
+		t.Fatal("sb-2 should still be cached")
+	}
+}
+
+func TestEndpointCache_GetOrFetch_Dedup(t *testing.T) {
+	c := NewEndpointCache(10, time.Minute)
+	key := endpointCacheKey{sandboxID: "sb-1", port: 8080}
+
+	var fetchCount int64
+	fetch := func() (*Endpoint, error) {
+		atomic.AddInt64(&fetchCount, 1)
+		time.Sleep(50 * time.Millisecond)
+		return &Endpoint{Endpoint: "result"}, nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ep, err := c.GetOrFetch(context.Background(), key, fetch)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if ep.Endpoint != "result" {
+				t.Errorf("got %q, want %q", ep.Endpoint, "result")
+			}
+		}()
+	}
+	wg.Wait()
+
+	count := atomic.LoadInt64(&fetchCount)
+	if count != 1 {
+		t.Fatalf("fetch called %d times, want 1 (singleflight dedup)", count)
+	}
+}
+
+func TestEndpointCache_GetOrFetch_CacheHit(t *testing.T) {
+	c := NewEndpointCache(10, time.Minute)
+	key := endpointCacheKey{sandboxID: "sb-1", port: 8080}
+
+	c.Put(key, &Endpoint{Endpoint: "cached"})
+
+	var fetchCount int64
+	ep, err := c.GetOrFetch(context.Background(), key, func() (*Endpoint, error) {
+		atomic.AddInt64(&fetchCount, 1)
+		return &Endpoint{Endpoint: "fetched"}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.Endpoint != "cached" {
+		t.Fatalf("got %q, want %q", ep.Endpoint, "cached")
+	}
+	if atomic.LoadInt64(&fetchCount) != 0 {
+		t.Fatal("fetch should not be called on cache hit")
+	}
+}
+
+func TestEndpointCache_GetOrFetch_Error(t *testing.T) {
+	c := NewEndpointCache(10, time.Minute)
+	key := endpointCacheKey{sandboxID: "sb-1", port: 8080}
+
+	_, err := c.GetOrFetch(context.Background(), key, func() (*Endpoint, error) {
+		return nil, fmt.Errorf("network error")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if c.Len() != 0 {
+		t.Fatal("failed fetch should not populate cache")
+	}
+}

--- a/sdks/sandbox/go/go.mod
+++ b/sdks/sandbox/go/go.mod
@@ -1,3 +1,5 @@
 module github.com/alibaba/OpenSandbox/sdks/sandbox/go
 
 go 1.20
+
+require golang.org/x/sync v0.7.0

--- a/sdks/sandbox/go/go.sum
+++ b/sdks/sandbox/go/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/sdks/sandbox/go/lifecycle.go
+++ b/sdks/sandbox/go/lifecycle.go
@@ -25,6 +25,7 @@ import (
 // LifecycleClient provides methods for the OpenSandbox Lifecycle API.
 type LifecycleClient struct {
 	*Client
+	cache *EndpointCache
 }
 
 // NewLifecycleClient creates a new LifecycleClient.
@@ -32,6 +33,15 @@ type LifecycleClient struct {
 func NewLifecycleClient(baseURL, apiKey string, opts ...Option) *LifecycleClient {
 	return &LifecycleClient{
 		Client: NewClient(baseURL, apiKey, "OPEN-SANDBOX-API-KEY", opts...),
+		cache:  NewEndpointCache(0, 0),
+	}
+}
+
+// NewLifecycleClientWithCache creates a LifecycleClient with custom cache settings.
+func NewLifecycleClientWithCache(baseURL, apiKey string, cache *EndpointCache, opts ...Option) *LifecycleClient {
+	return &LifecycleClient{
+		Client: NewClient(baseURL, apiKey, "OPEN-SANDBOX-API-KEY", opts...),
+		cache:  cache,
 	}
 }
 
@@ -187,9 +197,29 @@ func (c *LifecycleClient) RenewExpiration(ctx context.Context, id string, expire
 }
 
 // GetEndpoint retrieves the public access endpoint for a service running
-// on the specified port inside the sandbox. If useServerProxy is non-nil,
+// on the specified port inside the sandbox. Results are cached with LRU+TTL
+// and deduplicated via singleflight. If useServerProxy is non-nil,
 // the server proxy query parameter is included.
 func (c *LifecycleClient) GetEndpoint(ctx context.Context, sandboxID string, port int, useServerProxy *bool) (*Endpoint, error) {
+	if c.cache == nil {
+		return c.getEndpointFromServer(ctx, sandboxID, port, useServerProxy)
+	}
+
+	key := endpointCacheKey{
+		sandboxID:      sandboxID,
+		port:           port,
+		useServerProxy: useServerProxy != nil && *useServerProxy,
+	}
+
+	// The shared fetch uses a background context so one caller's deadline
+	// doesn't cancel the request for all waiters. Each caller's ctx is
+	// respected via DoChan select in GetOrFetch.
+	return c.cache.GetOrFetch(ctx, key, func() (*Endpoint, error) {
+		return c.getEndpointFromServer(context.Background(), sandboxID, port, useServerProxy)
+	})
+}
+
+func (c *LifecycleClient) getEndpointFromServer(ctx context.Context, sandboxID string, port int, useServerProxy *bool) (*Endpoint, error) {
 	path := fmt.Sprintf("/sandboxes/%s/endpoints/%d", url.PathEscape(sandboxID), port)
 	params := url.Values{}
 	if useServerProxy != nil {

--- a/sdks/sandbox/go/sandbox.go
+++ b/sdks/sandbox/go/sandbox.go
@@ -238,6 +238,9 @@ func (s *Sandbox) Resume(ctx context.Context, opts ...ReadyOptions) (*Sandbox, e
 
 // Kill terminates the sandbox. This is irreversible.
 func (s *Sandbox) Kill(ctx context.Context) error {
+	if s.lifecycle.cache != nil {
+		s.lifecycle.cache.Invalidate(s.id)
+	}
 	return s.lifecycle.DeleteSandbox(ctx, s.id)
 }
 
@@ -249,7 +252,11 @@ func (s *Sandbox) Close() error {
 }
 
 // Pause pauses the sandbox while preserving its state.
+// Endpoint cache is invalidated because endpoints may change across pause/resume.
 func (s *Sandbox) Pause(ctx context.Context) error {
+	if s.lifecycle.cache != nil {
+		s.lifecycle.cache.Invalidate(s.id)
+	}
 	return s.lifecycle.PauseSandbox(ctx, s.id)
 }
 

--- a/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
@@ -15,6 +15,7 @@
 import type { LifecycleClient } from "../openapi/lifecycleClient.js";
 import { throwOnOpenApiFetchError } from "./openapiError.js";
 import type { paths as LifecyclePaths } from "../api/lifecycle.js";
+import { EndpointCache } from "../core/endpointCache.js";
 import type {
   Sandboxes,
 } from "../services/sandboxes.js";
@@ -75,7 +76,21 @@ function encodeMetadataFilter(metadata: Record<string, string>): string {
 }
 
 export class SandboxesAdapter implements Sandboxes {
-  constructor(private readonly client: LifecycleClient) {}
+  private readonly endpointCache: EndpointCache | null;
+
+  constructor(
+    private readonly client: LifecycleClient,
+    cacheOpts?: { ttlMs?: number; maxSize?: number; disabled?: boolean }
+  ) {
+    if (cacheOpts?.disabled) {
+      this.endpointCache = null;
+    } else {
+      this.endpointCache = new EndpointCache({
+        ttlMs: cacheOpts?.ttlMs,
+        maxSize: cacheOpts?.maxSize,
+      });
+    }
+  }
 
   private parseIsoDate(field: string, v: unknown): Date {
     if (typeof v !== "string" || !v) {
@@ -291,6 +306,19 @@ export class SandboxesAdapter implements Sandboxes {
     port: number,
     useServerProxy = false
   ): Promise<Endpoint> {
+    if (this.endpointCache) {
+      return this.endpointCache.getOrFetch(sandboxId, port, useServerProxy, () =>
+        this.fetchSandboxEndpoint(sandboxId, port, useServerProxy)
+      );
+    }
+    return this.fetchSandboxEndpoint(sandboxId, port, useServerProxy);
+  }
+
+  private async fetchSandboxEndpoint(
+    sandboxId: SandboxId,
+    port: number,
+    useServerProxy: boolean
+  ): Promise<Endpoint> {
     const { data, error, response } = await this.client.GET("/sandboxes/{sandboxId}/endpoints/{port}", {
       params: { path: { sandboxId, port }, query: { use_server_proxy: useServerProxy } },
     });
@@ -300,6 +328,10 @@ export class SandboxesAdapter implements Sandboxes {
       throw new Error("Get sandbox endpoint failed: unexpected response shape");
     }
     return ok as unknown as Endpoint;
+  }
+
+  invalidateEndpointCache(sandboxId: SandboxId): void {
+    this.endpointCache?.invalidate(sandboxId);
   }
 
   async getSignedEndpoint(

--- a/sdks/sandbox/javascript/src/config/connection.ts
+++ b/sdks/sandbox/javascript/src/config/connection.ts
@@ -50,6 +50,18 @@ export interface ConnectionConfigOptions {
    * Useful when the client SDK cannot access the created sandbox directly.
    */
   useServerProxy?: boolean;
+  /**
+   * TTL in milliseconds for cached endpoint entries. Default: 600000 (10 minutes).
+   */
+  endpointCacheTtlMs?: number;
+  /**
+   * Maximum number of cached endpoint entries. Default: 1024.
+   */
+  endpointCacheSize?: number;
+  /**
+   * Disable endpoint caching entirely.
+   */
+  endpointCacheDisabled?: boolean;
 }
 
 function isNodeRuntime(): boolean {
@@ -266,6 +278,9 @@ export class ConnectionConfig {
    * Use sandbox server as proxy for endpoint requests (default false).
    */
   readonly useServerProxy: boolean;
+  readonly endpointCacheTtlMs: number;
+  readonly endpointCacheSize: number;
+  readonly endpointCacheDisabled: boolean;
   private _closeTransport: () => Promise<void>;
   private _closePromise: Promise<void> | null = null;
   private _transportInitialized = false;
@@ -294,6 +309,9 @@ export class ConnectionConfig {
         : 30;
     this.debug = !!opts.debug;
     this.useServerProxy = !!opts.useServerProxy;
+    this.endpointCacheTtlMs = opts.endpointCacheTtlMs ?? 600_000;
+    this.endpointCacheSize = opts.endpointCacheSize ?? 1024;
+    this.endpointCacheDisabled = !!opts.endpointCacheDisabled;
 
     const headers: Record<string, string> = { ...(opts.headers ?? {}) };
     // Attach API key via header unless the user already provided one.
@@ -378,6 +396,9 @@ export class ConnectionConfig {
       requestTimeoutSeconds: this.requestTimeoutSeconds,
       debug: this.debug,
       useServerProxy: this.useServerProxy,
+      endpointCacheTtlMs: this.endpointCacheTtlMs,
+      endpointCacheSize: this.endpointCacheSize,
+      endpointCacheDisabled: this.endpointCacheDisabled,
     });
     clone.initializeTransport();
     return clone;

--- a/sdks/sandbox/javascript/src/core/endpointCache.ts
+++ b/sdks/sandbox/javascript/src/core/endpointCache.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Endpoint } from "../models/sandboxes.js";
+
+interface CacheEntry {
+  endpoint: Endpoint;
+  expiresAt: number;
+}
+
+/**
+ * LRU + TTL endpoint cache with inflight deduplication.
+ *
+ * JS is single-threaded so no mutex needed — but concurrent async calls
+ * can overlap, so inflight dedup uses a shared Promise per key.
+ */
+export class EndpointCache {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inflight = new Map<string, Promise<Endpoint>>();
+  private readonly maxSize: number;
+  private readonly ttlMs: number;
+  private generation = 0;
+
+  constructor(opts: { maxSize?: number; ttlMs?: number } = {}) {
+    this.maxSize = opts.maxSize ?? 1024;
+    this.ttlMs = opts.ttlMs ?? 600_000;
+  }
+
+  private cloneEndpoint(ep: Endpoint): Endpoint {
+    return { ...ep, headers: ep.headers ? { ...ep.headers } : {} };
+  }
+
+  private makeKey(sandboxId: string, port: number, useServerProxy: boolean): string {
+    return `${sandboxId}:${port}:${useServerProxy}`;
+  }
+
+  get(sandboxId: string, port: number, useServerProxy: boolean): Endpoint | undefined {
+    const key = this.makeKey(sandboxId, port, useServerProxy);
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    // Move to end (most recently used) — delete + re-set.
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return this.cloneEndpoint(entry.endpoint);
+  }
+
+  put(sandboxId: string, port: number, useServerProxy: boolean, endpoint: Endpoint): void {
+    const key = this.makeKey(sandboxId, port, useServerProxy);
+    this.cache.delete(key);
+    while (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+      else break;
+    }
+    this.cache.set(key, { endpoint: this.cloneEndpoint(endpoint), expiresAt: Date.now() + this.ttlMs });
+  }
+
+  invalidate(sandboxId: string): void {
+    this.generation++;
+    const prefix = `${sandboxId}:`;
+    for (const key of [...this.cache.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.cache.delete(key);
+      }
+    }
+    for (const key of [...this.inflight.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.inflight.delete(key);
+      }
+    }
+  }
+
+  async getOrFetch(
+    sandboxId: string,
+    port: number,
+    useServerProxy: boolean,
+    fetcher: () => Promise<Endpoint>
+  ): Promise<Endpoint> {
+    const cached = this.get(sandboxId, port, useServerProxy);
+    if (cached) return cached;
+
+    const key = this.makeKey(sandboxId, port, useServerProxy);
+
+    const existing = this.inflight.get(key);
+    if (existing) return existing.then((ep) => this.cloneEndpoint(ep));
+
+    const genBefore = this.generation;
+    const promise = fetcher()
+      .then((ep) => {
+        // Only cache if no invalidation occurred during fetch.
+        if (this.generation === genBefore) {
+          this.put(sandboxId, port, useServerProxy, ep);
+        }
+        this.inflight.delete(key);
+        return this.cloneEndpoint(ep);
+      })
+      .catch((err) => {
+        this.inflight.delete(key);
+        throw err;
+      });
+
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/sdks/sandbox/javascript/src/factory/defaultAdapterFactory.ts
+++ b/sdks/sandbox/javascript/src/factory/defaultAdapterFactory.ts
@@ -42,7 +42,11 @@ export class DefaultAdapterFactory implements AdapterFactory {
       headers: opts.connectionConfig.headers,
       fetch: opts.connectionConfig.fetch,
     });
-    const sandboxes = new SandboxesAdapter(lifecycleClient);
+    const sandboxes = new SandboxesAdapter(lifecycleClient, {
+      ttlMs: opts.connectionConfig.endpointCacheTtlMs,
+      maxSize: opts.connectionConfig.endpointCacheSize,
+      disabled: opts.connectionConfig.endpointCacheDisabled,
+    });
     return { sandboxes };
   }
 

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -569,6 +569,7 @@ export class Sandbox {
   }
 
   async pause(): Promise<void> {
+    this.sandboxes.invalidateEndpointCache?.(this.id);
     await this.sandboxes.pauseSandbox(this.id);
   }
 
@@ -625,6 +626,7 @@ export class Sandbox {
   }
 
   async kill(): Promise<void> {
+    this.sandboxes.invalidateEndpointCache?.(this.id);
     await this.sandboxes.deleteSandbox(this.id);
   }
 

--- a/sdks/sandbox/javascript/src/services/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/services/sandboxes.ts
@@ -67,4 +67,6 @@ export interface Sandboxes {
     port: number,
     expires: number
   ): Promise<Endpoint>;
+
+  invalidateEndpointCache?(sandboxId: SandboxId): void;
 }

--- a/sdks/sandbox/javascript/tests/endpointCache.test.ts
+++ b/sdks/sandbox/javascript/tests/endpointCache.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EndpointCache } from "../src/core/endpointCache.js";
+
+function ep(addr: string) {
+  return { endpoint: addr, headers: {} };
+}
+
+describe("EndpointCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined on miss", () => {
+    const c = new EndpointCache();
+    expect(c.get("sb-1", 8080, false)).toBeUndefined();
+  });
+
+  it("returns cached endpoint on hit", () => {
+    const c = new EndpointCache();
+    c.put("sb-1", 8080, false, ep("localhost:8080"));
+    expect(c.get("sb-1", 8080, false)?.endpoint).toBe("localhost:8080");
+  });
+
+  it("expires entries after TTL", () => {
+    const c = new EndpointCache({ ttlMs: 1000 });
+    c.put("sb-1", 8080, false, ep("localhost:8080"));
+    expect(c.get("sb-1", 8080, false)).toBeDefined();
+    vi.advanceTimersByTime(1001);
+    expect(c.get("sb-1", 8080, false)).toBeUndefined();
+  });
+
+  it("evicts LRU when at capacity", () => {
+    const c = new EndpointCache({ maxSize: 3, ttlMs: 60000 });
+    c.put("sb-0", 8080, false, ep("h0"));
+    c.put("sb-1", 8080, false, ep("h1"));
+    c.put("sb-2", 8080, false, ep("h2"));
+    // Access sb-0 to make it recently used
+    c.get("sb-0", 8080, false);
+    // Insert 4th — sb-1 should be evicted (LRU)
+    c.put("sb-3", 8080, false, ep("h3"));
+    expect(c.get("sb-1", 8080, false)).toBeUndefined();
+    expect(c.get("sb-0", 8080, false)?.endpoint).toBe("h0");
+  });
+
+  it("invalidates all entries for a sandbox", () => {
+    const c = new EndpointCache();
+    c.put("sb-1", 8080, false, ep("a"));
+    c.put("sb-1", 18080, false, ep("b"));
+    c.put("sb-2", 8080, false, ep("c"));
+    c.invalidate("sb-1");
+    expect(c.get("sb-1", 8080, false)).toBeUndefined();
+    expect(c.get("sb-1", 18080, false)).toBeUndefined();
+    expect(c.get("sb-2", 8080, false)?.endpoint).toBe("c");
+  });
+
+  it("deduplicates concurrent fetches", async () => {
+    vi.useRealTimers();
+    const c = new EndpointCache();
+    let fetchCount = 0;
+    const fetcher = async () => {
+      fetchCount++;
+      await new Promise((r) => setTimeout(r, 50));
+      return ep("result");
+    };
+
+    const results = await Promise.all([
+      c.getOrFetch("sb-1", 8080, false, fetcher),
+      c.getOrFetch("sb-1", 8080, false, fetcher),
+      c.getOrFetch("sb-1", 8080, false, fetcher),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(results.every((r) => r.endpoint === "result")).toBe(true);
+  });
+
+  it("does not cache on fetch error", async () => {
+    vi.useRealTimers();
+    const c = new EndpointCache();
+    const fetcher = async () => {
+      throw new Error("network error");
+    };
+
+    await expect(c.getOrFetch("sb-1", 8080, false, fetcher)).rejects.toThrow("network error");
+    expect(c.size).toBe(0);
+  });
+
+  it("returns cached value without calling fetcher", async () => {
+    vi.useRealTimers();
+    const c = new EndpointCache();
+    c.put("sb-1", 8080, false, ep("cached"));
+    let called = false;
+    const result = await c.getOrFetch("sb-1", 8080, false, async () => {
+      called = true;
+      return ep("fetched");
+    });
+    expect(result.endpoint).toBe("cached");
+    expect(called).toBe(false);
+  });
+});

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -574,6 +574,7 @@ class Sandbox internal constructor(
      */
     fun pause() {
         logger.info("Pausing sandbox: {}", id)
+        sandboxService.invalidateEndpointCache(id)
         sandboxService.pauseSandbox(id)
     }
 
@@ -587,6 +588,7 @@ class Sandbox internal constructor(
      * @throws SandboxException if termination fails
      */
     fun kill() {
+        sandboxService.invalidateEndpointCache(id)
         sandboxService.killSandbox(id)
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -46,6 +46,12 @@ class ConnectionConfig private constructor(
      * Useful when the client SDK cannot access the created sandbox directly.
      */
     val useServerProxy: Boolean = false,
+    /** TTL for cached endpoint entries. Default: 10 minutes. */
+    val endpointCacheTtl: Duration = Duration.ofSeconds(600),
+    /** Maximum number of cached endpoint entries. Default: 1024. */
+    val endpointCacheSize: Int = 1024,
+    /** Disable endpoint caching entirely. */
+    val endpointCacheDisabled: Boolean = false,
 ) {
     /**
      * Creates a copy of this ConnectionConfig without copying the connectionPool.
@@ -63,6 +69,9 @@ class ConnectionConfig private constructor(
             connectionPool = null,
             connectionPoolManagedByUser = false,
             useServerProxy = this.useServerProxy,
+            endpointCacheTtl = this.endpointCacheTtl,
+            endpointCacheSize = this.endpointCacheSize,
+            endpointCacheDisabled = this.endpointCacheDisabled,
         )
 
     companion object {
@@ -146,6 +155,9 @@ class ConnectionConfig private constructor(
         private var connectionPoolManagedByUser: Boolean = false
 
         private var useServerProxy: Boolean = false
+        private var endpointCacheTtl: Duration = Duration.ofSeconds(600)
+        private var endpointCacheSize: Int = 1024
+        private var endpointCacheDisabled: Boolean = false
 
         /**
          * Use sandbox server as proxy for process execd requests.
@@ -153,6 +165,24 @@ class ConnectionConfig private constructor(
          */
         fun useServerProxy(useServerProxy: Boolean): Builder {
             this.useServerProxy = useServerProxy
+            return this
+        }
+
+        /** Set endpoint cache TTL. */
+        fun endpointCacheTtl(ttl: Duration): Builder {
+            this.endpointCacheTtl = ttl
+            return this
+        }
+
+        /** Set endpoint cache max size. */
+        fun endpointCacheSize(size: Int): Builder {
+            this.endpointCacheSize = size
+            return this
+        }
+
+        /** Disable endpoint caching. */
+        fun endpointCacheDisabled(disabled: Boolean): Builder {
+            this.endpointCacheDisabled = disabled
             return this
         }
 
@@ -293,6 +323,9 @@ class ConnectionConfig private constructor(
                 connectionPool = connectionPool,
                 connectionPoolManagedByUser = connectionPoolManagedByUser,
                 useServerProxy = useServerProxy,
+                endpointCacheTtl = endpointCacheTtl,
+                endpointCacheSize = endpointCacheSize,
+                endpointCacheDisabled = endpointCacheDisabled,
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
@@ -228,4 +228,7 @@ interface Sandboxes {
      * @param sandboxId Unique identifier of the sandbox
      */
     fun killSandbox(sandboxId: String)
+
+    /** Remove all cached endpoints for a sandbox. No-op if caching is disabled. */
+    fun invalidateEndpointCache(sandboxId: String) {}
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
@@ -74,6 +74,16 @@ internal class SandboxesAdapter(
     private val api = SandboxesApi(provider.config.getBaseUrl(), provider.authenticatedClient)
     private val snapshotApi = SnapshotsApi(provider.config.getBaseUrl(), provider.authenticatedClient)
 
+    private val endpointCache: com.alibaba.opensandbox.sandbox.infrastructure.cache.EndpointCache? =
+        if (!provider.config.endpointCacheDisabled) {
+            com.alibaba.opensandbox.sandbox.infrastructure.cache.EndpointCache(
+                maxSize = provider.config.endpointCacheSize,
+                ttl = provider.config.endpointCacheTtl,
+            )
+        } else {
+            null
+        }
+
     override fun createSandbox(
         spec: SandboxImageSpec?,
         entrypoint: List<String>?,
@@ -273,6 +283,16 @@ internal class SandboxesAdapter(
         port: Int,
         useServerProxy: Boolean,
     ): SandboxEndpoint {
+        val cache = endpointCache ?: return fetchSandboxEndpoint(sandboxId, port, useServerProxy)
+        val key = com.alibaba.opensandbox.sandbox.infrastructure.cache.EndpointCacheKey(sandboxId, port, useServerProxy)
+        return cache.getOrFetch(key) { fetchSandboxEndpoint(sandboxId, port, useServerProxy) }
+    }
+
+    private fun fetchSandboxEndpoint(
+        sandboxId: String,
+        port: Int,
+        useServerProxy: Boolean,
+    ): SandboxEndpoint {
         logger.debug("Retrieving sandbox endpoint: {}, port {}", sandboxId, port)
         return try {
             api.sandboxesSandboxIdEndpointsPortGet(sandboxId, port, useServerProxy).toSandboxEndpoint()
@@ -280,6 +300,10 @@ internal class SandboxesAdapter(
             logger.error("Failed to retrieve sandbox endpoint for sandbox {}", sandboxId, e)
             throw e.toSandboxException()
         }
+    }
+
+    override fun invalidateEndpointCache(sandboxId: String) {
+        endpointCache?.invalidate(sandboxId)
     }
 
     override fun getSignedSandboxEndpoint(

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/cache/EndpointCache.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/cache/EndpointCache.kt
@@ -1,0 +1,144 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.alibaba.opensandbox.sandbox.infrastructure.cache
+
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
+import java.time.Duration
+import java.util.LinkedHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+data class EndpointCacheKey(
+    val sandboxId: String,
+    val port: Int,
+    val useServerProxy: Boolean,
+)
+
+private data class CacheEntry(
+    val endpoint: SandboxEndpoint,
+    val expiresAtNanos: Long,
+)
+
+/**
+ * Thread-safe LRU + TTL endpoint cache with inflight deduplication.
+ */
+class EndpointCache(
+    maxSize: Int = 1024,
+    private val ttl: Duration = Duration.ofSeconds(600),
+) {
+    private val maxSize = maxOf(1, maxSize)
+    private val lock = ReentrantLock()
+    private var generation = 0L
+
+    private val cache =
+        object : LinkedHashMap<EndpointCacheKey, CacheEntry>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<EndpointCacheKey, CacheEntry>?): Boolean {
+                return size > this@EndpointCache.maxSize
+            }
+        }
+
+    private val inflight = mutableMapOf<EndpointCacheKey, InflightEntry>()
+
+    private fun cloneEndpoint(ep: SandboxEndpoint) = SandboxEndpoint(endpoint = ep.endpoint, headers = ep.headers.toMap())
+
+    private class InflightEntry {
+        @Volatile var result: SandboxEndpoint? = null
+
+        @Volatile var error: Exception? = null
+        val latch = java.util.concurrent.CountDownLatch(1)
+    }
+
+    fun get(key: EndpointCacheKey): SandboxEndpoint? =
+        lock.withLock {
+            val entry = cache[key] ?: return null
+            if (System.nanoTime() >= entry.expiresAtNanos) {
+                cache.remove(key)
+                return null
+            }
+            cloneEndpoint(entry.endpoint)
+        }
+
+    fun put(
+        key: EndpointCacheKey,
+        endpoint: SandboxEndpoint,
+    ) = lock.withLock {
+        cache[key] = CacheEntry(cloneEndpoint(endpoint), System.nanoTime() + ttl.toNanos())
+    }
+
+    fun invalidate(sandboxId: String) =
+        lock.withLock {
+            generation++
+            cache.keys.removeAll { it.sandboxId == sandboxId }
+            inflight.keys.removeAll { it.sandboxId == sandboxId }
+        }
+
+    fun getOrFetch(
+        key: EndpointCacheKey,
+        fetch: () -> SandboxEndpoint,
+    ): SandboxEndpoint {
+        get(key)?.let { return it }
+
+        val existingInflight: InflightEntry?
+        val myInflight: InflightEntry?
+        val genBefore: Long
+
+        lock.withLock {
+            // Double-check
+            val entry = cache[key]
+            if (entry != null && System.nanoTime() < entry.expiresAtNanos) {
+                return cloneEndpoint(entry.endpoint)
+            }
+            if (entry != null) cache.remove(key)
+
+            val existing = inflight[key]
+            if (existing != null) {
+                existingInflight = existing
+                myInflight = null
+                genBefore = -1
+            } else {
+                val inf = InflightEntry()
+                inflight[key] = inf
+                existingInflight = null
+                myInflight = inf
+                genBefore = generation
+            }
+        }
+
+        if (existingInflight != null) {
+            existingInflight.latch.await()
+            existingInflight.error?.let { throw it }
+            return existingInflight.result!!
+        }
+
+        try {
+            val endpoint = fetch()
+            lock.withLock {
+                if (generation == genBefore) {
+                    cache[key] = CacheEntry(cloneEndpoint(endpoint), System.nanoTime() + ttl.toNanos())
+                }
+            }
+            myInflight!!.result = endpoint
+            return endpoint
+        } catch (e: Exception) {
+            myInflight!!.error = e
+            throw e
+        } finally {
+            lock.withLock { inflight.remove(key) }
+            myInflight!!.latch.countDown()
+        }
+    }
+
+    val size: Int get() = lock.withLock { cache.size }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
@@ -255,19 +255,23 @@ class SandboxTest {
 
     @Test
     fun `pause should delegate to sandboxService`() {
+        every { sandboxService.invalidateEndpointCache(sandboxId) } just Runs
         every { sandboxService.pauseSandbox(sandboxId) } just Runs
 
         sandbox.pause()
 
+        verify { sandboxService.invalidateEndpointCache(sandboxId) }
         verify { sandboxService.pauseSandbox(sandboxId) }
     }
 
     @Test
     fun `kill should delegate to sandboxService`() {
+        every { sandboxService.invalidateEndpointCache(sandboxId) } just Runs
         every { sandboxService.killSandbox(sandboxId) } just Runs
 
         sandbox.kill()
 
+        verify { sandboxService.invalidateEndpointCache(sandboxId) }
         verify { sandboxService.killSandbox(sandboxId) }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/cache/EndpointCacheTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/cache/EndpointCacheTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.alibaba.opensandbox.sandbox.infrastructure.cache
+
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class EndpointCacheTest {
+    private fun ep(addr: String) = SandboxEndpoint(endpoint = addr, headers = emptyMap())
+
+    @Test
+    fun `get returns null on miss`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        assertNull(cache.get(key))
+    }
+
+    @Test
+    fun `get returns endpoint after put`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        cache.put(key, ep("localhost:8080"))
+        assertEquals("localhost:8080", cache.get(key)?.endpoint)
+    }
+
+    @Test
+    fun `entry expires after TTL`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMillis(50))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        cache.put(key, ep("localhost:8080"))
+        assertNotNull(cache.get(key))
+        Thread.sleep(60)
+        assertNull(cache.get(key))
+    }
+
+    @Test
+    fun `LRU eviction when at capacity`() {
+        val cache = EndpointCache(maxSize = 3, ttl = Duration.ofMinutes(1))
+        for (i in 0..2) {
+            cache.put(EndpointCacheKey("sb-$i", 8080, false), ep("host-$i:8080"))
+        }
+        // Access sb-0 to make it recently used
+        cache.get(EndpointCacheKey("sb-0", 8080, false))
+        // Insert 4th — sb-1 should be evicted
+        cache.put(EndpointCacheKey("sb-3", 8080, false), ep("host-3:8080"))
+        assertNull(cache.get(EndpointCacheKey("sb-1", 8080, false)))
+        assertNotNull(cache.get(EndpointCacheKey("sb-0", 8080, false)))
+    }
+
+    @Test
+    fun `invalidate removes all entries for sandbox`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        cache.put(EndpointCacheKey("sb-1", 8080, false), ep("a"))
+        cache.put(EndpointCacheKey("sb-1", 18080, false), ep("b"))
+        cache.put(EndpointCacheKey("sb-2", 8080, false), ep("c"))
+        cache.invalidate("sb-1")
+        assertNull(cache.get(EndpointCacheKey("sb-1", 8080, false)))
+        assertNull(cache.get(EndpointCacheKey("sb-1", 18080, false)))
+        assertNotNull(cache.get(EndpointCacheKey("sb-2", 8080, false)))
+    }
+
+    @Test
+    fun `getOrFetch deduplicates concurrent requests`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        val fetchCount = AtomicInteger(0)
+        val latch = CountDownLatch(5)
+
+        val threads =
+            (1..5).map {
+                thread {
+                    cache.getOrFetch(key) {
+                        fetchCount.incrementAndGet()
+                        Thread.sleep(50)
+                        ep("result")
+                    }
+                    latch.countDown()
+                }
+            }
+
+        latch.await()
+        assertEquals(1, fetchCount.get())
+    }
+
+    @Test
+    fun `getOrFetch returns cached value without calling fetcher`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        cache.put(key, ep("cached"))
+        var called = false
+        val result =
+            cache.getOrFetch(key) {
+                called = true
+                ep("fetched")
+            }
+        assertEquals("cached", result.endpoint)
+        assertFalse(called)
+    }
+
+    @Test
+    fun `getOrFetch does not cache on error`() {
+        val cache = EndpointCache(maxSize = 10, ttl = Duration.ofMinutes(1))
+        val key = EndpointCacheKey("sb-1", 8080, false)
+        assertThrows(RuntimeException::class.java) {
+            cache.getOrFetch(key) { throw RuntimeException("network error") }
+        }
+        assertEquals(0, cache.size)
+    }
+}

--- a/sdks/sandbox/python/src/opensandbox/adapters/endpoint_cache.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/endpoint_cache.py
@@ -1,0 +1,213 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+LRU + TTL endpoint cache with inflight deduplication.
+
+Async version uses asyncio.Future for inflight dedup.
+Sync version uses threading.Lock + threading.Event.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+
+from opensandbox.models.sandboxes import SandboxEndpoint
+
+DEFAULT_ENDPOINT_CACHE_TTL = 600.0
+DEFAULT_ENDPOINT_CACHE_SIZE = 1024
+
+
+class EndpointCache:
+    """Thread-safe LRU+TTL endpoint cache for sync usage."""
+
+    def __init__(
+        self,
+        maxsize: int = DEFAULT_ENDPOINT_CACHE_SIZE,
+        ttl: float = DEFAULT_ENDPOINT_CACHE_TTL,
+    ) -> None:
+        self._maxsize = max(1, maxsize)
+        self._ttl = ttl
+        self._cache: OrderedDict[tuple, tuple[SandboxEndpoint, float]] = OrderedDict()
+        self._lock = threading.Lock()
+        self._inflight: dict[tuple, _InflightEntry] = {}
+        self._generation = 0
+
+    def get(self, key: tuple) -> SandboxEndpoint | None:
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            endpoint, expires_at = entry
+            if time.monotonic() >= expires_at:
+                del self._cache[key]
+                return None
+            self._cache.move_to_end(key)
+            return endpoint
+
+    def put(self, key: tuple, endpoint: SandboxEndpoint) -> None:
+        with self._lock:
+            self._put_locked(key, endpoint)
+
+    def _put_locked(self, key: tuple, endpoint: SandboxEndpoint) -> None:
+        if key in self._cache:
+            self._cache.move_to_end(key)
+            self._cache[key] = (endpoint, time.monotonic() + self._ttl)
+            return
+        while len(self._cache) >= self._maxsize:
+            self._cache.popitem(last=False)
+        self._cache[key] = (endpoint, time.monotonic() + self._ttl)
+
+    def invalidate(self, sandbox_id: str) -> None:
+        with self._lock:
+            self._generation += 1
+            keys_to_remove = [k for k in self._cache if k[0] == sandbox_id]
+            for k in keys_to_remove:
+                del self._cache[k]
+            inflight_to_remove = [k for k in self._inflight if k[0] == sandbox_id]
+            for k in inflight_to_remove:
+                del self._inflight[k]
+
+    def get_or_fetch(
+        self,
+        key: tuple,
+        fetch: Callable[[], SandboxEndpoint],
+    ) -> SandboxEndpoint:
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is not None:
+                endpoint, expires_at = entry
+                if time.monotonic() < expires_at:
+                    self._cache.move_to_end(key)
+                    return endpoint
+                del self._cache[key]
+
+            gen_before = self._generation
+            if key in self._inflight:
+                inf = self._inflight[key]
+                is_owner = False
+            else:
+                inf = _InflightEntry()
+                self._inflight[key] = inf
+                is_owner = True
+
+        if not is_owner:
+            inf.event.wait()
+            if inf.error is not None:
+                raise inf.error
+            return inf.result  # type: ignore[return-value]
+
+        try:
+            endpoint = fetch()
+            with self._lock:
+                if self._generation == gen_before:
+                    self._put_locked(key, endpoint)
+            inf.result = endpoint
+            return endpoint
+        except Exception as e:
+            inf.error = e
+            raise
+        finally:
+            with self._lock:
+                self._inflight.pop(key, None)
+            inf.event.set()
+
+
+class _InflightEntry:
+    __slots__ = ("event", "result", "error", "owner")
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.result: SandboxEndpoint | None = None
+        self.error: Exception | None = None
+        self.owner: bool = False
+
+
+class AsyncEndpointCache:
+    """Async LRU+TTL endpoint cache with asyncio.Future-based inflight dedup."""
+
+    def __init__(
+        self,
+        maxsize: int = DEFAULT_ENDPOINT_CACHE_SIZE,
+        ttl: float = DEFAULT_ENDPOINT_CACHE_TTL,
+    ) -> None:
+        self._maxsize = max(1, maxsize)
+        self._ttl = ttl
+        self._cache: OrderedDict[tuple, tuple[SandboxEndpoint, float]] = OrderedDict()
+        self._inflight: dict[tuple, asyncio.Future[SandboxEndpoint]] = {}
+        self._generation = 0
+
+    def get(self, key: tuple) -> SandboxEndpoint | None:
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        endpoint, expires_at = entry
+        if time.monotonic() >= expires_at:
+            del self._cache[key]
+            return None
+        self._cache.move_to_end(key)
+        return endpoint
+
+    def put(self, key: tuple, endpoint: SandboxEndpoint) -> None:
+        if key in self._cache:
+            self._cache.move_to_end(key)
+            self._cache[key] = (endpoint, time.monotonic() + self._ttl)
+            return
+        while len(self._cache) >= self._maxsize:
+            self._cache.popitem(last=False)
+        self._cache[key] = (endpoint, time.monotonic() + self._ttl)
+
+    def invalidate(self, sandbox_id: str) -> None:
+        self._generation += 1
+        keys_to_remove = [k for k in self._cache if k[0] == sandbox_id]
+        for k in keys_to_remove:
+            del self._cache[k]
+        inflight_to_remove = [k for k in self._inflight if k[0] == sandbox_id]
+        for k in inflight_to_remove:
+            del self._inflight[k]
+
+    async def get_or_fetch(
+        self,
+        key: tuple,
+        fetch: Callable[[], Awaitable[SandboxEndpoint]],
+    ) -> SandboxEndpoint:
+        cached = self.get(key)
+        if cached is not None:
+            return cached
+
+        if key in self._inflight:
+            return await asyncio.shield(self._inflight[key])
+
+        gen_before = self._generation
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[SandboxEndpoint] = loop.create_future()
+        self._inflight[key] = future
+
+        try:
+            endpoint = await fetch()
+            if self._generation == gen_before:
+                self.put(key, endpoint)
+            future.set_result(endpoint)
+            return endpoint
+        except BaseException as e:
+            if not future.done():
+                future.set_exception(e)
+            raise
+        finally:
+            self._inflight.pop(key, None)

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -79,6 +79,17 @@ class SandboxesAdapter(Sandboxes):
             connection_config: Connection configuration (shared transport, headers, timeouts)
         """
         self.connection_config = connection_config
+
+        from opensandbox.adapters.endpoint_cache import AsyncEndpointCache
+
+        if not connection_config.endpoint_cache_disabled:
+            self._endpoint_cache: AsyncEndpointCache | None = AsyncEndpointCache(
+                maxsize=connection_config.endpoint_cache_size or 1024,
+                ttl=connection_config.endpoint_cache_ttl.total_seconds(),
+            )
+        else:
+            self._endpoint_cache = None
+
         from opensandbox.api.lifecycle import AuthenticatedClient
 
         api_key = self.connection_config.get_api_key()
@@ -350,6 +361,18 @@ class SandboxesAdapter(Sandboxes):
         self, sandbox_id: str, port: int, use_server_proxy: bool = False
     ) -> SandboxEndpoint:
         """Get network endpoint information for a sandbox service."""
+        if self._endpoint_cache is not None:
+            key = (sandbox_id, port, use_server_proxy)
+            return await self._endpoint_cache.get_or_fetch(
+                key,
+                lambda: self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy),
+            )
+        return await self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy)
+
+    async def _fetch_sandbox_endpoint(
+        self, sandbox_id: str, port: int, use_server_proxy: bool = False
+    ) -> SandboxEndpoint:
+        """Fetch endpoint from server (no cache)."""
         logger.debug(f"Retrieving sandbox endpoint: {sandbox_id}, port {port}")
 
         try:
@@ -381,6 +404,11 @@ class SandboxesAdapter(Sandboxes):
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def invalidate_endpoint_cache(self, sandbox_id: str) -> None:
+        """Remove all cached endpoints for a sandbox."""
+        if self._endpoint_cache is not None:
+            self._endpoint_cache.invalidate(sandbox_id)
 
     async def get_signed_sandbox_endpoint(
         self, sandbox_id: str, port: int, expires: int,

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -85,6 +85,18 @@ class ConnectionConfig(BaseModel):
             "It's useful when client sdk can't access the created sandbox directly"
         ),
     )
+    endpoint_cache_ttl: timedelta = Field(
+        default=timedelta(seconds=600),
+        description="TTL for cached endpoint entries.",
+    )
+    endpoint_cache_size: int = Field(
+        default=1024,
+        description="Maximum number of cached endpoint entries. 0 means default (1024).",
+    )
+    endpoint_cache_disabled: bool = Field(
+        default=False,
+        description="Disable endpoint caching entirely.",
+    )
 
     # Environment variable names
     _ENV_API_KEY = "OPEN_SANDBOX_API_KEY"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -72,6 +72,18 @@ class ConnectionConfigSync(BaseModel):
             "It's useful when client sdk can't access the created sandbox directly"
         ),
     )
+    endpoint_cache_ttl: timedelta = Field(
+        default=timedelta(seconds=600),
+        description="TTL for cached endpoint entries.",
+    )
+    endpoint_cache_size: int = Field(
+        default=1024,
+        description="Maximum number of cached endpoint entries. 0 means default (1024).",
+    )
+    endpoint_cache_disabled: bool = Field(
+        default=False,
+        description="Disable endpoint caching entirely.",
+    )
 
     _ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
     _ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -353,8 +353,8 @@ class Sandbox:
             SandboxException: if pause operation fails
         """
         logger.info(f"Pausing sandbox: {self.id}")
+        self._sandbox_service.invalidate_endpoint_cache(self.id)
         await self._sandbox_service.pause_sandbox(self.id)
-
 
     async def kill(self) -> None:
         """
@@ -369,6 +369,7 @@ class Sandbox:
             SandboxException: if termination fails
         """
         logger.info(f"Killing sandbox: {self.id}")
+        self._sandbox_service.invalidate_endpoint_cache(self.id)
         await self._sandbox_service.kill_sandbox(self.id)
 
     async def close(self) -> None:

--- a/sdks/sandbox/python/src/opensandbox/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/services/sandbox.py
@@ -250,3 +250,7 @@ class Sandboxes(Protocol):
     async def delete_snapshot(self, snapshot_id: str) -> None:
         """Delete a snapshot."""
         ...
+
+    def invalidate_endpoint_cache(self, sandbox_id: str) -> None:
+        """Remove all cached endpoints for a sandbox. No-op if caching is disabled."""
+        ...

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -59,6 +59,17 @@ logger = logging.getLogger(__name__)
 class SandboxesAdapterSync(SandboxesSync):
     def __init__(self, connection_config: ConnectionConfigSync) -> None:
         self.connection_config = connection_config
+
+        from opensandbox.adapters.endpoint_cache import EndpointCache
+
+        if not connection_config.endpoint_cache_disabled:
+            self._endpoint_cache: EndpointCache | None = EndpointCache(
+                maxsize=connection_config.endpoint_cache_size or 1024,
+                ttl=connection_config.endpoint_cache_ttl.total_seconds(),
+            )
+        else:
+            self._endpoint_cache = None
+
         from opensandbox.api.lifecycle import AuthenticatedClient
 
         api_key = self.connection_config.get_api_key()
@@ -228,6 +239,17 @@ class SandboxesAdapterSync(SandboxesSync):
     def get_sandbox_endpoint(
         self, sandbox_id: str, port: int, use_server_proxy: bool = False
     ) -> SandboxEndpoint:
+        if self._endpoint_cache is not None:
+            key = (sandbox_id, port, use_server_proxy)
+            return self._endpoint_cache.get_or_fetch(
+                key,
+                lambda: self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy),
+            )
+        return self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy)
+
+    def _fetch_sandbox_endpoint(
+        self, sandbox_id: str, port: int, use_server_proxy: bool = False
+    ) -> SandboxEndpoint:
         try:
             from opensandbox.api.lifecycle.api.sandboxes import (
                 get_sandboxes_sandbox_id_endpoints_port,
@@ -246,6 +268,11 @@ class SandboxesAdapterSync(SandboxesSync):
         except Exception as e:
             logger.error("Failed to retrieve sandbox endpoint for sandbox %s", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def invalidate_endpoint_cache(self, sandbox_id: str) -> None:
+        """Remove all cached endpoints for a sandbox."""
+        if self._endpoint_cache is not None:
+            self._endpoint_cache.invalidate(sandbox_id)
 
     def get_signed_sandbox_endpoint(
         self, sandbox_id: str, port: int, expires: int,

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -361,8 +361,8 @@ class SandboxSync:
             SandboxException: if pause operation fails
         """
         logger.info("Pausing sandbox: %s", self.id)
+        self._sandbox_service.invalidate_endpoint_cache(self.id)
         self._sandbox_service.pause_sandbox(self.id)
-
 
     def kill(self) -> None:
         """
@@ -377,6 +377,7 @@ class SandboxSync:
             SandboxException: if termination fails
         """
         logger.info("Killing sandbox: %s", self.id)
+        self._sandbox_service.invalidate_endpoint_cache(self.id)
         self._sandbox_service.kill_sandbox(self.id)
 
     def close(self) -> None:

--- a/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
@@ -251,3 +251,7 @@ class SandboxesSync(Protocol):
     def delete_snapshot(self, snapshot_id: str) -> None:
         """Delete a snapshot (blocking)."""
         ...
+
+    def invalidate_endpoint_cache(self, sandbox_id: str) -> None:
+        """Remove all cached endpoints for a sandbox. No-op if caching is disabled."""
+        ...

--- a/sdks/sandbox/python/tests/test_endpoint_cache.py
+++ b/sdks/sandbox/python/tests/test_endpoint_cache.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from opensandbox.adapters.endpoint_cache import AsyncEndpointCache, EndpointCache
+from opensandbox.models.sandboxes import SandboxEndpoint
+
+
+def _ep(addr: str) -> SandboxEndpoint:
+    return SandboxEndpoint(endpoint=addr, headers={})
+
+
+class TestEndpointCacheSync:
+    def test_get_put(self):
+        c = EndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+        assert c.get(key) is None
+        c.put(key, _ep("localhost:8080"))
+        assert c.get(key) is not None
+        assert c.get(key).endpoint == "localhost:8080"
+
+    def test_ttl_expiry(self):
+        c = EndpointCache(maxsize=10, ttl=0.05)
+        key = ("sb-1", 8080, False)
+        c.put(key, _ep("localhost:8080"))
+        assert c.get(key) is not None
+        time.sleep(0.06)
+        assert c.get(key) is None
+
+    def test_lru_eviction(self):
+        c = EndpointCache(maxsize=3, ttl=60.0)
+        for i in range(3):
+            c.put((f"sb-{i}", 8080, False), _ep(f"host-{i}:8080"))
+
+        # Access sb-0 to make it recently used
+        c.get(("sb-0", 8080, False))
+        # Insert 4th, should evict sb-1
+        c.put(("sb-3", 8080, False), _ep("host-3:8080"))
+
+        assert c.get(("sb-1", 8080, False)) is None
+        assert c.get(("sb-0", 8080, False)) is not None
+
+    def test_invalidate(self):
+        c = EndpointCache(maxsize=10, ttl=60.0)
+        c.put(("sb-1", 8080, False), _ep("a"))
+        c.put(("sb-1", 18080, False), _ep("b"))
+        c.put(("sb-2", 8080, False), _ep("c"))
+        c.invalidate("sb-1")
+        assert c.get(("sb-1", 8080, False)) is None
+        assert c.get(("sb-1", 18080, False)) is None
+        assert c.get(("sb-2", 8080, False)) is not None
+
+    def test_get_or_fetch_dedup(self):
+        c = EndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+        fetch_count = [0]
+
+        def fetch():
+            fetch_count[0] += 1
+            time.sleep(0.05)
+            return _ep("result")
+
+        threads = []
+        results = []
+
+        def worker():
+            results.append(c.get_or_fetch(key, fetch))
+
+        for _ in range(5):
+            t = threading.Thread(target=worker)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert fetch_count[0] == 1
+        assert all(r.endpoint == "result" for r in results)
+
+    def test_get_or_fetch_cache_hit(self):
+        c = EndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+        c.put(key, _ep("cached"))
+        fetch_count = [0]
+
+        def fetch():
+            fetch_count[0] += 1
+            return _ep("fetched")
+
+        result = c.get_or_fetch(key, fetch)
+        assert result.endpoint == "cached"
+        assert fetch_count[0] == 0
+
+
+class TestAsyncEndpointCache:
+    @pytest.mark.asyncio
+    async def test_get_put(self):
+        c = AsyncEndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+        assert c.get(key) is None
+        c.put(key, _ep("localhost:8080"))
+        assert c.get(key).endpoint == "localhost:8080"
+
+    @pytest.mark.asyncio
+    async def test_ttl_expiry(self):
+        c = AsyncEndpointCache(maxsize=10, ttl=0.05)
+        key = ("sb-1", 8080, False)
+        c.put(key, _ep("localhost:8080"))
+        assert c.get(key) is not None
+        await asyncio.sleep(0.06)
+        assert c.get(key) is None
+
+    @pytest.mark.asyncio
+    async def test_lru_eviction(self):
+        c = AsyncEndpointCache(maxsize=3, ttl=60.0)
+        for i in range(3):
+            c.put((f"sb-{i}", 8080, False), _ep(f"host-{i}:8080"))
+        c.get(("sb-0", 8080, False))
+        c.put(("sb-3", 8080, False), _ep("host-3:8080"))
+        assert c.get(("sb-1", 8080, False)) is None
+        assert c.get(("sb-0", 8080, False)) is not None
+
+    @pytest.mark.asyncio
+    async def test_invalidate(self):
+        c = AsyncEndpointCache(maxsize=10, ttl=60.0)
+        c.put(("sb-1", 8080, False), _ep("a"))
+        c.put(("sb-1", 18080, False), _ep("b"))
+        c.put(("sb-2", 8080, False), _ep("c"))
+        c.invalidate("sb-1")
+        assert c.get(("sb-1", 8080, False)) is None
+        assert c.get(("sb-2", 8080, False)) is not None
+
+    @pytest.mark.asyncio
+    async def test_get_or_fetch_dedup(self):
+        c = AsyncEndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+        fetch_count = [0]
+
+        async def fetch():
+            fetch_count[0] += 1
+            await asyncio.sleep(0.05)
+            return _ep("result")
+
+        results = await asyncio.gather(*[c.get_or_fetch(key, fetch) for _ in range(5)])
+        assert fetch_count[0] == 1
+        assert all(r.endpoint == "result" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_get_or_fetch_error(self):
+        c = AsyncEndpointCache(maxsize=10, ttl=60.0)
+        key = ("sb-1", 8080, False)
+
+        async def fetch():
+            raise RuntimeError("network error")
+
+        with pytest.raises(RuntimeError, match="network error"):
+            await c.get_or_fetch(key, fetch)
+
+        # Cache should not be populated on error
+        assert c.get(key) is None

--- a/tests/go/go.mod
+++ b/tests/go/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/tests/go/go.sum
+++ b/tests/go/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
# Summary
Cache (sandbox_id, port, use_server_proxy) → Endpoint to avoid repeated HTTP roundtrips. Default on: TTL=600s, MaxSize=1024, configurable via ConnectionConfig fields. kill() actively invalidates cached entries.

closes #582

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered