### PR TITLE
fix(k8s): fall back to stopped snapshot containers

### DIFF
--- a/kubernetes/cmd/image-committer/main.go
+++ b/kubernetes/cmd/image-committer/main.go
@@ -335,24 +335,61 @@ func parseContainerSpec(specStr string) (ContainerSpec, error) {
 //   - io.kubernetes.pod.namespace
 //   - io.kubernetes.container.name
 func getContainerIDByNerdctl(podName, podNamespace, containerName string) (string, error) {
-	// Use nerdctl ps with label filters to find the container directly
-	args := append(nerdctlBaseArgs(),
-		"ps", "-q",
+	containerID, err := lookupContainerIDByNerdctl(podName, podNamespace, containerName, false)
+	if err != nil {
+		return "", err
+	}
+	if containerID != "" {
+		return containerID, nil
+	}
+
+	containerID, err = lookupContainerIDByNerdctl(podName, podNamespace, containerName, true)
+	if err != nil {
+		return "", err
+	}
+	if containerID != "" {
+		return containerID, nil
+	}
+
+	return "", fmt.Errorf(
+		"container '%s' not found in pod %s/%s (nerdctl ps and nerdctl ps -a returned empty)",
+		containerName,
+		podNamespace,
+		podName,
+	)
+}
+
+func lookupContainerIDByNerdctl(podName, podNamespace, containerName string, includeStopped bool) (string, error) {
+	args := append(nerdctlBaseArgs(), "ps")
+	if includeStopped {
+		args = append(args, "-a")
+	}
+	args = append(args,
+		"-q",
 		"--filter", fmt.Sprintf("label=io.kubernetes.pod.name=%s", podName),
 		"--filter", fmt.Sprintf("label=io.kubernetes.pod.namespace=%s", podNamespace),
 		"--filter", fmt.Sprintf("label=io.kubernetes.container.name=%s", containerName),
 	)
-	cmd := exec.Command("nerdctl", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := commandCombinedOutput("nerdctl", args...)
 	if err != nil {
-		return "", fmt.Errorf("nerdctl ps failed for pod=%s ns=%s container=%s: %v, output: %s",
-			podName, podNamespace, containerName, err, strings.TrimSpace(string(output)))
+		mode := "nerdctl ps"
+		if includeStopped {
+			mode = "nerdctl ps -a"
+		}
+		return "", fmt.Errorf(
+			"%s failed for pod=%s ns=%s container=%s: %v, output: %s",
+			mode,
+			podName,
+			podNamespace,
+			containerName,
+			err,
+			strings.TrimSpace(string(output)),
+		)
 	}
 
 	containerID := strings.TrimSpace(string(output))
 	if containerID == "" {
-		return "", fmt.Errorf("container '%s' not found in pod %s/%s (nerdctl ps returned empty)",
-			containerName, podNamespace, podName)
+		return "", nil
 	}
 
 	// nerdctl ps -q may return multiple lines; take the first (most recently started)

--- a/kubernetes/cmd/image-committer/main_test.go
+++ b/kubernetes/cmd/image-committer/main_test.go
@@ -76,6 +76,96 @@ func TestGetImageDigestReturnsDigest(t *testing.T) {
 	}
 }
 
+func TestGetContainerIDByNerdctlReturnsRunningContainer(t *testing.T) {
+	original := commandCombinedOutput
+	t.Cleanup(func() { commandCombinedOutput = original })
+
+	calls := 0
+	commandCombinedOutput = func(name string, args ...string) ([]byte, error) {
+		calls++
+		if name != "nerdctl" {
+			t.Fatalf("unexpected command %q", name)
+		}
+		if calls != 1 {
+			t.Fatalf("expected a single nerdctl lookup, got %d", calls)
+		}
+		return []byte("container-running\n"), nil
+	}
+
+	containerID, err := getContainerIDByNerdctl("pod-1", "default", "sandbox")
+	if err != nil {
+		t.Fatalf("expected running container lookup to succeed, got %v", err)
+	}
+	if containerID != "container-running" {
+		t.Fatalf("unexpected container ID %q", containerID)
+	}
+}
+
+func TestGetContainerIDByNerdctlFallsBackToStoppedContainers(t *testing.T) {
+	original := commandCombinedOutput
+	t.Cleanup(func() { commandCombinedOutput = original })
+
+	var calls [][]string
+	commandCombinedOutput = func(name string, args ...string) ([]byte, error) {
+		if name != "nerdctl" {
+			t.Fatalf("unexpected command %q", name)
+		}
+		calls = append(calls, append([]string(nil), args...))
+		switch len(calls) {
+		case 1:
+			return []byte("\n"), nil
+		case 2:
+			return []byte("container-stopped\n"), nil
+		default:
+			t.Fatalf("unexpected extra nerdctl lookup #%d", len(calls))
+			return nil, nil
+		}
+	}
+
+	containerID, err := getContainerIDByNerdctl("pod-1", "default", "sandbox")
+	if err != nil {
+		t.Fatalf("expected stopped container fallback to succeed, got %v", err)
+	}
+	if containerID != "container-stopped" {
+		t.Fatalf("unexpected container ID %q", containerID)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected two nerdctl lookups, got %d", len(calls))
+	}
+	if contains(calls[0], "-a") {
+		t.Fatalf("first lookup should only inspect running containers: %v", calls[0])
+	}
+	if !contains(calls[1], "-a") {
+		t.Fatalf("second lookup should include stopped containers: %v", calls[1])
+	}
+}
+
+func TestGetContainerIDByNerdctlReturnsHelpfulErrorWhenBothLookupsAreEmpty(t *testing.T) {
+	original := commandCombinedOutput
+	t.Cleanup(func() { commandCombinedOutput = original })
+
+	commandCombinedOutput = func(_ string, _ ...string) ([]byte, error) {
+		return []byte("\n"), nil
+	}
+
+	_, err := getContainerIDByNerdctl("pod-1", "default", "sandbox")
+	if err == nil {
+		t.Fatal("expected lookup failure when both running and stopped container searches are empty")
+	}
+	if got := err.Error(); got != "container 'sandbox' not found in pod default/pod-1 (nerdctl ps and nerdctl ps -a returned empty)" {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestWriteSnapshotResultWritesTerminationMessage(t *testing.T) {
 	original := terminationMessagePath
 	t.Cleanup(func() { terminationMessagePath = original })


### PR DESCRIPTION
Fixes #1163.

## Summary
- fall back to `nerdctl ps -a` when the running-container lookup returns empty during Kubernetes snapshot commits
- keep preferring running containers first, but allow the snapshot committer to find exited containers that still exist locally
- add regression tests for the running path, the stopped-container fallback, and the double-empty error path

## Testing
- `cd kubernetes && go test ./cmd/image-committer`
