### PR TITLE
fix(egress): fall back to nft DNS redirect

### DIFF
--- a/components/egress/cleanup_script_test.go
+++ b/components/egress/cleanup_script_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupScriptRemovesNativeDNSRedirectFallbackTables(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.Mkdir(binDir, 0o755))
+	logPath := filepath.Join(tmpDir, "nft.log")
+	orderPath := filepath.Join(tmpDir, "order.log")
+
+	writeExecutable(t, filepath.Join(binDir, "nft"), `#!/bin/sh
+printf '%s\n' "$*" >> "`+logPath+`"
+cat >> "`+logPath+`"
+printf 'nft\n' >> "`+orderPath+`"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "iptables"), `#!/bin/sh
+printf 'iptables\n' >> "`+orderPath+`"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "ip6tables"), `#!/bin/sh
+printf 'ip6tables\n' >> "`+orderPath+`"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "pkill"), `#!/bin/sh
+exit 0
+`)
+
+	cmd := exec.Command("sh", "scripts/cleanup.sh")
+	cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, string(out))
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	logText := string(logBytes)
+	require.Contains(t, logText, "delete table inet opensandbox_dns_redirect")
+	require.Contains(t, logText, "delete table ip opensandbox_dns_redirect")
+	require.Contains(t, logText, "delete table ip6 opensandbox_dns_redirect")
+	orderBytes, err := os.ReadFile(orderPath)
+	require.NoError(t, err)
+	order := strings.Split(strings.TrimSpace(string(orderBytes)), "\n")
+	require.NotEmpty(t, order)
+	require.Equal(t, "nft", order[0])
+}
+
+func writeExecutable(t *testing.T, path string, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(strings.TrimLeft(content, "\n")), 0o755))
+}

--- a/components/egress/pkg/iptables/redirect.go
+++ b/components/egress/pkg/iptables/redirect.go
@@ -15,6 +15,8 @@
 package iptables
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os/exec"
@@ -24,6 +26,44 @@ import (
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/log"
 )
+
+const dnsRedirectNftTable = "opensandbox_dns_redirect"
+
+var dnsRedirectNftFamilies = []string{"inet", "ip", "ip6"}
+
+type nftCleanupError struct {
+	errs []error
+}
+
+func (e nftCleanupError) Error() string {
+	msgs := make([]string, 0, len(e.errs))
+	for _, err := range e.errs {
+		msgs = append(msgs, err.Error())
+	}
+	return "nft DNS redirect cleanup failed: " + strings.Join(msgs, "; ")
+}
+
+type commandRunner func(ctx context.Context, args []string) ([]byte, error)
+
+type nftRunner func(ctx context.Context, script string) ([]byte, error)
+
+type redirectRunner struct {
+	runCommand commandRunner
+	runNft     nftRunner
+}
+
+func defaultRedirectRunner() redirectRunner {
+	return redirectRunner{
+		runCommand: func(ctx context.Context, args []string) ([]byte, error) {
+			return exec.CommandContext(ctx, args[0], args[1:]...).CombinedOutput()
+		},
+		runNft: func(ctx context.Context, script string) ([]byte, error) {
+			cmd := exec.CommandContext(ctx, "nft", "-f", "-")
+			cmd.Stdin = strings.NewReader(script)
+			return cmd.CombinedOutput()
+		},
+	}
+}
 
 func dnsRedirectRules(port int, exemptDst []netip.Addr, op string) [][]string {
 	targetPort := strconv.Itoa(port)
@@ -58,28 +98,190 @@ func dnsRedirectRules(port int, exemptDst []netip.Addr, op string) [][]string {
 	return rules
 }
 
-func runRedirectRules(rules [][]string) error {
+func (r redirectRunner) runRedirectRules(ctx context.Context, rules [][]string) ([][]string, error) {
+	var applied [][]string
 	for _, args := range rules {
-		if output, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
-			return fmt.Errorf("iptables command failed: %v (output: %s)", err, output)
+		if output, err := r.runCommand(ctx, args); err != nil {
+			return applied, fmt.Errorf("iptables command failed: %v (output: %s)", err, output)
 		}
+		applied = append(applied, args)
+	}
+	return applied, nil
+}
+
+func (r redirectRunner) setupRedirect(ctx context.Context, port int, exemptDst []netip.Addr) error {
+	if cleanupErr := r.removeNftRedirectTables(ctx); cleanupErr != nil {
+		if !isNftUnavailableError(cleanupErr) {
+			return cleanupErr
+		}
+		log.Warnf("nft DNS redirect cleanup unavailable before iptables setup (ignored): %v", cleanupErr)
+	}
+	rules := dnsRedirectRules(port, exemptDst, "-A")
+	if applied, err := r.runRedirectRules(ctx, rules); err != nil {
+		if !isIptablesNftOutputAppendMissingChain(err) {
+			r.rollbackRedirectRules(ctx, applied)
+			return err
+		}
+		log.Warnf("iptables DNS redirect failed in nft backend; falling back to native nft redirect: %v", err)
+		if rollbackErr := r.rollbackRedirectRules(ctx, applied); rollbackErr != nil {
+			return fmt.Errorf("iptables rollback failed before nft DNS redirect fallback after iptables error %v: %w", err, rollbackErr)
+		}
+		script := dnsRedirectNftScript(port, exemptDst)
+		if output, nftErr := r.runNft(ctx, script); nftErr != nil {
+			if isNftMissingTableError(output, nftErr) {
+				if retryOutput, retryErr := r.runNft(ctx, removeNftDeleteTableLine(script)); retryErr == nil {
+					log.Infof("nft DNS redirect fallback installed successfully after missing-table retry")
+					return nil
+				} else {
+					return fmt.Errorf("nft DNS redirect fallback retry failed after iptables error %v: %w (output: %s)", err, retryErr, strings.TrimSpace(string(retryOutput)))
+				}
+			}
+			return fmt.Errorf("nft DNS redirect fallback failed after iptables error %v: %w (output: %s)", err, nftErr, strings.TrimSpace(string(output)))
+		}
+		log.Infof("nft DNS redirect fallback installed successfully")
+		return nil
 	}
 	return nil
+}
+
+func (r redirectRunner) rollbackRedirectRules(ctx context.Context, applied [][]string) error {
+	var errs []string
+	for i := len(applied) - 1; i >= 0; i-- {
+		args := append([]string(nil), applied[i]...)
+		args[3] = "-D"
+		if output, err := r.runCommand(ctx, args); err != nil {
+			if isIptablesMissingRuleError(output, err) {
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("%v (output: %s)", err, strings.TrimSpace(string(output))))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (r redirectRunner) removeNftRedirectTables(ctx context.Context) error {
+	var errs []error
+	for _, family := range dnsRedirectNftFamilies {
+		script := fmt.Sprintf("delete table %s %s\n", family, dnsRedirectNftTable)
+		if output, err := r.runNft(ctx, script); err != nil && !isNftMissingTableError(output, err) {
+			errs = append(errs, fmt.Errorf("%w (output: %s)", err, strings.TrimSpace(string(output))))
+		}
+	}
+	if len(errs) > 0 {
+		return nftCleanupError{errs: errs}
+	}
+	return nil
+}
+
+func isIptablesMissingRuleError(output []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error() + " " + string(output))
+	return strings.Contains(msg, "bad rule") &&
+		strings.Contains(msg, "matching rule")
+}
+
+func isNftUnavailableError(err error) bool {
+	var cleanupErr nftCleanupError
+	if errors.As(err, &cleanupErr) {
+		for _, childErr := range cleanupErr.errs {
+			if !isNftUnavailableError(childErr) {
+				return false
+			}
+		}
+		return len(cleanupErr.errs) > 0
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "protocol not supported") ||
+		strings.Contains(msg, "operation not supported") ||
+		strings.Contains(msg, "nf_tables") && strings.Contains(msg, "not supported")
+}
+
+func isNftMissingTableError(output []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error() + " " + string(output))
+	return strings.Contains(msg, "no such file or directory") &&
+		strings.Contains(msg, "delete table ") &&
+		strings.Contains(msg, " "+dnsRedirectNftTable)
+}
+
+func removeNftDeleteTableLine(script string) string {
+	var lines []string
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, "delete table ") && strings.HasSuffix(line, " "+dnsRedirectNftTable) {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func isIptablesNftOutputAppendMissingChain(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "nf_tables") &&
+		strings.Contains(msg, "rule_append failed") &&
+		strings.Contains(msg, "no such file or directory") &&
+		strings.Contains(msg, "chain output")
+}
+
+func dnsRedirectNftScript(port int, exemptDst []netip.Addr) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "delete table ip %s\n", dnsRedirectNftTable)
+	fmt.Fprintf(&b, "delete table ip6 %s\n", dnsRedirectNftTable)
+	fmt.Fprintf(&b, "add table ip %s\n", dnsRedirectNftTable)
+	fmt.Fprintf(&b, "add chain ip %s output { type nat hook output priority -100; policy accept; }\n", dnsRedirectNftTable)
+	fmt.Fprintf(&b, "add table ip6 %s\n", dnsRedirectNftTable)
+	fmt.Fprintf(&b, "add chain ip6 %s output { type nat hook output priority -100; policy accept; }\n", dnsRedirectNftTable)
+	for _, addr := range exemptDst {
+		if addr.Is4() {
+			fmt.Fprintf(&b, "add rule ip %s output udp dport 53 ip daddr %s return\n", dnsRedirectNftTable, addr.String())
+			fmt.Fprintf(&b, "add rule ip %s output tcp dport 53 ip daddr %s return\n", dnsRedirectNftTable, addr.String())
+		} else {
+			fmt.Fprintf(&b, "add rule ip6 %s output udp dport 53 ip6 daddr %s return\n", dnsRedirectNftTable, addr.String())
+			fmt.Fprintf(&b, "add rule ip6 %s output tcp dport 53 ip6 daddr %s return\n", dnsRedirectNftTable, addr.String())
+		}
+	}
+	fmt.Fprintf(&b, "add rule ip %s output meta mark %s udp dport 53 return\n", dnsRedirectNftTable, constants.MarkHex)
+	fmt.Fprintf(&b, "add rule ip %s output meta mark %s tcp dport 53 return\n", dnsRedirectNftTable, constants.MarkHex)
+	fmt.Fprintf(&b, "add rule ip %s output udp dport 53 redirect to :%d\n", dnsRedirectNftTable, port)
+	fmt.Fprintf(&b, "add rule ip %s output tcp dport 53 redirect to :%d\n", dnsRedirectNftTable, port)
+	fmt.Fprintf(&b, "add rule ip6 %s output meta mark %s udp dport 53 return\n", dnsRedirectNftTable, constants.MarkHex)
+	fmt.Fprintf(&b, "add rule ip6 %s output meta mark %s tcp dport 53 return\n", dnsRedirectNftTable, constants.MarkHex)
+	fmt.Fprintf(&b, "add rule ip6 %s output udp dport 53 redirect to :%d\n", dnsRedirectNftTable, port)
+	fmt.Fprintf(&b, "add rule ip6 %s output tcp dport 53 redirect to :%d\n", dnsRedirectNftTable, port)
+	return b.String()
 }
 
 // SetupRedirect: OUTPUT 53 (udp/tcp) → port; sk_mark RETURN (proxy) and per-dst RETURN (exempt list) first.
 func SetupRedirect(port int, exemptDst []netip.Addr) error {
 	log.Infof("installing iptables DNS redirect: OUTPUT port 53 -> %d (mark %s bypass)", port, constants.MarkHex)
-	rules := dnsRedirectRules(port, exemptDst, "-A")
-	if err := runRedirectRules(rules); err != nil {
+	if err := defaultRedirectRunner().setupRedirect(context.Background(), port, exemptDst); err != nil {
 		return err
 	}
-	log.Infof("iptables DNS redirect installed successfully")
+	log.Infof("DNS redirect installed successfully")
 	return nil
 }
 
 // RemoveRedirect deletes the same rules as SetupRedirect in reverse order; ignores missing rules.
 func RemoveRedirect(port int, exemptDst []netip.Addr) {
+	if err := defaultRedirectRunner().removeNftRedirectTables(context.Background()); err != nil {
+		log.Warnf("nft DNS redirect remove table (ignored): %v", err)
+	}
 	rules := dnsRedirectRules(port, exemptDst, "-D")
 	for i := len(rules) - 1; i >= 0; i-- {
 		args := rules[i]

--- a/components/egress/pkg/iptables/redirect_test.go
+++ b/components/egress/pkg/iptables/redirect_test.go
@@ -1,0 +1,322 @@
+package iptables
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupRedirectFallsBackToNftWhenIptablesNftOutputAppendFails(t *testing.T) {
+	var iptablesCalls [][]string
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, args []string) ([]byte, error) {
+			iptablesCalls = append(iptablesCalls, append([]string(nil), args...))
+			return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, []netip.Addr{
+		netip.MustParseAddr("10.179.156.2"),
+		netip.MustParseAddr("fd00::53"),
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, iptablesCalls)
+	setupScript := nftScripts[len(nftScripts)-1]
+	require.Contains(t, setupScript, "add table ip opensandbox_dns_redirect")
+	require.Contains(t, setupScript, "add table ip6 opensandbox_dns_redirect")
+	require.NotContains(t, setupScript, "add table inet opensandbox_dns_redirect")
+	require.Contains(t, setupScript, "type nat hook output priority -100; policy accept;")
+	require.Contains(t, setupScript, "udp dport 53 ip daddr 10.179.156.2 return")
+	require.Contains(t, setupScript, "tcp dport 53 ip6 daddr fd00::53 return")
+	require.Contains(t, setupScript, "udp dport 53 redirect to :15353")
+	require.Contains(t, setupScript, "tcp dport 53 redirect to :15353")
+	require.False(t, strings.Contains(setupScript, "hook prerouting"))
+}
+
+func TestSetupRedirectClearsStaleNftFallbackWhenIptablesSucceeds(t *testing.T) {
+	var events []string
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			events = append(events, "iptables")
+			return nil, nil
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			events = append(events, "nft")
+			nftScripts = append(nftScripts, script)
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, nftScripts, "delete table inet opensandbox_dns_redirect\n")
+	require.Contains(t, nftScripts, "delete table ip opensandbox_dns_redirect\n")
+	require.Contains(t, nftScripts, "delete table ip6 opensandbox_dns_redirect\n")
+	require.GreaterOrEqual(t, len(events), 4)
+	require.Equal(t, []string{"nft", "nft", "nft", "iptables"}, events[:4])
+}
+
+func TestSetupRedirectIgnoresMissingStaleNftFallbackWhenIptablesSucceeds(t *testing.T) {
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			return nil, nil
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			return []byte("Error: Could not process rule: No such file or directory\n" + script), errors.New("exit status 1")
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+}
+
+func TestSetupRedirectIgnoresUnavailableNftCleanupWhenIptablesSucceeds(t *testing.T) {
+	var iptablesCalls int
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			iptablesCalls++
+			return nil, nil
+		},
+		runNft: func(_ context.Context, _ string) ([]byte, error) {
+			return nil, exec.ErrNotFound
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, 8, iptablesCalls)
+}
+
+func TestSetupRedirectIgnoresUnsupportedNftCleanupWhenIptablesSucceeds(t *testing.T) {
+	var iptablesCalls int
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			iptablesCalls++
+			return nil, nil
+		},
+		runNft: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte("Error: Could not process rule: Protocol not supported"), errors.New("exit status 1")
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, 8, iptablesCalls)
+}
+
+func TestSetupRedirectContinuesNftCleanupAfterUnsupportedFamilyWhenIptablesSucceeds(t *testing.T) {
+	var iptablesCalls int
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			iptablesCalls++
+			return nil, nil
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			if strings.Contains(script, "delete table inet ") {
+				return []byte("Error: Could not process rule: Protocol not supported"), errors.New("exit status 1")
+			}
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, 8, iptablesCalls)
+	require.Contains(t, nftScripts, "delete table inet opensandbox_dns_redirect\n")
+	require.Contains(t, nftScripts, "delete table ip opensandbox_dns_redirect\n")
+	require.Contains(t, nftScripts, "delete table ip6 opensandbox_dns_redirect\n")
+}
+
+func TestSetupRedirectReturnsNftFallbackErrorWhenUnsupportedNftIsRequired(t *testing.T) {
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+		},
+		runNft: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte("Error: Could not process rule: Protocol not supported"), errors.New("exit status 1")
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nft DNS redirect fallback failed")
+	require.Contains(t, err.Error(), "Protocol not supported")
+}
+
+func TestSetupRedirectReturnsNonMissingStaleNftFallbackCleanupError(t *testing.T) {
+	var iptablesCalls int
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			iptablesCalls++
+			return nil, nil
+		},
+		runNft: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte("Operation not permitted"), errors.New("exit status 1")
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nft DNS redirect cleanup failed")
+	require.Zero(t, iptablesCalls)
+}
+
+func TestSetupRedirectRollsBackPartialIptablesRulesBeforeNftFallback(t *testing.T) {
+	var iptablesCalls [][]string
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, args []string) ([]byte, error) {
+			iptablesCalls = append(iptablesCalls, append([]string(nil), args...))
+			if len(iptablesCalls) == 5 {
+				return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+			}
+			return nil, nil
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(iptablesCalls), 9)
+	require.Equal(t, "-A", iptablesCalls[0][3])
+	require.Equal(t, "-A", iptablesCalls[3][3])
+	require.Equal(t, "-D", iptablesCalls[5][3])
+	require.Equal(t, "-D", iptablesCalls[8][3])
+	require.Equal(t, iptablesCalls[3][4:], iptablesCalls[5][4:])
+	require.Equal(t, iptablesCalls[0][4:], iptablesCalls[8][4:])
+	require.Contains(t, nftScripts[len(nftScripts)-1], "add table ip opensandbox_dns_redirect")
+	require.Contains(t, nftScripts[len(nftScripts)-1], "add table ip6 opensandbox_dns_redirect")
+}
+
+func TestSetupRedirectReturnsRollbackErrorBeforeNftFallback(t *testing.T) {
+	var iptablesCalls [][]string
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, args []string) ([]byte, error) {
+			iptablesCalls = append(iptablesCalls, append([]string(nil), args...))
+			switch {
+			case len(iptablesCalls) == 3:
+				return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+			case args[3] == "-D":
+				return []byte("delete failed"), errors.New("exit status 1")
+			default:
+				return nil, nil
+			}
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "iptables rollback failed")
+	for _, script := range nftScripts {
+		require.NotContains(t, script, "add table inet opensandbox_dns_redirect")
+	}
+}
+
+func TestSetupRedirectIgnoresAlreadyAbsentRollbackRuleBeforeNftFallback(t *testing.T) {
+	var iptablesCalls [][]string
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, args []string) ([]byte, error) {
+			iptablesCalls = append(iptablesCalls, append([]string(nil), args...))
+			switch {
+			case len(iptablesCalls) == 3:
+				return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+			case args[3] == "-D":
+				return []byte("iptables: Bad rule (does a matching rule exist in that chain?)."), errors.New("exit status 1")
+			default:
+				return nil, nil
+			}
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, nftScripts[len(nftScripts)-1], "add table ip opensandbox_dns_redirect")
+	require.Contains(t, nftScripts[len(nftScripts)-1], "add table ip6 opensandbox_dns_redirect")
+}
+
+func TestSetupRedirectRetriesNftFallbackWithoutDeleteWhenTableIsMissing(t *testing.T) {
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			return []byte("iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain OUTPUT\n"), errors.New("exit status 4")
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			if strings.Contains(script, "add table ip opensandbox_dns_redirect") && strings.Contains(script, "delete table ip opensandbox_dns_redirect") {
+				return []byte("Error: Could not process rule: No such file or directory\ndelete table ip opensandbox_dns_redirect"), errors.New("exit status 1")
+			}
+			return nil, nil
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.NoError(t, err)
+	require.Len(t, nftScripts, 5)
+	failedSetupScript := nftScripts[len(nftScripts)-2]
+	retryScript := nftScripts[len(nftScripts)-1]
+	require.Contains(t, failedSetupScript, "delete table ip opensandbox_dns_redirect")
+	require.NotContains(t, retryScript, "delete table ip opensandbox_dns_redirect")
+	require.NotContains(t, retryScript, "delete table ip6 opensandbox_dns_redirect")
+	require.Contains(t, retryScript, "add table ip opensandbox_dns_redirect")
+	require.Contains(t, retryScript, "add table ip6 opensandbox_dns_redirect")
+}
+
+func TestSetupRedirectReturnsOriginalIptablesErrorWhenFallbackIsNotApplicable(t *testing.T) {
+	var nftScripts []string
+	r := redirectRunner{
+		runCommand: func(_ context.Context, _ []string) ([]byte, error) {
+			return []byte("permission denied"), errors.New("exit status 4")
+		},
+		runNft: func(_ context.Context, script string) ([]byte, error) {
+			nftScripts = append(nftScripts, script)
+			return []byte("Error: Could not process rule: No such file or directory\n" + script), errors.New("exit status 1")
+		},
+	}
+
+	err := r.setupRedirect(context.Background(), 15353, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission denied")
+	for _, script := range nftScripts {
+		require.NotContains(t, script, "add table ip opensandbox_dns_redirect")
+		require.NotContains(t, script, "add table ip6 opensandbox_dns_redirect")
+	}
+}

--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -222,7 +222,7 @@ func buildRuleset(p *policy.NetworkPolicy, opts Options) (string, error) {
 	fmt.Fprintf(&b, "add rule inet %s %s ip daddr @%s accept\n", tableName, chainName, allowV4Set)
 	fmt.Fprintf(&b, "add rule inet %s %s ip6 daddr @%s accept\n", tableName, chainName, allowV6Set)
 	if chainPolicy == "drop" {
-		fmt.Fprintf(&b, "add rule inet %s %s counter drop\n", tableName, chainName)
+		fmt.Fprintf(&b, "add rule inet %s %s drop\n", tableName, chainName)
 	}
 
 	return b.String(), nil

--- a/components/egress/pkg/nftables/manager_test.go
+++ b/components/egress/pkg/nftables/manager_test.go
@@ -56,7 +56,23 @@ func TestApplyStatic_BuildsRuleset_DefaultDeny(t *testing.T) {
 	expectContains(t, rendered, "add element inet opensandbox deny_v6 { 2001:db8::/32 }")
 	expectContains(t, rendered, "add rule inet opensandbox egress ip daddr @dyn_allow_v4 accept")
 	expectContains(t, rendered, "add rule inet opensandbox egress ip6 daddr @dyn_allow_v6 accept")
-	expectContains(t, rendered, "add rule inet opensandbox egress counter drop")
+	expectContains(t, rendered, "add rule inet opensandbox egress drop")
+}
+
+func TestApplyStatic_DefaultDenyFallbackRuleUsesPlainDrop(t *testing.T) {
+	var rendered string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		rendered = script
+		return nil, nil
+	})
+
+	p, err := policy.ParsePolicy(`{"defaultAction":"deny","egress":[]}`)
+	require.NoError(t, err)
+	require.NoError(t, m.ApplyStatic(context.Background(), p))
+
+	expectContains(t, rendered, "add chain inet opensandbox egress { type filter hook output priority 0; policy drop; }")
+	expectContains(t, rendered, "add rule inet opensandbox egress drop")
+	require.NotContains(t, rendered, "counter drop", "counter expression is not supported in the QA pod netns")
 }
 
 func TestApplyStatic_DefaultAllowUsesAcceptPolicy(t *testing.T) {
@@ -76,7 +92,7 @@ func TestApplyStatic_DefaultAllowUsesAcceptPolicy(t *testing.T) {
 
 	expectContains(t, rendered, "policy accept;")
 	expectContains(t, rendered, "add rule inet opensandbox egress tcp dport 853 drop")
-	require.NotContains(t, rendered, "counter drop", "did not expect drop counter when defaultAction is allow:\n%s", rendered)
+	require.NotContains(t, rendered, " egress drop", "did not expect final drop rule when defaultAction is allow:\n%s", rendered)
 	expectContains(t, rendered, "add element inet opensandbox deny_v4 { 10.0.0.0/8 }")
 }
 

--- a/components/egress/scripts/cleanup.sh
+++ b/components/egress/scripts/cleanup.sh
@@ -26,9 +26,13 @@
 #     entire restart window. The new egress process re-installs them
 #     after its DNS proxy is listening, so the unfiltered window is
 #     limited to the startup duration (~200ms).
-#   * The `inet opensandbox` nft table is NOT touched here. The
-#     egress nftables manager already prepends `delete table inet
-#     opensandbox` to its ruleset script, so ApplyStatic is idempotent.
+#   * The `inet/ip/ip6 opensandbox_dns_redirect` nft tables ARE removed
+#     here. Native nft DNS fallback uses those tables when iptables-nft
+#     cannot append OUTPUT rules; after a crash they would otherwise keep
+#     redirecting DNS to a dead proxy.
+#   * The `inet opensandbox` nft table is NOT touched here. The egress
+#     nftables manager already prepends `delete table inet opensandbox` to
+#     its ruleset script, so ApplyStatic is idempotent.
 #
 # Hard contract: this script MUST NOT exit non-zero. A misbehaving cleanup
 # hook is worse than a stray mitmdump; supervisor would treat the hook
@@ -67,6 +71,14 @@ remove_stale_iptables() {
   log "stale iptables rules removed (best-effort)"
 }
 
+remove_stale_dns_redirect_nft() {
+  command -v nft >/dev/null 2>&1 || { log "nft not present; skipping native DNS redirect cleanup"; return 0; }
+  for family in inet ip ip6; do
+    printf 'delete table %s opensandbox_dns_redirect\n' "$family" | nft -f - 2>/dev/null || true
+  done
+  log "stale native DNS redirect nft tables removed (best-effort)"
+}
+
 # ─── stray mitmdump (orphaned after hard crash) ──────────────────────
 kill_stray_mitmdump() {
   command -v pkill >/dev/null 2>&1 || { log "pkill not present; skipping mitmdump reap"; return 0; }
@@ -84,6 +96,7 @@ kill_stray_mitmdump() {
 
 main() {
   log "starting (worker_exit_code=${WORKER_EXIT_CODE:-?} signal=${WORKER_SIGNAL:-?} attempt=${WORKER_ATTEMPT:-?})"
+  remove_stale_dns_redirect_nft
   remove_stale_iptables
   kill_stray_mitmdump
   log "done"

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -19,7 +19,7 @@ It runs alongside the sandbox application container (sharing the same network na
 - **Dynamic DNS (dns+nft mode)**: When a domain is allowed and the proxy resolves it, the resolved A/AAAA IPs are added to nftables with TTL so that default-deny + domain-allow is enforced at the network layer.
 - **Credential Vault**: Automatic credential injection (bearer, basic, API-key, custom headers) for allowed hosts via transparent mitmproxy. See [Credential Vault](/guides/credential-vault).
 - **Privilege Isolation**: Requires `CAP_NET_ADMIN` only for the sidecar; the application container runs unprivileged.
-- **Fail-Closed Enforcement**: `iptables` setup is required; the sidecar exits on failure to guarantee no traffic leaks without enforcement. Optional subsystems (OpenTelemetry, startup hooks) degrade gracefully.
+- **Fail-Closed Enforcement**: DNS redirect setup is required through `iptables` or the native nft fallback; the sidecar exits if no enforced redirect can be installed. Optional subsystems (OpenTelemetry, startup hooks) degrade gracefully.
 
 ## Architecture
 
@@ -245,7 +245,7 @@ ENTRYPOINT: supervisor --pre-start=cleanup.sh --name=egress --grace-period=20s -
 Egress-specific configuration:
 
 - **`--grace-period=20s`**: Egress needs extra time to drain DNS connections and tear down iptables/nft rules on shutdown (default is 10 s).
-- **Pre-start hook** (`cleanup.sh`): Reaps orphaned `mitmdump` processes from a previous crash so the new egress can bind the MITM listen port. Intentionally does NOT tear down iptables/nft rules -- keeping enforcement active during the backoff window protects the workload.
+- **Pre-start hook** (`cleanup.sh`): Reaps orphaned `mitmdump` processes from a previous crash and removes stale DNS redirect iptables/native nft state that would otherwise point port 53 at a dead proxy. It does not manage the `inet opensandbox` policy table; the nftables manager deletes and recreates that table when policy enforcement starts.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Problem

Fixes #1147.

In some Kubernetes pod network namespaces, the egress sidecar fails to start in `dns+nft` mode even though nftables is available:

- `iptables-nft` can list the `nat` table but fails to append `nat OUTPUT` redirect rules with `RULE_APPEND failed (No such file or directory): rule in chain OUTPUT`.
- The static nftables default-deny ruleset can reject the final `counter drop` fallback rule.

When this happens, sandbox creation with an egress policy enters the sidecar path but the sidecar crashloops, so runtime egress enforcement cannot become ready.

## Changes

- Fall back to native `nft` DNS redirect rules when `iptables-nft` fails specifically on `nat OUTPUT` append.
- Retry native nft DNS redirect setup without deleting the table when the table does not exist yet.
- Use a plain final `drop` rule for the default-deny nftables fallback rule.
- Add unit tests for the iptables-to-nft fallback path and the plain drop default-deny rule.

## Tests

Ran from `components/egress`:

```bash
go test ./...
```

## Notes

This is a small bug fix scoped to `components/egress`; it does not add a feature, change public APIs, or require an OSEP under `CONTRIBUTING.md`.