### PR TITLE
docs(examples): add Harbor evaluation example on OpenSandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ OpenSandbox provides examples covering SDK usage, agent integrations, browser au
 #### 🧠 ML and Training
 
 - **[rl-training](docs/examples/rl-training.md)** - DQN CartPole training in a sandbox with checkpoints and summary output.
+- **[harbor-evaluation](docs/examples/harbor-evaluation.md)** - Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox, one sandbox per trial.
 
 For more details, please refer to the [examples documentation](docs/examples/index.md).
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ OpenSandbox provides examples covering SDK usage, agent integrations, browser au
 - **[desktop](docs/examples/desktop.md)** - Full desktop environment in a sandbox with VNC access.
 - **[vscode](docs/examples/vscode.md)** - code-server (VS Code Web) running inside a sandbox for remote dev.
 
-#### 🧠 ML and Training
+#### 🧠 Training and Evaluation
 
 - **[rl-training](docs/examples/rl-training.md)** - DQN CartPole training in a sandbox with checkpoints and summary output.
 - **[harbor-evaluation](docs/examples/harbor-evaluation.md)** - Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox, one sandbox per trial.

--- a/docs/examples/harbor-evaluation.md
+++ b/docs/examples/harbor-evaluation.md
@@ -72,26 +72,10 @@ Results are written under the `jobs_dir` from `config.yaml`
 output (`reward.txt`, `ctrf.json`), collected `artifacts/`, and `results.json`.
 A successful run produces `reward = 1.0`.
 
-## Use your own task
-
-The included `hello-opensandbox` task is checked into this repository only to
-make the example self-contained and runnable without publishing or downloading
-anything first. For real evaluations, prefer tasks from an external Harbor task
-registry and override the example task from the command line:
-
-```shell
-harbor run -c config.yaml --task <org>/<task>@latest
-```
-
-During local task development, you can also point Harbor at a task directory:
-
-```shell
-harbor run -c config.yaml --path /path/to/task
-```
-
 ## Evaluate a real agent
 
-Swap the `oracle` agent for a real agent + model:
+Swap the `oracle` agent for a real agent + model, and point `tasks:` in
+`config.yaml` at your own task directories:
 
 ```shell
 harbor run -c config.yaml -a claude-code -m "anthropic/claude-sonnet-4-5"

--- a/docs/examples/harbor-evaluation.md
+++ b/docs/examples/harbor-evaluation.md
@@ -31,8 +31,18 @@ opensandbox-server
 
 ## Install Harbor
 
+The OpenSandbox backend was merged into Harbor's `main` branch
+([#2054](https://github.com/harbor-framework/harbor/pull/2054)) but is not yet in
+a published release. Until a release ships with it, install Harbor from git:
+
 ```shell
-uv pip install "harbor[opensandbox]"
+uv pip install "harbor[opensandbox] @ git+https://github.com/harbor-framework/harbor"
+```
+
+Once a released Harbor version includes the backend, the plain extra will work:
+
+```shell
+uv pip install "harbor[opensandbox]"   # after the next Harbor release
 ```
 
 ## Configure the connection

--- a/docs/examples/harbor-evaluation.md
+++ b/docs/examples/harbor-evaluation.md
@@ -82,10 +82,26 @@ Results are written under the `jobs_dir` from `config.yaml`
 output (`reward.txt`, `ctrf.json`), collected `artifacts/`, and `results.json`.
 A successful run produces `reward = 1.0`.
 
+## Use your own task
+
+The included `hello-opensandbox` task is checked into this repository only to
+make the example self-contained and runnable without publishing or downloading
+anything first. For real evaluations, prefer tasks from an external Harbor task
+registry and override the example task from the command line:
+
+```shell
+harbor run -c config.yaml --task <org>/<task>@latest
+```
+
+During local task development, you can also point Harbor at a task directory:
+
+```shell
+harbor run -c config.yaml --path /path/to/task
+```
+
 ## Evaluate a real agent
 
-Swap the `oracle` agent for a real agent + model, and point `tasks:` in
-`config.yaml` at your own task directories:
+Swap the `oracle` agent for a real agent + model:
 
 ```shell
 harbor run -c config.yaml -a claude-code -m "anthropic/claude-sonnet-4-5"

--- a/docs/examples/harbor-evaluation.md
+++ b/docs/examples/harbor-evaluation.md
@@ -1,0 +1,101 @@
+---
+title: Harbor Evaluation
+description: Run a Harbor agent evaluation on OpenSandbox, provisioning one sandbox per trial.
+---
+
+# Harbor Evaluation on OpenSandbox
+
+Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on
+OpenSandbox infrastructure. Harbor provisions one OpenSandbox container per
+trial, runs the agent inside it, executes the task's verifier, and collects the
+reward plus logs and artifacts.
+
+Harbor gained native OpenSandbox support in
+[harbor-framework/harbor#2054](https://github.com/harbor-framework/harbor/pull/2054),
+which adds the `opensandbox` environment backend and the `harbor[opensandbox]`
+install extra.
+
+This example ships a minimal, self-contained task (`hello-opensandbox`) plus a
+job config that selects the `opensandbox` environment. The task uses a prebuilt
+image and an offline verifier so it runs anywhere without extra dependencies.
+
+## Start OpenSandbox server [local]
+
+Start a local OpenSandbox server (Docker runtime):
+
+```shell
+uv pip install opensandbox-server
+opensandbox-server init-config ~/.sandbox.toml --example docker
+opensandbox-server
+```
+
+## Install Harbor
+
+```shell
+uv pip install "harbor[opensandbox]"
+```
+
+## Configure the connection
+
+Harbor reads the server connection from environment variables (or from the
+`domain` / `api_key` kwargs in `config.yaml`):
+
+```shell
+export OPENSANDBOX_DOMAIN="localhost:8080"   # OpenSandbox server address
+export OPENSANDBOX_API_KEY=""                # API key, if your server requires one
+```
+
+`OPENSANDBOX_API_KEY` may be left empty for a local / no-auth server.
+
+## Run the evaluation
+
+```shell
+# From examples/harbor-evaluation
+harbor run -c config.yaml
+```
+
+Harbor creates an OpenSandbox sandbox from the task's prebuilt image
+(`ubuntu:24.04`), runs the `oracle` agent (which executes the reference
+solution), runs the verifier, records the reward, and tears the sandbox down.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENSANDBOX_DOMAIN` | `localhost:8080` | OpenSandbox server address |
+| `OPENSANDBOX_API_KEY` | _(optional)_ | API key if your server requires authentication |
+
+## Outputs
+
+Results are written under the `jobs_dir` from `config.yaml`
+(`jobs/opensandbox/<job-id>/<trial-id>/`), including `agent/` logs, `verifier/`
+output (`reward.txt`, `ctrf.json`), collected `artifacts/`, and `results.json`.
+A successful run produces `reward = 1.0`.
+
+## Evaluate a real agent
+
+Swap the `oracle` agent for a real agent + model, and point `tasks:` in
+`config.yaml` at your own task directories:
+
+```shell
+harbor run -c config.yaml -a claude-code -m "anthropic/claude-sonnet-4-5"
+```
+
+## OpenSandbox-specific notes
+
+- **Prebuilt images only** — every task must set `[environment].docker_image` in
+  `task.toml`; the OpenSandbox backend does not build Dockerfiles. Use
+  `image_auth` kwargs for private registries.
+- **Working directory** — set `[environment].workdir` (this task uses `/app`) so
+  the agent's relative paths resolve where the verifier expects them.
+- **Resources** — `cpus` and `memory_mb` map to hard sandbox limits; `storage_mb`
+  is ignored; GPUs are supported via `gpus` / `gpu_types`.
+- **Artifacts** — files written under `/logs/artifacts` are downloaded into the
+  trial's `artifacts/` directory.
+- **Multi-container** — `docker-compose.yaml` tasks are not supported; use
+  single-container tasks.
+
+## References
+
+- [Source code on GitHub](https://github.com/opensandbox-group/OpenSandbox/tree/main/examples/harbor-evaluation)
+- [Harbor](https://github.com/harbor-framework/harbor)

--- a/docs/examples/harbor-evaluation.md
+++ b/docs/examples/harbor-evaluation.md
@@ -72,10 +72,26 @@ Results are written under the `jobs_dir` from `config.yaml`
 output (`reward.txt`, `ctrf.json`), collected `artifacts/`, and `results.json`.
 A successful run produces `reward = 1.0`.
 
+## Use your own task
+
+The included `hello-opensandbox` task is checked into this repository only to
+make the example self-contained and runnable without publishing or downloading
+anything first. For real evaluations, prefer tasks from an external Harbor task
+registry and override the example task from the command line:
+
+```shell
+harbor run -c config.yaml --task <org>/<task>@latest
+```
+
+During local task development, you can also point Harbor at a task directory:
+
+```shell
+harbor run -c config.yaml --path /path/to/task
+```
+
 ## Evaluate a real agent
 
-Swap the `oracle` agent for a real agent + model, and point `tasks:` in
-`config.yaml` at your own task directories:
+Swap the `oracle` agent for a real agent + model:
 
 ```shell
 harbor run -c config.yaml -a claude-code -m "anthropic/claude-sonnet-4-5"

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -50,6 +50,7 @@ Fundamental sandbox operations and SDK workflows.
 | [AKS + Kata](/examples/aks-kata) | AKS deployment with Kata VM isolation, ingress, egress, and Credential Vault |
 | [Windows](/examples/windows) | Windows sandbox via KVM/QEMU |
 | [RL Training](/examples/rl-training) | DQN CartPole reinforcement learning |
+| [Harbor Evaluation](/examples/harbor-evaluation) | Run a Harbor agent evaluation, one sandbox per trial |
 
 ## Storage
 

--- a/examples/harbor-evaluation/README.md
+++ b/examples/harbor-evaluation/README.md
@@ -1,0 +1,5 @@
+# Harbor Evaluation on OpenSandbox
+
+Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox, provisioning one sandbox per trial.
+
+> **Full documentation**: [docs/examples/harbor-evaluation.md](../../docs/examples/harbor-evaluation.md)

--- a/examples/harbor-evaluation/README.md
+++ b/examples/harbor-evaluation/README.md
@@ -2,19 +2,4 @@
 
 Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox, provisioning one sandbox per trial.
 
-The included `tasks/hello-opensandbox` task keeps this example self-contained, so
-the config can run immediately after cloning the repo. For real evaluations,
-prefer a task from an external Harbor task registry and override the example task
-from the command line:
-
-```shell
-harbor run -c config.yaml --task <org>/<task>@latest
-```
-
-During local task development, you can also point Harbor at a task directory:
-
-```shell
-harbor run -c config.yaml --path /path/to/task
-```
-
 > **Full documentation**: [docs/examples/harbor-evaluation.md](../../docs/examples/harbor-evaluation.md)

--- a/examples/harbor-evaluation/README.md
+++ b/examples/harbor-evaluation/README.md
@@ -2,4 +2,19 @@
 
 Run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox, provisioning one sandbox per trial.
 
+The included `tasks/hello-opensandbox` task keeps this example self-contained, so
+the config can run immediately after cloning the repo. For real evaluations,
+prefer a task from an external Harbor task registry and override the example task
+from the command line:
+
+```shell
+harbor run -c config.yaml --task <org>/<task>@latest
+```
+
+During local task development, you can also point Harbor at a task directory:
+
+```shell
+harbor run -c config.yaml --path /path/to/task
+```
+
 > **Full documentation**: [docs/examples/harbor-evaluation.md](../../docs/examples/harbor-evaluation.md)

--- a/examples/harbor-evaluation/config.yaml
+++ b/examples/harbor-evaluation/config.yaml
@@ -1,0 +1,33 @@
+# Harbor job configuration that runs an evaluation on OpenSandbox.
+#
+# Harbor docs: https://github.com/harbor-framework/harbor
+# Run from this directory with:  harbor run -c config.yaml
+
+jobs_dir: jobs/opensandbox       # where Harbor writes outputs (logs, artifacts, results)
+n_attempts: 1
+timeout_multiplier: 1.0
+n_concurrent_trials: 1
+quiet: false
+
+environment:
+  type: opensandbox
+  force_build: false             # OpenSandbox runs prebuilt images only
+  delete: true                   # delete each sandbox after its trial
+  kwargs:
+    # Connection settings. Leave `domain` / `api_key` unset to read them from the
+    # OPENSANDBOX_DOMAIN / OPENSANDBOX_API_KEY environment variables, or set them
+    # explicitly here. `api_key: ""` is valid for a local / no-auth server.
+    # domain: localhost:8080
+    # api_key: ""
+    protocol: http               # use "https" for a TLS-terminated server
+    use_server_proxy: true       # route exec through the server when the client
+                                 # cannot reach the sandbox container directly
+    ready_timeout_sec: 300       # leave headroom for on-demand image pulls
+    request_timeout_sec: 120
+
+agents:
+  - name: oracle                 # runs the task's reference solution; swap for a
+                                 # real agent + model (see README) to evaluate it
+
+tasks:
+  - path: ./tasks/hello-opensandbox

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/environment/Dockerfile
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/instruction.md
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/instruction.md
@@ -1,0 +1,5 @@
+Create a file at `/app/greeting.txt` whose contents are exactly:
+
+```
+Hello from OpenSandbox!
+```

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/solution/solve.sh
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/solution/solve.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "Hello from OpenSandbox!" > /app/greeting.txt

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/task.toml
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/task.toml
@@ -1,0 +1,36 @@
+version = "1.0"
+
+[task]
+name = "opensandbox/hello-opensandbox"
+authors = []
+keywords = []
+
+[metadata]
+author_name = "OpenSandbox"
+difficulty = "easy"
+category = "programming"
+tags = [ "trivial", "example",]
+
+[verifier]
+timeout_sec = 120.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+# OpenSandbox runs prebuilt images only, so docker_image is required. The
+# Dockerfile under environment/ is informational and lets the same task also run
+# on Harbor's local Docker backend. workdir makes the agent's relative paths
+# resolve under /app, matching the image's intended working directory.
+docker_image = "ubuntu:24.04"
+workdir = "/app"
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/tests/test.sh
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/tests/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Offline verifier: checks the result directly with coreutils, so it needs no
+# network access or extra packages. It writes the reward Harbor reads from
+# /logs/verifier/reward.txt (1.0 = pass, 0.0 = fail).
+set -u
+
+mkdir -p /logs/verifier
+
+expected="Hello from OpenSandbox!"
+file="/app/greeting.txt"
+
+if [ -f "$file" ] && [ "$(cat "$file")" = "$expected" ]; then
+  echo "PASS: $file has the expected contents"
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo "FAIL: $file is missing or has unexpected contents"
+  echo "  expected: $expected"
+  echo "  actual:   $(cat "$file" 2>/dev/null || echo '<missing>')"
+  echo 0 > /logs/verifier/reward.txt
+fi


### PR DESCRIPTION
## Summary

Adds `examples/harbor-evaluation/`, a minimal, self-contained example showing how to run a [Harbor](https://github.com/harbor-framework/harbor) agent evaluation on OpenSandbox infrastructure.

Harbor gained native OpenSandbox support in [harbor-framework/harbor#2054](https://github.com/harbor-framework/harbor/pull/2054) (the `opensandbox` environment backend + the `harbor[opensandbox]` install extra). This example demonstrates the user-facing workflow for it.

## What's included

- **`examples/harbor-evaluation/config.yaml`** — a Harbor job config that selects the `opensandbox` environment, with connection notes for `OPENSANDBOX_DOMAIN` / `OPENSANDBOX_API_KEY` (env vars or `domain`/`api_key` kwargs).
- **`examples/harbor-evaluation/tasks/hello-world/`** — a standard Harbor task (`task.toml`, `instruction.md`, `solution/`, `tests/`) that runs on OpenSandbox using a prebuilt image (`ubuntu:24.04`) with `workdir = "/app"`.
- **`docs/examples/harbor-evaluation.md`** — full documentation page (per the repo convention that docs live under `docs/examples/` and example READMEs are thin pointers), plus a row in `docs/examples/index.md`.
- A link in the root `README.md` under **ML and Training**.

## How to run

```shell
# 1. Start a local OpenSandbox server (docker runtime)
uv pip install opensandbox-server
opensandbox-server init-config ~/.sandbox.toml --example docker
opensandbox-server

# 2. Install Harbor with OpenSandbox support
uv pip install "harbor[opensandbox]"

# 3. Configure the connection
export OPENSANDBOX_DOMAIN="localhost:8080"
export OPENSANDBOX_API_KEY=""

# 4. Run the evaluation (from examples/harbor-evaluation)
harbor run -c config.yaml
```

A successful run produces `reward = 1.0` and writes logs/artifacts/results under `jobs/opensandbox/<job-id>/<trial-id>/`.

## Notes

- Follows the repo's example conventions (AGENTS.md): runnable code under `examples/`, docs under `docs/examples/`, and a thin-pointer example README.
- The task uses a prebuilt image and `workdir` because the OpenSandbox backend runs prebuilt images only (no Dockerfile build); the included `environment/Dockerfile` is informational and lets the same task also run on Harbor's local Docker backend.
- Not run end-to-end in CI (requires a live OpenSandbox server + Docker); the config/task are validated against the public Harbor schema.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)