### PR TITLE
fix(k8s): fail fast on missing poolRef

### DIFF
--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -91,6 +91,7 @@ from opensandbox_server.services.validators import (
 )
 from opensandbox_server.services.k8s.client import K8sClient
 from opensandbox_server.services.k8s.provider_factory import create_workload_provider
+from opensandbox_server.services.k8s.pool_service import PoolService
 from opensandbox_server.services.snapshot_restore import resolve_sandbox_image_from_request
 
 logger = logging.getLogger(__name__)
@@ -633,7 +634,11 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         Raises:
             HTTPException: If creation fails, timeout, or invalid parameters
         """
-        has_pool_ref = bool((request.extensions or {}).get("poolRef", "").strip())
+        pool_ref = (request.extensions or {}).get("poolRef", "").strip()
+        has_pool_ref = bool(pool_ref)
+
+        if has_pool_ref:
+            PoolService(self.k8s_client, self.namespace).get_pool(pool_ref)
 
         if not has_pool_ref:
             request = resolve_sandbox_image_from_request(request)

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -668,6 +668,34 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.create_workload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_create_sandbox_pool_mode_fails_fast_when_pool_is_missing(
+        self, k8s_service
+    ):
+        from opensandbox_server.api.schema import CreateSandboxRequest
+
+        pool_request = CreateSandboxRequest(
+            extensions={"poolRef": "does-not-exist-pool"},
+        )
+
+        with patch(
+            "opensandbox_server.services.k8s.kubernetes_service.PoolService.get_pool",
+            side_effect=HTTPException(
+                status_code=404,
+                detail={
+                    "code": SandboxErrorCodes.K8S_POOL_NOT_FOUND,
+                    "message": "Pool 'does-not-exist-pool' not found.",
+                },
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await k8s_service.create_sandbox(pool_request)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["code"] == SandboxErrorCodes.K8S_POOL_NOT_FOUND
+        assert "does-not-exist-pool" in exc_info.value.detail["message"]
+        k8s_service.workload_provider.create_workload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_create_sandbox_pool_mode_skips_image_and_entrypoint_validation(
         self, k8s_service, mock_workload
     ):
@@ -692,7 +720,11 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.get_endpoint_info.return_value = "10.244.0.5:8080"
         k8s_service.workload_provider.get_expiration.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        response = await k8s_service.create_sandbox(pool_request)
+        with patch(
+            "opensandbox_server.services.k8s.kubernetes_service.PoolService.get_pool",
+            return_value=MagicMock(),
+        ):
+            response = await k8s_service.create_sandbox(pool_request)
 
         assert response.id is not None
         assert response.status.state == "Running"
@@ -724,8 +756,12 @@ class TestKubernetesSandboxServiceCreate:
         k8s_service.workload_provider.get_endpoint_info.return_value = "10.244.0.6:8080"
         k8s_service.workload_provider.get_expiration.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        # Should not raise AttributeError on None.auth
-        response = await k8s_service.create_sandbox(pool_request)
+        with patch(
+            "opensandbox_server.services.k8s.kubernetes_service.PoolService.get_pool",
+            return_value=MagicMock(),
+        ):
+            # Should not raise AttributeError on None.auth
+            response = await k8s_service.create_sandbox(pool_request)
         assert response.id is not None
 
 class TestWaitForSandboxReady:


### PR DESCRIPTION
## Summary
- validate `extensions.poolRef` before entering Kubernetes pool-mode sandbox creation
- reuse the existing pool not-found error instead of creating a pending `BatchSandbox`
- add focused regression coverage for missing-pool fail-fast behavior

Closes #1175

## Testing
- `cd server && uv run pytest tests/k8s/test_kubernetes_service.py -q -k 'test_create_sandbox_pool_mode_fails_fast_when_pool_is_missing or test_create_sandbox_pool_mode_skips_image_and_entrypoint_validation or test_create_sandbox_pool_mode_image_auth_guard_no_error'`
