### PR TITLE
fix(server): handle multi-container diagnostics logs

### DIFF
--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -84,11 +84,16 @@ def get_sandbox_logs(
         deprecated=True,
         description="Deprecated plain-text logs only. Only return logs newer than this duration (e.g. 10m, 1h).",
     ),
+    container: Optional[str] = Query(
+        None,
+        deprecated=True,
+        description="Deprecated plain-text logs only. Container name to read when the sandbox pod has multiple containers.",
+    ),
 ) -> JSONResponse | PlainTextResponse:
     """Retrieve diagnostic logs for a sandbox."""
     if scope is not None:
         return _diagnostics_not_implemented_response()
-    text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since)
+    text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since, container=container)
     return _deprecated_plain_text_response(text)
 
 

--- a/server/opensandbox_server/services/docker/docker_diagnostics.py
+++ b/server/opensandbox_server/services/docker/docker_diagnostics.py
@@ -44,7 +44,13 @@ def _parse_since_to_timestamp(since: str) -> int:
 class DockerDiagnosticsMixin:
     """Mixin that implements diagnostics methods for the Docker backend."""
 
-    def get_sandbox_logs(self, sandbox_id: str, tail: int = 100, since: str | None = None) -> str:
+    def get_sandbox_logs(
+        self,
+        sandbox_id: str,
+        tail: int = 100,
+        since: str | None = None,
+        container: str | None = None,
+    ) -> str:
         container = self._get_container_by_sandbox_id(sandbox_id)
         kwargs: dict = {"tail": tail, "timestamps": True}
         if since:

--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -21,14 +21,85 @@ by querying K8s Pod state and events. Mixed into KubernetesSandboxService.
 
 from __future__ import annotations
 
+import json
 import re
 
 from fastapi import HTTPException, status
+from kubernetes.client import ApiException
 
 from opensandbox_server.services.constants import (
     SANDBOX_ID_LABEL,
     SandboxErrorCodes,
 )
+
+
+def _extract_k8s_api_message(exc: ApiException) -> str:
+    body = getattr(exc, "body", None)
+    if body:
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict) and payload.get("message"):
+            return str(payload["message"])
+    return getattr(exc, "reason", None) or str(exc)
+
+
+def _select_log_container(pod) -> str | None:
+    spec = getattr(pod, "spec", None)
+    containers = list(getattr(spec, "containers", None) or [])
+    init_containers = list(getattr(spec, "init_containers", None) or [])
+
+    container_names = [getattr(container, "name", None) for container in containers]
+    container_names = [name for name in container_names if name]
+    if "sandbox" in container_names:
+        return "sandbox"
+    if container_names:
+        return container_names[0]
+
+    init_names = [getattr(container, "name", None) for container in init_containers]
+    init_names = [name for name in init_names if name]
+    if init_names:
+        return init_names[0]
+    return None
+
+
+def _raise_log_api_exception(sandbox_id: str, container_name: str | None, exc: ApiException) -> HTTPException:
+    target = f" container {container_name!r}" if container_name else ""
+    message = _extract_k8s_api_message(exc)
+
+    if exc.status == 404:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": SandboxErrorCodes.K8S_SANDBOX_NOT_FOUND,
+                "message": f"Failed to read logs for sandbox {sandbox_id!r}{target}: {message}",
+            },
+        ) from exc
+    if exc.status == 400:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": f"Failed to read logs for sandbox {sandbox_id!r}{target}: {message}",
+            },
+        ) from exc
+    if exc.status in {401, 403}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": SandboxErrorCodes.K8S_API_ERROR,
+                "message": f"Failed to read logs for sandbox {sandbox_id!r}{target}: {message}",
+            },
+        ) from exc
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail={
+            "code": SandboxErrorCodes.K8S_API_ERROR,
+            "message": f"Failed to read logs for sandbox {sandbox_id!r}{target}: {message}",
+        },
+    ) from exc
 
 
 def _parse_since(since: str) -> int:
@@ -71,10 +142,17 @@ class K8sDiagnosticsMixin:
             )
         return pods[0]
 
-    def get_sandbox_logs(self, sandbox_id: str, tail: int = 100, since: str | None = None) -> str:
+    def get_sandbox_logs(
+        self,
+        sandbox_id: str,
+        tail: int = 100,
+        since: str | None = None,
+        container: str | None = None,
+    ) -> str:
         pod = self._find_pod_for_sandbox(sandbox_id)
         pod_name = pod.metadata.name
         core_v1 = self.k8s_client.get_core_v1_api()
+        container_name = container or _select_log_container(pod)
 
         kwargs: dict = {
             "name": pod_name,
@@ -82,10 +160,15 @@ class K8sDiagnosticsMixin:
             "tail_lines": tail,
             "timestamps": True,
         }
+        if container_name:
+            kwargs["container"] = container_name
         if since:
             kwargs["since_seconds"] = _parse_since(since)
 
-        log_text = core_v1.read_namespaced_pod_log(**kwargs)
+        try:
+            log_text = core_v1.read_namespaced_pod_log(**kwargs)
+        except ApiException as exc:
+            _raise_log_api_exception(sandbox_id, container_name, exc)
         return log_text or "(no logs)"
 
     def get_sandbox_inspect(self, sandbox_id: str) -> str:

--- a/server/opensandbox_server/services/sandbox_service.py
+++ b/server/opensandbox_server/services/sandbox_service.py
@@ -256,7 +256,13 @@ class SandboxService(ABC):
     # ------------------------------------------------------------------
 
     @abstractmethod
-    def get_sandbox_logs(self, sandbox_id: str, tail: int = 100, since: str | None = None) -> str:
+    def get_sandbox_logs(
+        self,
+        sandbox_id: str,
+        tail: int = 100,
+        since: str | None = None,
+        container: str | None = None,
+    ) -> str:
         """
         Retrieve container logs for a sandbox.
 
@@ -264,6 +270,7 @@ class SandboxService(ABC):
             sandbox_id: Unique sandbox identifier
             tail: Number of trailing log lines to return
             since: Only return logs newer than this duration (e.g. "10m", "1h")
+            container: Optional container name for multi-container runtimes
 
         Returns:
             str: Plain-text log output

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
-from kubernetes.client import V1ResourceRequirements
+from kubernetes.client import ApiException, V1ResourceRequirements
 
 from opensandbox_server.services.constants import SANDBOX_ID_LABEL
 from opensandbox_server.services.k8s.k8s_diagnostics import (
@@ -56,7 +56,13 @@ def _status(
     )
 
 
-def _pod(container_statuses=None, init_container_statuses=None, conditions=None):
+def _pod(
+    container_statuses=None,
+    init_container_statuses=None,
+    conditions=None,
+    containers=None,
+    init_containers=None,
+):
     return SimpleNamespace(
         metadata=SimpleNamespace(
             name="pod-1",
@@ -66,15 +72,18 @@ def _pod(container_statuses=None, init_container_statuses=None, conditions=None)
         spec=SimpleNamespace(
             node_name="node-1",
             runtime_class_name="gvisor",
-            containers=[
+            containers=containers
+            if containers is not None
+            else [
                 SimpleNamespace(
-                    name="main",
+                    name="sandbox",
                     resources=V1ResourceRequirements(
                         requests={"cpu": "500m"},
                         limits={"memory": "512Mi"},
                     ),
                 )
             ],
+            init_containers=init_containers if init_containers is not None else [],
         ),
         status=SimpleNamespace(
             phase="Running",
@@ -125,6 +134,7 @@ def test_get_sandbox_logs_passes_tail_and_since() -> None:
     service.core_v1.read_namespaced_pod_log.assert_called_once_with(
         name="pod-1",
         namespace="sandbox-system",
+        container="sandbox",
         tail_lines=10,
         timestamps=True,
         since_seconds=3600,
@@ -136,6 +146,87 @@ def test_get_sandbox_logs_returns_placeholder_for_empty_output() -> None:
     service.core_v1.read_namespaced_pod_log.return_value = ""
 
     assert service.get_sandbox_logs("sbx-1") == "(no logs)"
+
+
+def test_get_sandbox_logs_prefers_sandbox_container_for_multi_container_pods() -> None:
+    service = _DiagnosticsService([
+        _pod(
+            containers=[
+                SimpleNamespace(name="sandbox", resources=V1ResourceRequirements()),
+                SimpleNamespace(name="egress", resources=V1ResourceRequirements()),
+            ]
+        )
+    ])
+    service.core_v1.read_namespaced_pod_log.return_value = "sandbox logs"
+
+    assert service.get_sandbox_logs("sbx-1", tail=20) == "sandbox logs"
+
+    service.core_v1.read_namespaced_pod_log.assert_called_once_with(
+        name="pod-1",
+        namespace="sandbox-system",
+        container="sandbox",
+        tail_lines=20,
+        timestamps=True,
+    )
+
+
+def test_get_sandbox_logs_falls_back_to_first_regular_container_then_init_container() -> None:
+    service = _DiagnosticsService([
+        _pod(
+            containers=[SimpleNamespace(name="worker", resources=V1ResourceRequirements())],
+        )
+    ])
+    service.core_v1.read_namespaced_pod_log.return_value = "worker logs"
+
+    assert service.get_sandbox_logs("sbx-1") == "worker logs"
+    service.core_v1.read_namespaced_pod_log.assert_called_once_with(
+        name="pod-1",
+        namespace="sandbox-system",
+        container="worker",
+        tail_lines=100,
+        timestamps=True,
+    )
+
+    service = _DiagnosticsService([
+        _pod(
+            containers=[],
+            container_statuses=[],
+            init_containers=[SimpleNamespace(name="execd-installer")],
+        )
+    ])
+    service.core_v1.read_namespaced_pod_log.return_value = "init logs"
+
+    assert service.get_sandbox_logs("sbx-1") == "init logs"
+    service.core_v1.read_namespaced_pod_log.assert_called_once_with(
+        name="pod-1",
+        namespace="sandbox-system",
+        container="execd-installer",
+        tail_lines=100,
+        timestamps=True,
+    )
+
+
+def test_get_sandbox_logs_maps_k8s_api_exceptions() -> None:
+    service = _DiagnosticsService([_pod()])
+    bad_request_exc = ApiException(status=400, reason="Bad Request")
+    bad_request_exc.body = '{"message":"choose one of: [sandbox egress]"}'
+    service.core_v1.read_namespaced_pod_log.side_effect = bad_request_exc
+
+    with pytest.raises(HTTPException) as bad_request:
+        service.get_sandbox_logs("sbx-1")
+    assert bad_request.value.status_code == 400
+    assert bad_request.value.detail["code"] == "SANDBOX::INVALID_PARAMETER"
+    assert "choose one of" in bad_request.value.detail["message"]
+
+    service.core_v1.read_namespaced_pod_log.side_effect = ApiException(status=403, reason="Forbidden")
+    with pytest.raises(HTTPException) as forbidden:
+        service.get_sandbox_logs("sbx-1")
+    assert forbidden.value.status_code == 403
+
+    service.core_v1.read_namespaced_pod_log.side_effect = ApiException(status=500, reason="boom")
+    with pytest.raises(HTTPException) as upstream_error:
+        service.get_sandbox_logs("sbx-1")
+    assert upstream_error.value.status_code == 502
 
 
 def test_get_sandbox_inspect_formats_runtime_statuses_and_resources() -> None:

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -24,7 +24,12 @@ def test_diagnostics_logs_with_scope_returns_not_implemented(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_logs(sandbox_id: str, tail: int, since: str | None = None) -> str:
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
             raise AssertionError("stable diagnostics requests must not call legacy logs")
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
@@ -46,16 +51,22 @@ def test_diagnostics_logs_without_scope_preserves_deprecated_plain_text(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_logs(sandbox_id: str, tail: int, since: str | None = None) -> str:
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
             assert sandbox_id == "sbx-001"
             assert tail == 25
             assert since == "5m"
+            assert container == "egress"
             return "legacy logs"
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
     response = client.get(
-        "/v1/sandboxes/sbx-001/diagnostics/logs?tail=25&since=5m",
+        "/v1/sandboxes/sbx-001/diagnostics/logs?tail=25&since=5m&container=egress",
         headers=auth_headers,
     )
 


### PR DESCRIPTION
## Summary
- default Kubernetes diagnostics log reads to the canonical `sandbox` container on multi-container pods
- allow deprecated diagnostics log reads to target an explicit `container` when needed
- map Kubernetes log read API errors to structured HTTP responses instead of leaking an opaque 500

## Testing
- `cd server && uv run pytest tests/k8s/test_k8s_diagnostics.py tests/test_devops.py -q`
