### PR TITLE
feat(sdk/go): add client-side sandbox pool with in-memory state store

### DIFF
--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -52,15 +52,23 @@ func NewSandboxPool(config PoolConfig) *SandboxPool {
 
 // Start begins the background reconciliation loop. Returns an error if
 // the pool configuration is invalid or the pool is already started.
+// A stopped pool can be restarted by calling Start again.
 func (p *SandboxPool) Start(ctx context.Context) error {
 	if err := p.config.validate(); err != nil {
 		return err
 	}
 
 	p.mu.Lock()
-	if p.state != PoolStateCreated {
+	if p.state == PoolStateRunning {
 		p.mu.Unlock()
 		return &PoolNotRunningError{PoolName: p.config.PoolName, State: p.state}
+	}
+	// Allow restart from STOPPED state
+	if p.state == PoolStateStopped {
+		p.stopCh = make(chan struct{})
+		p.doneCh = make(chan struct{})
+		p.shutdownMu = sync.Once{}
+		p.recon = newReconcileState(p.config.DegradedThreshold)
 	}
 	p.state = PoolStateRunning
 	p.mu.Unlock()
@@ -242,13 +250,22 @@ done:
 // runReconcileLoop is the background goroutine that maintains idle sandbox count.
 func (p *SandboxPool) runReconcileLoop(ctx context.Context) {
 	defer func() {
-		close(p.doneCh)
-		// If context was cancelled, transition to STOPPED
+		// If context was cancelled (not graceful shutdown), clean up idle sandboxes
 		p.mu.Lock()
-		if p.state == PoolStateRunning {
+		wasRunning := p.state == PoolStateRunning
+		if wasRunning {
 			p.state = PoolStateStopped
 		}
 		p.mu.Unlock()
+
+		if wasRunning {
+			p.ReleaseAllIdle(context.Background())
+			if p.config.StateStore != nil {
+				_ = p.config.StateStore.ReleaseLock(context.Background(), p.config.PoolName, p.config.OwnerID)
+			}
+		}
+
+		close(p.doneCh)
 	}()
 
 	// Create a cancellable context for reconcile work
@@ -360,18 +377,19 @@ func (p *SandboxPool) warmupOne(ctx context.Context) error {
 	}
 
 	sb, err := CreateSandbox(ctx, p.config.ConnectionConfig, SandboxCreateOptions{
-		Image:          spec.Image,
-		Entrypoint:     spec.Entrypoint,
-		ResourceLimits: spec.ResourceLimits,
-		TimeoutSeconds: &timeout,
-		Env:            spec.Env,
-		Metadata:       spec.Metadata,
-		NetworkPolicy:  spec.NetworkPolicy,
-		Volumes:        spec.Volumes,
-		Extensions:     spec.Extensions,
-		ImageAuth:      spec.ImageAuth,
-		HealthCheck:    p.config.HealthCheck,
-		ReadyTimeout:   p.config.AcquireReadyTimeout,
+		Image:            spec.Image,
+		Entrypoint:       spec.Entrypoint,
+		ResourceLimits:   spec.ResourceLimits,
+		ResourceRequests: spec.ResourceRequests,
+		TimeoutSeconds:   &timeout,
+		Env:              spec.Env,
+		Metadata:         spec.Metadata,
+		NetworkPolicy:    spec.NetworkPolicy,
+		Volumes:          spec.Volumes,
+		Extensions:       spec.Extensions,
+		ImageAuth:        spec.ImageAuth,
+		HealthCheck:      p.config.HealthCheck,
+		ReadyTimeout:     p.config.AcquireReadyTimeout,
 		HealthCheckInterval: p.config.AcquireHealthCheckInterval,
 	})
 	if err != nil {
@@ -386,6 +404,13 @@ func (p *SandboxPool) warmupOne(ctx context.Context) error {
 		}
 	}
 
+	// Renew server-side TTL after preparer to align with idle expiry stamp
+	idleDur := time.Duration(timeout) * time.Second
+	if _, err := sb.Renew(ctx, idleDur); err != nil {
+		_ = sb.Kill(context.Background())
+		return fmt.Errorf("warmup renew: %w", err)
+	}
+
 	// Verify we still hold the lock before publishing to shared store
 	renewed, _ := p.config.StateStore.RenewLock(ctx, p.config.PoolName, p.config.OwnerID, p.config.PrimaryLockTTL)
 	if !renewed {
@@ -394,7 +419,7 @@ func (p *SandboxPool) warmupOne(ctx context.Context) error {
 	}
 
 	// Put into idle set with TTL aligned to sandbox server-side expiration
-	expiresAt := time.Now().Add(time.Duration(timeout) * time.Second)
+	expiresAt := time.Now().Add(idleDur)
 	if err := p.config.StateStore.PutIdle(ctx, p.config.PoolName, sb.ID(), expiresAt); err != nil {
 		_ = sb.Kill(context.Background())
 		return fmt.Errorf("warmup put idle: %w", err)
@@ -442,18 +467,19 @@ func (p *SandboxPool) directCreate(ctx context.Context, timeout time.Duration) (
 	}
 
 	return CreateSandbox(ctx, p.config.ConnectionConfig, SandboxCreateOptions{
-		Image:          spec.Image,
-		Entrypoint:     spec.Entrypoint,
-		ResourceLimits: spec.ResourceLimits,
-		TimeoutSeconds: &t,
-		Env:            spec.Env,
-		Metadata:       spec.Metadata,
-		NetworkPolicy:  spec.NetworkPolicy,
-		Volumes:        spec.Volumes,
-		Extensions:     spec.Extensions,
-		ImageAuth:      spec.ImageAuth,
-		HealthCheck:    p.config.HealthCheck,
-		ReadyTimeout:   p.config.AcquireReadyTimeout,
+		Image:            spec.Image,
+		Entrypoint:       spec.Entrypoint,
+		ResourceLimits:   spec.ResourceLimits,
+		ResourceRequests: spec.ResourceRequests,
+		TimeoutSeconds:   &t,
+		Env:              spec.Env,
+		Metadata:         spec.Metadata,
+		NetworkPolicy:    spec.NetworkPolicy,
+		Volumes:          spec.Volumes,
+		Extensions:       spec.Extensions,
+		ImageAuth:        spec.ImageAuth,
+		HealthCheck:      p.config.HealthCheck,
+		ReadyTimeout:     p.config.AcquireReadyTimeout,
 		HealthCheckInterval: p.config.AcquireHealthCheckInterval,
 	})
 }

--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -92,9 +92,9 @@ func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sand
 		fn(o)
 	}
 
-	// Try to get an idle sandbox
+	// Try to get an idle sandbox; on transient store error, fall through to direct create
 	sandboxID, ok, err := p.config.StateStore.TryTakeIdle(ctx, p.config.PoolName)
-	if err != nil {
+	if err != nil && o.policy == FailFast {
 		return nil, fmt.Errorf("pool %q: state store error: %w", p.config.PoolName, err)
 	}
 
@@ -117,7 +117,7 @@ func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sand
 		}
 	}
 
-	// No idle sandbox available
+	// No idle sandbox available (or store error under DirectCreate)
 	switch o.policy {
 	case FailFast:
 		return nil, &PoolEmptyError{PoolName: p.config.PoolName}
@@ -164,8 +164,14 @@ func (p *SandboxPool) Snapshot() PoolSnapshot {
 	idleCount, _ := p.config.StateStore.CountIdle(context.Background(), p.config.PoolName)
 	failureCount, lastError, backoffActive := p.recon.snapshot()
 
+	// Reflect degraded state when in backoff
+	reportedState := state
+	if state == PoolStateRunning && backoffActive {
+		reportedState = PoolStateDegraded
+	}
+
 	return PoolSnapshot{
-		State:         state,
+		State:         reportedState,
 		IdleCount:     idleCount,
 		InFlight:      atomic.LoadInt32(&p.inFlight),
 		FailureCount:  failureCount,
@@ -177,6 +183,7 @@ func (p *SandboxPool) Snapshot() PoolSnapshot {
 // Shutdown gracefully stops the pool. It waits for in-flight operations
 // to complete (up to DrainTimeout), then kills remaining idle sandboxes.
 // Shutdown is idempotent and safe to call concurrently.
+// Returns an error if idle sandbox cleanup fails.
 func (p *SandboxPool) Shutdown(ctx context.Context) error {
 	var alreadyStopped bool
 
@@ -203,7 +210,6 @@ func (p *SandboxPool) Shutdown(ctx context.Context) error {
 		select {
 		case <-p.doneCh:
 		case <-ctx.Done():
-			// Context expired; proceed with cleanup anyway
 		}
 	}
 
@@ -219,21 +225,31 @@ func (p *SandboxPool) Shutdown(ctx context.Context) error {
 
 done:
 	// Kill all remaining idle sandboxes
-	p.ReleaseAllIdle(context.Background())
+	_, releaseErr := p.ReleaseAllIdle(context.Background())
 
 	// Release the leader lock
-	_ = p.config.StateStore.ReleaseLock(context.Background(), p.config.PoolName, p.config.OwnerID)
+	if p.config.StateStore != nil {
+		_ = p.config.StateStore.ReleaseLock(context.Background(), p.config.PoolName, p.config.OwnerID)
+	}
 
 	p.mu.Lock()
 	p.state = PoolStateStopped
 	p.mu.Unlock()
 
-	return nil
+	return releaseErr
 }
 
 // runReconcileLoop is the background goroutine that maintains idle sandbox count.
 func (p *SandboxPool) runReconcileLoop(ctx context.Context) {
-	defer close(p.doneCh)
+	defer func() {
+		close(p.doneCh)
+		// If context was cancelled, transition to STOPPED
+		p.mu.Lock()
+		if p.state == PoolStateRunning {
+			p.state = PoolStateStopped
+		}
+		p.mu.Unlock()
+	}()
 
 	// Create a cancellable context for reconcile work
 	reconCtx, reconCancel := context.WithCancel(ctx)
@@ -353,6 +369,10 @@ func (p *SandboxPool) warmupOne(ctx context.Context) error {
 		NetworkPolicy:  spec.NetworkPolicy,
 		Volumes:        spec.Volumes,
 		Extensions:     spec.Extensions,
+		ImageAuth:      spec.ImageAuth,
+		HealthCheck:    p.config.HealthCheck,
+		ReadyTimeout:   p.config.AcquireReadyTimeout,
+		HealthCheckInterval: p.config.AcquireHealthCheckInterval,
 	})
 	if err != nil {
 		return fmt.Errorf("warmup create: %w", err)
@@ -408,10 +428,14 @@ func (p *SandboxPool) connectAndValidate(ctx context.Context, sandboxID string, 
 
 func (p *SandboxPool) directCreate(ctx context.Context, timeout time.Duration) (*Sandbox, error) {
 	spec := p.config.CreationSpec
-	t := spec.Timeout
+
+	// Use idle timeout as default TTL for consistency with warmed sandboxes
+	t := int(p.config.IdleTimeout.Seconds())
+	if spec.Timeout > 0 && spec.Timeout < t {
+		t = spec.Timeout
+	}
 	if timeout > 0 {
-		secs := int(timeout.Seconds())
-		t = secs
+		t = int(timeout.Seconds())
 	}
 	if t == 0 {
 		t = DefaultTimeoutSeconds
@@ -427,7 +451,10 @@ func (p *SandboxPool) directCreate(ctx context.Context, timeout time.Duration) (
 		NetworkPolicy:  spec.NetworkPolicy,
 		Volumes:        spec.Volumes,
 		Extensions:     spec.Extensions,
+		ImageAuth:      spec.ImageAuth,
 		HealthCheck:    p.config.HealthCheck,
+		ReadyTimeout:   p.config.AcquireReadyTimeout,
+		HealthCheckInterval: p.config.AcquireHealthCheckInterval,
 	})
 }
 

--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -27,11 +27,13 @@ import (
 type SandboxPool struct {
 	config PoolConfig
 
-	mu       sync.Mutex
-	state    PoolState
-	inFlight int32 // atomic
-	stopCh   chan struct{}
-	doneCh   chan struct{}
+	mu         sync.Mutex
+	state      PoolState
+	inFlight   int32 // atomic
+	stopCh     chan struct{}
+	doneCh     chan struct{}
+	started    int32 // atomic: 1 if reconciler goroutine launched
+	shutdownMu sync.Once
 
 	recon *reconcileState
 }
@@ -63,6 +65,7 @@ func (p *SandboxPool) Start(ctx context.Context) error {
 	p.state = PoolStateRunning
 	p.mu.Unlock()
 
+	atomic.StoreInt32(&p.started, 1)
 	go p.runReconcileLoop(ctx)
 	return nil
 }
@@ -70,15 +73,18 @@ func (p *SandboxPool) Start(ctx context.Context) error {
 // Acquire obtains a sandbox from the pool. If no idle sandbox is available,
 // behavior depends on AcquirePolicy (default: DirectCreate).
 func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sandbox, error) {
+	// Increment inFlight first, then check state to prevent race with Shutdown.
+	atomic.AddInt32(&p.inFlight, 1)
+
 	p.mu.Lock()
-	if p.state != PoolStateRunning {
-		state := p.state
-		p.mu.Unlock()
-		return nil, &PoolNotRunningError{PoolName: p.config.PoolName, State: state}
-	}
+	state := p.state
 	p.mu.Unlock()
 
-	atomic.AddInt32(&p.inFlight, 1)
+	if state != PoolStateRunning {
+		atomic.AddInt32(&p.inFlight, -1)
+		return nil, &PoolNotRunningError{PoolName: p.config.PoolName, State: state}
+	}
+
 	defer atomic.AddInt32(&p.inFlight, -1)
 
 	o := &acquireOpts{policy: DirectCreate}
@@ -93,13 +99,22 @@ func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sand
 	}
 
 	if ok {
-		sb, err := p.connectAndValidate(ctx, sandboxID, o.sandboxTimeout)
-		if err == nil {
+		sb, connectErr := p.connectAndValidate(ctx, sandboxID, o.sandboxTimeout)
+		if connectErr == nil {
 			return sb, nil
 		}
-		// Stale sandbox; clean up and fall through
+		// Stale sandbox; clean up
 		_ = p.config.StateStore.RemoveIdle(ctx, p.config.PoolName, sandboxID)
 		go p.killSandbox(sandboxID)
+
+		// Under FailFast, report the actual connect failure
+		if o.policy == FailFast {
+			return nil, &PoolAcquireFailedError{
+				PoolName:  p.config.PoolName,
+				SandboxID: sandboxID,
+				Err:       connectErr,
+			}
+		}
 	}
 
 	// No idle sandbox available
@@ -111,10 +126,11 @@ func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sand
 	}
 }
 
-// Resize dynamically changes the target idle count.
+// Resize dynamically changes the target idle count. Zero is allowed to
+// temporarily disable replenishment without shutting down.
 func (p *SandboxPool) Resize(_ context.Context, maxIdle int) error {
-	if maxIdle <= 0 {
-		return &InvalidArgumentError{Field: "maxIdle", Message: "must be positive"}
+	if maxIdle < 0 {
+		return &InvalidArgumentError{Field: "maxIdle", Message: "must be non-negative"}
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -160,22 +176,35 @@ func (p *SandboxPool) Snapshot() PoolSnapshot {
 
 // Shutdown gracefully stops the pool. It waits for in-flight operations
 // to complete (up to DrainTimeout), then kills remaining idle sandboxes.
+// Shutdown is idempotent and safe to call concurrently.
 func (p *SandboxPool) Shutdown(ctx context.Context) error {
-	p.mu.Lock()
-	if p.state == PoolStateStopped {
+	var alreadyStopped bool
+
+	p.shutdownMu.Do(func() {
+		p.mu.Lock()
+		if p.state == PoolStateStopped {
+			alreadyStopped = true
+			p.mu.Unlock()
+			return
+		}
+		p.state = PoolStateDraining
 		p.mu.Unlock()
+
+		// Signal reconciler to stop
+		close(p.stopCh)
+	})
+
+	if alreadyStopped {
 		return nil
 	}
-	p.state = PoolStateDraining
-	p.mu.Unlock()
 
-	// Signal reconciler to stop
-	close(p.stopCh)
-
-	// Wait for reconciler goroutine to finish
-	select {
-	case <-p.doneCh:
-	case <-ctx.Done():
+	// Wait for reconciler goroutine to finish (only if it was started)
+	if atomic.LoadInt32(&p.started) == 1 {
+		select {
+		case <-p.doneCh:
+		case <-ctx.Done():
+			// Context expired; proceed with cleanup anyway
+		}
 	}
 
 	// Wait for in-flight operations
@@ -206,8 +235,12 @@ done:
 func (p *SandboxPool) runReconcileLoop(ctx context.Context) {
 	defer close(p.doneCh)
 
+	// Create a cancellable context for reconcile work
+	reconCtx, reconCancel := context.WithCancel(ctx)
+	defer reconCancel()
+
 	// Immediate first tick
-	p.runReconcileTick(ctx)
+	p.runReconcileTick(reconCtx)
 
 	ticker := time.NewTicker(p.config.ReconcileInterval)
 	defer ticker.Stop()
@@ -215,16 +248,25 @@ func (p *SandboxPool) runReconcileLoop(ctx context.Context) {
 	for {
 		select {
 		case <-p.stopCh:
+			reconCancel()
 			return
 		case <-ctx.Done():
+			reconCancel()
 			return
 		case <-ticker.C:
-			p.runReconcileTick(ctx)
+			p.runReconcileTick(reconCtx)
 		}
 	}
 }
 
 func (p *SandboxPool) runReconcileTick(ctx context.Context) {
+	// Check if shutting down
+	select {
+	case <-p.stopCh:
+		return
+	default:
+	}
+
 	// Acquire leader lock
 	acquired, err := p.config.StateStore.TryAcquireLock(ctx, p.config.PoolName, p.config.OwnerID, p.config.PrimaryLockTTL)
 	if err != nil || !acquired {
@@ -290,7 +332,13 @@ func (p *SandboxPool) runReconcileTick(ctx context.Context) {
 
 func (p *SandboxPool) warmupOne(ctx context.Context) error {
 	spec := p.config.CreationSpec
-	timeout := spec.Timeout
+
+	// Use idle timeout as sandbox TTL to align server-side expiration with pool membership.
+	idleSecs := int(p.config.IdleTimeout.Seconds())
+	timeout := idleSecs
+	if spec.Timeout > 0 && spec.Timeout < idleSecs {
+		timeout = spec.Timeout
+	}
 	if timeout == 0 {
 		timeout = DefaultTimeoutSeconds
 	}
@@ -318,8 +366,15 @@ func (p *SandboxPool) warmupOne(ctx context.Context) error {
 		}
 	}
 
-	// Put into idle set
-	expiresAt := time.Now().Add(p.config.IdleTimeout)
+	// Verify we still hold the lock before publishing to shared store
+	renewed, _ := p.config.StateStore.RenewLock(ctx, p.config.PoolName, p.config.OwnerID, p.config.PrimaryLockTTL)
+	if !renewed {
+		_ = sb.Kill(context.Background())
+		return fmt.Errorf("warmup: lost primary lock, discarding sandbox")
+	}
+
+	// Put into idle set with TTL aligned to sandbox server-side expiration
+	expiresAt := time.Now().Add(time.Duration(timeout) * time.Second)
 	if err := p.config.StateStore.PutIdle(ctx, p.config.PoolName, sb.ID(), expiresAt); err != nil {
 		_ = sb.Kill(context.Background())
 		return fmt.Errorf("warmup put idle: %w", err)

--- a/sdks/sandbox/go/pool.go
+++ b/sdks/sandbox/go/pool.go
@@ -1,0 +1,382 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SandboxPool maintains a pool of pre-warmed sandbox instances for
+// millisecond-level acquisition. It implements OSEP-0005.
+type SandboxPool struct {
+	config PoolConfig
+
+	mu       sync.Mutex
+	state    PoolState
+	inFlight int32 // atomic
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+
+	recon *reconcileState
+}
+
+// NewSandboxPool creates a new pool. Call Start to begin reconciliation.
+func NewSandboxPool(config PoolConfig) *SandboxPool {
+	config.applyDefaults()
+	return &SandboxPool{
+		config: config,
+		state:  PoolStateCreated,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+		recon:  newReconcileState(config.DegradedThreshold),
+	}
+}
+
+// Start begins the background reconciliation loop. Returns an error if
+// the pool configuration is invalid or the pool is already started.
+func (p *SandboxPool) Start(ctx context.Context) error {
+	if err := p.config.validate(); err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	if p.state != PoolStateCreated {
+		p.mu.Unlock()
+		return &PoolNotRunningError{PoolName: p.config.PoolName, State: p.state}
+	}
+	p.state = PoolStateRunning
+	p.mu.Unlock()
+
+	go p.runReconcileLoop(ctx)
+	return nil
+}
+
+// Acquire obtains a sandbox from the pool. If no idle sandbox is available,
+// behavior depends on AcquirePolicy (default: DirectCreate).
+func (p *SandboxPool) Acquire(ctx context.Context, opts ...AcquireOption) (*Sandbox, error) {
+	p.mu.Lock()
+	if p.state != PoolStateRunning {
+		state := p.state
+		p.mu.Unlock()
+		return nil, &PoolNotRunningError{PoolName: p.config.PoolName, State: state}
+	}
+	p.mu.Unlock()
+
+	atomic.AddInt32(&p.inFlight, 1)
+	defer atomic.AddInt32(&p.inFlight, -1)
+
+	o := &acquireOpts{policy: DirectCreate}
+	for _, fn := range opts {
+		fn(o)
+	}
+
+	// Try to get an idle sandbox
+	sandboxID, ok, err := p.config.StateStore.TryTakeIdle(ctx, p.config.PoolName)
+	if err != nil {
+		return nil, fmt.Errorf("pool %q: state store error: %w", p.config.PoolName, err)
+	}
+
+	if ok {
+		sb, err := p.connectAndValidate(ctx, sandboxID, o.sandboxTimeout)
+		if err == nil {
+			return sb, nil
+		}
+		// Stale sandbox; clean up and fall through
+		_ = p.config.StateStore.RemoveIdle(ctx, p.config.PoolName, sandboxID)
+		go p.killSandbox(sandboxID)
+	}
+
+	// No idle sandbox available
+	switch o.policy {
+	case FailFast:
+		return nil, &PoolEmptyError{PoolName: p.config.PoolName}
+	default:
+		return p.directCreate(ctx, o.sandboxTimeout)
+	}
+}
+
+// Resize dynamically changes the target idle count.
+func (p *SandboxPool) Resize(_ context.Context, maxIdle int) error {
+	if maxIdle <= 0 {
+		return &InvalidArgumentError{Field: "maxIdle", Message: "must be positive"}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config.MaxIdle = maxIdle
+	return nil
+}
+
+// ReleaseAllIdle kills all idle sandboxes and returns the count released.
+func (p *SandboxPool) ReleaseAllIdle(ctx context.Context) (int, error) {
+	count := 0
+	for {
+		id, ok, err := p.config.StateStore.TryTakeIdle(ctx, p.config.PoolName)
+		if err != nil {
+			return count, err
+		}
+		if !ok {
+			break
+		}
+		go p.killSandbox(id)
+		count++
+	}
+	return count, nil
+}
+
+// Snapshot returns a point-in-time view of the pool state.
+func (p *SandboxPool) Snapshot() PoolSnapshot {
+	p.mu.Lock()
+	state := p.state
+	p.mu.Unlock()
+
+	idleCount, _ := p.config.StateStore.CountIdle(context.Background(), p.config.PoolName)
+	failureCount, lastError, backoffActive := p.recon.snapshot()
+
+	return PoolSnapshot{
+		State:         state,
+		IdleCount:     idleCount,
+		InFlight:      atomic.LoadInt32(&p.inFlight),
+		FailureCount:  failureCount,
+		LastError:     lastError,
+		BackoffActive: backoffActive,
+	}
+}
+
+// Shutdown gracefully stops the pool. It waits for in-flight operations
+// to complete (up to DrainTimeout), then kills remaining idle sandboxes.
+func (p *SandboxPool) Shutdown(ctx context.Context) error {
+	p.mu.Lock()
+	if p.state == PoolStateStopped {
+		p.mu.Unlock()
+		return nil
+	}
+	p.state = PoolStateDraining
+	p.mu.Unlock()
+
+	// Signal reconciler to stop
+	close(p.stopCh)
+
+	// Wait for reconciler goroutine to finish
+	select {
+	case <-p.doneCh:
+	case <-ctx.Done():
+	}
+
+	// Wait for in-flight operations
+	deadline := time.After(p.config.DrainTimeout)
+	for atomic.LoadInt32(&p.inFlight) > 0 {
+		select {
+		case <-deadline:
+			goto done
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+done:
+	// Kill all remaining idle sandboxes
+	p.ReleaseAllIdle(context.Background())
+
+	// Release the leader lock
+	_ = p.config.StateStore.ReleaseLock(context.Background(), p.config.PoolName, p.config.OwnerID)
+
+	p.mu.Lock()
+	p.state = PoolStateStopped
+	p.mu.Unlock()
+
+	return nil
+}
+
+// runReconcileLoop is the background goroutine that maintains idle sandbox count.
+func (p *SandboxPool) runReconcileLoop(ctx context.Context) {
+	defer close(p.doneCh)
+
+	// Immediate first tick
+	p.runReconcileTick(ctx)
+
+	ticker := time.NewTicker(p.config.ReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.runReconcileTick(ctx)
+		}
+	}
+}
+
+func (p *SandboxPool) runReconcileTick(ctx context.Context) {
+	// Acquire leader lock
+	acquired, err := p.config.StateStore.TryAcquireLock(ctx, p.config.PoolName, p.config.OwnerID, p.config.PrimaryLockTTL)
+	if err != nil || !acquired {
+		return
+	}
+
+	// Reap expired idle entries
+	_ = p.config.StateStore.ReapExpired(ctx, p.config.PoolName, time.Now())
+
+	// Check if in backoff
+	if p.recon.isBackoffActive() {
+		return
+	}
+
+	// Compute deficit
+	currentIdle, err := p.config.StateStore.CountIdle(ctx, p.config.PoolName)
+	if err != nil {
+		return
+	}
+
+	p.mu.Lock()
+	maxIdle := p.config.MaxIdle
+	p.mu.Unlock()
+
+	deficit := maxIdle - currentIdle
+	if deficit <= 0 {
+		return
+	}
+
+	// Limit concurrent warmup
+	toCreate := deficit
+	if toCreate > p.config.WarmupConcurrency {
+		toCreate = p.config.WarmupConcurrency
+	}
+
+	// Create sandboxes
+	var wg sync.WaitGroup
+	failures := int32(0)
+
+	for i := 0; i < toCreate; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := p.warmupOne(ctx); err != nil {
+				atomic.AddInt32(&failures, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Record results
+	failCount := int(atomic.LoadInt32(&failures))
+	if failCount > 0 {
+		p.recon.recordFailure(fmt.Sprintf("%d/%d warmup failures", failCount, toCreate))
+	}
+	if failCount < toCreate {
+		p.recon.recordSuccess()
+	}
+
+	// Renew lock after work
+	_, _ = p.config.StateStore.RenewLock(ctx, p.config.PoolName, p.config.OwnerID, p.config.PrimaryLockTTL)
+}
+
+func (p *SandboxPool) warmupOne(ctx context.Context) error {
+	spec := p.config.CreationSpec
+	timeout := spec.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeoutSeconds
+	}
+
+	sb, err := CreateSandbox(ctx, p.config.ConnectionConfig, SandboxCreateOptions{
+		Image:          spec.Image,
+		Entrypoint:     spec.Entrypoint,
+		ResourceLimits: spec.ResourceLimits,
+		TimeoutSeconds: &timeout,
+		Env:            spec.Env,
+		Metadata:       spec.Metadata,
+		NetworkPolicy:  spec.NetworkPolicy,
+		Volumes:        spec.Volumes,
+		Extensions:     spec.Extensions,
+	})
+	if err != nil {
+		return fmt.Errorf("warmup create: %w", err)
+	}
+
+	// Run optional preparer
+	if p.config.SandboxPreparer != nil {
+		if err := p.config.SandboxPreparer(ctx, sb); err != nil {
+			_ = sb.Kill(context.Background())
+			return fmt.Errorf("warmup preparer: %w", err)
+		}
+	}
+
+	// Put into idle set
+	expiresAt := time.Now().Add(p.config.IdleTimeout)
+	if err := p.config.StateStore.PutIdle(ctx, p.config.PoolName, sb.ID(), expiresAt); err != nil {
+		_ = sb.Kill(context.Background())
+		return fmt.Errorf("warmup put idle: %w", err)
+	}
+
+	return nil
+}
+
+func (p *SandboxPool) connectAndValidate(ctx context.Context, sandboxID string, renewDuration time.Duration) (*Sandbox, error) {
+	readyOpts := ReadyOptions{
+		Timeout:         p.config.AcquireReadyTimeout,
+		PollingInterval: p.config.AcquireHealthCheckInterval,
+		HealthCheck:     p.config.HealthCheck,
+	}
+
+	sb, err := ConnectSandbox(ctx, p.config.ConnectionConfig, sandboxID, readyOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Renew TTL if requested
+	if renewDuration > 0 {
+		if _, err := sb.Renew(ctx, renewDuration); err != nil {
+			_ = sb.Close()
+			return nil, fmt.Errorf("renew after acquire: %w", err)
+		}
+	}
+
+	return sb, nil
+}
+
+func (p *SandboxPool) directCreate(ctx context.Context, timeout time.Duration) (*Sandbox, error) {
+	spec := p.config.CreationSpec
+	t := spec.Timeout
+	if timeout > 0 {
+		secs := int(timeout.Seconds())
+		t = secs
+	}
+	if t == 0 {
+		t = DefaultTimeoutSeconds
+	}
+
+	return CreateSandbox(ctx, p.config.ConnectionConfig, SandboxCreateOptions{
+		Image:          spec.Image,
+		Entrypoint:     spec.Entrypoint,
+		ResourceLimits: spec.ResourceLimits,
+		TimeoutSeconds: &t,
+		Env:            spec.Env,
+		Metadata:       spec.Metadata,
+		NetworkPolicy:  spec.NetworkPolicy,
+		Volumes:        spec.Volumes,
+		Extensions:     spec.Extensions,
+		HealthCheck:    p.config.HealthCheck,
+	})
+}
+
+func (p *SandboxPool) killSandbox(sandboxID string) {
+	lc := p.config.ConnectionConfig.lifecycleClient()
+	_ = lc.DeleteSandbox(context.Background(), sandboxID)
+}

--- a/sdks/sandbox/go/pool_config.go
+++ b/sdks/sandbox/go/pool_config.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// PoolState represents the lifecycle state of a SandboxPool.
+type PoolState int
+
+const (
+	PoolStateCreated  PoolState = iota
+	PoolStateRunning
+	PoolStateDraining
+	PoolStateStopped
+)
+
+func (s PoolState) String() string {
+	switch s {
+	case PoolStateCreated:
+		return "CREATED"
+	case PoolStateRunning:
+		return "RUNNING"
+	case PoolStateDraining:
+		return "DRAINING"
+	case PoolStateStopped:
+		return "STOPPED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// AcquirePolicy defines behavior when no idle sandbox is available.
+type AcquirePolicy int
+
+const (
+	// DirectCreate creates a new sandbox on-demand if the pool is empty.
+	DirectCreate AcquirePolicy = iota
+	// FailFast returns an error immediately if no idle sandbox is available.
+	FailFast
+)
+
+// Pool configuration defaults.
+const (
+	DefaultReconcileInterval         = 30 * time.Second
+	DefaultDegradedThreshold         = 3
+	DefaultIdleTimeout               = 24 * time.Hour
+	DefaultDrainTimeout              = 30 * time.Second
+	DefaultAcquireReadyTimeout       = 30 * time.Second
+	DefaultAcquireHealthCheckInterval = 200 * time.Millisecond
+	DefaultPrimaryLockTTL            = 60 * time.Second
+)
+
+// PoolConfig configures a SandboxPool.
+type PoolConfig struct {
+	// PoolName identifies this pool (required).
+	PoolName string
+	// MaxIdle is the target number of idle sandboxes to maintain (required).
+	MaxIdle int
+	// ConnectionConfig for communicating with the OpenSandbox server (required).
+	ConnectionConfig ConnectionConfig
+	// CreationSpec is the template for creating pool sandboxes (required).
+	CreationSpec PoolCreationSpec
+	// StateStore manages idle sandbox state (required).
+	StateStore PoolStateStore
+
+	// OwnerID uniquely identifies this pool instance for leader election.
+	// Auto-generated if empty.
+	OwnerID string
+	// WarmupConcurrency limits parallel sandbox creation during reconcile.
+	// Default: max(1, ceil(MaxIdle * 0.2))
+	WarmupConcurrency int
+	// ReconcileInterval between background reconciliation ticks.
+	ReconcileInterval time.Duration
+	// DegradedThreshold is the number of consecutive warmup failures before
+	// entering DEGRADED backoff.
+	DegradedThreshold int
+	// IdleTimeout is the TTL for idle sandboxes in the pool.
+	IdleTimeout time.Duration
+	// DrainTimeout is the maximum time to wait for in-flight operations on shutdown.
+	DrainTimeout time.Duration
+	// AcquireReadyTimeout is the timeout for health-checking an acquired sandbox.
+	AcquireReadyTimeout time.Duration
+	// AcquireHealthCheckInterval is the polling interval for acquire health checks.
+	AcquireHealthCheckInterval time.Duration
+	// AcquireMinRemainingTTL skips idle sandboxes whose remaining TTL is below this.
+	// Default: min(60s, IdleTimeout/2)
+	AcquireMinRemainingTTL time.Duration
+	// PrimaryLockTTL is the TTL for the leader election lock.
+	PrimaryLockTTL time.Duration
+
+	// HealthCheck is an optional custom health check function.
+	// If nil, the default execd /ping check is used.
+	HealthCheck func(ctx context.Context, sb *Sandbox) (bool, error)
+	// SandboxPreparer is an optional hook called after a sandbox is created
+	// during warmup (e.g., to pre-install packages).
+	SandboxPreparer func(ctx context.Context, sb *Sandbox) error
+}
+
+func (c *PoolConfig) validate() error {
+	if c.PoolName == "" {
+		return &InvalidArgumentError{Field: "PoolName", Message: "pool name is required"}
+	}
+	if c.MaxIdle <= 0 {
+		return &InvalidArgumentError{Field: "MaxIdle", Message: "must be positive"}
+	}
+	if c.CreationSpec.Image == "" {
+		return &InvalidArgumentError{Field: "CreationSpec.Image", Message: "image is required"}
+	}
+	if c.StateStore == nil {
+		return &InvalidArgumentError{Field: "StateStore", Message: "state store is required"}
+	}
+	return nil
+}
+
+func (c *PoolConfig) applyDefaults() {
+	if c.WarmupConcurrency <= 0 {
+		wc := (c.MaxIdle + 4) / 5 // ceil(MaxIdle * 0.2)
+		if wc < 1 {
+			wc = 1
+		}
+		c.WarmupConcurrency = wc
+	}
+	if c.ReconcileInterval <= 0 {
+		c.ReconcileInterval = DefaultReconcileInterval
+	}
+	if c.DegradedThreshold <= 0 {
+		c.DegradedThreshold = DefaultDegradedThreshold
+	}
+	if c.IdleTimeout <= 0 {
+		c.IdleTimeout = DefaultIdleTimeout
+	}
+	if c.DrainTimeout <= 0 {
+		c.DrainTimeout = DefaultDrainTimeout
+	}
+	if c.AcquireReadyTimeout <= 0 {
+		c.AcquireReadyTimeout = DefaultAcquireReadyTimeout
+	}
+	if c.AcquireHealthCheckInterval <= 0 {
+		c.AcquireHealthCheckInterval = DefaultAcquireHealthCheckInterval
+	}
+	if c.AcquireMinRemainingTTL <= 0 {
+		minTTL := 60 * time.Second
+		half := c.IdleTimeout / 2
+		if half < minTTL {
+			minTTL = half
+		}
+		c.AcquireMinRemainingTTL = minTTL
+	}
+	if c.PrimaryLockTTL <= 0 {
+		c.PrimaryLockTTL = DefaultPrimaryLockTTL
+	}
+	if c.OwnerID == "" {
+		c.OwnerID = fmt.Sprintf("pool-%s-%d", c.PoolName, time.Now().UnixNano())
+	}
+}
+
+// PoolCreationSpec is the template for creating sandboxes in the pool.
+type PoolCreationSpec struct {
+	Image          string
+	Timeout        int
+	Entrypoint     []string
+	ResourceLimits ResourceLimits
+	Env            map[string]string
+	Metadata       map[string]string
+	NetworkPolicy  *NetworkPolicy
+	Volumes        []Volume
+	Extensions     map[string]string
+}
+
+// PoolSnapshot contains a point-in-time view of pool state.
+type PoolSnapshot struct {
+	State         PoolState
+	IdleCount     int
+	InFlight      int32
+	FailureCount  int
+	LastError     string
+	BackoffActive bool
+}
+
+// acquireOpts holds options for a single Acquire call.
+type acquireOpts struct {
+	sandboxTimeout time.Duration
+	policy         AcquirePolicy
+}
+
+// AcquireOption configures an Acquire call.
+type AcquireOption func(*acquireOpts)
+
+// WithSandboxTimeout sets the TTL to renew the acquired sandbox to.
+func WithSandboxTimeout(d time.Duration) AcquireOption {
+	return func(o *acquireOpts) { o.sandboxTimeout = d }
+}
+
+// WithAcquirePolicy sets the fallback behavior when no idle sandbox is available.
+func WithAcquirePolicy(p AcquirePolicy) AcquireOption {
+	return func(o *acquireOpts) { o.policy = p }
+}

--- a/sdks/sandbox/go/pool_config.go
+++ b/sdks/sandbox/go/pool_config.go
@@ -175,16 +175,17 @@ func (c *PoolConfig) applyDefaults() {
 
 // PoolCreationSpec is the template for creating sandboxes in the pool.
 type PoolCreationSpec struct {
-	Image          string
-	Timeout        int
-	Entrypoint     []string
-	ResourceLimits ResourceLimits
-	Env            map[string]string
-	Metadata       map[string]string
-	NetworkPolicy  *NetworkPolicy
-	Volumes        []Volume
-	Extensions     map[string]string
-	ImageAuth      *ImageAuth
+	Image            string
+	Timeout          int
+	Entrypoint       []string
+	ResourceLimits   ResourceLimits
+	ResourceRequests ResourceLimits
+	Env              map[string]string
+	Metadata         map[string]string
+	NetworkPolicy    *NetworkPolicy
+	Volumes          []Volume
+	Extensions       map[string]string
+	ImageAuth        *ImageAuth
 }
 
 // PoolSnapshot contains a point-in-time view of pool state.

--- a/sdks/sandbox/go/pool_config.go
+++ b/sdks/sandbox/go/pool_config.go
@@ -116,8 +116,8 @@ func (c *PoolConfig) validate() error {
 	if c.PoolName == "" {
 		return &InvalidArgumentError{Field: "PoolName", Message: "pool name is required"}
 	}
-	if c.MaxIdle <= 0 {
-		return &InvalidArgumentError{Field: "MaxIdle", Message: "must be positive"}
+	if c.MaxIdle < 0 {
+		return &InvalidArgumentError{Field: "MaxIdle", Message: "must be non-negative"}
 	}
 	if c.CreationSpec.Image == "" {
 		return &InvalidArgumentError{Field: "CreationSpec.Image", Message: "image is required"}

--- a/sdks/sandbox/go/pool_config.go
+++ b/sdks/sandbox/go/pool_config.go
@@ -26,6 +26,7 @@ type PoolState int
 const (
 	PoolStateCreated  PoolState = iota
 	PoolStateRunning
+	PoolStateDegraded
 	PoolStateDraining
 	PoolStateStopped
 )
@@ -36,6 +37,8 @@ func (s PoolState) String() string {
 		return "CREATED"
 	case PoolStateRunning:
 		return "RUNNING"
+	case PoolStateDegraded:
+		return "DEGRADED"
 	case PoolStateDraining:
 		return "DRAINING"
 	case PoolStateStopped:
@@ -181,6 +184,7 @@ type PoolCreationSpec struct {
 	NetworkPolicy  *NetworkPolicy
 	Volumes        []Volume
 	Extensions     map[string]string
+	ImageAuth      *ImageAuth
 }
 
 // PoolSnapshot contains a point-in-time view of pool state.

--- a/sdks/sandbox/go/pool_errors.go
+++ b/sdks/sandbox/go/pool_errors.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import "fmt"
+
+// PoolEmptyError is returned when Acquire is called with FailFast policy
+// and no idle sandbox is available.
+type PoolEmptyError struct {
+	PoolName string
+}
+
+func (e *PoolEmptyError) Error() string {
+	return fmt.Sprintf("pool %q has no idle sandboxes available", e.PoolName)
+}
+
+// PoolAcquireFailedError is returned when an idle sandbox was found but
+// could not be connected or failed health check.
+type PoolAcquireFailedError struct {
+	PoolName  string
+	SandboxID string
+	Err       error
+}
+
+func (e *PoolAcquireFailedError) Error() string {
+	return fmt.Sprintf("pool %q: failed to acquire sandbox %s: %v", e.PoolName, e.SandboxID, e.Err)
+}
+
+func (e *PoolAcquireFailedError) Unwrap() error { return e.Err }
+
+// PoolNotRunningError is returned when an operation is attempted on a pool
+// that is not in RUNNING state.
+type PoolNotRunningError struct {
+	PoolName string
+	State    PoolState
+}
+
+func (e *PoolNotRunningError) Error() string {
+	return fmt.Sprintf("pool %q is not running (current state: %s)", e.PoolName, e.State)
+}

--- a/sdks/sandbox/go/pool_reconciler.go
+++ b/sdks/sandbox/go/pool_reconciler.go
@@ -49,9 +49,14 @@ func (r *reconcileState) recordFailure(errMsg string) {
 	r.lastError = errMsg
 	if r.failureCount >= r.threshold {
 		r.backoffAttempts++
-		backoff := time.Duration(1<<uint(r.backoffAttempts-1)) * 30 * time.Second
+		// Clamp shift to prevent overflow of time.Duration (max ~292 years)
+		shift := r.backoffAttempts - 1
+		if shift > 20 {
+			shift = 20
+		}
+		backoff := time.Duration(1<<uint(shift)) * 30 * time.Second
 		maxBackoff := 24 * time.Hour
-		if backoff > maxBackoff {
+		if backoff <= 0 || backoff > maxBackoff {
 			backoff = maxBackoff
 		}
 		r.backoffUntil = time.Now().Add(backoff)

--- a/sdks/sandbox/go/pool_reconciler.go
+++ b/sdks/sandbox/go/pool_reconciler.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"sync"
+	"time"
+)
+
+// reconcileState tracks consecutive warmup failures and backoff.
+type reconcileState struct {
+	mu              sync.Mutex
+	threshold       int
+	failureCount    int
+	lastError       string
+	backoffUntil    time.Time
+	backoffAttempts int
+}
+
+func newReconcileState(threshold int) *reconcileState {
+	return &reconcileState{threshold: threshold}
+}
+
+func (r *reconcileState) recordSuccess() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failureCount = 0
+	r.lastError = ""
+	r.backoffUntil = time.Time{}
+	r.backoffAttempts = 0
+}
+
+func (r *reconcileState) recordFailure(errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failureCount++
+	r.lastError = errMsg
+	if r.failureCount >= r.threshold {
+		r.backoffAttempts++
+		backoff := time.Duration(1<<uint(r.backoffAttempts-1)) * 30 * time.Second
+		maxBackoff := 24 * time.Hour
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		r.backoffUntil = time.Now().Add(backoff)
+	}
+}
+
+func (r *reconcileState) isBackoffActive() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.backoffUntil.IsZero() {
+		return false
+	}
+	return time.Now().Before(r.backoffUntil)
+}
+
+func (r *reconcileState) isDegraded() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failureCount >= r.threshold
+}
+
+func (r *reconcileState) snapshot() (failureCount int, lastError string, backoffActive bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failureCount, r.lastError, !r.backoffUntil.IsZero() && time.Now().Before(r.backoffUntil)
+}

--- a/sdks/sandbox/go/pool_state_store.go
+++ b/sdks/sandbox/go/pool_state_store.go
@@ -136,7 +136,14 @@ func (s *InMemoryPoolStateStore) ReapExpired(_ context.Context, poolName string,
 func (s *InMemoryPoolStateStore) CountIdle(_ context.Context, poolName string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.idle[poolName]), nil
+	now := time.Now()
+	count := 0
+	for _, e := range s.idle[poolName] {
+		if now.Before(e.ExpiresAt) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (s *InMemoryPoolStateStore) TryAcquireLock(_ context.Context, poolName, ownerID string, ttl time.Duration) (bool, error) {

--- a/sdks/sandbox/go/pool_state_store.go
+++ b/sdks/sandbox/go/pool_state_store.go
@@ -75,20 +75,22 @@ func (s *InMemoryPoolStateStore) TryTakeIdle(_ context.Context, poolName string)
 	defer s.mu.Unlock()
 
 	entries := s.idle[poolName]
-	if len(entries) == 0 {
-		return "", false, nil
+	now := time.Now()
+
+	// Scan past expired entries to find a valid one
+	for len(entries) > 0 {
+		entry := entries[0]
+		entries = entries[1:]
+
+		if now.Before(entry.ExpiresAt) {
+			s.idle[poolName] = entries
+			return entry.SandboxID, true, nil
+		}
+		// Entry expired, skip and continue
 	}
 
-	// Take from the front (FIFO)
-	entry := entries[0]
-	s.idle[poolName] = entries[1:]
-
-	// Skip expired entries
-	if time.Now().After(entry.ExpiresAt) {
-		return "", false, nil
-	}
-
-	return entry.SandboxID, true, nil
+	s.idle[poolName] = entries
+	return "", false, nil
 }
 
 func (s *InMemoryPoolStateStore) PutIdle(_ context.Context, poolName string, sandboxID string, expiresAt time.Time) error {

--- a/sdks/sandbox/go/pool_state_store.go
+++ b/sdks/sandbox/go/pool_state_store.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// PoolStateStore defines the interface for managing pool idle sandbox state.
+// Implementations must be safe for concurrent use.
+type PoolStateStore interface {
+	// TryTakeIdle atomically removes and returns one idle sandbox ID.
+	// Returns ("", false, nil) if no idle sandbox is available.
+	TryTakeIdle(ctx context.Context, poolName string) (sandboxID string, ok bool, err error)
+	// PutIdle adds a sandbox to the idle set with an expiration time.
+	PutIdle(ctx context.Context, poolName string, sandboxID string, expiresAt time.Time) error
+	// RemoveIdle removes a specific sandbox from the idle set.
+	RemoveIdle(ctx context.Context, poolName string, sandboxID string) error
+	// ReapExpired removes all idle entries whose expiresAt is before now.
+	ReapExpired(ctx context.Context, poolName string, now time.Time) error
+	// CountIdle returns the number of idle sandboxes.
+	CountIdle(ctx context.Context, poolName string) (int, error)
+
+	// TryAcquireLock attempts to acquire the primary reconciler lock.
+	TryAcquireLock(ctx context.Context, poolName, ownerID string, ttl time.Duration) (bool, error)
+	// RenewLock extends the TTL of an existing lock held by ownerID.
+	RenewLock(ctx context.Context, poolName, ownerID string, ttl time.Duration) (bool, error)
+	// ReleaseLock releases the primary lock if held by ownerID.
+	ReleaseLock(ctx context.Context, poolName, ownerID string) error
+}
+
+// idleEntry represents a sandbox in the idle set.
+type idleEntry struct {
+	SandboxID string
+	ExpiresAt time.Time
+}
+
+// lockEntry represents the primary leader lock.
+type lockEntry struct {
+	OwnerID   string
+	ExpiresAt time.Time
+}
+
+// InMemoryPoolStateStore is a single-process in-memory implementation of PoolStateStore.
+type InMemoryPoolStateStore struct {
+	mu    sync.Mutex
+	idle  map[string][]idleEntry // poolName -> entries
+	locks map[string]*lockEntry  // poolName -> lock
+}
+
+// NewInMemoryPoolStateStore creates a new in-memory state store.
+func NewInMemoryPoolStateStore() *InMemoryPoolStateStore {
+	return &InMemoryPoolStateStore{
+		idle:  make(map[string][]idleEntry),
+		locks: make(map[string]*lockEntry),
+	}
+}
+
+func (s *InMemoryPoolStateStore) TryTakeIdle(_ context.Context, poolName string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries := s.idle[poolName]
+	if len(entries) == 0 {
+		return "", false, nil
+	}
+
+	// Take from the front (FIFO)
+	entry := entries[0]
+	s.idle[poolName] = entries[1:]
+
+	// Skip expired entries
+	if time.Now().After(entry.ExpiresAt) {
+		return "", false, nil
+	}
+
+	return entry.SandboxID, true, nil
+}
+
+func (s *InMemoryPoolStateStore) PutIdle(_ context.Context, poolName string, sandboxID string, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.idle[poolName] = append(s.idle[poolName], idleEntry{
+		SandboxID: sandboxID,
+		ExpiresAt: expiresAt,
+	})
+	return nil
+}
+
+func (s *InMemoryPoolStateStore) RemoveIdle(_ context.Context, poolName string, sandboxID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries := s.idle[poolName]
+	for i, e := range entries {
+		if e.SandboxID == sandboxID {
+			s.idle[poolName] = append(entries[:i], entries[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *InMemoryPoolStateStore) ReapExpired(_ context.Context, poolName string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries := s.idle[poolName]
+	kept := entries[:0]
+	for _, e := range entries {
+		if now.Before(e.ExpiresAt) {
+			kept = append(kept, e)
+		}
+	}
+	s.idle[poolName] = kept
+	return nil
+}
+
+func (s *InMemoryPoolStateStore) CountIdle(_ context.Context, poolName string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.idle[poolName]), nil
+}
+
+func (s *InMemoryPoolStateStore) TryAcquireLock(_ context.Context, poolName, ownerID string, ttl time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lock := s.locks[poolName]
+	now := time.Now()
+
+	// Lock is free or expired
+	if lock == nil || now.After(lock.ExpiresAt) {
+		s.locks[poolName] = &lockEntry{
+			OwnerID:   ownerID,
+			ExpiresAt: now.Add(ttl),
+		}
+		return true, nil
+	}
+
+	// Already held by this owner
+	if lock.OwnerID == ownerID {
+		lock.ExpiresAt = now.Add(ttl)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (s *InMemoryPoolStateStore) RenewLock(_ context.Context, poolName, ownerID string, ttl time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lock := s.locks[poolName]
+	if lock == nil || lock.OwnerID != ownerID {
+		return false, nil
+	}
+
+	lock.ExpiresAt = time.Now().Add(ttl)
+	return true, nil
+}
+
+func (s *InMemoryPoolStateStore) ReleaseLock(_ context.Context, poolName, ownerID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	lock := s.locks[poolName]
+	if lock != nil && lock.OwnerID == ownerID {
+		delete(s.locks, poolName)
+	}
+	return nil
+}

--- a/sdks/sandbox/go/pool_test.go
+++ b/sdks/sandbox/go/pool_test.go
@@ -32,9 +32,14 @@ func TestNewSandboxPoolValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "missing max idle",
-			config:  PoolConfig{PoolName: "test", MaxIdle: 0, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
+			name:    "negative max idle",
+			config:  PoolConfig{PoolName: "test", MaxIdle: -1, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
 			wantErr: true,
+		},
+		{
+			name:    "zero max idle is valid (disable replenishment)",
+			config:  PoolConfig{PoolName: "test", MaxIdle: 0, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
+			wantErr: false,
 		},
 		{
 			name:    "missing image",
@@ -141,6 +146,27 @@ func TestInMemoryPoolStateStore(t *testing.T) {
 	count, _ = store.CountIdle(ctx, pool)
 	if count != 0 {
 		t.Errorf("CountIdle after remove = %d, want 0", count)
+	}
+}
+
+func TestInMemoryPoolStateStoreTryTakeSkipsExpired(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryPoolStateStore()
+	pool := "test-pool"
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	store.PutIdle(ctx, pool, "expired-1", past)
+	store.PutIdle(ctx, pool, "expired-2", past)
+	store.PutIdle(ctx, pool, "valid-1", future)
+
+	// Should skip expired entries and return the valid one
+	id, ok, err := store.TryTakeIdle(ctx, pool)
+	if err != nil {
+		t.Fatalf("TryTakeIdle error: %v", err)
+	}
+	if !ok || id != "valid-1" {
+		t.Errorf("TryTakeIdle = (%q, %v), want (valid-1, true)", id, ok)
 	}
 }
 

--- a/sdks/sandbox/go/pool_test.go
+++ b/sdks/sandbox/go/pool_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewSandboxPoolValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PoolConfig
+		wantErr bool
+	}{
+		{
+			name:    "missing pool name",
+			config:  PoolConfig{MaxIdle: 5, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
+			wantErr: true,
+		},
+		{
+			name:    "missing max idle",
+			config:  PoolConfig{PoolName: "test", MaxIdle: 0, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
+			wantErr: true,
+		},
+		{
+			name:    "missing image",
+			config:  PoolConfig{PoolName: "test", MaxIdle: 5, CreationSpec: PoolCreationSpec{}, StateStore: NewInMemoryPoolStateStore()},
+			wantErr: true,
+		},
+		{
+			name:    "missing state store",
+			config:  PoolConfig{PoolName: "test", MaxIdle: 5, CreationSpec: PoolCreationSpec{Image: "test"}},
+			wantErr: true,
+		},
+		{
+			name:    "valid config",
+			config:  PoolConfig{PoolName: "test", MaxIdle: 5, CreationSpec: PoolCreationSpec{Image: "test"}, StateStore: NewInMemoryPoolStateStore()},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := NewSandboxPool(tt.config)
+			err := pool.Start(context.Background())
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if err == nil {
+				pool.Shutdown(context.Background())
+			}
+		})
+	}
+}
+
+func TestPoolConfigDefaults(t *testing.T) {
+	config := PoolConfig{
+		PoolName:     "test",
+		MaxIdle:      10,
+		CreationSpec: PoolCreationSpec{Image: "test"},
+		StateStore:   NewInMemoryPoolStateStore(),
+	}
+	config.applyDefaults()
+
+	if config.WarmupConcurrency != 2 { // ceil(10 * 0.2) = 2
+		t.Errorf("WarmupConcurrency = %d, want 2", config.WarmupConcurrency)
+	}
+	if config.ReconcileInterval != DefaultReconcileInterval {
+		t.Errorf("ReconcileInterval = %v, want %v", config.ReconcileInterval, DefaultReconcileInterval)
+	}
+	if config.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", config.IdleTimeout, DefaultIdleTimeout)
+	}
+	if config.OwnerID == "" {
+		t.Error("OwnerID should be auto-generated")
+	}
+}
+
+func TestInMemoryPoolStateStore(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryPoolStateStore()
+	pool := "test-pool"
+
+	// Initially empty
+	_, ok, err := store.TryTakeIdle(ctx, pool)
+	if err != nil {
+		t.Fatalf("TryTakeIdle error: %v", err)
+	}
+	if ok {
+		t.Error("expected no idle sandbox")
+	}
+
+	// Put some idle
+	future := time.Now().Add(time.Hour)
+	if err := store.PutIdle(ctx, pool, "sb-1", future); err != nil {
+		t.Fatalf("PutIdle error: %v", err)
+	}
+	if err := store.PutIdle(ctx, pool, "sb-2", future); err != nil {
+		t.Fatalf("PutIdle error: %v", err)
+	}
+
+	// Count
+	count, err := store.CountIdle(ctx, pool)
+	if err != nil {
+		t.Fatalf("CountIdle error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("CountIdle = %d, want 2", count)
+	}
+
+	// Take (FIFO)
+	id, ok, err := store.TryTakeIdle(ctx, pool)
+	if err != nil {
+		t.Fatalf("TryTakeIdle error: %v", err)
+	}
+	if !ok || id != "sb-1" {
+		t.Errorf("TryTakeIdle = (%q, %v), want (sb-1, true)", id, ok)
+	}
+
+	// Remove specific
+	if err := store.RemoveIdle(ctx, pool, "sb-2"); err != nil {
+		t.Fatalf("RemoveIdle error: %v", err)
+	}
+	count, _ = store.CountIdle(ctx, pool)
+	if count != 0 {
+		t.Errorf("CountIdle after remove = %d, want 0", count)
+	}
+}
+
+func TestInMemoryPoolStateStoreReapExpired(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryPoolStateStore()
+	pool := "test-pool"
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	store.PutIdle(ctx, pool, "expired", past)
+	store.PutIdle(ctx, pool, "valid", future)
+
+	if err := store.ReapExpired(ctx, pool, time.Now()); err != nil {
+		t.Fatalf("ReapExpired error: %v", err)
+	}
+
+	count, _ := store.CountIdle(ctx, pool)
+	if count != 1 {
+		t.Errorf("CountIdle after reap = %d, want 1", count)
+	}
+
+	id, ok, _ := store.TryTakeIdle(ctx, pool)
+	if !ok || id != "valid" {
+		t.Errorf("remaining entry = (%q, %v), want (valid, true)", id, ok)
+	}
+}
+
+func TestInMemoryPoolStateStoreLock(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryPoolStateStore()
+	pool := "test-pool"
+
+	// Acquire lock
+	ok, err := store.TryAcquireLock(ctx, pool, "owner-1", time.Minute)
+	if err != nil || !ok {
+		t.Fatalf("TryAcquireLock = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	// Another owner cannot acquire
+	ok, err = store.TryAcquireLock(ctx, pool, "owner-2", time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquireLock error: %v", err)
+	}
+	if ok {
+		t.Error("owner-2 should not acquire lock held by owner-1")
+	}
+
+	// Same owner can renew
+	ok, _ = store.RenewLock(ctx, pool, "owner-1", time.Minute)
+	if !ok {
+		t.Error("owner-1 should be able to renew")
+	}
+
+	// Release
+	store.ReleaseLock(ctx, pool, "owner-1")
+
+	// Now owner-2 can acquire
+	ok, _ = store.TryAcquireLock(ctx, pool, "owner-2", time.Minute)
+	if !ok {
+		t.Error("owner-2 should acquire after release")
+	}
+}
+
+func TestReconcileState(t *testing.T) {
+	rs := newReconcileState(3)
+
+	// Not degraded initially
+	if rs.isDegraded() {
+		t.Error("should not be degraded initially")
+	}
+
+	// Record failures below threshold
+	rs.recordFailure("err1")
+	rs.recordFailure("err2")
+	if rs.isDegraded() {
+		t.Error("should not be degraded below threshold")
+	}
+
+	// Hit threshold
+	rs.recordFailure("err3")
+	if !rs.isDegraded() {
+		t.Error("should be degraded at threshold")
+	}
+	if !rs.isBackoffActive() {
+		t.Error("backoff should be active")
+	}
+
+	// Success resets
+	rs.recordSuccess()
+	if rs.isDegraded() {
+		t.Error("should not be degraded after success")
+	}
+	if rs.isBackoffActive() {
+		t.Error("backoff should not be active after success")
+	}
+}
+
+func TestPoolAcquireNotRunning(t *testing.T) {
+	pool := NewSandboxPool(PoolConfig{
+		PoolName:     "test",
+		MaxIdle:      5,
+		CreationSpec: PoolCreationSpec{Image: "test"},
+		StateStore:   NewInMemoryPoolStateStore(),
+	})
+
+	// Don't call Start
+	_, err := pool.Acquire(context.Background())
+	if err == nil {
+		t.Error("expected error acquiring from non-started pool")
+	}
+	if _, ok := err.(*PoolNotRunningError); !ok {
+		t.Errorf("expected PoolNotRunningError, got %T: %v", err, err)
+	}
+}
+
+func TestPoolSnapshot(t *testing.T) {
+	store := NewInMemoryPoolStateStore()
+	pool := NewSandboxPool(PoolConfig{
+		PoolName:     "test",
+		MaxIdle:      5,
+		CreationSpec: PoolCreationSpec{Image: "test"},
+		StateStore:   store,
+	})
+
+	snap := pool.Snapshot()
+	if snap.State != PoolStateCreated {
+		t.Errorf("State = %v, want CREATED", snap.State)
+	}
+	if snap.IdleCount != 0 {
+		t.Errorf("IdleCount = %d, want 0", snap.IdleCount)
+	}
+}
+
+func TestPoolAcquireFailFastEmpty(t *testing.T) {
+	store := NewInMemoryPoolStateStore()
+	config := PoolConfig{
+		PoolName:         "test",
+		MaxIdle:          5,
+		ConnectionConfig: ConnectionConfig{Domain: "localhost:9999", APIKey: "test"},
+		CreationSpec:     PoolCreationSpec{Image: "test:latest"},
+		StateStore:       store,
+		ReconcileInterval: time.Hour, // don't auto-reconcile during test
+	}
+	pool := NewSandboxPool(config)
+	ctx := context.Background()
+
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	defer pool.Shutdown(ctx)
+
+	// Pool is empty, FailFast should error
+	_, err := pool.Acquire(ctx, WithAcquirePolicy(FailFast))
+	if err == nil {
+		t.Fatal("expected PoolEmptyError")
+	}
+	if _, ok := err.(*PoolEmptyError); !ok {
+		t.Errorf("expected *PoolEmptyError, got %T: %v", err, err)
+	}
+}

--- a/tests/go/pool_e2e_test.go
+++ b/tests/go/pool_e2e_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	opensandbox "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPool_AcquireFromPreWarmedIdle(t *testing.T) {
+	if os.Getenv("RUN_POOL_E2E") != "true" {
+		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
+	}
+
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	store := opensandbox.NewInMemoryPoolStateStore()
+	pool := opensandbox.NewSandboxPool(opensandbox.PoolConfig{
+		PoolName:         "e2e-test-pool",
+		MaxIdle:          2,
+		ConnectionConfig: config,
+		CreationSpec: opensandbox.PoolCreationSpec{
+			Image:   getSandboxImage(),
+			Timeout: 300,
+			Env:     map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s"},
+		},
+		StateStore:        store,
+		ReconcileInterval: 5 * time.Second,
+		IdleTimeout:       5 * time.Minute,
+	})
+
+	// Start the pool and wait for warmup
+	err := pool.Start(ctx)
+	require.NoError(t, err)
+	defer pool.Shutdown(context.Background())
+
+	// Wait for reconciler to warm up at least 1 sandbox
+	var snap opensandbox.PoolSnapshot
+	for i := 0; i < 60; i++ {
+		snap = pool.Snapshot()
+		if snap.IdleCount > 0 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	require.Greater(t, snap.IdleCount, 0, "pool should have warmed up at least 1 sandbox")
+
+	// Acquire a sandbox from the pool
+	sb, err := pool.Acquire(ctx, opensandbox.WithSandboxTimeout(2*time.Minute))
+	require.NoError(t, err)
+	require.NotNil(t, sb)
+	defer sb.Kill(context.Background())
+
+	// Verify the sandbox is functional
+	assert.True(t, sb.IsHealthy(ctx))
+
+	// Run a command to confirm it works
+	exec, err := sb.RunCommand(ctx, "echo pool-test-ok", nil)
+	require.NoError(t, err)
+	require.NotNil(t, exec.ExitCode)
+	assert.Equal(t, 0, *exec.ExitCode)
+	assert.Contains(t, exec.Text(), "pool-test-ok")
+}
+
+func TestPool_AcquireFailFastWhenEmpty(t *testing.T) {
+	if os.Getenv("RUN_POOL_E2E") != "true" {
+		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
+	}
+
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	store := opensandbox.NewInMemoryPoolStateStore()
+	pool := opensandbox.NewSandboxPool(opensandbox.PoolConfig{
+		PoolName:         "e2e-failfast-pool",
+		MaxIdle:          0, // no warmup
+		ConnectionConfig: config,
+		CreationSpec: opensandbox.PoolCreationSpec{
+			Image:   getSandboxImage(),
+			Timeout: 300,
+		},
+		StateStore:        store,
+		ReconcileInterval: time.Hour, // don't auto-reconcile
+	})
+
+	err := pool.Start(ctx)
+	require.NoError(t, err)
+	defer pool.Shutdown(context.Background())
+
+	// FailFast should return error immediately when pool is empty
+	_, err = pool.Acquire(ctx, opensandbox.WithAcquirePolicy(opensandbox.FailFast))
+	require.Error(t, err)
+
+	var poolEmpty *opensandbox.PoolEmptyError
+	require.ErrorAs(t, err, &poolEmpty)
+}
+
+func TestPool_AcquireDirectCreateFallback(t *testing.T) {
+	if os.Getenv("RUN_POOL_E2E") != "true" {
+		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
+	}
+
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	store := opensandbox.NewInMemoryPoolStateStore()
+	pool := opensandbox.NewSandboxPool(opensandbox.PoolConfig{
+		PoolName:         "e2e-directcreate-pool",
+		MaxIdle:          0, // no warmup
+		ConnectionConfig: config,
+		CreationSpec: opensandbox.PoolCreationSpec{
+			Image:   getSandboxImage(),
+			Timeout: 300,
+			Env:     map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s"},
+		},
+		StateStore:        store,
+		ReconcileInterval: time.Hour,
+	})
+
+	err := pool.Start(ctx)
+	require.NoError(t, err)
+	defer pool.Shutdown(context.Background())
+
+	// DirectCreate (default) should create a new sandbox on-demand
+	sb, err := pool.Acquire(ctx, opensandbox.WithSandboxTimeout(2*time.Minute))
+	require.NoError(t, err)
+	require.NotNil(t, sb)
+	defer sb.Kill(context.Background())
+
+	assert.True(t, sb.IsHealthy(ctx))
+}
+
+func TestPool_ResizeAndSnapshot(t *testing.T) {
+	if os.Getenv("RUN_POOL_E2E") != "true" {
+		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
+	}
+
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	store := opensandbox.NewInMemoryPoolStateStore()
+	pool := opensandbox.NewSandboxPool(opensandbox.PoolConfig{
+		PoolName:         "e2e-resize-pool",
+		MaxIdle:          1,
+		ConnectionConfig: config,
+		CreationSpec: opensandbox.PoolCreationSpec{
+			Image:   getSandboxImage(),
+			Timeout: 300,
+			Env:     map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s"},
+		},
+		StateStore:        store,
+		ReconcileInterval: 5 * time.Second,
+		IdleTimeout:       5 * time.Minute,
+	})
+
+	err := pool.Start(ctx)
+	require.NoError(t, err)
+	defer pool.Shutdown(context.Background())
+
+	// Wait for initial warmup
+	for i := 0; i < 60; i++ {
+		if pool.Snapshot().IdleCount >= 1 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	snap := pool.Snapshot()
+	assert.Equal(t, opensandbox.PoolStateRunning, snap.State)
+	assert.GreaterOrEqual(t, snap.IdleCount, 1)
+
+	// Resize to 0 (disable replenishment)
+	err = pool.Resize(ctx, 0)
+	require.NoError(t, err)
+
+	// Release all idle
+	released, err := pool.ReleaseAllIdle(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, released, 1)
+
+	// Verify pool is empty after release
+	snap = pool.Snapshot()
+	assert.Equal(t, 0, snap.IdleCount)
+}
+
+func TestPool_GracefulShutdown(t *testing.T) {
+	if os.Getenv("RUN_POOL_E2E") != "true" {
+		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
+	}
+
+	config := getConnectionConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	store := opensandbox.NewInMemoryPoolStateStore()
+	pool := opensandbox.NewSandboxPool(opensandbox.PoolConfig{
+		PoolName:         "e2e-shutdown-pool",
+		MaxIdle:          1,
+		ConnectionConfig: config,
+		CreationSpec: opensandbox.PoolCreationSpec{
+			Image:   getSandboxImage(),
+			Timeout: 300,
+			Env:     map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s"},
+		},
+		StateStore:        store,
+		ReconcileInterval: 5 * time.Second,
+		IdleTimeout:       5 * time.Minute,
+		DrainTimeout:      10 * time.Second,
+	})
+
+	err := pool.Start(ctx)
+	require.NoError(t, err)
+
+	// Wait for warmup
+	for i := 0; i < 60; i++ {
+		if pool.Snapshot().IdleCount >= 1 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	// Shutdown should clean up idle sandboxes
+	err = pool.Shutdown(ctx)
+	require.NoError(t, err)
+
+	snap := pool.Snapshot()
+	assert.Equal(t, opensandbox.PoolStateStopped, snap.State)
+	assert.Equal(t, 0, snap.IdleCount)
+
+	// Acquire after shutdown should fail
+	_, err = pool.Acquire(ctx)
+	require.Error(t, err)
+	var notRunning *opensandbox.PoolNotRunningError
+	require.ErrorAs(t, err, &notRunning)
+}

--- a/tests/go/pool_e2e_test.go
+++ b/tests/go/pool_e2e_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -26,9 +25,6 @@ import (
 )
 
 func TestPool_AcquireFromPreWarmedIdle(t *testing.T) {
-	if os.Getenv("RUN_POOL_E2E") != "true" {
-		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
-	}
 
 	config := getConnectionConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -83,9 +79,6 @@ func TestPool_AcquireFromPreWarmedIdle(t *testing.T) {
 }
 
 func TestPool_AcquireFailFastWhenEmpty(t *testing.T) {
-	if os.Getenv("RUN_POOL_E2E") != "true" {
-		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
-	}
 
 	config := getConnectionConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -117,9 +110,6 @@ func TestPool_AcquireFailFastWhenEmpty(t *testing.T) {
 }
 
 func TestPool_AcquireDirectCreateFallback(t *testing.T) {
-	if os.Getenv("RUN_POOL_E2E") != "true" {
-		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
-	}
 
 	config := getConnectionConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -153,9 +143,6 @@ func TestPool_AcquireDirectCreateFallback(t *testing.T) {
 }
 
 func TestPool_ResizeAndSnapshot(t *testing.T) {
-	if os.Getenv("RUN_POOL_E2E") != "true" {
-		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
-	}
 
 	config := getConnectionConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -207,9 +194,6 @@ func TestPool_ResizeAndSnapshot(t *testing.T) {
 }
 
 func TestPool_GracefulShutdown(t *testing.T) {
-	if os.Getenv("RUN_POOL_E2E") != "true" {
-		t.Skip("Set RUN_POOL_E2E=true to run pool e2e tests")
-	}
 
 	config := getConnectionConfig(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
Implement OSEP-0005 client-side pool for the Go SDK, enabling millisecond-level sandbox acquisition through pre-warmed idle instances.

Features:
- Configurable pool size with automatic reconciliation
- Acquire with DirectCreate/FailFast policies
- Health checking and stale instance recycling
- Exponential backoff on consecutive warmup failures
- InMemoryPoolStateStore for single-process deployments
- Graceful shutdown with drain timeout
- Resize, ReleaseAllIdle, Snapshot operations

Closes #1166

## Summary
- Implement OSEP-0005 client-side sandbox pool for the Go SDK
- Enable millisecond-level sandbox acquisition through pre-warmed idle instances
- Add InMemoryPoolStateStore for single-process deployments

## Features
- `SandboxPool` with Start/Acquire/Resize/Shutdown/Snapshot/ReleaseAllIdle
- `AcquirePolicy`: DirectCreate (default) and FailFast
- Background reconciliation with leader election and exponential backoff
- Health checking and stale instance recycling
- Graceful shutdown with configurable drain timeout

## Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

## Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

## Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

Closes #1166

