### PR TITLE
server: fail fast for missing poolRef pools

### DIFF
--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -36,6 +36,7 @@ OPENSANDBOX_API_GROUP = "sandbox.opensandbox.io"
 OPENSANDBOX_API_VERSION = "v1alpha1"
 POOL_KIND = "Pool"
 POOL_PLURAL = "pools"
+POOL_AUTO_ASSIGN_REF = "*"
 
 _InformerKey = Tuple[str, str, str, str]  # (group, version, plural, namespace)
 

--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -32,6 +32,11 @@ from opensandbox_server.services.k8s.rate_limiter import TokenBucketRateLimiter
 
 logger = logging.getLogger(__name__)
 
+OPENSANDBOX_API_GROUP = "sandbox.opensandbox.io"
+OPENSANDBOX_API_VERSION = "v1alpha1"
+POOL_KIND = "Pool"
+POOL_PLURAL = "pools"
+
 _InformerKey = Tuple[str, str, str, str]  # (group, version, plural, namespace)
 
 

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -322,10 +322,8 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 plural=POOL_PLURAL,
                 name=pool_ref,
             )
-        except HTTPException:
-            raise
         except Exception as e:
-            logger.error(f"Failed to validate poolRef {pool_ref}: {e}")
+            logger.exception("Failed to validate poolRef %s", pool_ref)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail={

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -93,6 +93,7 @@ from opensandbox_server.services.k8s.client import (
     K8sClient,
     OPENSANDBOX_API_GROUP,
     OPENSANDBOX_API_VERSION,
+    POOL_AUTO_ASSIGN_REF,
     POOL_PLURAL,
 )
 from opensandbox_server.services.k8s.provider_factory import create_workload_provider
@@ -738,7 +739,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     },
                 )
 
-            if has_pool_ref:
+            if has_pool_ref and pool_ref != POOL_AUTO_ASSIGN_REF:
                 await asyncio.to_thread(self._ensure_pool_ref_exists, pool_ref)
 
             # Auto-create PVCs that don't exist yet

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -89,7 +89,12 @@ from opensandbox_server.services.validators import (
     ensure_timeout_within_limit,
     ensure_volumes_valid,
 )
-from opensandbox_server.services.k8s.client import K8sClient
+from opensandbox_server.services.k8s.client import (
+    K8sClient,
+    OPENSANDBOX_API_GROUP,
+    OPENSANDBOX_API_VERSION,
+    POOL_PLURAL,
+)
 from opensandbox_server.services.k8s.provider_factory import create_workload_provider
 from opensandbox_server.services.snapshot_restore import resolve_sandbox_image_from_request
 
@@ -306,6 +311,37 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 ),
             },
         )
+
+    def _ensure_pool_ref_exists(self, pool_ref: str) -> None:
+        """Validate that the referenced Pool exists before creating a BatchSandbox."""
+        try:
+            pool = self.k8s_client.get_custom_object(
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
+                namespace=self.namespace,
+                plural=POOL_PLURAL,
+                name=pool_ref,
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to validate poolRef {pool_ref}: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "code": SandboxErrorCodes.K8S_POOL_API_ERROR,
+                    "message": f"Failed to validate pool '{pool_ref}': {str(e)}",
+                },
+            ) from e
+
+        if pool is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "code": SandboxErrorCodes.K8S_POOL_NOT_FOUND,
+                    "message": f"Pool '{pool_ref}' not found.",
+                },
+            )
 
     def _ensure_pvc_volumes(self, volumes: list, sandbox_id: str) -> list[str]:
         """
@@ -633,7 +669,8 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         Raises:
             HTTPException: If creation fails, timeout, or invalid parameters
         """
-        has_pool_ref = bool((request.extensions or {}).get("poolRef", "").strip())
+        pool_ref = (request.extensions or {}).get("poolRef", "").strip()
+        has_pool_ref = bool(pool_ref)
 
         if not has_pool_ref:
             request = resolve_sandbox_image_from_request(request)
@@ -702,6 +739,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                         ),
                     },
                 )
+
+            if has_pool_ref:
+                await asyncio.to_thread(self._ensure_pool_ref_exists, pool_ref)
 
             # Auto-create PVCs that don't exist yet
             if request.volumes:

--- a/server/opensandbox_server/services/k8s/pool_service.py
+++ b/server/opensandbox_server/services/k8s/pool_service.py
@@ -29,13 +29,15 @@ from opensandbox_server.api.schema import (
     UpdatePoolRequest,
 )
 from opensandbox_server.services.constants import SandboxErrorCodes
-from opensandbox_server.services.k8s.client import K8sClient
+from opensandbox_server.services.k8s.client import (
+    K8sClient,
+    OPENSANDBOX_API_GROUP,
+    OPENSANDBOX_API_VERSION,
+    POOL_KIND,
+    POOL_PLURAL,
+)
 
 logger = logging.getLogger(__name__)
-
-_GROUP = "sandbox.opensandbox.io"
-_VERSION = "v1alpha1"
-_PLURAL = "pools"
 
 
 class PoolService:
@@ -55,8 +57,8 @@ class PoolService:
     ) -> Dict[str, Any]:
         """Build a Pool CRD manifest dict."""
         return {
-            "apiVersion": f"{_GROUP}/{_VERSION}",
-            "kind": "Pool",
+            "apiVersion": f"{OPENSANDBOX_API_GROUP}/{OPENSANDBOX_API_VERSION}",
+            "kind": POOL_KIND,
             "metadata": {
                 "name": name,
                 "namespace": namespace,
@@ -113,10 +115,10 @@ class PoolService:
 
         try:
             created = self._custom_api.create_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
                 namespace=self._namespace,
-                plural=_PLURAL,
+                plural=POOL_PLURAL,
                 body=manifest,
             )
             logger.info(f"Created pool: name={request.name}, namespace={self._namespace}")
@@ -153,10 +155,10 @@ class PoolService:
         """Retrieve a Pool by name."""
         try:
             raw = self._custom_api.get_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
                 namespace=self._namespace,
-                plural=_PLURAL,
+                plural=POOL_PLURAL,
                 name=pool_name,
             )
             return self._pool_from_raw(raw)
@@ -194,10 +196,10 @@ class PoolService:
         """List all Pools in the configured namespace."""
         try:
             result = self._custom_api.list_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
                 namespace=self._namespace,
-                plural=_PLURAL,
+                plural=POOL_PLURAL,
             )
             items: List[PoolResponse] = [
                 self._pool_from_raw(item) for item in result.get("items", [])
@@ -242,10 +244,10 @@ class PoolService:
 
         try:
             updated = self._custom_api.patch_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
                 namespace=self._namespace,
-                plural=_PLURAL,
+                plural=POOL_PLURAL,
                 name=pool_name,
                 body=patch_body,
             )
@@ -285,10 +287,10 @@ class PoolService:
         """Delete a Pool resource."""
         try:
             self._custom_api.delete_namespaced_custom_object(
-                group=_GROUP,
-                version=_VERSION,
+                group=OPENSANDBOX_API_GROUP,
+                version=OPENSANDBOX_API_VERSION,
                 namespace=self._namespace,
-                plural=_PLURAL,
+                plural=POOL_PLURAL,
                 name=pool_name,
                 grace_period_seconds=0,
             )

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -698,6 +698,38 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.delete_workload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_create_sandbox_pool_mode_auto_assign_skips_pool_lookup(
+        self, k8s_service, mock_workload
+    ):
+        """Pool auto-assignment uses '*' and must be handled by the controller."""
+        from opensandbox_server.api.schema import CreateSandboxRequest
+
+        pool_request = CreateSandboxRequest(
+            extensions={"poolRef": "*"},
+        )
+
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-pool-auto",
+            "uid": "pool-auto-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Pod is running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+        k8s_service.workload_provider.get_endpoint_info.return_value = "10.244.0.5:8080"
+        k8s_service.workload_provider.get_expiration.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        response = await k8s_service.create_sandbox(pool_request)
+
+        assert response.id is not None
+        k8s_service.k8s_client.get_custom_object.assert_not_called()
+        k8s_service.workload_provider.create_workload.assert_called_once()
+        assert k8s_service.workload_provider.create_workload.call_args.kwargs["extensions"] == {"poolRef": "*"}
+
+    @pytest.mark.asyncio
     async def test_create_sandbox_pool_mode_skips_image_and_entrypoint_validation(
         self, k8s_service, mock_workload
     ):

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -668,6 +668,36 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.create_workload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_create_sandbox_pool_mode_missing_pool_fails_fast(
+        self, k8s_service
+    ):
+        """Pool mode validates poolRef before creating the BatchSandbox."""
+        from opensandbox_server.api.schema import CreateSandboxRequest
+
+        pool_request = CreateSandboxRequest(
+            extensions={"poolRef": "does-not-exist-pool"},
+        )
+        k8s_service.k8s_client.get_custom_object.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await k8s_service.create_sandbox(pool_request)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == {
+            "code": SandboxErrorCodes.K8S_POOL_NOT_FOUND,
+            "message": "Pool 'does-not-exist-pool' not found.",
+        }
+        k8s_service.k8s_client.get_custom_object.assert_called_once_with(
+            group="sandbox.opensandbox.io",
+            version="v1alpha1",
+            namespace=k8s_service.namespace,
+            plural="pools",
+            name="does-not-exist-pool",
+        )
+        k8s_service.workload_provider.create_workload.assert_not_called()
+        k8s_service.workload_provider.delete_workload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_create_sandbox_pool_mode_skips_image_and_entrypoint_validation(
         self, k8s_service, mock_workload
     ):


### PR DESCRIPTION
## Summary
- validate extensions.poolRef against the Pool CRD before creating a BatchSandbox
- return KUBERNETES::POOL_NOT_FOUND when the referenced Pool is absent
- centralize Pool GVK constants in the Kubernetes client module

## Testing
- cd server && venv/bin/python -m pytest tests/k8s/test_kubernetes_service.py::TestKubernetesSandboxServiceCreate::test_create_sandbox_pool_mode_missing_pool_fails_fast tests/k8s/test_kubernetes_service.py::TestKubernetesSandboxServiceCreate::test_create_sandbox_pool_mode_skips_image_and_entrypoint_validation tests/k8s/test_kubernetes_service.py::TestKubernetesSandboxServiceCreate::test_create_sandbox_pool_mode_image_auth_guard_no_error
- cd server && venv/bin/ruff check opensandbox_server/services/k8s/client.py opensandbox_server/services/k8s/kubernetes_service.py opensandbox_server/services/k8s/pool_service.py tests/k8s/test_kubernetes_service.py

Fixes #1175