### PR TITLE
Update Python SDK repository URLs to opensandbox-group owner

### DIFF
--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -55,9 +55,9 @@ pool-redis = [
 
 [project.urls]
 Homepage = "https://open-sandbox.ai"
-Repository = "https://github.com/alibaba/OpenSandbox"
+Repository = "https://github.com/opensandbox-group/OpenSandbox"
 Documentation = "https://open-sandbox.ai"
-Issues = "https://github.com/alibaba/OpenSandbox/issues"
+Issues = "https://github.com/opensandbox-group/OpenSandbox/issues"
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Summary

Updates the repository metadata URLs in the **sandbox** Python SDK to point at the new `opensandbox-group` owner, as the repo has been moved to a new owner.

Scope: this PR is intentionally limited to `sdks/sandbox/python`. Other Python SDK packages (`sdks/mcp/sandbox/python`, `sdks/code-interpreter/python`) still reference the old `alibaba` URLs and will be updated separately as part of the broader #1134 effort.

### Changes
- `sdks/sandbox/python/pyproject.toml`:
  - `Repository` URL: `https://github.com/alibaba/OpenSandbox` → `https://github.com/opensandbox-group/OpenSandbox`
  - `Issues` URL: `https://github.com/alibaba/OpenSandbox/issues` → `https://github.com/opensandbox-group/OpenSandbox/issues`

### Notes
- In Python, the import path is the top-level package name (`opensandbox`), which is already correct — there is no owner/org prefix in Python imports (unlike Go modules or Java namespaces). So within `sdks/sandbox/python`, these project-metadata URLs were the only `alibaba` *path* references.
- Copyright headers (`Alibaba Group Holding Ltd.`) and the author email are not paths and are left unchanged.

Refs #1134