### PR TITLE
fix(sdks): point package metadata at opensandbox-group repo

### DIFF
--- a/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/OpenSandbox.CodeInterpreter.csproj
+++ b/sdks/code-interpreter/csharp/src/OpenSandbox.CodeInterpreter/OpenSandbox.CodeInterpreter.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright 2026 Alibaba Group Holding Ltd.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://open-sandbox.ai</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/alibaba/OpenSandbox.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/opensandbox-group/OpenSandbox.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>sandbox;code-interpreter;execution;opensandbox;alibaba;python;javascript</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/sdks/code-interpreter/javascript/package.json
+++ b/sdks/code-interpreter/javascript/package.json
@@ -18,10 +18,10 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/alibaba/OpenSandbox.git"
+    "url": "https://github.com/opensandbox-group/OpenSandbox.git"
   },
   "bugs": {
-    "url": "https://github.com/alibaba/OpenSandbox/issues"
+    "url": "https://github.com/opensandbox-group/OpenSandbox/issues"
   },
   "homepage": "https://open-sandbox.ai",
   "files": [

--- a/sdks/code-interpreter/kotlin/build.gradle.kts
+++ b/sdks/code-interpreter/kotlin/build.gradle.kts
@@ -124,7 +124,7 @@ subprojects {
             name.set(project.name)
             description.set("Alibaba Code Interpreter SDK")
             inceptionYear.set("2025")
-            url.set("https://github.com/alibaba/OpenSandbox")
+            url.set("https://github.com/opensandbox-group/OpenSandbox")
             licenses {
                 license {
                     name.set("The Apache License, Version 2.0")
@@ -141,9 +141,9 @@ subprojects {
                 }
             }
             scm {
-                url.set("https://github.com/alibaba/OpenSandbox")
-                connection.set("scm:git:https://github.com/alibaba/OpenSandbox.git")
-                developerConnection.set("scm:git:ssh://git@github.com/alibaba/OpenSandbox.git")
+                url.set("https://github.com/opensandbox-group/OpenSandbox")
+                connection.set("scm:git:https://github.com/opensandbox-group/OpenSandbox.git")
+                developerConnection.set("scm:git:ssh://git@github.com/opensandbox-group/OpenSandbox.git")
             }
         }
     }

--- a/sdks/code-interpreter/python/pyproject.toml
+++ b/sdks/code-interpreter/python/pyproject.toml
@@ -48,9 +48,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://open-sandbox.ai"
-Repository = "https://github.com/alibaba/OpenSandbox"
+Repository = "https://github.com/opensandbox-group/OpenSandbox"
 Documentation = "https://open-sandbox.ai"
-Issues = "https://github.com/alibaba/OpenSandbox/issues"
+Issues = "https://github.com/opensandbox-group/OpenSandbox/issues"
 
 [tool.hatch.version]
 source = "vcs"

--- a/sdks/mcp/sandbox/python/pyproject.toml
+++ b/sdks/mcp/sandbox/python/pyproject.toml
@@ -48,9 +48,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://open-sandbox.ai"
-Repository = "https://github.com/alibaba/OpenSandbox"
+Repository = "https://github.com/opensandbox-group/OpenSandbox"
 Documentation = "https://open-sandbox.ai"
-Issues = "https://github.com/alibaba/OpenSandbox/issues"
+Issues = "https://github.com/opensandbox-group/OpenSandbox/issues"
 
 [project.scripts]
 opensandbox-mcp = "opensandbox_mcp.__main__:main"

--- a/sdks/sandbox/csharp/src/OpenSandbox/OpenSandbox.csproj
+++ b/sdks/sandbox/csharp/src/OpenSandbox/OpenSandbox.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright 2026 Alibaba Group Holding Ltd.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://open-sandbox.ai</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/alibaba/OpenSandbox.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/opensandbox-group/OpenSandbox.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>sandbox;container;docker;execution;opensandbox;alibaba</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/sdks/sandbox/javascript/package.json
+++ b/sdks/sandbox/javascript/package.json
@@ -24,10 +24,10 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/alibaba/OpenSandbox.git"
+    "url": "https://github.com/opensandbox-group/OpenSandbox.git"
   },
   "bugs": {
-    "url": "https://github.com/alibaba/OpenSandbox/issues"
+    "url": "https://github.com/opensandbox-group/OpenSandbox/issues"
   },
   "homepage": "https://open-sandbox.ai",
   "files": [

--- a/sdks/sandbox/kotlin/build.gradle.kts
+++ b/sdks/sandbox/kotlin/build.gradle.kts
@@ -125,7 +125,7 @@ subprojects {
             name.set(project.name)
             description.set("Alibaba Open Sandbox SDK")
             inceptionYear.set("2025")
-            url.set("https://github.com/alibaba/OpenSandbox")
+            url.set("https://github.com/opensandbox-group/OpenSandbox")
             licenses {
                 license {
                     name.set("The Apache License, Version 2.0")
@@ -142,9 +142,9 @@ subprojects {
                 }
             }
             scm {
-                url.set("https://github.com/alibaba/OpenSandbox")
-                connection.set("scm:git:https://github.com/alibaba/OpenSandbox.git")
-                developerConnection.set("scm:git:ssh://git@github.com/alibaba/OpenSandbox.git")
+                url.set("https://github.com/opensandbox-group/OpenSandbox")
+                connection.set("scm:git:https://github.com/opensandbox-group/OpenSandbox.git")
+                developerConnection.set("scm:git:ssh://git@github.com/opensandbox-group/OpenSandbox.git")
             }
         }
     }


### PR DESCRIPTION
## Summary

Continues #1134.

Updates the remaining SDK package metadata that still points to the old `alibaba/OpenSandbox` owner so package consumers land on the current `opensandbox-group/OpenSandbox` repository and issues page.

## Changes

- update repository / bugs URLs in both JavaScript SDK package manifests
- update SCM / project URLs in both Kotlin SDK Gradle publish metadata blocks
- update repository URLs in both C# SDK project files
- update repository / issues URLs in the MCP Python SDK and code-interpreter Python SDK metadata

## Notes

- This is intentionally non-breaking.
- It does **not** rename published package names, group IDs, namespaces, or Go module paths.
- It only fixes owner/repository metadata that package registries and generated package pages surface to users.

## Validation

- JSON metadata assertions for both JavaScript package manifests
- TOML / XML / Kotlin metadata assertions for Python, C#, and Kotlin package metadata
- `git diff --check`
