### PR TITLE
fix(docker): return sandbox extensions in lifecycle responses

### DIFF
--- a/server/opensandbox_server/extensions/__init__.py
+++ b/server/opensandbox_server/extensions/__init__.py
@@ -18,8 +18,8 @@ CreateSandbox ``extensions`` shared logic: well-known keys, HTTP validation, wor
 
 from opensandbox_server.extensions.codec import (
     apply_access_renew_extend_seconds_to_mapping,
-    apply_extensions_to_annotations,
-    extract_extensions_from_annotations,
+    apply_extensions_to_mapping,
+    extract_extensions_from_mapping,
 )
 from opensandbox_server.extensions.keys import (
     ACCESS_RENEW_EXTEND_SECONDS_KEY,
@@ -42,8 +42,8 @@ __all__ = [
     "ACCESS_RENEW_EXTEND_SECONDS_MAX",
     "validate_extensions",
     "apply_access_renew_extend_seconds_to_mapping",
-    "apply_extensions_to_annotations",
-    "extract_extensions_from_annotations",
+    "apply_extensions_to_mapping",
+    "extract_extensions_from_mapping",
     "EXTENSIONS_ANNOTATION_PREFIX",
     "ANNOTATION_METADATA_PREFIX",
     "BOOTSTRAP_EXECD_ISOLATION_KEY",

--- a/server/opensandbox_server/extensions/codec.py
+++ b/server/opensandbox_server/extensions/codec.py
@@ -46,7 +46,7 @@ def apply_access_renew_extend_seconds_to_mapping(
     mapping[metadata_key] = s
 
 
-def apply_extensions_to_annotations(
+def apply_extensions_to_mapping(
     annotations: MutableMapping[str, str],
     extensions: Optional[Dict[str, str]],
 ) -> None:
@@ -70,7 +70,7 @@ def apply_extensions_to_annotations(
             annotations[annotation_key] = value
 
 
-def extract_extensions_from_annotations(
+def extract_extensions_from_mapping(
     annotations: Optional[Mapping[str, str]],
 ) -> Optional[Dict[str, str]]:
     """

--- a/server/opensandbox_server/services/docker/container_ops.py
+++ b/server/opensandbox_server/services/docker/container_ops.py
@@ -31,6 +31,7 @@ from fastapi import HTTPException, status
 
 from opensandbox_server.extensions import (
     apply_access_renew_extend_seconds_to_mapping,
+    apply_extensions_to_mapping,
 )
 
 from opensandbox_server.api.schema import (
@@ -304,6 +305,7 @@ class DockerContainerOpsMixin:
             labels[SANDBOX_SNAPSHOT_ID_LABEL] = request.snapshot_id
 
         apply_access_renew_extend_seconds_to_mapping(labels, request.extensions)
+        apply_extensions_to_mapping(labels, request.extensions)
 
         env_dict = request.env or {}
         environment = []

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -41,7 +41,9 @@ from opensandbox_server.extensions import (
     ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY,
     BOOTSTRAP_EXECD_ISOLATION_KEY,
     ISOLATION_UPPER_MOUNT_PATH,
+    extract_extensions_from_mapping,
 )
+from opensandbox_server.extensions.keys import EXTENSIONS_ANNOTATION_PREFIX
 from opensandbox_server.api.schema import (
     CreateSandboxRequest,
     CreateSandboxResponse,
@@ -594,6 +596,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             platform=platform_spec,
             status=status_info,
             metadata=metadata,
+            extensions=extract_extensions_from_mapping(labels),
             entrypoint=entrypoint,
             expiresAt=expires_at,
             createdAt=created_at,
@@ -762,6 +765,10 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         snapshot_id = getattr(pending.request, "snapshot_id", None)
         if not isinstance(snapshot_id, str) or not snapshot_id:
             snapshot_id = None
+        extensions = {
+            k: v for k, v in (pending.request.extensions or {}).items()
+            if k.startswith(EXTENSIONS_ANNOTATION_PREFIX)
+        } or None
         return Sandbox(
             id=sandbox_id,
             image=None if snapshot_id else pending.request.image,
@@ -769,6 +776,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             platform=pending.request.platform,
             status=pending.status,
             metadata=pending.request.metadata,
+            extensions=extensions,
             entrypoint=pending.request.entrypoint,
             expiresAt=pending.expires_at,
             createdAt=pending.created_at,
@@ -1029,6 +1037,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             id=sandbox_id,
             status=status_info,
             metadata=request.metadata,
+            extensions=extract_extensions_from_mapping(labels),
             platform=effective_platform or request.platform,
             expiresAt=expires_at,
             createdAt=created_at,

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -30,8 +30,8 @@ from fastapi import HTTPException, status
 
 from opensandbox_server.extensions import (
     apply_access_renew_extend_seconds_to_mapping,
-    apply_extensions_to_annotations,
-    extract_extensions_from_annotations,
+    apply_extensions_to_mapping,
+    extract_extensions_from_mapping,
 )
 from opensandbox_server.extensions.keys import ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY
 from opensandbox_server.api.schema import (
@@ -677,7 +677,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 secure_access_token_factory=generate_secure_access_token,
             )
             apply_access_renew_extend_seconds_to_mapping(context.annotations, request.extensions)
-            apply_extensions_to_annotations(context.annotations, request.extensions)
+            apply_extensions_to_mapping(context.annotations, request.extensions)
 
             ensure_volumes_valid(
                 request.volumes,
@@ -832,7 +832,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     created_at=created_at,
                     expires_at=context.expires_at,
                     metadata=request.metadata,
-                    extensions=extract_extensions_from_annotations(annotations),
+                    extensions=extract_extensions_from_mapping(annotations),
                     entrypoint=request.entrypoint,
                     platform=effective_platform or request.platform,
                 )

--- a/server/opensandbox_server/services/k8s/workload_mapper.py
+++ b/server/opensandbox_server/services/k8s/workload_mapper.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from opensandbox_server.api.schema import ImageSpec, PlatformSpec, Sandbox, SandboxStatus
-from opensandbox_server.extensions import extract_extensions_from_annotations
+from opensandbox_server.extensions import extract_extensions_from_mapping
 from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SANDBOX_SNAPSHOT_ID_LABEL
 
 
@@ -78,7 +78,7 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
         created_at=creation_timestamp,
         expires_at=expires_at,
         metadata=user_metadata if user_metadata else None,
-        extensions=extract_extensions_from_annotations(annotations),
+        extensions=extract_extensions_from_mapping(annotations),
         image=image_spec,
         snapshotId=snapshot_id,
         entrypoint=entrypoint,

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -1348,6 +1348,119 @@ def test_build_labels_stores_extensions_json():
 
     assert labels[ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY] == "3600"
 
+
+def test_build_labels_stores_opensandbox_extensions():
+    service = DockerSandboxService(config=_app_config())
+    request = CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.11"),
+        resourceLimits=ResourceLimits(root={}),
+        env={},
+        entrypoint=["python"],
+        extensions={
+            "opensandbox.extensions.pool-ref": "my-pool",
+            "opensandbox.extensions.custom": "value",
+            "access.renew.extend.seconds": "1800",
+        },
+    )
+
+    labels, _ = service._build_labels_and_env("sandbox-ext2", request, None)
+
+    assert labels["opensandbox.io/extensions.pool-ref"] == "my-pool"
+    assert labels["opensandbox.io/extensions.custom"] == "value"
+    assert "opensandbox.io/extensions.access.renew.extend.seconds" not in labels
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_container_to_sandbox_returns_extensions(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    container = MagicMock()
+    container.attrs = {
+        "Config": {
+            "Labels": {
+                SANDBOX_ID_LABEL: "sandbox-ext",
+                "opensandbox.io/extensions.pool-ref": "my-pool",
+                "opensandbox.io/extensions.custom": "value",
+                "opensandbox.io/access-renew-extend-seconds": "1800",
+            },
+            "Cmd": ["python"],
+        },
+        "Created": "2025-01-01T00:00:00Z",
+        "State": {
+            "Status": "running",
+            "Running": True,
+            "FinishedAt": "0001-01-01T00:00:00Z",
+            "ExitCode": 0,
+        },
+    }
+    container.image = MagicMock(tags=["python:3.11"], short_id="sha-img")
+
+    sandbox = service._container_to_sandbox(container)
+
+    assert sandbox.extensions == {
+        "opensandbox.extensions.pool-ref": "my-pool",
+        "opensandbox.extensions.custom": "value",
+    }
+    assert sandbox.metadata is None
+
+
+@pytest.mark.asyncio
+@patch("opensandbox_server.services.docker.docker_service.docker")
+async def test_create_sandbox_response_includes_extensions(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    request = CreateSandboxRequest(
+        image=ImageSpec(uri="python:3.11"),
+        resourceLimits=ResourceLimits(root={}),
+        env={},
+        entrypoint=["python"],
+        extensions={"opensandbox.extensions.test-key": "test-value"},
+    )
+
+    with patch.object(service, "_create_and_start_container") as mock_create:
+        mock_container = MagicMock()
+        mock_container.image = MagicMock(tags=["python:3.11"])
+        mock_create.return_value = mock_container
+        response = await service.create_sandbox(request)
+
+    assert response.extensions == {"opensandbox.extensions.test-key": "test-value"}
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_pending_sandbox_includes_extensions(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    pending = PendingSandbox(
+        request=MagicMock(
+            metadata=None,
+            entrypoint=["python"],
+            image=ImageSpec(uri="python:3.11"),
+            platform=None,
+            snapshot_id=None,
+            extensions={
+                "opensandbox.extensions.pool-ref": "my-pool",
+                "access.renew.extend.seconds": "1800",
+            },
+        ),
+        created_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc),
+        status=SandboxStatus(state="Pending"),
+    )
+
+    sandbox = service._pending_to_sandbox("sandbox-pending-ext", pending)
+
+    assert sandbox.extensions == {"opensandbox.extensions.pool-ref": "my-pool"}
+
+
 def test_build_labels_store_platform_constraints():
     service = DockerSandboxService(config=_app_config())
     request = CreateSandboxRequest(

--- a/server/tests/test_extensions.py
+++ b/server/tests/test_extensions.py
@@ -21,8 +21,8 @@ from opensandbox_server.extensions import (
     ACCESS_RENEW_EXTEND_SECONDS_METADATA_KEY,
     ACCESS_RENEW_EXTEND_SECONDS_MIN,
     apply_access_renew_extend_seconds_to_mapping,
-    apply_extensions_to_annotations,
-    extract_extensions_from_annotations,
+    apply_extensions_to_mapping,
+    extract_extensions_from_mapping,
     validate_extensions
 )
 
@@ -105,7 +105,7 @@ class TestExtensionsToAnnotations:
     def test_single_extension_propagated(self):
         annotations: dict[str, str] = {}
         extensions = {"opensandbox.extensions.pool-ref": "my-pool"}
-        apply_extensions_to_annotations(annotations, extensions)
+        apply_extensions_to_mapping(annotations, extensions)
         assert annotations == {"opensandbox.io/extensions.pool-ref": "my-pool"}
 
     def test_multiple_extensions_propagated(self):
@@ -114,7 +114,7 @@ class TestExtensionsToAnnotations:
             "opensandbox.extensions.pool-ref": "my-pool",
             "opensandbox.extensions.custom-key": "custom-value",
         }
-        apply_extensions_to_annotations(annotations, extensions)
+        apply_extensions_to_mapping(annotations, extensions)
         assert annotations == {
             "opensandbox.io/extensions.pool-ref": "my-pool",
             "opensandbox.io/extensions.custom-key": "custom-value",
@@ -126,7 +126,7 @@ class TestExtensionsToAnnotations:
             "poolRef": "my-pool",
             "other.key": "value",
         }
-        apply_extensions_to_annotations(annotations, extensions)
+        apply_extensions_to_mapping(annotations, extensions)
         assert annotations == {}
 
     def test_mixed_extensions_propagated_only_prefix_keys(self):
@@ -136,23 +136,23 @@ class TestExtensionsToAnnotations:
             "poolRef": "ignored",
             "access.renew.extend.seconds": "1800",
         }
-        apply_extensions_to_annotations(annotations, extensions)
+        apply_extensions_to_mapping(annotations, extensions)
         assert annotations == {"opensandbox.io/extensions.pool-ref": "my-pool"}
 
     def test_empty_extensions_noop(self):
         annotations: dict[str, str] = {"existing": "value"}
-        apply_extensions_to_annotations(annotations, None)
+        apply_extensions_to_mapping(annotations, None)
         assert annotations == {"existing": "value"}
 
     def test_empty_extensions_dict_noop(self):
         annotations: dict[str, str] = {"existing": "value"}
-        apply_extensions_to_annotations(annotations, {})
+        apply_extensions_to_mapping(annotations, {})
         assert annotations == {"existing": "value"}
 
     def test_preserves_existing_annotations(self):
         annotations: dict[str, str] = {"existing": "value"}
         extensions = {"opensandbox.extensions.new-key": "new-value"}
-        apply_extensions_to_annotations(annotations, extensions)
+        apply_extensions_to_mapping(annotations, extensions)
         assert annotations == {
             "existing": "value",
             "opensandbox.io/extensions.new-key": "new-value",
@@ -166,7 +166,7 @@ class TestExtensionsFromAnnotations:
             "opensandbox.io/extensions.localized": "中文数据",
         }
 
-        assert extract_extensions_from_annotations(annotations) == {
+        assert extract_extensions_from_mapping(annotations) == {
             "opensandbox.extensions.custom-key": "custom-value",
             "opensandbox.extensions.localized": "中文数据",
         }
@@ -177,8 +177,8 @@ class TestExtensionsFromAnnotations:
             "other": "value",
         }
 
-        assert extract_extensions_from_annotations(annotations) is None
+        assert extract_extensions_from_mapping(annotations) is None
 
     def test_empty_annotations_return_none(self):
-        assert extract_extensions_from_annotations({}) is None
-        assert extract_extensions_from_annotations(None) is None
+        assert extract_extensions_from_mapping({}) is None
+        assert extract_extensions_from_mapping(None) is None

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -111,7 +111,7 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
         }
         finally
         {
-            try { await sandbox.KillAsync(); } catch { }
+            try { await sandbox.KillAsync(); } catch (SandboxApiException) { }
             await sandbox.DisposeAsync();
         }
     }

--- a/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/SandboxE2ETests.cs
@@ -86,6 +86,37 @@ public class SandboxE2ETests : IClassFixture<SandboxE2ETestFixture>
     }
 
     [Fact(Timeout = 2 * 60 * 1000)]
+    public async Task Sandbox_Extensions_RoundTrip()
+    {
+        var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+        {
+            ConnectionConfig = _fixture.ConnectionConfig,
+            Image = _fixture.DefaultImage,
+            TimeoutSeconds = 120,
+            ReadyTimeoutSeconds = _fixture.DefaultReadyTimeoutSeconds,
+            Metadata = new Dictionary<string, string> { ["tag"] = "e2e-extensions" },
+            Extensions = new Dictionary<string, string>
+            {
+                ["opensandbox.extensions.test-key"] = "test-value",
+                ["opensandbox.extensions.second"] = "second-value",
+            },
+            HealthCheckPollingInterval = 500
+        });
+        try
+        {
+            var info = await sandbox.GetInfoAsync();
+            Assert.NotNull(info.Extensions);
+            Assert.Equal("test-value", info.Extensions["opensandbox.extensions.test-key"]);
+            Assert.Equal("second-value", info.Extensions["opensandbox.extensions.second"]);
+        }
+        finally
+        {
+            try { await sandbox.KillAsync(); } catch { }
+            await sandbox.DisposeAsync();
+        }
+    }
+
+    [Fact(Timeout = 2 * 60 * 1000)]
     public async Task Sandbox_XRequestId_Passthrough_OnServerError()
     {
         var requestId = $"e2e-csharp-server-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";

--- a/tests/go/sandbox_e2e_test.go
+++ b/tests/go/sandbox_e2e_test.go
@@ -66,6 +66,37 @@ func TestSandbox_CreateAndKill(t *testing.T) {
 	t.Log("Sandbox killed successfully")
 }
 
+func TestSandbox_ExtensionsRoundTrip(t *testing.T) {
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	sb, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
+		Image:      getSandboxImage(),
+		Entrypoint: []string{"tail", "-f", "/dev/null"},
+		ResourceLimits: opensandbox.ResourceLimits{
+			"cpu":    "500m",
+			"memory": "256Mi",
+		},
+		Metadata: map[string]string{"tag": "go-e2e-extensions"},
+		Extensions: map[string]string{
+			"opensandbox.extensions.test-key": "test-value",
+			"opensandbox.extensions.second":   "second-value",
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = sb.Kill(context.Background())
+	}()
+
+	info, err := sb.GetInfo(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, info.Extensions, "extensions missing from GetInfo")
+	require.Equal(t, "test-value", info.Extensions["opensandbox.extensions.test-key"])
+	require.Equal(t, "second-value", info.Extensions["opensandbox.extensions.second"])
+	t.Logf("extensions round-trip OK: %v", info.Extensions)
+}
+
 func TestSandbox_Renew(t *testing.T) {
 	ctx, sb := createTestSandbox(t)
 

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -224,6 +224,36 @@ public class SandboxE2ETest extends BaseE2ETest {
 
     @Test
     @Order(1)
+    @DisplayName("Sandbox extensions round-trip")
+    @Timeout(value = 2, unit = TimeUnit.MINUTES)
+    void testSandboxExtensionsRoundTrip() {
+        Sandbox extSandbox =
+                Sandbox.builder()
+                        .connectionConfig(sharedConnectionConfig)
+                        .image(getSandboxImage())
+                        .timeout(Duration.ofMinutes(2))
+                        .readyTimeout(Duration.ofSeconds(60))
+                        .metadata(Map.of("tag", "e2e-extensions"))
+                        .extension("opensandbox.extensions.test-key", "test-value")
+                        .extension("opensandbox.extensions.second", "second-value")
+                        .healthCheckPollingInterval(Duration.ofMillis(500))
+                        .build();
+        try {
+            SandboxInfo info = extSandbox.getInfo();
+            assertNotNull(info.getExtensions(), "extensions missing from getInfo");
+            assertEquals("test-value", info.getExtensions().get("opensandbox.extensions.test-key"));
+            assertEquals("second-value", info.getExtensions().get("opensandbox.extensions.second"));
+        } finally {
+            try {
+                extSandbox.kill();
+            } catch (Exception ignored) {
+            }
+            extSandbox.close();
+        }
+    }
+
+    @Test
+    @Order(1)
     @DisplayName("Sandbox manual cleanup returns null expiresAt")
     @Timeout(value = 2, unit = TimeUnit.MINUTES)
     void testSandboxManualCleanup() {

--- a/tests/javascript/tests/test_sandbox_e2e.test.ts
+++ b/tests/javascript/tests/test_sandbox_e2e.test.ts
@@ -121,6 +121,34 @@ test("01 sandbox lifecycle, health, endpoint, metrics, renew, connect", async ()
   }
 });
 
+test("01 extensions round-trip", async () => {
+  const connectionConfig = createConnectionConfig();
+  const extSandbox = await Sandbox.create({
+    connectionConfig,
+    image: getSandboxImage(),
+    timeoutSeconds: 2 * 60,
+    readyTimeoutSeconds: 60,
+    metadata: { tag: "e2e-extensions" },
+    extensions: {
+      "opensandbox.extensions.test-key": "test-value",
+      "opensandbox.extensions.second": "second-value",
+    },
+    healthCheckPollingInterval: 200,
+  });
+  try {
+    const info = await extSandbox.getInfo();
+    expect(info.extensions).toBeDefined();
+    expect(info.extensions!["opensandbox.extensions.test-key"]).toBe("test-value");
+    expect(info.extensions!["opensandbox.extensions.second"]).toBe("second-value");
+  } finally {
+    try {
+      await extSandbox.kill();
+    } catch {
+      // ignore teardown errors
+    }
+  }
+});
+
 test("01b manual cleanup sandbox returns null expiresAt", async () => {
   const connectionConfig = createConnectionConfig();
   const manualSandbox = await Sandbox.create({

--- a/tests/python/tests/test_sandbox_e2e.py
+++ b/tests/python/tests/test_sandbox_e2e.py
@@ -357,6 +357,36 @@ class TestSandboxE2E:
 
         logger.info("TEST 1 PASSED: Sandbox lifecycle and health test completed successfully")
 
+    @pytest.mark.timeout(120)
+    @pytest.mark.order(1)
+    async def test_01_extensions_round_trip(self):
+        """Verify extensions are returned in create response, get_info, and list."""
+        cfg = create_connection_config()
+        ext_sandbox = await Sandbox.create(
+            image=SandboxImageSpec(get_sandbox_image()),
+            resource=get_e2e_sandbox_resource(),
+            connection_config=cfg,
+            timeout=timedelta(minutes=2),
+            ready_timeout=timedelta(seconds=30),
+            metadata={"tag": "e2e-extensions"},
+            extensions={
+                "opensandbox.extensions.test-key": "test-value",
+                "opensandbox.extensions.second": "second-value",
+            },
+            health_check_polling_interval=timedelta(milliseconds=500),
+        )
+        try:
+            info = await ext_sandbox.get_info()
+            assert info.extensions is not None, "extensions missing from get_info"
+            assert info.extensions.get("opensandbox.extensions.test-key") == "test-value"
+            assert info.extensions.get("opensandbox.extensions.second") == "second-value"
+            logger.info("extensions round-trip OK: %s", info.extensions)
+        finally:
+            try:
+                await ext_sandbox.kill()
+            except Exception as e:
+                logger.warning("extensions test teardown kill failed: %s", e)
+            await ext_sandbox.close()
 
     @pytest.mark.timeout(120)
     @pytest.mark.order(1)

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -273,6 +273,37 @@ class TestSandboxE2ESync:
 
     @pytest.mark.timeout(120)
     @pytest.mark.order(1)
+    def test_01_extensions_round_trip(self) -> None:
+        """Verify extensions are returned in create response and get_info."""
+        cfg = create_connection_config_sync()
+        ext_sandbox = SandboxSync.create(
+            image=SandboxImageSpec(get_sandbox_image()),
+            resource=get_e2e_sandbox_resource(),
+            connection_config=cfg,
+            timeout=timedelta(minutes=2),
+            ready_timeout=timedelta(seconds=30),
+            metadata={"tag": "e2e-extensions"},
+            extensions={
+                "opensandbox.extensions.test-key": "test-value",
+                "opensandbox.extensions.second": "second-value",
+            },
+            health_check_polling_interval=timedelta(milliseconds=500),
+        )
+        try:
+            info = ext_sandbox.get_info()
+            assert info.extensions is not None, "extensions missing from get_info"
+            assert info.extensions.get("opensandbox.extensions.test-key") == "test-value"
+            assert info.extensions.get("opensandbox.extensions.second") == "second-value"
+            logger.info("extensions round-trip OK: %s", info.extensions)
+        finally:
+            try:
+                ext_sandbox.kill()
+            except Exception as e:
+                logger.warning("extensions test teardown kill failed: %s", e)
+            ext_sandbox.close()
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.order(1)
     def test_01a_network_policy_create(self) -> None:
         if is_kubernetes_runtime():
             pytest.skip("Network policy is not covered in the Kubernetes runtime suite")


### PR DESCRIPTION
## Summary

- Store `opensandbox.extensions.*` keys as Docker container labels and return them in `CreateSandboxResponse`, `get_sandbox`, and `list_sandboxes` — matching the Kubernetes provider behavior added in #1112
- Rename `apply_extensions_to_annotations`/`extract_extensions_from_annotations` to `apply_extensions_to_mapping`/`extract_extensions_from_mapping` since these functions operate on generic mappings, not just k8s annotations
- Add 4 unit tests for Docker extensions round-trip (label storage, container→sandbox extraction, create response, pending state)
- Add e2e test verifying extensions survive create→get_info round-trip

Supplements #1112

## Test plan

- [x] `cd server && uv run pytest tests/test_docker_service.py tests/test_extensions.py -q` → 141 passed
- [x] `cd server && uv run pytest tests/k8s/test_workload_mapper.py tests/k8s/test_kubernetes_service.py -q` → 102 passed
- [ ] `cd tests/python && uv run pytest tests/test_sandbox_e2e.py::TestSandboxE2E::test_01_extensions_round_trip` (requires running server + Docker)