### PR TITLE
fix(server): unblock event loop during image pull and enable graceful shutdown

### DIFF
--- a/server/configuration.md
+++ b/server/configuration.md
@@ -66,6 +66,7 @@ Example files in this repository:
 | `eip` | string \| omitted | `null` | Public IP or hostname used as the **host part** when the server returns sandbox endpoint URLs (notably Docker runtime). |
 | `max_sandbox_timeout_seconds` | integer \| omitted | `null` | Upper bound on sandbox TTL in seconds for **create** requests that specify `timeout`. Must be ≥ **60** if set. Omit to disable the server-side cap. |
 | `timeout_keep_alive` | integer | `30` | Idle keep-alive timeout (seconds) passed to uvicorn. |
+| `timeout_graceful_shutdown` | integer | `5` | Seconds uvicorn waits for in-flight requests to finish before forcing shutdown. Ensures Ctrl+C terminates promptly even when a long-running operation (e.g. image pull) is in progress. |
 | `limit_concurrency` | integer | `1024` | Maximum concurrent connections before returning 503. Provides backpressure protection under burst load. Set to `0` to disable the cap (TOML cannot express `null`). |
 | `backlog` | integer | `2048` | Socket listen backlog passed to uvicorn. |
 | `thread_pool_size` | integer | `200` | Maximum size of the anyio default threadpool used by FastAPI to run sync route handlers. The anyio default of 40 throttles bursts of blocking sandbox list/get/delete operations under high concurrency. |

--- a/server/opensandbox_server/cli.py
+++ b/server/opensandbox_server/cli.py
@@ -305,6 +305,7 @@ def main() -> None:
         backlog=server_cfg.backlog,
         loop=server_cfg.loop,
         http=server_cfg.http,
+        timeout_graceful_shutdown=server_cfg.timeout_graceful_shutdown,
     )
 
 

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -470,6 +470,15 @@ class ServerConfig(BaseModel):
         # no concurrency cap. TOML has no null literal, so 0 is the only way
         # to disable the limit from the config file.
         return None if value == 0 else value
+    timeout_graceful_shutdown: Optional[int] = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Seconds uvicorn waits for in-flight requests to finish before "
+            "forcing shutdown. Ensures Ctrl+C terminates promptly even when "
+            "a long-running operation (e.g. image pull) is in progress."
+        ),
+    )
     backlog: int = Field(
         default=2048,
         ge=1,

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -210,4 +210,5 @@ if __name__ == "__main__":
         timeout_keep_alive=app_config.server.timeout_keep_alive,
         loop=app_config.server.loop,
         http=app_config.server.http,
+        timeout_graceful_shutdown=app_config.server.timeout_graceful_shutdown,
     )

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -21,6 +21,7 @@ using Docker containers for sandbox lifecycle management.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import logging
@@ -30,7 +31,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from threading import Lock, Timer
+from threading import Lock, Thread, Timer
 from typing import Any, Dict, Optional
 
 import docker
@@ -656,11 +657,26 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
 
         pvc_inspect_cache, auto_created_volumes = self._validate_volumes(request)
         sandbox_id, created_at, expires_at = self._prepare_creation_context(request)
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[CreateSandboxResponse] = loop.create_future()
+
+        def _run() -> None:
+            try:
+                result = self._provision_sandbox(
+                    sandbox_id, request, created_at, expires_at,
+                    pvc_inspect_cache, auto_created_volumes,
+                    sandbox_env=sandbox_env, egress_env=egress_env,
+                )
+                loop.call_soon_threadsafe(future.set_result, result)
+            except BaseException as exc:
+                try:
+                    loop.call_soon_threadsafe(future.set_exception, exc)
+                except RuntimeError:
+                    pass
+
+        Thread(target=_run, daemon=True).start()
         try:
-            return self._provision_sandbox(
-                sandbox_id, request, created_at, expires_at, pvc_inspect_cache, auto_created_volumes,
-                sandbox_env=sandbox_env, egress_env=egress_env,
-            )
+            return await future
         except ValueError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -215,6 +215,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self._pending_cleanup_timers: Dict[str, Timer] = {}
         self._ossfs_mount_lock = Lock()
         self._ossfs_mount_ref_counts: Dict[str, int] = {}
+        self._provision_semaphore = asyncio.Semaphore(10)
         self._restore_existing_sandboxes()
 
         # Initialize secure runtime resolver
@@ -657,34 +658,35 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
 
         pvc_inspect_cache, auto_created_volumes = self._validate_volumes(request)
         sandbox_id, created_at, expires_at = self._prepare_creation_context(request)
-        loop = asyncio.get_running_loop()
-        future: asyncio.Future[CreateSandboxResponse] = loop.create_future()
+        async with self._provision_semaphore:
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[CreateSandboxResponse] = loop.create_future()
 
-        def _run() -> None:
-            try:
-                result = self._provision_sandbox(
-                    sandbox_id, request, created_at, expires_at,
-                    pvc_inspect_cache, auto_created_volumes,
-                    sandbox_env=sandbox_env, egress_env=egress_env,
-                )
-                loop.call_soon_threadsafe(future.set_result, result)
-            except BaseException as exc:
+            def _run() -> None:
                 try:
-                    loop.call_soon_threadsafe(future.set_exception, exc)
-                except RuntimeError:
-                    pass
+                    result = self._provision_sandbox(
+                        sandbox_id, request, created_at, expires_at,
+                        pvc_inspect_cache, auto_created_volumes,
+                        sandbox_env=sandbox_env, egress_env=egress_env,
+                    )
+                    loop.call_soon_threadsafe(future.set_result, result)
+                except BaseException as exc:
+                    try:
+                        loop.call_soon_threadsafe(future.set_exception, exc)
+                    except RuntimeError:
+                        pass
 
-        Thread(target=_run, daemon=True).start()
-        try:
-            return await future
-        except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "code": SandboxErrorCodes.INVALID_PARAMETER,
-                    "message": str(e),
-                },
-            ) from e
+            Thread(target=_run, daemon=True).start()
+            try:
+                return await future
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "code": SandboxErrorCodes.INVALID_PARAMETER,
+                        "message": str(e),
+                    },
+                ) from e
 
     def _async_provision_worker(
         self,

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -215,7 +215,6 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self._pending_cleanup_timers: Dict[str, Timer] = {}
         self._ossfs_mount_lock = Lock()
         self._ossfs_mount_ref_counts: Dict[str, int] = {}
-        self._provision_semaphore = asyncio.Semaphore(10)
         self._restore_existing_sandboxes()
 
         # Initialize secure runtime resolver
@@ -658,35 +657,34 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
 
         pvc_inspect_cache, auto_created_volumes = self._validate_volumes(request)
         sandbox_id, created_at, expires_at = self._prepare_creation_context(request)
-        async with self._provision_semaphore:
-            loop = asyncio.get_running_loop()
-            future: asyncio.Future[CreateSandboxResponse] = loop.create_future()
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[CreateSandboxResponse] = loop.create_future()
 
-            def _run() -> None:
-                try:
-                    result = self._provision_sandbox(
-                        sandbox_id, request, created_at, expires_at,
-                        pvc_inspect_cache, auto_created_volumes,
-                        sandbox_env=sandbox_env, egress_env=egress_env,
-                    )
-                    loop.call_soon_threadsafe(future.set_result, result)
-                except BaseException as exc:
-                    try:
-                        loop.call_soon_threadsafe(future.set_exception, exc)
-                    except RuntimeError:
-                        pass
-
-            Thread(target=_run, daemon=True).start()
+        def _run() -> None:
             try:
-                return await future
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail={
-                        "code": SandboxErrorCodes.INVALID_PARAMETER,
-                        "message": str(e),
-                    },
-                ) from e
+                result = self._provision_sandbox(
+                    sandbox_id, request, created_at, expires_at,
+                    pvc_inspect_cache, auto_created_volumes,
+                    sandbox_env=sandbox_env, egress_env=egress_env,
+                )
+                loop.call_soon_threadsafe(future.set_result, result)
+            except BaseException as exc:
+                try:
+                    loop.call_soon_threadsafe(future.set_exception, exc)
+                except RuntimeError:
+                    pass
+
+        Thread(target=_run, daemon=True).start()
+        try:
+            return await future
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": SandboxErrorCodes.INVALID_PARAMETER,
+                    "message": str(e),
+                },
+            ) from e
 
     def _async_provision_worker(
         self,


### PR DESCRIPTION
# Summary
  
  - `DockerSandboxService.create_sandbox` calls `_provision_sandbox` synchronously on the asyncio event loop. When a Docker image pull takes minutes, the server cannot handle any other HTTP requests (including health checks) and Ctrl+C is unresponsive until the pull completes.
  - Move `_provision_sandbox` into a daemon thread with an `asyncio.Future` so the event loop stays free to serve concurrent requests.
  - Add `timeout_graceful_shutdown` config option (default 5 s) passed to uvicorn, so the server exits promptly on SIGINT even when a long-running operation is still in progress.
  - Add `timeout_graceful_shutdown` to `configuration.md` reference table.

  # Testing

  - [x] Unit tests (`uv run pytest tests/test_docker_service.py` — 113/113 passed, no test changes required)
  - [x] Manual verification: started server, triggered image pull via `POST /sandboxes`, confirmed other endpoints remain responsive during pull, and confirmed Ctrl+C terminates the server within ~5 seconds.

  # Breaking Changes

  - [x] None

  # Checklist

  - [x] Linked Issue or clearly described motivation
  - [x] Added/updated docs (if needed)
  - [ ] Added/updated tests (if needed)
  - [x] Security impact considered
  - [x] Backward compatibility considered