### PR TITLE
ci(workflow): auto-apply PR labels instead of leaving comments

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -1,28 +1,27 @@
-name: PR Label Check
+name: PR Auto Label
 
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, synchronize]
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
-  check-labels:
+  auto-label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            const labels = pr.labels;
             const prNumber = pr.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const marker = "<!-- LABEL_CHECK_BOT -->";
 
-            function suggestLabels(files) {
+            function inferLabels(files) {
               const dirs = new Set();
               for (const f of files) {
                 const p = f.filename.split("/");
@@ -44,11 +43,9 @@ jobs:
                 s.push("component/egress", "component/ingress");
               }
 
-              // k8s / server
               if (dirs.has("kubernetes")) s.push("component/k8s");
               if (dirs.has("server")) s.push("component/server");
 
-              // SDK
               if (dirs.has("sdks")) {
                 s.push("sdks");
                 if (dirs.has("sdks/go")) s.push("sdk/go");
@@ -61,65 +58,37 @@ jobs:
               return [...new Set(s)].sort();
             }
 
-            if (labels.length === 0) {
-              const { data: files } = await github.rest.pulls.listFiles({
-                owner, repo, pull_number: prNumber,
-              });
-              const suggested = suggestLabels(files);
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner, repo, pull_number: prNumber,
+            });
+            const inferred = inferLabels(files);
 
-              const { data: allLabels } = await github.rest.issues.listLabelsForRepo({
-                owner, repo,
-              });
-
-              let tip = "";
-              const suggestedSet = new Set(suggested);
-              const allow = ["bug", "documentation", "feature", "dependencies", "packages"];
-              const otherLabels = allLabels.filter(l =>
-                !suggestedSet.has(l.name) && allow.includes(l.name)
-              );
-              if (suggested.length > 0) {
-                tip = `\n\n📋 **Recommended labels** (based on changed files):\n`;
-                for (const name of suggested) {
-                  tip += `- \`${name}\` ⬅️\n`;
-                }
-                if (otherLabels.length > 0) {
-                  tip += `\nOther available labels:\n`;
-                  for (const lab of otherLabels) {
-                    const desc = lab.description ? ` - ${lab.description}` : "";
-                    tip += `- \`${lab.name}\`${desc}\n`;
-                  }
-                }
-              }
-
-              const touchedDirs = [...new Set(files.map(f => f.filename.split("/")[0]))].join("、");
-              const hint = `\n\n💡 Tip: Use \`feature\` for new functionality or improvements, \`bug\` for fixes.`;
-              const { data: comments } = await github.rest.issues.listComments({
-                owner, repo, issue_number: prNumber,
-              });
-              const existing = comments.filter(
-                c => c.user?.type === "Bot" && c.body?.includes(marker)
-              );
-              if (existing.length === 0) {
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: prNumber,
-                  body: `${marker}
-            ⚠️  This PR has no labels. Please add one based on the changes.
-
-            Changed directories: ${touchedDirs}.${tip}${hint}
-
-            cc @${pr.user.login}`,
-                });
-              }
-            } else {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner, repo, issue_number: prNumber,
-              });
-              const botComments = comments.filter(
-                c => c.user?.type === "Bot" && c.body?.includes(marker)
-              );
-              for (const c of botComments) {
-                await github.rest.issues.deleteComment({
-                  owner, repo, comment_id: c.id,
-                });
-              }
+            if (inferred.length === 0) {
+              core.info("No labels inferred from changed files, skipping.");
+              return;
             }
+
+            const existing = new Set(pr.labels.map(l => l.name));
+            const toAdd = inferred.filter(l => !existing.has(l));
+
+            if (toAdd.length === 0) {
+              core.info("All inferred labels already present.");
+              return;
+            }
+
+            const { data: repoLabels } = await github.rest.issues.listLabelsForRepo({
+              owner, repo,
+            });
+            const repoLabelNames = new Set(repoLabels.map(l => l.name));
+            const valid = toAdd.filter(l => repoLabelNames.has(l));
+
+            if (valid.length === 0) {
+              core.info("Inferred labels don't exist in repo, skipping.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: prNumber,
+              labels: valid,
+            });
+            core.info(`Added labels: ${valid.join(", ")}`);


### PR DESCRIPTION
## Summary
- Replace comment-based label suggestion with automatic label application via GitHub API
- Labels inferred from changed file paths (e.g. `components/egress` → `component/egress`)
- Idempotent: skips labels already present or not defined in repo
- Removed `labeled`/`unlabeled` triggers to prevent infinite loops

## Test plan
- [ ] Open PR touching `components/egress` → verify `component/egress` label auto-applied
- [ ] Open PR touching `sdks/python` → verify `sdk/python` + `sdks` labels applied
- [ ] Open PR touching only root files → verify no labels added, no error
- [ ] Manually add label before workflow runs → verify no duplicate