### PR TITLE
fix(meta): point server and cli metadata at opensandbox-group repo

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -51,9 +51,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://open-sandbox.ai"
-Repository = "https://github.com/alibaba/OpenSandbox"
+Repository = "https://github.com/opensandbox-group/OpenSandbox"
 Documentation = "https://open-sandbox.ai"
-Issues = "https://github.com/alibaba/OpenSandbox/issues"
+Issues = "https://github.com/opensandbox-group/OpenSandbox/issues"
 
 [project.scripts]
 opensandbox = "opensandbox_cli.main:cli"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -58,9 +58,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/alibaba/OpenSandbox"
-Repository = "https://github.com/alibaba/OpenSandbox"
-Issues = "https://github.com/alibaba/OpenSandbox/issues"
+Homepage = "https://github.com/opensandbox-group/OpenSandbox"
+Repository = "https://github.com/opensandbox-group/OpenSandbox"
+Issues = "https://github.com/opensandbox-group/OpenSandbox/issues"
 
 [project.scripts]
 opensandbox-server = "opensandbox_server.cli:main"


### PR DESCRIPTION
## Summary

Continues #1134.

Updates the remaining non-SDK package metadata that still points to the old `alibaba/OpenSandbox` owner so server/CLI package pages resolve to the current `opensandbox-group/OpenSandbox` repository and issue tracker.

## Changes

- update `server/pyproject.toml` homepage / repository / issues URLs
- update `cli/pyproject.toml` repository / issues URLs

## Notes

- This is intentionally metadata-only and non-breaking.
- It does not rename published package names, namespaces, module paths, or import paths.
- PR #1139 already handled the SDK / code-interpreter / MCP package metadata side; this follow-up covers the remaining server + CLI package metadata.

## Validation

- TOML metadata assertions for `server/pyproject.toml` and `cli/pyproject.toml`
- `git diff --check`
