### PR TITLE
feat(k8s): Add capacity predicate in pool-assign

### DIFF
--- a/kubernetes/internal/controller/poolassign/default_test.go
+++ b/kubernetes/internal/controller/poolassign/default_test.go
@@ -46,6 +46,9 @@ func makePool(name string, image string, total, allocated int32) *sandboxv1alpha
 					Containers: []corev1.Container{{Image: image}},
 				},
 			},
+			CapacitySpec: sandboxv1alpha1.CapacitySpec{
+				PoolMax: total,
+			},
 		},
 		Status: sandboxv1alpha1.PoolStatus{
 			Total:     total,
@@ -164,6 +167,128 @@ func TestDefaultAssigner_AssignPool(t *testing.T) {
 		_, err := assigner.AssignPool(ctx, sbx, nil)
 		if err == nil {
 			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("fully allocated pool filtered by capacity predicate", func(t *testing.T) {
+		assigner := NewDefaultAssigner(DefaultProfile())
+		sbx := makeSBX("sbx-1", "nginx")
+		pools := []*sandboxv1alpha1.Pool{
+			makePool("pool-full", "nginx", 10, 10),
+			makePool("pool-avail", "nginx", 10, 5),
+		}
+
+		name, err := assigner.AssignPool(ctx, sbx, pools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "pool-avail" {
+			t.Errorf("AssignPool() = %q, want %q (full pool should be filtered)", name, "pool-avail")
+		}
+	})
+
+	t.Run("MostAllocated skips fully allocated pool", func(t *testing.T) {
+		profile := &Profile{
+			Name: "most-allocated-cap",
+			Plugins: PluginsSpec{
+				Predicate: []string{"capacity", "image"},
+				Score:     []ScoreSpec{{Name: "resbalance", Weight: 100}},
+			},
+			PluginConf: []PluginConf{
+				{Name: "resbalance", Args: map[string]interface{}{"strategy": "MostAllocated"}},
+			},
+		}
+		assigner := NewDefaultAssigner(profile)
+		sbx := makeSBX("sbx-1", "nginx")
+		pools := []*sandboxv1alpha1.Pool{
+			makePool("pool-full", "nginx", 10, 10),
+			makePool("pool-partial", "nginx", 10, 8),
+		}
+
+		name, err := assigner.AssignPool(ctx, sbx, pools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "pool-partial" {
+			t.Errorf("AssignPool() = %q, want %q (full pool should be filtered even with MostAllocated)", name, "pool-partial")
+		}
+	})
+
+	t.Run("all pools fully allocated - error", func(t *testing.T) {
+		assigner := NewDefaultAssigner(DefaultProfile())
+		sbx := makeSBX("sbx-1", "nginx")
+		pools := []*sandboxv1alpha1.Pool{
+			makePool("pool-a", "nginx", 10, 10),
+			makePool("pool-b", "nginx", 5, 5),
+		}
+
+		_, err := assigner.AssignPool(ctx, sbx, pools)
+		if err == nil {
+			t.Fatal("expected error when all pools are full, got nil")
+		}
+	})
+
+	t.Run("scale-from-zero pool is eligible", func(t *testing.T) {
+		assigner := NewDefaultAssigner(DefaultProfile())
+		sbx := makeSBX("sbx-1", "nginx")
+		zeroPool := &sandboxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool-zero"},
+			Spec: sandboxv1alpha1.PoolSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Image: "nginx"}},
+					},
+				},
+				CapacitySpec: sandboxv1alpha1.CapacitySpec{PoolMax: 5},
+			},
+			Status: sandboxv1alpha1.PoolStatus{Total: 0, Allocated: 0},
+		}
+		pools := []*sandboxv1alpha1.Pool{makePool("pool-full", "nginx", 3, 3), zeroPool}
+
+		name, err := assigner.AssignPool(ctx, sbx, pools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "pool-zero" {
+			t.Errorf("AssignPool() = %q, want %q (scale-from-zero pool should be selected)", name, "pool-zero")
+		}
+	})
+
+	t.Run("capacity requires room for all desired replicas", func(t *testing.T) {
+		assigner := NewDefaultAssigner(DefaultProfile())
+		sbx := makeSBX("sbx-1", "nginx")
+		sbx.Spec.Replicas = int32Ptr(2)
+		smallPool := &sandboxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool-small"},
+			Spec: sandboxv1alpha1.PoolSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Image: "nginx"}},
+					},
+				},
+				CapacitySpec: sandboxv1alpha1.CapacitySpec{PoolMax: 1},
+			},
+			Status: sandboxv1alpha1.PoolStatus{Total: 1, Allocated: 0},
+		}
+		bigPool := &sandboxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool-big"},
+			Spec: sandboxv1alpha1.PoolSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Image: "nginx"}},
+					},
+				},
+				CapacitySpec: sandboxv1alpha1.CapacitySpec{PoolMax: 10},
+			},
+			Status: sandboxv1alpha1.PoolStatus{Total: 10, Allocated: 5},
+		}
+
+		name, err := assigner.AssignPool(ctx, sbx, []*sandboxv1alpha1.Pool{smallPool, bigPool})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "pool-big" {
+			t.Errorf("AssignPool() = %q, want %q (pool with PoolMax<replicas must be filtered)", name, "pool-big")
 		}
 	})
 }

--- a/kubernetes/internal/controller/poolassign/factory_test.go
+++ b/kubernetes/internal/controller/poolassign/factory_test.go
@@ -22,13 +22,14 @@ import (
 )
 
 func TestNewPredicates(t *testing.T) {
-	t.Run("default profile creates image, resource, nodeselector predicates", func(t *testing.T) {
+	t.Run("default profile creates capacity, image, resource, nodeselector predicates", func(t *testing.T) {
 		predicates, err := NewPredicates(DefaultProfile())
 		require.NoError(t, err)
-		assert.Len(t, predicates, 3)
-		assert.IsType(t, &imagePredicate{}, predicates[0])
-		assert.IsType(t, &resourcePredicate{}, predicates[1])
-		assert.IsType(t, &nodeSelectorPredicate{}, predicates[2])
+		assert.Len(t, predicates, 4)
+		assert.IsType(t, &capacityPredicate{}, predicates[0])
+		assert.IsType(t, &imagePredicate{}, predicates[1])
+		assert.IsType(t, &resourcePredicate{}, predicates[2])
+		assert.IsType(t, &nodeSelectorPredicate{}, predicates[3])
 	})
 
 	t.Run("profile with labelselector predicate", func(t *testing.T) {

--- a/kubernetes/internal/controller/poolassign/predicate_capacity.go
+++ b/kubernetes/internal/controller/poolassign/predicate_capacity.go
@@ -14,12 +14,22 @@
 
 package assign
 
-func init() {
-	registerPredicate("image", newImagePredicate)
-	registerPredicate("resource", newResourcePredicate)
-	registerPredicate("nodeselector", newNodeSelectorPredicate)
-	registerPredicate("labelselector", newLabelSelectorPredicate)
-	registerPredicate("capacity", newCapacityPredicate)
+import (
+	"context"
 
-	registerScorer("resbalance", newResBalanceScorer)
+	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+)
+
+type capacityPredicate struct{}
+
+func newCapacityPredicate(_ map[string]interface{}) (Predicate, error) {
+	return &capacityPredicate{}, nil
+}
+
+func (p *capacityPredicate) Predicate(_ context.Context, sbx *sandboxv1alpha1.BatchSandbox, pool *sandboxv1alpha1.Pool) bool {
+	desired := int32(1)
+	if sbx.Spec.Replicas != nil {
+		desired = *sbx.Spec.Replicas
+	}
+	return pool.Spec.CapacitySpec.PoolMax-pool.Status.Allocated >= desired
 }

--- a/kubernetes/internal/controller/poolassign/predicate_capacity_test.go
+++ b/kubernetes/internal/controller/poolassign/predicate_capacity_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assign
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+)
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestCapacityPredicate(t *testing.T) {
+	p, err := newCapacityPredicate(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		replicas  *int32
+		poolMax   int32
+		allocated int32
+		expect    bool
+	}{
+		{
+			name:      "nil replicas defaults to 1 - pool has headroom",
+			replicas:  nil,
+			poolMax:   10,
+			allocated: 5,
+			expect:    true,
+		},
+		{
+			name:      "nil replicas defaults to 1 - pool full",
+			replicas:  nil,
+			poolMax:   10,
+			allocated: 10,
+			expect:    false,
+		},
+		{
+			name:      "replicas fit exactly in headroom",
+			replicas:  int32Ptr(3),
+			poolMax:   10,
+			allocated: 7,
+			expect:    true,
+		},
+		{
+			name:      "replicas exceed headroom by one",
+			replicas:  int32Ptr(3),
+			poolMax:   10,
+			allocated: 8,
+			expect:    false,
+		},
+		{
+			name:      "replicas exceed PoolMax outright",
+			replicas:  int32Ptr(5),
+			poolMax:   3,
+			allocated: 0,
+			expect:    false,
+		},
+		{
+			name:      "scale-from-zero pool can accept replicas within PoolMax",
+			replicas:  int32Ptr(3),
+			poolMax:   5,
+			allocated: 0,
+			expect:    true,
+		},
+		{
+			name:      "zero PoolMax pool always ineligible",
+			replicas:  int32Ptr(1),
+			poolMax:   0,
+			allocated: 0,
+			expect:    false,
+		},
+		{
+			name:      "zero replicas is trivially satisfied",
+			replicas:  int32Ptr(0),
+			poolMax:   1,
+			allocated: 1,
+			expect:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &sandboxv1alpha1.BatchSandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-1"},
+				Spec:       sandboxv1alpha1.BatchSandboxSpec{Replicas: tt.replicas},
+			}
+			pool := &sandboxv1alpha1.Pool{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-test"},
+				Spec: sandboxv1alpha1.PoolSpec{
+					CapacitySpec: sandboxv1alpha1.CapacitySpec{PoolMax: tt.poolMax},
+				},
+				Status: sandboxv1alpha1.PoolStatus{Allocated: tt.allocated},
+			}
+			got := p.Predicate(ctx, sbx, pool)
+			if got != tt.expect {
+				t.Errorf("capacityPredicate.Predicate() = %v, want %v (poolMax=%d, allocated=%d, replicas=%v)",
+					got, tt.expect, tt.poolMax, tt.allocated, tt.replicas)
+			}
+		})
+	}
+}

--- a/kubernetes/internal/controller/poolassign/profile.go
+++ b/kubernetes/internal/controller/poolassign/profile.go
@@ -41,7 +41,7 @@ func DefaultProfile() *Profile {
 	return &Profile{
 		Name: DefaultProfileName,
 		Plugins: PluginsSpec{
-			Predicate: []string{"image", "resource", "nodeselector"},
+			Predicate: []string{"capacity", "image", "resource", "nodeselector"},
 			Score:     []ScoreSpec{{Name: "resbalance", Weight: 100}},
 		},
 		PluginConf: []PluginConf{

--- a/kubernetes/test/e2e/e2e_test.go
+++ b/kubernetes/test/e2e/e2e_test.go
@@ -4580,6 +4580,135 @@ spec:
 			cmd = exec.Command("kubectl", "delete", "pool", poolSmallName, "-n", testNamespace)
 			_, _ = utils.Run(cmd)
 		})
+
+		It("should auto-assign to the non-full Pool when one Pool is fully allocated", func() {
+			const poolFullName = "test-pool-cap-full"
+			const poolAvailName = "test-pool-cap-avail"
+			const testNamespace = "default"
+
+			By("creating pool-avail with capacity")
+			poolAvailYAML, err := renderTemplate("testdata/pool-basic.yaml", map[string]interface{}{
+				"PoolName":     poolAvailName,
+				"SandboxImage": utils.SandboxImage,
+				"Namespace":    testNamespace,
+				"BufferMax":    3,
+				"BufferMin":    2,
+				"PoolMax":      5,
+				"PoolMin":      2,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			poolAvailFile := filepath.Join("/tmp", poolAvailName+".yaml")
+			err = os.WriteFile(poolAvailFile, []byte(poolAvailYAML), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(poolAvailFile)
+
+			cmd := exec.Command("kubectl", "apply", "-f", poolAvailFile)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating pool-full with minimal capacity")
+			poolFullYAML, err := renderTemplate("testdata/pool-basic.yaml", map[string]interface{}{
+				"PoolName":     poolFullName,
+				"SandboxImage": utils.SandboxImage,
+				"Namespace":    testNamespace,
+				"BufferMax":    1,
+				"BufferMin":    1,
+				"PoolMax":      1,
+				"PoolMin":      1,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			poolFullFile := filepath.Join("/tmp", poolFullName+".yaml")
+			err = os.WriteFile(poolFullFile, []byte(poolFullYAML), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(poolFullFile)
+
+			cmd = exec.Command("kubectl", "apply", "-f", poolFullFile)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for both pools to be stable")
+			waitPoolStable(poolAvailName, testNamespace, 3*time.Minute)
+			waitPoolStable(poolFullName, testNamespace, 3*time.Minute)
+
+			By("allocating pool-full completely with a BatchSandbox targeting pool-full")
+			const bsFillName = "test-bs-cap-fill"
+			bsFillYAML := fmt.Sprintf(`apiVersion: sandbox.opensandbox.io/v1alpha1
+kind: BatchSandbox
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  poolRef: %s
+`, bsFillName, testNamespace, poolFullName)
+
+			bsFillFile := filepath.Join("/tmp", bsFillName+".yaml")
+			err = os.WriteFile(bsFillFile, []byte(bsFillYAML), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(bsFillFile)
+
+			cmd = exec.Command("kubectl", "apply", "-f", bsFillFile)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the first BatchSandbox to be allocated")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "batchsandbox", bsFillName, "-n", testNamespace,
+					"-o", "jsonpath={.status.allocated}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}, 2*time.Minute).Should(Succeed())
+
+			By("verifying pool-full is now at capacity")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pool", poolFullName, "-n", testNamespace,
+					"-o", "jsonpath={.status.allocated}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("1"))
+			}, 1*time.Minute).Should(Succeed())
+
+			By("creating a second BatchSandbox that should go to pool-avail")
+			const bsCapName = "test-bs-cap-assign"
+			bsCapYAML, err := renderTemplate("testdata/batchsandbox-auto-assign-with-template.yaml", map[string]interface{}{
+				"BatchSandboxName": bsCapName,
+				"Namespace":        testNamespace,
+				"Replicas":         1,
+				"SandboxImage":     utils.SandboxImage,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			bsCapFile := filepath.Join("/tmp", bsCapName+".yaml")
+			err = os.WriteFile(bsCapFile, []byte(bsCapYAML), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(bsCapFile)
+
+			cmd = exec.Command("kubectl", "apply", "-f", bsCapFile)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the second BatchSandbox is assigned to pool-avail (not the full pool)")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "batchsandbox", bsCapName, "-n", testNamespace,
+					"-o", "jsonpath={.spec.poolRef}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(poolAvailName))
+			}, 2*time.Minute).Should(Succeed())
+
+			By("cleaning up")
+			cmd = exec.Command("kubectl", "delete", "batchsandbox", bsCapName, "-n", testNamespace)
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "batchsandbox", bsFillName, "-n", testNamespace)
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pool", poolFullName, "-n", testNamespace)
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pool", poolAvailName, "-n", testNamespace)
+			_, _ = utils.Run(cmd)
+		})
 	})
 
 })


### PR DESCRIPTION
# Summary
- What is changing and why?

Add a capacity predicate to pool-assign to filter out pools with no available pod capacity.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
