### PR TITLE
fix(ci): paginate PR files and match real SDK directory layout

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -25,8 +25,9 @@ jobs:
               const dirs = new Set();
               for (const f of files) {
                 const p = f.filename.split("/");
-                dirs.add(p[0]);
-                if (p.length >= 2) dirs.add(p[0] + "/" + p[1]);
+                for (let i = 1; i <= p.length; i++) {
+                  dirs.add(p.slice(0, i).join("/"));
+                }
               }
               const s = [];
 
@@ -46,19 +47,30 @@ jobs:
               if (dirs.has("kubernetes")) s.push("component/k8s");
               if (dirs.has("server")) s.push("component/server");
 
+              // SDK — layout: sdks/{sandbox,code-interpreter,mcp}/{go,python,...}
               if (dirs.has("sdks")) {
                 s.push("sdks");
-                if (dirs.has("sdks/go")) s.push("sdk/go");
-                if (dirs.has("sdks/java")) s.push("sdk/java");
-                if (dirs.has("sdks/python")) s.push("sdk/python");
-                if (dirs.has("sdks/js")) s.push("sdk/js");
-                if (dirs.has("sdks/csharp")) s.push("sdk/c#");
+                const langMap = {
+                  go: "sdk/go",
+                  kotlin: "sdk/java",
+                  python: "sdk/python",
+                  javascript: "sdk/js",
+                  csharp: "sdk/c#",
+                };
+                for (const [dir, label] of Object.entries(langMap)) {
+                  for (const d of dirs) {
+                    if (d.startsWith("sdks/") && d.endsWith("/" + dir)) {
+                      s.push(label);
+                      break;
+                    }
+                  }
+                }
               }
 
               return [...new Set(s)].sort();
             }
 
-            const { data: files } = await github.rest.pulls.listFiles({
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: prNumber,
             });
             const inferred = inferLabels(files);


### PR DESCRIPTION
## Summary
- **Paginate PR file listing**: `listFiles` defaults to 30 files per page, so large PRs (e.g. SDK regeneration) silently missed labels for directories beyond page 1. Switched to `github.paginate()` to fetch all pages.
- **Fix SDK language detection**: The actual SDK layout is three-level (`sdks/{sandbox,code-interpreter,mcp}/{go,python,...}`), but `inferLabels` only checked two-level paths (`sdks/python`, `sdks/js`). Language-specific labels like `sdk/python` and `sdk/js` were never applied. Now scans all path prefixes and matches against the real directory names.

## Test plan
- [ ] Open a PR touching 30+ files spanning multiple directories — verify all expected labels are suggested
- [ ] Open a PR touching only `sdks/sandbox/python/` — verify `sdk/python` label is applied
- [ ] Open a PR touching only `sdks/code-interpreter/javascript/` — verify `sdk/js` label is applied
- [ ] Open a PR touching `sdks/sandbox/kotlin/` — verify `sdk/java` label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)