### PR TITLE
refactor(server): remove unused PendingSandbox mechanism and fix spec

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -74,7 +74,6 @@ Once the server is running, interactive API docs are available at:
 |----------|-------------|
 | `SANDBOX_CONFIG_PATH` | Override the config file path |
 | `DOCKER_HOST` | Custom Docker daemon address |
-| `PENDING_FAILURE_TTL` | TTL for sandboxes stuck in Pending state |
 | `OPENSANDBOX_INSECURE_SERVER` | Set to `YES` to run without API key in non-interactive mode |
 
 ## Related

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -103,19 +103,16 @@ export interface paths {
             };
             responses: {
                 /**
-                 * @description Sandbox created and accepted for provisioning.
+                 * @description Sandbox created and provisioned successfully.
                  *
                  *     The returned sandbox includes:
                  *     - `id`: Unique sandbox identifier
-                 *     - `status.state: "Pending"` (auto-starting provisioning or restore)
-                 *     - `status.reason` and `status.message` indicating initialization stage
+                 *     - `status.state: "Running"` (provisioning completed synchronously)
+                 *     - `status.reason` and `status.message` indicating current state
                  *     - `metadata`, `expiresAt`, `createdAt`: Core sandbox information
                  *
                  *     Note: startup source details and `updatedAt` are not included in the create response.
                  *     Use GET /sandboxes/{sandboxId} to retrieve the complete sandbox information.
-                 *
-                 *     To track provisioning progress, poll GET /sandboxes/{sandboxId}.
-                 *     The sandbox will automatically transition to `Running` state once provisioning or restore completes.
                  */
                 202: {
                     headers: {
@@ -1253,14 +1250,18 @@ export interface components {
         };
         /**
          * @description Credential Vault proxy startup settings. This is an explicit opt-in for
-         *     transparent MITM support used by credential injection; plain egress
-         *     network policy remains DNS/FQDN policy enforcement only.
+         *     transparent MITM support used by credential injection. Credential Vault
+         *     requires `dns+nft` enforcement and a network policy. A deny-default policy
+         *     is strongly recommended; default-allow remains temporarily supported for
+         *     backward compatibility and emits a security warning.
          */
         CredentialProxyConfig: {
             /**
              * @description When true, the server starts the egress sidecar with transparent
              *     MITM enabled and installs the runtime-managed MITM CA bundle into
-             *     the sandbox container. Requires `networkPolicy`.
+             *     the sandbox container. Requires `networkPolicy` and server
+             *     `[egress].mode = "dns+nft"`. `defaultAction: deny` is strongly
+             *     recommended; default-allow support is deprecated.
              * @default false
              */
             enabled: boolean;

--- a/sdks/sandbox/python/src/opensandbox/api/egress/api/credential_vault/post_credential_vault.py
+++ b/sdks/sandbox/python/src/opensandbox/api/egress/api/credential_vault/post_credential_vault.py
@@ -95,7 +95,9 @@ def sync_detailed(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -128,7 +130,9 @@ def sync(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -156,7 +160,9 @@ async def asyncio_detailed(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -187,7 +193,9 @@ async def asyncio(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
@@ -130,8 +130,10 @@ class CreateSandboxRequest:
                 object or null results in allow-all behavior at startup.
             credential_proxy (CredentialProxyConfig | Unset): Credential Vault proxy startup settings. This is an explicit
                 opt-in for
-                transparent MITM support used by credential injection; plain egress
-                network policy remains DNS/FQDN policy enforcement only.
+                transparent MITM support used by credential injection. Credential Vault
+                requires `dns+nft` enforcement and a network policy. A deny-default policy
+                is strongly recommended; default-allow remains temporarily supported for
+                backward compatibility and emits a security warning.
             secure_access (bool | Unset): Opts the sandbox into secured access for endpoint access.
                 This is currently supported only for Kubernetes sandboxes exposed
                 through ingress gateway mode. When enabled, the server provisions

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
@@ -29,13 +29,17 @@ T = TypeVar("T", bound="CredentialProxyConfig")
 @_attrs_define
 class CredentialProxyConfig:
     """Credential Vault proxy startup settings. This is an explicit opt-in for
-    transparent MITM support used by credential injection; plain egress
-    network policy remains DNS/FQDN policy enforcement only.
+    transparent MITM support used by credential injection. Credential Vault
+    requires `dns+nft` enforcement and a network policy. A deny-default policy
+    is strongly recommended; default-allow remains temporarily supported for
+    backward compatibility and emits a security warning.
 
         Attributes:
             enabled (bool | Unset): When true, the server starts the egress sidecar with transparent
                 MITM enabled and installs the runtime-managed MITM CA bundle into
-                the sandbox container. Requires `networkPolicy`.
+                the sandbox container. Requires `networkPolicy` and server
+                `[egress].mode = "dns+nft"`. `defaultAction: deny` is strongly
+                recommended; default-allow support is deprecated.
                  Default: False.
     """
 

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -304,7 +304,6 @@ These are read by the server or runtime code in addition to the TOML file:
 | `SANDBOX_CONFIG_PATH` | `config.py`, CLI | Path to the TOML file. Overrides the default `~/.sandbox.toml` when set. |
 | `OPENSANDBOX_SERVER_API_KEY` | `config.py` | Overrides the API key from the TOML file. |
 | `DOCKER_HOST` | Docker service | Standard Docker daemon address (e.g. `unix:///var/run/docker.sock`). |
-| `PENDING_FAILURE_TTL` | Docker service | Seconds to retain **failed Pending** sandboxes before cleanup; default **`3600`**. |
 
 ---
 

--- a/server/opensandbox_server/services/docker/__init__.py
+++ b/server/opensandbox_server/services/docker/__init__.py
@@ -14,7 +14,6 @@
 
 from opensandbox_server.services.docker.docker_service import (
     DockerSandboxService,
-    PendingSandbox,
 )
 
-__all__ = ["DockerSandboxService", "PendingSandbox"]
+__all__ = ["DockerSandboxService"]

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -29,7 +29,6 @@ import math
 import os
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from threading import Lock, Thread, Timer
 from typing import Any, Dict, Optional
@@ -44,7 +43,6 @@ from opensandbox_server.extensions import (
     ISOLATION_UPPER_MOUNT_PATH,
     extract_extensions_from_mapping,
 )
-from opensandbox_server.extensions.keys import EXTENSIONS_ANNOTATION_PREFIX
 from opensandbox_server.api.schema import (
     CreateSandboxRequest,
     CreateSandboxResponse,
@@ -124,17 +122,6 @@ from opensandbox_server.services.validators import (
 )
 logger = logging.getLogger(__name__)
 
-PENDING_FAILURE_TTL_SECONDS = int(os.environ.get("PENDING_FAILURE_TTL", "3600"))
-
-
-@dataclass
-class PendingSandbox:
-    request: CreateSandboxRequest
-    created_at: datetime
-    expires_at: Optional[datetime]
-    status: SandboxStatus
-
-
 class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVolumesMixin, DockerNetworkingMixin, DockerContainerOpsMixin, OSSFSMixin, SandboxService, ExtensionService):
     """
     Docker-based implementation of SandboxService.
@@ -212,9 +199,6 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self._bootstrap_script_lock = Lock()
         self._sandbox_expirations: Dict[str, datetime] = {}
         self._expiration_timers: Dict[str, Timer] = {}
-        self._pending_sandboxes: Dict[str, PendingSandbox] = {}
-        self._pending_lock = Lock()
-        self._pending_cleanup_timers: Dict[str, Timer] = {}
         self._ossfs_mount_lock = Lock()
         self._ossfs_mount_ref_counts: Dict[str, int] = {}
         self._restore_existing_sandboxes()
@@ -689,128 +673,6 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                 },
             ) from e
 
-    def _async_provision_worker(
-        self,
-        sandbox_id: str,
-        request: CreateSandboxRequest,
-        created_at: datetime,
-        expires_at: Optional[datetime],
-        pvc_inspect_cache: Optional[dict[str, dict]] = None,
-    ) -> None:
-        try:
-            self._provision_sandbox(sandbox_id, request, created_at, expires_at, pvc_inspect_cache)
-        except HTTPException as exc:
-            message = exc.detail.get("message") if isinstance(exc.detail, dict) else str(exc)
-            self._mark_pending_failed(sandbox_id, message or "Sandbox provisioning failed.")
-            self._cleanup_failed_containers(sandbox_id)
-            self._schedule_pending_cleanup(sandbox_id)
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Unexpected error provisioning sandbox %s: %s", sandbox_id, exc)
-            self._mark_pending_failed(sandbox_id, str(exc))
-            self._cleanup_failed_containers(sandbox_id)
-            self._schedule_pending_cleanup(sandbox_id)
-        else:
-            self._remove_pending_sandbox(sandbox_id)
-
-    def _mark_pending_failed(self, sandbox_id: str, message: str) -> None:
-        with self._pending_lock:
-            pending = self._pending_sandboxes.get(sandbox_id)
-            if not pending:
-                return
-            pending.status = SandboxStatus(
-                state="Failed",
-                reason="PROVISIONING_ERROR",
-                message=message,
-                last_transition_at=datetime.now(timezone.utc),
-            )
-
-    def _cleanup_failed_containers(self, sandbox_id: str) -> None:
-        """
-        Best-effort cleanup for containers left behind after a failed provision.
-        """
-        label_selector = f"{SANDBOX_ID_LABEL}={sandbox_id}"
-        try:
-            containers = self.docker_client.containers.list(
-                all=True, filters={"label": label_selector}
-            )
-        except DockerException as exc:
-            logger.warning("sandbox=%s | cleanup listing failed containers: %s", sandbox_id, exc)
-            self._cleanup_egress_sidecar(sandbox_id)
-            return
-
-        for container in containers:
-            labels = container.attrs.get("Config", {}).get("Labels") or {}
-            mount_keys_raw = labels.get(SANDBOX_OSSFS_MOUNTS_LABEL, "[]")
-            try:
-                mount_keys: list[str] = json.loads(mount_keys_raw)
-            except (TypeError, json.JSONDecodeError):
-                mount_keys = []
-            try:
-                with self._docker_operation("cleanup failed sandbox container", sandbox_id):
-                    container.remove(force=True)
-            except DockerException as exc:
-                logger.warning(
-                    "sandbox=%s | failed to remove leftover container %s: %s",
-                    sandbox_id,
-                    container.id,
-                    exc,
-                )
-            finally:
-                self._release_ossfs_mounts(mount_keys)
-        # Always attempt to cleanup sidecar as well
-        self._cleanup_egress_sidecar(sandbox_id)
-
-    def _remove_pending_sandbox(self, sandbox_id: str) -> None:
-        with self._pending_lock:
-            timer = self._pending_cleanup_timers.pop(sandbox_id, None)
-            if timer:
-                timer.cancel()
-            self._pending_sandboxes.pop(sandbox_id, None)
-
-    def _get_pending_sandbox(self, sandbox_id: str) -> Optional[PendingSandbox]:
-        with self._pending_lock:
-            pending = self._pending_sandboxes.get(sandbox_id)
-            return pending
-
-    def _iter_pending_sandboxes(self) -> list[tuple[str, PendingSandbox]]:
-        with self._pending_lock:
-            return list(self._pending_sandboxes.items())
-
-    @staticmethod
-    def _pending_to_sandbox(sandbox_id: str, pending: PendingSandbox) -> Sandbox:
-        snapshot_id = getattr(pending.request, "snapshot_id", None)
-        if not isinstance(snapshot_id, str) or not snapshot_id:
-            snapshot_id = None
-        extensions = {
-            k: v for k, v in (pending.request.extensions or {}).items()
-            if k.startswith(EXTENSIONS_ANNOTATION_PREFIX)
-        } or None
-        return Sandbox(
-            id=sandbox_id,
-            image=None if snapshot_id else pending.request.image,
-            snapshotId=snapshot_id,
-            platform=pending.request.platform,
-            status=pending.status,
-            metadata=pending.request.metadata,
-            extensions=extensions,
-            entrypoint=pending.request.entrypoint,
-            expiresAt=pending.expires_at,
-            createdAt=pending.created_at,
-        )
-
-    def _schedule_pending_cleanup(self, sandbox_id: str) -> None:
-        def _cleanup():
-            self._remove_pending_sandbox(sandbox_id)
-
-        timer = Timer(PENDING_FAILURE_TTL_SECONDS, _cleanup)
-        timer.daemon = True
-        with self._pending_lock:
-            existing = self._pending_cleanup_timers.pop(sandbox_id, None)
-            if existing:
-                existing.cancel()
-            self._pending_cleanup_timers[sandbox_id] = timer
-        timer.start()
-
     def _provision_sandbox(
         self,
         sandbox_id: str,
@@ -1090,14 +952,6 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             if matches_filter(sandbox_obj, request.filter):
                 sandboxes_by_id[sandbox_id] = sandbox_obj
 
-        for sandbox_id, pending in self._iter_pending_sandboxes():
-            if sandbox_id in container_ids:
-                # If a real container exists, prefer its state regardless of filter outcome.
-                continue
-            sandbox_obj = self._pending_to_sandbox(sandbox_id, pending)
-            if matches_filter(sandbox_obj, request.filter):
-                sandboxes_by_id[sandbox_id] = sandbox_obj
-
         sandboxes: list[Sandbox] = list(sandboxes_by_id.values())
 
         sandboxes.sort(key=lambda s: s.created_at or datetime.min, reverse=True)
@@ -1139,16 +993,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         Raises:
             HTTPException: If sandbox not found
         """
-        # Prefer real container state; fall back to pending record only if no container exists.
-        try:
-            container = self._get_container_by_sandbox_id(sandbox_id)
-        except HTTPException as exc:
-            if exc.status_code != status.HTTP_404_NOT_FOUND:
-                raise
-            pending = self._get_pending_sandbox(sandbox_id)
-            if pending:
-                return self._pending_to_sandbox(sandbox_id, pending)
-            raise
+        container = self._get_container_by_sandbox_id(sandbox_id)
         return self._container_to_sandbox(container, sandbox_id)
 
     def delete_sandbox(self, sandbox_id: str) -> None:

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -51,7 +51,7 @@ from opensandbox_server.services.constants import (
     SANDBOX_SNAPSHOT_ID_LABEL,
     SandboxErrorCodes,
 )
-from opensandbox_server.services.docker import DockerSandboxService, PendingSandbox
+from opensandbox_server.services.docker import DockerSandboxService
 from opensandbox_server.services.helpers import (
     parse_gpu_request,
     parse_memory_limit,
@@ -65,13 +65,10 @@ from opensandbox_server.api.schema import (
     Host,
     ImageSpec,
     NetworkPolicy,
-    ListSandboxesRequest,
     OSSFS,
     PlatformSpec,
     PVC,
     ResourceLimits,
-    Sandbox,
-    SandboxFilter,
     SandboxStatus,
     Volume,
 )
@@ -1432,35 +1429,6 @@ async def test_create_sandbox_response_includes_extensions(mock_docker):
     assert response.extensions == {"opensandbox.extensions.test-key": "test-value"}
 
 
-@patch("opensandbox_server.services.docker.docker_service.docker")
-def test_pending_sandbox_includes_extensions(mock_docker):
-    mock_client = MagicMock()
-    mock_client.containers.list.return_value = []
-    mock_docker.from_env.return_value = mock_client
-
-    service = DockerSandboxService(config=_app_config())
-    pending = PendingSandbox(
-        request=MagicMock(
-            metadata=None,
-            entrypoint=["python"],
-            image=ImageSpec(uri="python:3.11"),
-            platform=None,
-            snapshot_id=None,
-            extensions={
-                "opensandbox.extensions.pool-ref": "my-pool",
-                "access.renew.extend.seconds": "1800",
-            },
-        ),
-        created_at=datetime.now(timezone.utc),
-        expires_at=datetime.now(timezone.utc),
-        status=SandboxStatus(state="Pending"),
-    )
-
-    sandbox = service._pending_to_sandbox("sandbox-pending-ext", pending)
-
-    assert sandbox.extensions == {"opensandbox.extensions.pool-ref": "my-pool"}
-
-
 def test_build_labels_store_platform_constraints():
     service = DockerSandboxService(config=_app_config())
     request = CreateSandboxRequest(
@@ -1995,31 +1963,6 @@ def test_restore_existing_sandboxes_ignores_manual_cleanup_without_warning():
     mock_warning.assert_not_called()
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
-def test_pending_snapshot_restore_reports_snapshot_id_without_image(mock_docker):
-    mock_client = MagicMock()
-    mock_client.containers.list.return_value = []
-    mock_docker.from_env.return_value = mock_client
-
-    service = DockerSandboxService(config=_app_config())
-    pending = PendingSandbox(
-        request=MagicMock(
-            metadata={"team": "platform"},
-            entrypoint=["tail", "-f", "/dev/null"],
-            image=ImageSpec(uri="opensandbox-snapshots:snap-001"),
-            platform=None,
-            snapshot_id="snap-001",
-        ),
-        created_at=datetime.now(timezone.utc),
-        expires_at=datetime.now(timezone.utc),
-        status=SandboxStatus(state="Pending"),
-    )
-
-    sandbox = service._pending_to_sandbox("sandbox-123", pending)
-
-    assert sandbox.snapshot_id == "snap-001"
-    assert sandbox.image is None
-
-@patch("opensandbox_server.services.docker.docker_service.docker")
 def test_container_snapshot_restore_reports_snapshot_id_without_image(mock_docker):
     mock_client = MagicMock()
     mock_client.containers.list.return_value = []
@@ -2189,139 +2132,6 @@ async def test_get_sandbox_returns_pending_state(mock_docker):
 
     assert response.status.state == "Running"
     assert response.entrypoint == ["python", "app.py"]
-
-@patch("opensandbox_server.services.docker.docker_service.docker")
-def test_list_sandboxes_deduplicates_container_and_pending(mock_docker):
-    # Build a realistic container mock to avoid parse_timestamp errors.
-    container = MagicMock()
-    container.attrs = {
-        "Config": {"Labels": {SANDBOX_ID_LABEL: "sandbox-123"}},
-        "Created": "2025-01-01T00:00:00Z",
-        "State": {
-            "Status": "running",
-            "Running": True,
-            "FinishedAt": "0001-01-01T00:00:00Z",
-            "ExitCode": 0,
-        },
-    }
-    container.image = MagicMock(tags=["image:latest"], short_id="sha-image")
-
-    mock_client = MagicMock()
-    mock_client.containers.list.return_value = [container]
-    mock_docker.from_env.return_value = mock_client
-
-    service = DockerSandboxService(config=_app_config())
-    sandbox_id = "sandbox-123"
-
-    # Prepare container and pending representations
-    container_sandbox = Sandbox(
-        id=sandbox_id,
-        image=ImageSpec(uri="image:latest"),
-        status=SandboxStatus(
-            state="Running",
-            reason="CONTAINER_RUNNING",
-            message="running",
-            last_transition_at=datetime.now(timezone.utc),
-        ),
-        metadata={"team": "c"},
-        entrypoint=["/bin/sh"],
-        expiresAt=datetime.now(timezone.utc),
-        createdAt=datetime.now(timezone.utc),
-    )
-    # Force container state to be returned
-    service._container_to_sandbox = MagicMock(return_value=container_sandbox)
-
-    response = service.list_sandboxes(ListSandboxesRequest(filter=SandboxFilter(), pagination=None))
-
-    assert len(response.items) == 1
-    assert response.items[0].status.state == "Running"
-    assert response.items[0].metadata == {"team": "c"}
-
-@patch("opensandbox_server.services.docker.docker_service.docker")
-def test_get_sandbox_prefers_container_over_pending(mock_docker):
-    mock_client = MagicMock()
-    mock_client.containers.list.return_value = []
-    mock_docker.from_env.return_value = mock_client
-
-    service = DockerSandboxService(config=_app_config())
-    sandbox_id = "sandbox-abc"
-
-    pending_status = SandboxStatus(
-        state="Pending",
-        reason="SANDBOX_SCHEDULED",
-        message="pending",
-        last_transition_at=datetime.now(timezone.utc),
-    )
-    service._pending_sandboxes[sandbox_id] = PendingSandbox(
-        request=MagicMock(metadata={}, entrypoint=["/bin/sh"], image=ImageSpec(uri="image:latest")),
-        created_at=datetime.now(timezone.utc),
-        expires_at=datetime.now(timezone.utc),
-        status=pending_status,
-    )
-
-    container_sandbox = Sandbox(
-        id=sandbox_id,
-        image=ImageSpec(uri="image:latest"),
-        status=SandboxStatus(
-            state="Running",
-            reason="CONTAINER_RUNNING",
-            message="running",
-            last_transition_at=datetime.now(timezone.utc),
-        ),
-        metadata={},
-        entrypoint=["/bin/sh"],
-        expiresAt=datetime.now(timezone.utc),
-        createdAt=datetime.now(timezone.utc),
-    )
-
-    service._get_container_by_sandbox_id = MagicMock(return_value=MagicMock())
-    service._container_to_sandbox = MagicMock(return_value=container_sandbox)
-
-    sandbox = service.get_sandbox(sandbox_id)
-    assert sandbox.status.state == "Running"
-    assert sandbox.entrypoint == ["/bin/sh"]
-
-@patch("opensandbox_server.services.docker.docker_service.docker")
-def test_async_worker_cleans_up_leftover_container_on_failure(mock_docker):
-    mock_client = MagicMock()
-    mock_client.containers.list.return_value = []
-    mock_docker.from_env.return_value = mock_client
-
-    service = DockerSandboxService(config=_app_config())
-    sandbox_id = "sandbox-fail"
-    created_at = datetime.now(timezone.utc)
-    expires_at = created_at
-
-    pending_status = SandboxStatus(
-        state="Pending",
-        reason="SANDBOX_SCHEDULED",
-        message="pending",
-        last_transition_at=created_at,
-    )
-    service._pending_sandboxes[sandbox_id] = PendingSandbox(
-        request=MagicMock(metadata={}, entrypoint=["/bin/sh"], image=ImageSpec(uri="image:latest")),
-        created_at=created_at,
-        expires_at=expires_at,
-        status=pending_status,
-    )
-
-    service._provision_sandbox = MagicMock(
-        side_effect=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"message": "boom"},
-        )
-    )
-    service._cleanup_failed_containers = MagicMock()
-
-    service._async_provision_worker(
-        sandbox_id,
-        MagicMock(),
-        created_at,
-        expires_at,
-    )
-
-    service._cleanup_failed_containers.assert_called_once_with(sandbox_id)
-    assert service._pending_sandboxes[sandbox_id].status.state == "Failed"
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
 class TestBuildVolumeBinds:

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -12,8 +12,8 @@ info:
 
     A sandbox follows this lifecycle:
 
-    1. **Creation** → Sandbox enters `Pending` state (auto-starts)
-    2. **Execution** → Transitions to `Running` state
+    1. **Creation** → Sandbox is provisioned and enters `Running` state
+    2. **Execution** → Sandbox is running and ready to accept requests
     3. **Pause** (optional) → `Pausing` → `Paused` (asynchronous process)
     4. **Resume** (optional) → `Resuming` → `Running` (asynchronous process)
     5. **Termination** → `Stopping` → `Terminated` (can be triggered by kill action, TTL expiry, or error)

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -204,19 +204,16 @@ paths:
       responses:
         '202':
           description: |
-            Sandbox created and accepted for provisioning.
+            Sandbox created and provisioned successfully.
 
             The returned sandbox includes:
             - `id`: Unique sandbox identifier
-            - `status.state: "Pending"` (auto-starting provisioning or restore)
-            - `status.reason` and `status.message` indicating initialization stage
+            - `status.state: "Running"` (provisioning completed synchronously)
+            - `status.reason` and `status.message` indicating current state
             - `metadata`, `expiresAt`, `createdAt`: Core sandbox information
 
             Note: startup source details and `updatedAt` are not included in the create response.
             Use GET /sandboxes/{sandboxId} to retrieve the complete sandbox information.
-
-            To track provisioning progress, poll GET /sandboxes/{sandboxId}.
-            The sandbox will automatically transition to `Running` state once provisioning or restore completes.
           content:
             application/json:
               schema:


### PR DESCRIPTION
# Summary
  - Remove dead PendingSandbox async provisioning code that was never connected to any call path: _async_provision_worker, _mark_pending_failed, _cleanup_failed_containers, and 5 other related methods, the PENDING_FAILURE_TTL constant, and 5 associated tests (−357 lines total).
  - Correct the POST /sandboxes 202 response description in the API spec: both Docker and K8s implementations provision synchronously and return Running directly. The previous spec described a polling-based Pending→Running flow that was never implemented — if SDKs followed it, it would generate unnecessary polling traffic against the server.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
