### PR TITLE
fix(docker): skip egress ipv6 sysctls without procfs

### DIFF
--- a/server/opensandbox_server/services/docker/networking.py
+++ b/server/opensandbox_server/services/docker/networking.py
@@ -67,6 +67,18 @@ def _running_inside_docker_container() -> bool:
     return os.path.exists("/.dockerenv")
 
 
+def _docker_ipv6_disable_sysctls_supported() -> bool:
+    """Return True when the host exposes the IPv6 procfs knobs used by Docker sysctls."""
+    return all(
+        os.path.exists(path)
+        for path in (
+            "/proc/sys/net/ipv6/conf/all/disable_ipv6",
+            "/proc/sys/net/ipv6/conf/default/disable_ipv6",
+            "/proc/sys/net/ipv6/conf/lo/disable_ipv6",
+        )
+    )
+
+
 HOST_NETWORK_MODE = "host"
 BRIDGE_NETWORK_MODE = "bridge"
 EGRESS_SIDECAR_LABEL = "opensandbox.io/egress-sidecar-for"
@@ -425,12 +437,18 @@ class DockerNetworkingMixin:
                 f"{runtime_volume_name}:{OPENSANDBOX_RUNTIME_MOUNT_PATH}:rw"
             ]
         if self.app_config.egress.disable_ipv6:
-            # Optional: disable IPv6 in the shared namespace when egress.disable_ipv6 is set.
-            sidecar_host_config_kwargs["sysctls"] = {
-                "net.ipv6.conf.all.disable_ipv6": 1,
-                "net.ipv6.conf.default.disable_ipv6": 1,
-                "net.ipv6.conf.lo.disable_ipv6": 1,
-            }
+            if _docker_ipv6_disable_sysctls_supported():
+                # Optional: disable IPv6 in the shared namespace when egress.disable_ipv6 is set.
+                sidecar_host_config_kwargs["sysctls"] = {
+                    "net.ipv6.conf.all.disable_ipv6": 1,
+                    "net.ipv6.conf.default.disable_ipv6": 1,
+                    "net.ipv6.conf.lo.disable_ipv6": 1,
+                }
+            else:
+                logger.warning(
+                    "sandbox=%s | skip egress IPv6 sysctls because host procfs entries are unavailable",
+                    sandbox_id,
+                )
 
         sidecar_host_config = self.docker_client.api.create_host_config(
             **sidecar_host_config_kwargs

--- a/server/opensandbox_server/services/docker/networking.py
+++ b/server/opensandbox_server/services/docker/networking.py
@@ -67,14 +67,15 @@ def _running_inside_docker_container() -> bool:
     return os.path.exists("/.dockerenv")
 
 
-def _docker_ipv6_disable_sysctls_supported() -> bool:
-    """Return True when the host exposes the IPv6 procfs knobs used by Docker sysctls."""
-    return all(
-        os.path.exists(path)
-        for path in (
-            "/proc/sys/net/ipv6/conf/all/disable_ipv6",
-            "/proc/sys/net/ipv6/conf/default/disable_ipv6",
-            "/proc/sys/net/ipv6/conf/lo/disable_ipv6",
+def _docker_error_indicates_unsupported_ipv6_sysctls(exc: DockerException) -> bool:
+    """Return True when Docker rejects IPv6-disable sysctls for the target daemon."""
+    message = str(exc).lower()
+    return (
+        "disable_ipv6" in message
+        and (
+            "/proc/sys/net/ipv6/" in message
+            or "no such file or directory" in message
+            or "sysctl" in message
         )
     )
 
@@ -427,46 +428,70 @@ class DockerNetworkingMixin:
         if extra_port_bindings:
             sidecar_port_bindings.update(extra_port_bindings)
 
-        sidecar_host_config_kwargs: dict[str, Any] = {
+        base_sidecar_host_config_kwargs: dict[str, Any] = {
             "network_mode": BRIDGE_NETWORK_MODE,
             "cap_add": ["NET_ADMIN"],
             "port_bindings": normalize_port_bindings(sidecar_port_bindings),
         }
         if runtime_volume_name:
-            sidecar_host_config_kwargs["binds"] = [
+            base_sidecar_host_config_kwargs["binds"] = [
                 f"{runtime_volume_name}:{OPENSANDBOX_RUNTIME_MOUNT_PATH}:rw"
             ]
-        if self.app_config.egress.disable_ipv6:
-            if _docker_ipv6_disable_sysctls_supported():
+
+        def build_sidecar_host_config(*, include_ipv6_sysctls: bool) -> Any:
+            sidecar_host_config_kwargs = dict(base_sidecar_host_config_kwargs)
+            if include_ipv6_sysctls:
                 # Optional: disable IPv6 in the shared namespace when egress.disable_ipv6 is set.
                 sidecar_host_config_kwargs["sysctls"] = {
                     "net.ipv6.conf.all.disable_ipv6": 1,
                     "net.ipv6.conf.default.disable_ipv6": 1,
                     "net.ipv6.conf.lo.disable_ipv6": 1,
                 }
-            else:
-                logger.warning(
-                    "sandbox=%s | skip egress IPv6 sysctls because host procfs entries are unavailable",
-                    sandbox_id,
-                )
+            return self.docker_client.api.create_host_config(**sidecar_host_config_kwargs)
 
-        sidecar_host_config = self.docker_client.api.create_host_config(
-            **sidecar_host_config_kwargs
+        include_ipv6_sysctls = self.app_config.egress.disable_ipv6
+        sidecar_host_config = build_sidecar_host_config(
+            include_ipv6_sysctls=include_ipv6_sysctls
         )
 
         sidecar_container = None
         sidecar_container_id: Optional[str] = None
         try:
-            with self._docker_operation("create egress sidecar", sandbox_id):
-                sidecar_resp = self.docker_client.api.create_container(
-                    image=egress_image,
-                    name=sidecar_name,
-                    host_config=sidecar_host_config,
-                    labels=sidecar_labels,
-                    environment=sidecar_env,
-                    # Expose the ports that have host bindings so Docker publishes them in bridge mode.
-                    ports=[normalize_container_port_spec(p) for p in sidecar_port_bindings.keys()],
+            try:
+                with self._docker_operation("create egress sidecar", sandbox_id):
+                    sidecar_resp = self.docker_client.api.create_container(
+                        image=egress_image,
+                        name=sidecar_name,
+                        host_config=sidecar_host_config,
+                        labels=sidecar_labels,
+                        environment=sidecar_env,
+                        # Expose the ports that have host bindings so Docker publishes them in bridge mode.
+                        ports=[normalize_container_port_spec(p) for p in sidecar_port_bindings.keys()],
+                    )
+            except DockerException as exc:
+                if not (
+                    include_ipv6_sysctls
+                    and _docker_error_indicates_unsupported_ipv6_sysctls(exc)
+                ):
+                    raise
+                logger.warning(
+                    "sandbox=%s | retry egress sidecar without IPv6 sysctls after daemon rejection: %s",
+                    sandbox_id,
+                    exc,
                 )
+                sidecar_host_config = build_sidecar_host_config(
+                    include_ipv6_sysctls=False
+                )
+                with self._docker_operation("create egress sidecar", sandbox_id):
+                    sidecar_resp = self.docker_client.api.create_container(
+                        image=egress_image,
+                        name=sidecar_name,
+                        host_config=sidecar_host_config,
+                        labels=sidecar_labels,
+                        environment=sidecar_env,
+                        # Expose the ports that have host bindings so Docker publishes them in bridge mode.
+                        ports=[normalize_container_port_spec(p) for p in sidecar_port_bindings.keys()],
+                    )
             sidecar_container_id = sidecar_resp.get("Id")
             if not sidecar_container_id:
                 raise HTTPException(

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -1183,6 +1183,7 @@ def test_egress_sidecar_host_config_sysctls_only_when_egress_disable_ipv6(mock_d
     with (
         patch.object(service2, "_ensure_image_available"),
         patch.object(service2, "_docker_operation") as mock_op2,
+        patch("opensandbox_server.services.docker.networking.os.path.exists", side_effect=lambda path: path.startswith("/proc/sys/net/ipv6/") or path == "/.dockerenv"),
     ):
         mock_op2.return_value.__enter__.return_value = None
         mock_op2.return_value.__exit__.return_value = None
@@ -1196,6 +1197,43 @@ def test_egress_sidecar_host_config_sysctls_only_when_egress_disable_ipv6(mock_d
 
     hc2 = mock_client.api.create_host_config.call_args.kwargs
     assert hc2["sysctls"]["net.ipv6.conf.all.disable_ipv6"] == 1
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+
+    def host_cfg_side_effect(**kwargs):
+        return kwargs
+
+    mock_client.api.create_host_config.side_effect = host_cfg_side_effect
+    mock_client.api.create_container.return_value = {"Id": "sidecar-id"}
+    mock_client.containers.get.return_value = MagicMock()
+    mock_docker.from_env.return_value = mock_client
+
+    cfg = _app_config()
+    cfg.docker.network_mode = "bridge"
+    cfg.egress = EgressConfig(image="egress:latest", disable_ipv6=True)
+    service = DockerSandboxService(config=cfg)
+
+    with (
+        patch.object(service, "_ensure_image_available"),
+        patch.object(service, "_docker_operation") as mock_op,
+        patch("opensandbox_server.services.docker.networking.os.path.exists", side_effect=lambda path: path == "/.dockerenv"),
+    ):
+        mock_op.return_value.__enter__.return_value = None
+        mock_op.return_value.__exit__.return_value = None
+        service._start_egress_sidecar(
+            "sandbox-id",
+            NetworkPolicy(defaultAction="deny", egress=[]),
+            egress_token="egress-token",
+            host_execd_port=44772,
+            host_http_port=8080,
+        )
+
+    hc = mock_client.api.create_host_config.call_args.kwargs
+    assert "sysctls" not in hc
 
 
 @patch("opensandbox_server.services.docker.docker_service.docker")

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -1183,7 +1183,6 @@ def test_egress_sidecar_host_config_sysctls_only_when_egress_disable_ipv6(mock_d
     with (
         patch.object(service2, "_ensure_image_available"),
         patch.object(service2, "_docker_operation") as mock_op2,
-        patch("opensandbox_server.services.docker.networking.os.path.exists", side_effect=lambda path: path.startswith("/proc/sys/net/ipv6/") or path == "/.dockerenv"),
     ):
         mock_op2.return_value.__enter__.return_value = None
         mock_op2.return_value.__exit__.return_value = None
@@ -1200,7 +1199,7 @@ def test_egress_sidecar_host_config_sysctls_only_when_egress_disable_ipv6(mock_d
 
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
-def test_egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing(mock_docker):
+def test_egress_sidecar_retries_without_ipv6_sysctls_when_daemon_rejects_them(mock_docker):
     mock_client = MagicMock()
     mock_client.containers.list.return_value = []
 
@@ -1208,7 +1207,16 @@ def test_egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing(
         return kwargs
 
     mock_client.api.create_host_config.side_effect = host_cfg_side_effect
-    mock_client.api.create_container.return_value = {"Id": "sidecar-id"}
+
+    def create_container_side_effect(**kwargs):
+        host_config = kwargs["host_config"]
+        if "sysctls" in host_config:
+            raise DockerException(
+                "open /proc/sys/net/ipv6/conf/all/disable_ipv6: no such file or directory"
+            )
+        return {"Id": "sidecar-id"}
+
+    mock_client.api.create_container.side_effect = create_container_side_effect
     mock_client.containers.get.return_value = MagicMock()
     mock_docker.from_env.return_value = mock_client
 
@@ -1220,7 +1228,6 @@ def test_egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing(
     with (
         patch.object(service, "_ensure_image_available"),
         patch.object(service, "_docker_operation") as mock_op,
-        patch("opensandbox_server.services.docker.networking.os.path.exists", side_effect=lambda path: path == "/.dockerenv"),
     ):
         mock_op.return_value.__enter__.return_value = None
         mock_op.return_value.__exit__.return_value = None
@@ -1232,8 +1239,10 @@ def test_egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing(
             host_http_port=8080,
         )
 
-    hc = mock_client.api.create_host_config.call_args.kwargs
-    assert "sysctls" not in hc
+    first_create = mock_client.api.create_container.call_args_list[0].kwargs
+    second_create = mock_client.api.create_container.call_args_list[1].kwargs
+    assert first_create["host_config"]["sysctls"]["net.ipv6.conf.all.disable_ipv6"] == 1
+    assert "sysctls" not in second_create["host_config"]
 
 
 @patch("opensandbox_server.services.docker.docker_service.docker")


### PR DESCRIPTION
Fixes #1168.

## Summary
- skip Docker egress sidecar IPv6 sysctl injection when the host does not expose the required `/proc/sys/net/ipv6/.../disable_ipv6` entries
- keep the existing `egress.disable_ipv6=true` behavior when those procfs knobs are actually available
- add a regression test that covers the missing-procfs startup path without weakening the existing enabled-path test

## Testing
- `cd server && uv run pytest tests/test_docker_service.py -q -k 'egress_sidecar_host_config_sysctls_only_when_egress_disable_ipv6 or egress_sidecar_skips_ipv6_sysctls_when_host_procfs_entries_are_missing'`
