### PR TITLE
feat(sandbox): per-sandbox serviceAccountName passthrough

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -816,6 +816,15 @@ public class CreateSandboxRequest
     public bool? SecureAccess { get; set; }
 
     /// <summary>
+    /// Gets or sets the Kubernetes ServiceAccount bound to the sandbox Pod,
+    /// enabling per-sandbox cloud identity (e.g. Workload Identity federation).
+    /// Ignored by the Docker runtime; not supported together with pool-based
+    /// creation.
+    /// </summary>
+    [JsonPropertyName("serviceAccountName")]
+    public string? ServiceAccountName { get; set; }
+
+    /// <summary>
     /// Gets or sets the custom metadata tags.
     /// </summary>
     [JsonPropertyName("metadata")]

--- a/sdks/sandbox/csharp/src/OpenSandbox/Options.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Options.cs
@@ -101,6 +101,14 @@ public class SandboxCreateOptions
     public bool SecureAccess { get; set; }
 
     /// <summary>
+    /// Gets or sets the Kubernetes ServiceAccount bound to the sandbox Pod,
+    /// enabling per-sandbox cloud identity (e.g. Workload Identity federation).
+    /// Ignored by the Docker runtime; not supported together with pool-based
+    /// creation.
+    /// </summary>
+    public string? ServiceAccountName { get; set; }
+
+    /// <summary>
     /// Gets or sets the resource limits.
     /// </summary>
     public IReadOnlyDictionary<string, string>? Resource { get; set; }

--- a/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Sandbox.cs
@@ -193,6 +193,7 @@ public sealed class Sandbox : IAsyncDisposable
             ResourceRequests = options.ResourceRequests,
             Env = options.Env,
             SecureAccess = options.SecureAccess,
+            ServiceAccountName = options.ServiceAccountName,
             Metadata = options.Metadata,
             Platform = options.Platform,
             NetworkPolicy = options.NetworkPolicy != null

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxesAdapterTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxesAdapterTests.cs
@@ -136,6 +136,47 @@ public class SandboxesAdapterTests
     }
 
     [Fact]
+    public async Task CreateSandboxAsync_ShouldSerializeServiceAccountName()
+    {
+        var handler = new CaptureCreateRequestHandler();
+        var client = new HttpClient(handler);
+        var wrapper = new HttpClientWrapper(client, "http://localhost:8080/v1");
+        var adapter = new SandboxesAdapter(wrapper);
+
+        _ = await adapter.CreateSandboxAsync(new CreateSandboxRequest
+        {
+            Image = new ImageSpec { Uri = "python:3.11" },
+            ResourceLimits = new Dictionary<string, string>(),
+            Entrypoint = new List<string> { "python" },
+            ServiceAccountName = "agent-finance-sa"
+        });
+
+        handler.RequestBody.Should().NotBeNullOrEmpty();
+        using var json = JsonDocument.Parse(handler.RequestBody!);
+        json.RootElement.GetProperty("serviceAccountName").GetString().Should().Be("agent-finance-sa");
+    }
+
+    [Fact]
+    public async Task CreateSandboxAsync_ShouldOmitServiceAccountNameWhenNull()
+    {
+        var handler = new CaptureCreateRequestHandler();
+        var client = new HttpClient(handler);
+        var wrapper = new HttpClientWrapper(client, "http://localhost:8080/v1");
+        var adapter = new SandboxesAdapter(wrapper);
+
+        _ = await adapter.CreateSandboxAsync(new CreateSandboxRequest
+        {
+            Image = new ImageSpec { Uri = "python:3.11" },
+            ResourceLimits = new Dictionary<string, string>(),
+            Entrypoint = new List<string> { "python" }
+        });
+
+        handler.RequestBody.Should().NotBeNullOrEmpty();
+        using var json = JsonDocument.Parse(handler.RequestBody!);
+        json.RootElement.TryGetProperty("serviceAccountName", out _).Should().BeFalse();
+    }
+
+    [Fact]
     public async Task PatchSandboxMetadataAsync_ShouldSendMetadataBodyAndPreserveNull()
     {
         var handler = new CapturePatchMetadataRequestHandler();

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -206,6 +206,51 @@ func TestCreateSandbox_SecureAccess(t *testing.T) {
 	require.NoErrorf(t, err, "CreateSandbox with SecureAccess")
 }
 
+func TestCreateSandbox_ServiceAccountName(t *testing.T) {
+	_, client := newLifecycleServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var req CreateSandboxRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		require.Equal(t, "agent-finance-sa", req.ServiceAccountName)
+
+		jsonResponse(w, http.StatusCreated, SandboxInfo{
+			ID:        "sbx-sa",
+			Status:    SandboxStatus{State: StatePending},
+			CreatedAt: time.Now().UTC().Truncate(time.Second),
+		})
+	})
+
+	_, err := client.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Image:              &ImageSpec{URI: "python:3.12"},
+		Entrypoint:         []string{"/bin/sh"},
+		ResourceLimits:     ResourceLimits{"cpu": "500m"},
+		ServiceAccountName: "agent-finance-sa",
+	})
+	require.NoErrorf(t, err, "CreateSandbox with ServiceAccountName")
+}
+
+func TestCreateSandbox_ServiceAccountNameOmittedWhenEmpty(t *testing.T) {
+	_, client := newLifecycleServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "serviceAccountName") {
+			t.Errorf("expected serviceAccountName to be omitted, got body %q", string(body))
+		}
+
+		jsonResponse(w, http.StatusCreated, SandboxInfo{
+			ID:        "sbx-no-sa",
+			Status:    SandboxStatus{State: StatePending},
+			CreatedAt: time.Now().UTC().Truncate(time.Second),
+		})
+	})
+
+	_, err := client.CreateSandbox(context.Background(), CreateSandboxRequest{
+		Image:          &ImageSpec{URI: "python:3.12"},
+		Entrypoint:     []string{"/bin/sh"},
+		ResourceLimits: ResourceLimits{"cpu": "500m"},
+	})
+	require.NoErrorf(t, err, "CreateSandbox without ServiceAccountName")
+}
+
 func TestCreateSandbox_ManualCleanup(t *testing.T) {
 	_, client := newLifecycleServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)

--- a/sdks/sandbox/go/sandbox.go
+++ b/sdks/sandbox/go/sandbox.go
@@ -51,6 +51,12 @@ type SandboxCreateOptions struct {
 	// SecureAccess enables secured access for sandbox endpoints.
 	SecureAccess bool
 
+	// ServiceAccountName binds a Kubernetes ServiceAccount to the sandbox Pod,
+	// enabling per-sandbox cloud identity (e.g. Workload Identity federation).
+	// Ignored by the Docker runtime; not supported together with pool-based
+	// creation (Extensions["poolRef"]).
+	ServiceAccountName string
+
 	// Metadata for filtering and tagging.
 	Metadata map[string]string
 
@@ -133,20 +139,21 @@ func CreateSandbox(ctx context.Context, config ConnectionConfig, opts SandboxCre
 	lc := config.lifecycleClient()
 
 	req := CreateSandboxRequest{
-		Image:            nil,
-		SnapshotID:       opts.SnapshotID,
-		Entrypoint:       entrypoint,
-		ResourceLimits:   limits,
-		ResourceRequests: opts.ResourceRequests,
-		Timeout:          timeout,
-		Env:              opts.Env,
-		SecureAccess:     opts.SecureAccess,
-		Metadata:         opts.Metadata,
-		NetworkPolicy:    opts.NetworkPolicy,
-		CredentialProxy:  opts.CredentialProxy,
-		Volumes:          opts.Volumes,
-		Extensions:       opts.Extensions,
-		Platform:         opts.Platform,
+		Image:              nil,
+		SnapshotID:         opts.SnapshotID,
+		Entrypoint:         entrypoint,
+		ResourceLimits:     limits,
+		ResourceRequests:   opts.ResourceRequests,
+		Timeout:            timeout,
+		Env:                opts.Env,
+		SecureAccess:       opts.SecureAccess,
+		ServiceAccountName: opts.ServiceAccountName,
+		Metadata:           opts.Metadata,
+		NetworkPolicy:      opts.NetworkPolicy,
+		CredentialProxy:    opts.CredentialProxy,
+		Volumes:            opts.Volumes,
+		Extensions:         opts.Extensions,
+		Platform:           opts.Platform,
 	}
 	if opts.Image != "" {
 		req.Image = &ImageSpec{URI: opts.Image, Auth: opts.ImageAuth}

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -149,20 +149,21 @@ type CredentialProxyConfig struct {
 
 // CreateSandboxRequest is the request body for creating a new sandbox.
 type CreateSandboxRequest struct {
-	Image            *ImageSpec             `json:"image,omitempty"`
-	SnapshotID       string                 `json:"snapshotId,omitempty"`
-	Timeout          *int                   `json:"timeout,omitempty"`
-	ResourceLimits   ResourceLimits         `json:"resourceLimits"`
-	ResourceRequests ResourceLimits         `json:"resourceRequests,omitempty"`
-	Env              map[string]string      `json:"env,omitempty"`
-	SecureAccess     bool                   `json:"secureAccess,omitempty"`
-	Metadata         map[string]string      `json:"metadata,omitempty"`
-	Entrypoint       []string               `json:"entrypoint,omitempty"`
-	NetworkPolicy    *NetworkPolicy         `json:"networkPolicy,omitempty"`
-	CredentialProxy  *CredentialProxyConfig `json:"credentialProxy,omitempty"`
-	Volumes          []Volume               `json:"volumes,omitempty"`
-	Extensions       map[string]string      `json:"extensions,omitempty"`
-	Platform         *PlatformSpec          `json:"platform,omitempty"`
+	Image              *ImageSpec             `json:"image,omitempty"`
+	SnapshotID         string                 `json:"snapshotId,omitempty"`
+	Timeout            *int                   `json:"timeout,omitempty"`
+	ResourceLimits     ResourceLimits         `json:"resourceLimits"`
+	ResourceRequests   ResourceLimits         `json:"resourceRequests,omitempty"`
+	Env                map[string]string      `json:"env,omitempty"`
+	SecureAccess       bool                   `json:"secureAccess,omitempty"`
+	ServiceAccountName string                 `json:"serviceAccountName,omitempty"`
+	Metadata           map[string]string      `json:"metadata,omitempty"`
+	Entrypoint         []string               `json:"entrypoint,omitempty"`
+	NetworkPolicy      *NetworkPolicy         `json:"networkPolicy,omitempty"`
+	CredentialProxy    *CredentialProxyConfig `json:"credentialProxy,omitempty"`
+	Volumes            []Volume               `json:"volumes,omitempty"`
+	Extensions         map[string]string      `json:"extensions,omitempty"`
+	Platform           *PlatformSpec          `json:"platform,omitempty"`
 }
 
 // SandboxInfo represents a runtime execution environment provisioned from a

--- a/sdks/sandbox/javascript/src/api/egress.ts
+++ b/sdks/sandbox/javascript/src/api/egress.ts
@@ -164,7 +164,9 @@ export interface paths {
          * Create a sandbox-local Credential Vault
          * @description Create the initial sandbox-local Credential Vault revision and activate it
          *     in Credential Proxy. Inline credential values are write-only and are never
-         *     returned by this API.
+         *     returned by this API. The sidecar must run in `dns+nft` mode and requires
+         *     an egress policy. `defaultAction: deny` is strongly recommended;
+         *     default-allow remains temporarily supported with a security warning.
          */
         post: {
             parameters: {

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -1151,6 +1151,25 @@ export interface components {
              */
             secureAccess: boolean;
             /**
+             * @description Kubernetes ServiceAccount bound to the sandbox Pod.
+             *
+             *     Only meaningful for Kubernetes-based runtimes; ignored by the Docker
+             *     runtime. When provided, the sandbox Pod runs under this ServiceAccount,
+             *     enabling per-sandbox cloud identity (e.g. Workload Identity federation)
+             *     and least-privilege access to external resources.
+             *
+             *     When omitted, the server falls back to the globally configured default
+             *     ServiceAccount (`kubernetes.service_account`); if neither is set, the
+             *     namespace `default` ServiceAccount is used.
+             *
+             *     The ServiceAccount must already exist in the sandbox namespace, and the
+             *     name must be a valid RFC 1123 DNS label. Not supported together with
+             *     `extensions.poolRef` (pool ServiceAccount is defined by the pool
+             *     template).
+             * @example agent-finance-sa
+             */
+            serviceAccountName?: string;
+            /**
              * @description Storage mounts for the sandbox. Each volume entry specifies a named backend-specific
              *     storage source and common mount settings. Exactly one backend type must be specified
              *     per volume entry.
@@ -1253,14 +1272,18 @@ export interface components {
         };
         /**
          * @description Credential Vault proxy startup settings. This is an explicit opt-in for
-         *     transparent MITM support used by credential injection; plain egress
-         *     network policy remains DNS/FQDN policy enforcement only.
+         *     transparent MITM support used by credential injection. Credential Vault
+         *     requires `dns+nft` enforcement and a network policy. A deny-default policy
+         *     is strongly recommended; default-allow remains temporarily supported for
+         *     backward compatibility and emits a security warning.
          */
         CredentialProxyConfig: {
             /**
              * @description When true, the server starts the egress sidecar with transparent
              *     MITM enabled and installs the runtime-managed MITM CA bundle into
-             *     the sandbox container. Requires `networkPolicy`.
+             *     the sandbox container. Requires `networkPolicy` and server
+             *     `[egress].mode = "dns+nft"`. `defaultAction: deny` is strongly
+             *     recommended; default-allow support is deprecated.
              * @default false
              */
             enabled: boolean;

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -431,6 +431,12 @@ export interface CreateSandboxRequest extends Record<string, unknown> {
    */
   secureAccess?: boolean;
   /**
+   * Kubernetes ServiceAccount bound to the sandbox Pod. Only meaningful for
+   * Kubernetes-based runtimes; ignored by the Docker runtime. Not supported
+   * together with pool-based creation (`extensions.poolRef`).
+   */
+  serviceAccountName?: string;
+  /**
    * Timeout in seconds (server semantics).
    */
   timeout?: number | null;

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -161,6 +161,13 @@ export interface SandboxCreateOptions {
   secureAccess?: boolean;
 
   /**
+   * Kubernetes ServiceAccount bound to the sandbox Pod. Enables per-sandbox
+   * cloud identity (e.g. Workload Identity federation). Ignored by the Docker
+   * runtime; not supported together with pool-based creation.
+   */
+  serviceAccountName?: string;
+
+  /**
    * Resource limits applied to the sandbox container.
    *
    * This is forwarded to the Lifecycle API as `resourceLimits`.
@@ -381,6 +388,7 @@ export class Sandbox {
       resourceLimits: opts.resource ?? DEFAULT_RESOURCE_LIMITS,
       resourceRequests: opts.resourceRequests,
       secureAccess: opts.secureAccess ?? false,
+      serviceAccountName: opts.serviceAccountName,
       env: opts.env ?? {},
       metadata: opts.metadata ?? {},
       networkPolicy: opts.networkPolicy

--- a/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
@@ -124,6 +124,35 @@ test("Sandbox.create forwards secureAccess", async () => {
   assert.equal(recordedRequests[0].secureAccess, true);
 });
 
+test("Sandbox.create forwards serviceAccountName", async () => {
+  const { adapterFactory, recordedRequests } = createAdapterFactory();
+
+  await Sandbox.create({
+    adapterFactory,
+    connectionConfig: { domain: "http://127.0.0.1:8080" },
+    image: "python:3.12",
+    serviceAccountName: "agent-finance-sa",
+    skipHealthCheck: true,
+  });
+
+  assert.equal(recordedRequests.length, 1);
+  assert.equal(recordedRequests[0].serviceAccountName, "agent-finance-sa");
+});
+
+test("Sandbox.create omits serviceAccountName when not provided", async () => {
+  const { adapterFactory, recordedRequests } = createAdapterFactory();
+
+  await Sandbox.create({
+    adapterFactory,
+    connectionConfig: { domain: "http://127.0.0.1:8080" },
+    image: "python:3.12",
+    skipHealthCheck: true,
+  });
+
+  assert.equal(recordedRequests.length, 1);
+  assert.equal(recordedRequests[0].serviceAccountName, undefined);
+});
+
 test("Sandbox.create forwards credentialProxy", async () => {
   const { adapterFactory, recordedRequests } = createAdapterFactory();
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -315,6 +315,8 @@ class Sandbox internal constructor(
          * @param healthCheckPollingInterval Polling interval for readiness/health check
          * @param extensions Optional extension parameters for server-side customized behaviors
          * @param volumes Optional list of volume mounts for persistent storage
+         * @param serviceAccountName Optional Kubernetes ServiceAccount bound to the sandbox Pod. Ignored by the Docker
+         *   runtime; not supported together with pool-based creation.
          * @return Fully configured and ready Sandbox instance
          * @throws SandboxException if sandbox creation or initialization fails
          */
@@ -338,6 +340,7 @@ class Sandbox internal constructor(
             skipHealthCheck: Boolean,
             volumes: List<Volume>?,
             resourceRequests: Map<String, String>? = null,
+            serviceAccountName: String? = null,
         ): Sandbox {
             val timeoutLabel = if (timeout != null) "${timeout.seconds}s" else "manual-cleanup"
             return initializeSandbox(
@@ -364,6 +367,7 @@ class Sandbox internal constructor(
                         secureAccess = secureAccess,
                         snapshotId = snapshotId,
                         resourceRequests = resourceRequests,
+                        serviceAccountName = serviceAccountName,
                     )
                 InitializationResult.NewSandbox(response.id)
             }
@@ -940,6 +944,11 @@ class Sandbox internal constructor(
         private var secureAccess: Boolean = false
 
         /**
+         * Optional Kubernetes ServiceAccount bound to the sandbox Pod.
+         */
+        private var serviceAccountName: String? = null
+
+        /**
          * Optional runtime platform constraint used for sandbox provisioning.
          */
         private var platform: PlatformSpec? = null
@@ -1222,6 +1231,18 @@ class Sandbox internal constructor(
         }
 
         /**
+         * Sets the Kubernetes ServiceAccount bound to the sandbox Pod.
+         *
+         * Enables per-sandbox cloud identity (e.g. Workload Identity federation).
+         * Ignored by the Docker runtime; not supported together with pool-based
+         * creation (`extensions["poolRef"]`).
+         */
+        fun serviceAccountName(serviceAccountName: String): Builder {
+            this.serviceAccountName = serviceAccountName
+            return this
+        }
+
+        /**
          * Sets an explicit runtime platform constraint.
          */
         fun platform(platform: PlatformSpec): Builder {
@@ -1439,6 +1460,7 @@ class Sandbox internal constructor(
                 skipHealthCheck = skipHealthCheck,
                 volumes = if (volumes.isEmpty()) null else volumes.toList(),
                 resourceRequests = resourceRequests,
+                serviceAccountName = serviceAccountName,
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/Sandboxes.kt
@@ -55,6 +55,8 @@ interface Sandboxes {
      * @param extensions Opaque extension parameters passed through to the server as-is. Prefer namespaced keys
      * @param volumes Optional list of volume mounts for persistent storage
      * @param snapshotId Optional snapshot identifier used to restore a sandbox instead of booting from an image
+     * @param serviceAccountName Optional Kubernetes ServiceAccount bound to the sandbox Pod. Ignored by the Docker
+     *   runtime; not supported together with pool-based creation.
      * @return Sandbox creation response containing the sandbox id
      */
     fun createSandbox(
@@ -71,6 +73,7 @@ interface Sandboxes {
         secureAccess: Boolean = false,
         snapshotId: String? = null,
         resourceRequests: Map<String, String>? = null,
+        serviceAccountName: String? = null,
     ): SandboxCreateResponse
 
     /**
@@ -91,6 +94,7 @@ interface Sandboxes {
         snapshotId: String? = null,
         credentialProxy: CredentialProxyConfig?,
         resourceRequests: Map<String, String>? = null,
+        serviceAccountName: String? = null,
     ): SandboxCreateResponse {
         if (credentialProxy == null) {
             return createSandbox(
@@ -107,6 +111,7 @@ interface Sandboxes {
                 secureAccess = secureAccess,
                 snapshotId = snapshotId,
                 resourceRequests = resourceRequests,
+                serviceAccountName = serviceAccountName,
             )
         }
         throw UnsupportedOperationException(

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -263,6 +263,7 @@ internal object SandboxModelConverter {
         volumes: List<Volume>?,
         snapshotId: String?,
         resourceRequests: Map<String, String>? = null,
+        serviceAccountName: String? = null,
     ): CreateSandboxRequest {
         return CreateSandboxRequest(
             image = spec?.toApiImageSpec(),
@@ -277,6 +278,7 @@ internal object SandboxModelConverter {
             networkPolicy = networkPolicy?.toApiNetworkPolicy(),
             credentialProxy = credentialProxy?.toApiCredentialProxyConfig(),
             secureAccess = secureAccess,
+            serviceAccountName = serviceAccountName,
             extensions = extensions,
             volumes = volumes?.map { it.toApiVolume() },
         )

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
@@ -98,6 +98,7 @@ internal class SandboxesAdapter(
         secureAccess: Boolean,
         snapshotId: String?,
         resourceRequests: Map<String, String>?,
+        serviceAccountName: String?,
     ): SandboxCreateResponse =
         createSandbox(
             spec = spec,
@@ -114,6 +115,7 @@ internal class SandboxesAdapter(
             snapshotId = snapshotId,
             credentialProxy = null,
             resourceRequests = resourceRequests,
+            serviceAccountName = serviceAccountName,
         )
 
     override fun createSandbox(
@@ -131,6 +133,7 @@ internal class SandboxesAdapter(
         snapshotId: String?,
         credentialProxy: CredentialProxyConfig?,
         resourceRequests: Map<String, String>?,
+        serviceAccountName: String?,
     ): SandboxCreateResponse {
         logger.info("Creating sandbox with startup source: {}", spec?.image ?: snapshotId)
 
@@ -151,6 +154,7 @@ internal class SandboxesAdapter(
                     volumes = volumes,
                     snapshotId = snapshotId,
                     resourceRequests = resourceRequests,
+                    serviceAccountName = serviceAccountName,
                 )
             val apiResponse = api.sandboxesPost(createRequest)
             val response = apiResponse.toSandboxCreateResponse()

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/services/SandboxesCompatibilityTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/services/SandboxesCompatibilityTest.kt
@@ -105,6 +105,7 @@ class SandboxesCompatibilityTest {
             secureAccess: Boolean,
             snapshotId: String?,
             resourceRequests: Map<String, String>?,
+            serviceAccountName: String?,
         ): SandboxCreateResponse = SandboxCreateResponse("legacy-sandbox")
 
         override fun getSandboxInfo(sandboxId: String): SandboxInfo = unsupported()

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -160,6 +160,75 @@ class SandboxesAdapterTest {
     }
 
     @Test
+    fun `createSandbox should forward serviceAccountName in request`() {
+        val responseBody =
+            """
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "status": { "state": "Running" },
+                "createdAt": "2023-01-01T10:00:00Z",
+                "entrypoint": ["bash"]
+            }
+            """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(201))
+
+        val spec = SandboxImageSpec.builder().image("ubuntu:latest").build()
+        sandboxesAdapter.createSandbox(
+            spec = spec,
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = Duration.ofSeconds(600),
+            resource = mapOf("cpu" to "1"),
+            networkPolicy = null,
+            extensions = emptyMap(),
+            volumes = null,
+            secureAccess = false,
+            snapshotId = null,
+            serviceAccountName = "agent-finance-sa",
+        )
+
+        val request = mockWebServer.takeRequest()
+        val payload = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals("agent-finance-sa", payload["serviceAccountName"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `createSandbox should not send a serviceAccountName value when not provided`() {
+        val responseBody =
+            """
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "status": { "state": "Running" },
+                "createdAt": "2023-01-01T10:00:00Z",
+                "entrypoint": ["bash"]
+            }
+            """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(201))
+
+        val spec = SandboxImageSpec.builder().image("ubuntu:latest").build()
+        sandboxesAdapter.createSandbox(
+            spec = spec,
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = Duration.ofSeconds(600),
+            resource = mapOf("cpu" to "1"),
+            networkPolicy = null,
+            extensions = emptyMap(),
+            volumes = null,
+            secureAccess = false,
+            snapshotId = null,
+        )
+
+        val request = mockWebServer.takeRequest()
+        val payload = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+        // The generated client serializes unset optional fields as explicit JSON null,
+        // which the server treats as "not provided".
+        assertEquals(JsonNull, payload["serviceAccountName"])
+    }
+
+    @Test
     fun `createSandbox should forward windows platform in request`() {
         val responseBody =
             """

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -182,6 +182,7 @@ class SandboxModelConverter:
         snapshot_id: str | None = None,
         credential_proxy: CredentialProxyConfig | None = None,
         resource_requests: dict[str, str] | None = None,
+        service_account_name: str | None = None,
     ) -> CreateSandboxRequest:
         """Convert domain parameters to API CreateSandboxRequest."""
         from opensandbox.api.lifecycle.models.create_sandbox_request import (
@@ -314,6 +315,9 @@ class SandboxModelConverter:
             extensions=api_extensions,
             volumes=api_volumes,
             secure_access=secure_access,
+            service_account_name=(
+                service_account_name if service_account_name is not None else UNSET
+            ),
         )
         if timeout is None:
             # Preserve an explicit manual-cleanup request as JSON null.

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -141,6 +141,7 @@ class SandboxesAdapter(Sandboxes):
         snapshot_id: str | None = None,
         credential_proxy: CredentialProxyConfig | None = None,
         resource_requests: dict[str, str] | None = None,
+        service_account_name: str | None = None,
     ) -> SandboxCreateResponse:
         """Create a new sandbox instance with the specified configuration."""
         logger.info(
@@ -166,6 +167,7 @@ class SandboxesAdapter(Sandboxes):
                 secure_access=secure_access,
                 snapshot_id=snapshot_id,
                 resource_requests=resource_requests,
+                service_account_name=service_account_name,
             )
 
             client = await self._get_client()

--- a/sdks/sandbox/python/src/opensandbox/api/egress/api/credential_vault/post_credential_vault.py
+++ b/sdks/sandbox/python/src/opensandbox/api/egress/api/credential_vault/post_credential_vault.py
@@ -95,7 +95,9 @@ def sync_detailed(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -128,7 +130,9 @@ def sync(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -156,7 +160,9 @@ async def asyncio_detailed(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):
@@ -187,7 +193,9 @@ async def asyncio(
 
      Create the initial sandbox-local Credential Vault revision and activate it
     in Credential Proxy. Inline credential values are write-only and are never
-    returned by this API.
+    returned by this API. The sidecar must run in `dns+nft` mode and requires
+    an egress policy. `defaultAction: deny` is strongly recommended;
+    default-allow remains temporarily supported with a security warning.
 
     Args:
         body (CredentialVaultCreateRequest):

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/create_sandbox_request.py
@@ -130,8 +130,10 @@ class CreateSandboxRequest:
                 object or null results in allow-all behavior at startup.
             credential_proxy (CredentialProxyConfig | Unset): Credential Vault proxy startup settings. This is an explicit
                 opt-in for
-                transparent MITM support used by credential injection; plain egress
-                network policy remains DNS/FQDN policy enforcement only.
+                transparent MITM support used by credential injection. Credential Vault
+                requires `dns+nft` enforcement and a network policy. A deny-default policy
+                is strongly recommended; default-allow remains temporarily supported for
+                backward compatibility and emits a security warning.
             secure_access (bool | Unset): Opts the sandbox into secured access for endpoint access.
                 This is currently supported only for Kubernetes sandboxes exposed
                 through ingress gateway mode. When enabled, the server provisions
@@ -141,6 +143,22 @@ class CreateSandboxRequest:
                 accessible without the additional access token for backward
                 compatibility.
                  Default: False.
+            service_account_name (str | Unset): Kubernetes ServiceAccount bound to the sandbox Pod.
+
+                Only meaningful for Kubernetes-based runtimes; ignored by the Docker
+                runtime. When provided, the sandbox Pod runs under this ServiceAccount,
+                enabling per-sandbox cloud identity (e.g. Workload Identity federation)
+                and least-privilege access to external resources.
+
+                When omitted, the server falls back to the globally configured default
+                ServiceAccount (`kubernetes.service_account`); if neither is set, the
+                namespace `default` ServiceAccount is used.
+
+                The ServiceAccount must already exist in the sandbox namespace, and the
+                name must be a valid RFC 1123 DNS label. Not supported together with
+                `extensions.poolRef` (pool ServiceAccount is defined by the pool
+                template).
+                 Example: agent-finance-sa.
             volumes (list[Volume] | Unset): Storage mounts for the sandbox. Each volume entry specifies a named backend-
                 specific
                 storage source and common mount settings. Exactly one backend type must be specified
@@ -174,6 +192,7 @@ class CreateSandboxRequest:
     network_policy: NetworkPolicy | Unset = UNSET
     credential_proxy: CredentialProxyConfig | Unset = UNSET
     secure_access: bool | Unset = False
+    service_account_name: str | Unset = UNSET
     volumes: list[Volume] | Unset = UNSET
     extensions: CreateSandboxRequestExtensions | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -225,6 +244,8 @@ class CreateSandboxRequest:
 
         secure_access = self.secure_access
 
+        service_account_name = self.service_account_name
+
         volumes: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.volumes, Unset):
             volumes = []
@@ -263,6 +284,8 @@ class CreateSandboxRequest:
             field_dict["credentialProxy"] = credential_proxy
         if secure_access is not UNSET:
             field_dict["secureAccess"] = secure_access
+        if service_account_name is not UNSET:
+            field_dict["serviceAccountName"] = service_account_name
         if volumes is not UNSET:
             field_dict["volumes"] = volumes
         if extensions is not UNSET:
@@ -354,6 +377,8 @@ class CreateSandboxRequest:
 
         secure_access = d.pop("secureAccess", UNSET)
 
+        service_account_name = d.pop("serviceAccountName", UNSET)
+
         _volumes = d.pop("volumes", UNSET)
         volumes: list[Volume] | Unset = UNSET
         if _volumes is not UNSET:
@@ -383,6 +408,7 @@ class CreateSandboxRequest:
             network_policy=network_policy,
             credential_proxy=credential_proxy,
             secure_access=secure_access,
+            service_account_name=service_account_name,
             volumes=volumes,
             extensions=extensions,
         )

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/credential_proxy_config.py
@@ -29,13 +29,17 @@ T = TypeVar("T", bound="CredentialProxyConfig")
 @_attrs_define
 class CredentialProxyConfig:
     """Credential Vault proxy startup settings. This is an explicit opt-in for
-    transparent MITM support used by credential injection; plain egress
-    network policy remains DNS/FQDN policy enforcement only.
+    transparent MITM support used by credential injection. Credential Vault
+    requires `dns+nft` enforcement and a network policy. A deny-default policy
+    is strongly recommended; default-allow remains temporarily supported for
+    backward compatibility and emits a security warning.
 
         Attributes:
             enabled (bool | Unset): When true, the server starts the egress sidecar with transparent
                 MITM enabled and installs the runtime-managed MITM CA bundle into
-                the sandbox container. Requires `networkPolicy`.
+                the sandbox container. Requires `networkPolicy` and server
+                `[egress].mode = "dns+nft"`. `defaultAction: deny` is strongly
+                recommended; default-allow support is deprecated.
                  Default: False.
     """
 

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -505,6 +505,7 @@ class Sandbox:
         credential_proxy: CredentialProxyConfig | None = None,
         extensions: dict[str, str] | None = None,
         secure_access: bool = False,
+        service_account_name: str | None = None,
         entrypoint: list[str] | None = None,
         volumes: list[Volume] | None = None,
         connection_config: ConnectionConfig | None = None,
@@ -527,6 +528,9 @@ class Sandbox:
             extensions: Opaque extension parameters passed through to the server as-is.
                 Prefer namespaced keys (e.g. ``storage.id``).
             secure_access: Whether to enable secured access for sandbox endpoints.
+            service_account_name: Optional Kubernetes ServiceAccount bound to the sandbox Pod.
+                Enables per-sandbox cloud identity (e.g. Workload Identity federation).
+                Ignored by the Docker runtime; not supported together with pool-based creation.
             entrypoint: Command to run as entrypoint
             volumes: Optional list of volume mounts for persistent storage.
                 Each volume specifies a backend (host path, PVC, or OSSFS) and mount configuration.
@@ -584,6 +588,7 @@ class Sandbox:
                 secure_access=secure_access,
                 snapshot_id=snapshot_id,
                 resource_requests=resource_requests,
+                service_account_name=service_account_name,
             )
             sandbox_id = response.id
 

--- a/sdks/sandbox/python/src/opensandbox/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/services/sandbox.py
@@ -65,6 +65,7 @@ class Sandboxes(Protocol):
         snapshot_id: str | None = None,
         credential_proxy: CredentialProxyConfig | None = None,
         resource_requests: dict[str, str] | None = None,
+        service_account_name: str | None = None,
     ) -> SandboxCreateResponse:
         """
         Create a new sandbox with the specified configuration.
@@ -82,6 +83,9 @@ class Sandboxes(Protocol):
                 Prefer namespaced keys (e.g. ``storage.id``).
             volumes: Optional list of volume mounts for persistent storage.
             secure_access: Whether to enable secured access for sandbox endpoints.
+            service_account_name: Optional Kubernetes ServiceAccount bound to the
+                sandbox Pod. Ignored by the Docker runtime. Not supported together
+                with pool-based creation (``extensions.poolRef``).
 
         Returns:
             Sandbox create response

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -118,6 +118,7 @@ class SandboxesAdapterSync(SandboxesSync):
         snapshot_id: str | None = None,
         credential_proxy: CredentialProxyConfig | None = None,
         resource_requests: dict[str, str] | None = None,
+        service_account_name: str | None = None,
     ) -> SandboxCreateResponse:
         logger.info(
             "Creating sandbox with startup source: %s",
@@ -144,6 +145,7 @@ class SandboxesAdapterSync(SandboxesSync):
                 secure_access=secure_access,
                 snapshot_id=snapshot_id,
                 resource_requests=resource_requests,
+                service_account_name=service_account_name,
             )
             response_obj = post_sandboxes.sync_detailed(client=self._get_client(), body=create_request)
             handle_api_error(response_obj, "Create sandbox")

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -495,6 +495,7 @@ class SandboxSync:
         credential_proxy: CredentialProxyConfig | None = None,
         extensions: dict[str, str] | None = None,
         secure_access: bool = False,
+        service_account_name: str | None = None,
         entrypoint: list[str] | None = None,
         volumes: list[Volume] | None = None,
         connection_config: ConnectionConfigSync | None = None,
@@ -517,6 +518,9 @@ class SandboxSync:
             extensions: Opaque extension parameters passed through to the server as-is.
                 Prefer namespaced keys (e.g. ``storage.id``).
             secure_access: Whether to enable secured access for sandbox endpoints.
+            service_account_name: Optional Kubernetes ServiceAccount bound to the sandbox Pod.
+                Enables per-sandbox cloud identity (e.g. Workload Identity federation).
+                Ignored by the Docker runtime; not supported together with pool-based creation.
             entrypoint: Command to run as entrypoint
             volumes: Optional list of volumes to mount in the sandbox.
             connection_config: Connection configuration
@@ -573,6 +577,7 @@ class SandboxSync:
                 secure_access=secure_access,
                 snapshot_id=snapshot_id,
                 resource_requests=resource_requests,
+                service_account_name=service_account_name,
             )
             sandbox_id = response.id
             execd_endpoint = sandbox_service.get_sandbox_endpoint(

--- a/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/sandbox.py
@@ -66,6 +66,7 @@ class SandboxesSync(Protocol):
         snapshot_id: str | None = None,
         credential_proxy: CredentialProxyConfig | None = None,
         resource_requests: dict[str, str] | None = None,
+        service_account_name: str | None = None,
     ) -> SandboxCreateResponse:
         """
         Create a new sandbox with the specified configuration (blocking).
@@ -83,6 +84,9 @@ class SandboxesSync(Protocol):
                 Prefer namespaced keys (e.g. ``storage.id``).
             volumes: Optional list of volumes to mount in the sandbox.
             secure_access: Whether to enable secured access for sandbox endpoints.
+            service_account_name: Optional Kubernetes ServiceAccount bound to the
+                sandbox Pod. Ignored by the Docker runtime. Not supported together
+                with pool-based creation (``extensions.poolRef``).
 
         Returns:
             Sandbox create response.

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -312,6 +312,43 @@ def test_sandbox_model_converter_snapshot_restore_request() -> None:
     assert "entrypoint" not in dumped
 
 
+def test_sandbox_model_converter_sets_service_account_name() -> None:
+    req = SandboxModelConverter.to_api_create_sandbox_request(
+        spec=SandboxImageSpec("python:3.11"),
+        entrypoint=["/bin/sh"],
+        env={},
+        metadata={},
+        timeout=None,
+        resource={"cpu": "100m"},
+        platform=None,
+        network_policy=None,
+        extensions={},
+        volumes=None,
+        service_account_name="agent-finance-sa",
+    )
+
+    dumped = req.to_dict()
+    assert dumped["serviceAccountName"] == "agent-finance-sa"
+
+
+def test_sandbox_model_converter_omits_service_account_name_when_absent() -> None:
+    req = SandboxModelConverter.to_api_create_sandbox_request(
+        spec=SandboxImageSpec("python:3.11"),
+        entrypoint=["/bin/sh"],
+        env={},
+        metadata={},
+        timeout=None,
+        resource={"cpu": "100m"},
+        platform=None,
+        network_policy=None,
+        extensions={},
+        volumes=None,
+    )
+
+    dumped = req.to_dict()
+    assert "serviceAccountName" not in dumped
+
+
 def test_sandbox_model_converter_maps_platform_from_create_response() -> None:
     from opensandbox.api.lifecycle.models.create_sandbox_response import (
         CreateSandboxResponse,

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -491,6 +491,7 @@ async def test_create_passes_new_signature_keywords_even_when_unused(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             assert spec is not None
             assert entrypoint is not None
@@ -578,6 +579,7 @@ async def test_create_restore_from_snapshot_passes_snapshot_id(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             self.create_calls.append((spec, entrypoint))
             assert isinstance(env, dict)
@@ -656,6 +658,7 @@ async def test_create_restore_from_snapshot_preserves_custom_entrypoint(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             assert isinstance(env, dict)
             assert isinstance(metadata, dict)

--- a/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_business_logic.py
@@ -277,6 +277,7 @@ def test_sync_create_passes_new_signature_keywords_even_when_unused(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             assert spec is not None
             assert entrypoint is not None
@@ -427,6 +428,7 @@ def test_sync_create_restore_from_snapshot_passes_snapshot_id(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             assert isinstance(env, dict)
             assert isinstance(metadata, dict)
@@ -503,6 +505,7 @@ def test_sync_create_restore_from_snapshot_preserves_custom_entrypoint(
             snapshot_id=None,
             credential_proxy=None,
             resource_requests=None,
+            service_account_name=None,
         ):
             assert isinstance(env, dict)
             assert isinstance(metadata, dict)

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -120,7 +120,7 @@ If `runtime.type = "kubernetes"` and the `[kubernetes]` table is absent, the ser
 |-----|------|---------|-------------|
 | `kubeconfig_path` | string \| omitted | `null` | Path to kubeconfig (expandable, e.g. `~/.kube/config`). In-cluster configs often leave this unset and rely on in-cluster credentials. |
 | `namespace` | string \| omitted | `null` | Namespace for sandbox workloads. |
-| `service_account` | string \| omitted | `null` | ServiceAccount name bound to workload pods. |
+| `service_account` | string \| omitted | `null` | Default ServiceAccount bound to workload pods. Used when a create request omits `serviceAccountName`; per-request values take precedence. |
 | `workload_provider` | string \| omitted | `null` | One of: **`batchsandbox`**, **`agent-sandbox`**. If omitted, the **first registered** provider is used (currently **`batchsandbox`**). |
 | `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. |
 | `image_pull_policy` | string \| omitted | `"IfNotPresent"` | Image pull policy for the BatchSandbox main container. Values: **`Always`**, **`IfNotPresent`**, **`Never`**. |

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -478,6 +478,22 @@ class CreateSandboxRequest(BaseModel):
             "When enabled, the server provisions access credentials and returns required endpoint headers."
         ),
     )
+    service_account_name: Optional[str] = Field(
+        None,
+        alias="serviceAccountName",
+        min_length=1,
+        max_length=253,
+        pattern=r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+        description=(
+            "Kubernetes ServiceAccount bound to the sandbox Pod. Only meaningful for "
+            "Kubernetes-based runtimes; ignored by the Docker runtime. When provided, the "
+            "sandbox Pod runs under this ServiceAccount, enabling per-sandbox cloud identity "
+            "(e.g. Workload Identity federation). When omitted, falls back to the globally "
+            "configured default ServiceAccount (kubernetes.service_account), then the namespace "
+            "default. The ServiceAccount must already exist in the sandbox namespace. Not "
+            "supported together with extensions.poolRef."
+        ),
+    )
     volumes: Optional[List[Volume]] = Field(
         None,
         description=(
@@ -501,6 +517,11 @@ class CreateSandboxRequest(BaseModel):
                 raise ValueError("snapshotId cannot be used together with poolRef.")
             if self.credential_proxy and self.credential_proxy.enabled:
                 raise ValueError("credentialProxy.enabled cannot be used together with poolRef.")
+            if self.service_account_name:
+                raise ValueError(
+                    "serviceAccountName cannot be used together with poolRef. "
+                    "The ServiceAccount is defined by the pool template."
+                )
             # Normalize blank snapshotId so downstream code won't see
             # a truthy whitespace string (e.g. "   ") as a real value.
             if self.snapshot_id is not None and not self.snapshot_id.strip():

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -593,7 +593,10 @@ class KubernetesRuntimeConfig(BaseModel):
     )
     service_account: Optional[str] = Field(
         default=None,
-        description="Service account bound to sandbox workloads.",
+        description=(
+            "Default service account bound to sandbox workloads. Used when a create "
+            "request does not specify serviceAccountName; per-request values take precedence."
+        ),
     )
     workload_provider: Optional[str] = Field(
         default=None,

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -143,6 +143,7 @@ class AgentSandboxProvider(WorkloadProvider):
         credential_proxy_enabled: bool = False,
         resource_requests: Optional[Dict[str, str]] = None,
         egress_env: Optional[Dict[str, Optional[str]]] = None,
+        service_account_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create an agent-sandbox Sandbox CRD workload."""
         if is_windows_profile(platform):
@@ -170,8 +171,9 @@ class AgentSandboxProvider(WorkloadProvider):
         if volumes:
             apply_volumes_to_pod_spec(pod_spec, volumes)
 
-        if self.service_account:
-            pod_spec["serviceAccountName"] = self.service_account
+        effective_service_account = service_account_name or self.service_account
+        if effective_service_account:
+            pod_spec["serviceAccountName"] = effective_service_account
         self._apply_platform_node_selector(pod_spec, platform)
 
         resource_name = self._resource_name(sandbox_id)

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -78,6 +78,7 @@ class BatchSandboxProvider(WorkloadProvider):
             logger.info(f"Using BatchSandbox template file: {template_file_path}")
         self.execd_init_resources = k8s_config.execd_init_resources if k8s_config else None
         self.image_pull_policy = k8s_config.image_pull_policy if k8s_config else "IfNotPresent"
+        self.service_account = k8s_config.service_account if k8s_config else None
 
         self.resolver = SecureRuntimeResolver(app_config) if app_config else None
         self.runtime_class = (
@@ -122,10 +123,12 @@ class BatchSandboxProvider(WorkloadProvider):
         credential_proxy_enabled: bool = False,
         resource_requests: Optional[Dict[str, str]] = None,
         egress_env: Optional[Dict[str, Optional[str]]] = None,
+        service_account_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a BatchSandbox in template mode or pool mode."""
         extensions = extensions or {}
         windows_profile = is_windows_profile(platform)
+        effective_service_account = service_account_name or self.service_account
 
         if self.runtime_class:
             logger.info(f"Using Kubernetes RuntimeClass '{self.runtime_class}' for sandbox {sandbox_id}")
@@ -140,6 +143,11 @@ class BatchSandboxProvider(WorkloadProvider):
                 raise ValueError(
                     "Pool mode does not support volumes. "
                     "Remove 'volumes' from request or use template mode."
+                )
+            if service_account_name:
+                raise ValueError(
+                    "Pool mode does not support serviceAccountName. "
+                    "The ServiceAccount is defined by the pool template."
                 )
             return self._create_workload_from_pool(
                 batchsandbox_name=sandbox_id,
@@ -226,6 +234,9 @@ class BatchSandboxProvider(WorkloadProvider):
         containers = pod_spec.get("containers", [])
         if self.runtime_class:
             pod_spec["runtimeClassName"] = self.runtime_class
+
+        if effective_service_account:
+            pod_spec["serviceAccountName"] = effective_service_account
 
         if image_spec.auth:
             secret_name = build_image_pull_secret_name(sandbox_id)

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -745,6 +745,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     egress_env=context.egress_env,
                     volumes=request.volumes,
                     platform=request.platform,
+                    service_account_name=request.service_account_name,
                 )
                 workload_left_alive = True
             except ValueError:

--- a/server/opensandbox_server/services/k8s/workload_provider.py
+++ b/server/opensandbox_server/services/k8s/workload_provider.py
@@ -55,6 +55,7 @@ class WorkloadProvider(ABC):
         credential_proxy_enabled: bool = False,
         resource_requests: Optional[Dict[str, str]] = None,
         egress_env: Optional[Dict[str, Optional[str]]] = None,
+        service_account_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Create a new workload resource.
@@ -78,6 +79,8 @@ class WorkloadProvider(ABC):
             egress_mode: Sidecar ``OPENSANDBOX_EGRESS_MODE`` (from app ``[egress].mode`` when using network policy).
             credential_proxy_enabled: Enable transparent MITM support required by Credential Vault injection.
             volumes: Optional list of volume mounts for the sandbox.
+            service_account_name: Optional per-sandbox ServiceAccount for the Pod.
+                When omitted, providers fall back to their configured default ServiceAccount.
 
         Returns:
             Dict containing workload metadata (name, uid, etc.)

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -108,6 +108,55 @@ class TestAgentSandboxProvider:
         assert "containers" in body["spec"]["podTemplate"]["spec"]
         assert "volumes" in body["spec"]["podTemplate"]["spec"]
 
+    def test_create_workload_per_request_service_account_overrides_config(self, mock_k8s_client):
+        """A per-request serviceAccountName overrides the configured default SA."""
+        provider = AgentSandboxProvider(
+            mock_k8s_client,
+            _app_config(shutdown_policy="Delete", service_account="agent-sa"),
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+            service_account_name="agent-override-sa",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        assert body["spec"]["podTemplate"]["spec"]["serviceAccountName"] == "agent-override-sa"
+
+    def test_create_workload_without_service_account_omits_field(self, mock_k8s_client):
+        """No configured SA and none requested leaves serviceAccountName unset."""
+        provider = AgentSandboxProvider(mock_k8s_client, _app_config())
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        assert "serviceAccountName" not in body["spec"]["podTemplate"]["spec"]
+
+
     def test_create_workload_injects_platform_node_selector(self, mock_k8s_client):
         provider = AgentSandboxProvider(mock_k8s_client, _app_config())
         mock_k8s_client.create_custom_object.return_value = {

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -90,6 +90,17 @@ def _app_config_with_egress_disable_ipv6(disable_ipv6: bool = True) -> AppConfig
     )
 
 
+def _app_config_with_service_account(service_account: str) -> AppConfig:
+    """Build an AppConfig with a default ``kubernetes.service_account`` set."""
+    return AppConfig(
+        runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
+        kubernetes=KubernetesRuntimeConfig(
+            namespace="test-ns",
+            service_account=service_account,
+        ),
+    )
+
+
 class TestBatchSandboxProvider:
     # ===== Initialization Tests =====
 
@@ -2877,6 +2888,126 @@ spec:
                 extensions={"poolRef": "my-pool"},
                 volumes=volumes,
             )
+
+    def test_create_workload_sets_per_request_service_account(self, mock_k8s_client):
+        """A per-request serviceAccountName lands on the pod spec."""
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+            service_account_name="agent-finance-sa",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        pod_spec = body["spec"]["template"]["spec"]
+        assert pod_spec["serviceAccountName"] == "agent-finance-sa"
+
+    def test_create_workload_falls_back_to_configured_service_account(self, mock_k8s_client):
+        """When no per-request SA is given, the configured default is used."""
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_service_account("default-sa")
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        pod_spec = body["spec"]["template"]["spec"]
+        assert pod_spec["serviceAccountName"] == "default-sa"
+
+    def test_create_workload_per_request_service_account_overrides_default(self, mock_k8s_client):
+        """A per-request SA takes precedence over the configured default."""
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_service_account("default-sa")
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+            service_account_name="agent-override-sa",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        pod_spec = body["spec"]["template"]["spec"]
+        assert pod_spec["serviceAccountName"] == "agent-override-sa"
+
+    def test_create_workload_without_service_account_omits_field(self, mock_k8s_client):
+        """No SA configured and none requested leaves serviceAccountName unset."""
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={"cpu": "1", "memory": "1Gi"},
+            labels={"opensandbox.io/id": "test-id"},
+            expires_at=None,
+            execd_image="execd:latest",
+        )
+
+        body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
+        pod_spec = body["spec"]["template"]["spec"]
+        assert "serviceAccountName" not in pod_spec
+
+    def test_create_workload_pool_mode_rejects_service_account(self, mock_k8s_client):
+        """Pool mode rejects a per-request serviceAccountName with a clear error."""
+        provider = BatchSandboxProvider(mock_k8s_client)
+
+        with pytest.raises(
+            ValueError, match="Pool mode does not support serviceAccountName"
+        ):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+                extensions={"poolRef": "my-pool"},
+                service_account_name="agent-finance-sa",
+            )
+
 
     def test_apply_volumes_to_pod_spec_empty_volumes(self, mock_k8s_client):
         """

--- a/server/tests/test_schema.py
+++ b/server/tests/test_schema.py
@@ -688,6 +688,17 @@ class TestCreateSandboxRequestPoolMode:
             exc_info.value
         )
 
+    def test_pool_mode_rejects_service_account_name(self):
+        """serviceAccountName and poolRef cannot be used together."""
+        with pytest.raises(ValidationError) as exc_info:
+            CreateSandboxRequest(
+                extensions={"poolRef": "my-pool"},
+                serviceAccountName="agent-finance-sa",
+            )
+        assert "serviceAccountName cannot be used together with poolRef" in str(
+            exc_info.value
+        )
+
     def test_resource_limits_required_without_pool_ref(self):
         """Without poolRef, resourceLimits is still required (image mode)."""
         with pytest.raises(ValidationError):
@@ -710,3 +721,44 @@ class TestCreateSandboxRequestPoolMode:
             CreateSandboxRequest(
                 extensions={"poolRef": "   "},
             )
+
+
+class TestCreateSandboxRequestServiceAccount:
+    """Tests for the serviceAccountName field."""
+
+    def test_accepts_valid_service_account_name(self):
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            entrypoint=["python"],
+            resourceLimits=ResourceLimits(root={"cpu": "500m"}),
+            serviceAccountName="agent-finance-sa",
+        )
+        assert request.service_account_name == "agent-finance-sa"
+
+    def test_omitting_service_account_name_defaults_to_none(self):
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            entrypoint=["python"],
+            resourceLimits=ResourceLimits(root={"cpu": "500m"}),
+        )
+        assert request.service_account_name is None
+
+    def test_rejects_invalid_service_account_name(self):
+        """Uppercase / invalid characters violate the RFC 1123 DNS label pattern."""
+        with pytest.raises(ValidationError):
+            CreateSandboxRequest(
+                image=ImageSpec(uri="python:3.11"),
+                entrypoint=["python"],
+                resourceLimits=ResourceLimits(root={"cpu": "500m"}),
+                serviceAccountName="Invalid_SA",
+            )
+
+    def test_rejects_empty_service_account_name(self):
+        with pytest.raises(ValidationError):
+            CreateSandboxRequest(
+                image=ImageSpec(uri="python:3.11"),
+                entrypoint=["python"],
+                resourceLimits=ResourceLimits(root={"cpu": "500m"}),
+                serviceAccountName="",
+            )
+

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1315,6 +1315,29 @@ components:
             accessible without the additional access token for backward
             compatibility.
 
+        serviceAccountName:
+          type: string
+          minLength: 1
+          maxLength: 253
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          description: |
+            Kubernetes ServiceAccount bound to the sandbox Pod.
+
+            Only meaningful for Kubernetes-based runtimes; ignored by the Docker
+            runtime. When provided, the sandbox Pod runs under this ServiceAccount,
+            enabling per-sandbox cloud identity (e.g. Workload Identity federation)
+            and least-privilege access to external resources.
+
+            When omitted, the server falls back to the globally configured default
+            ServiceAccount (`kubernetes.service_account`); if neither is set, the
+            namespace `default` ServiceAccount is used.
+
+            The ServiceAccount must already exist in the sandbox namespace, and the
+            name must be a valid RFC 1123 DNS label. Not supported together with
+            `extensions.poolRef` (pool ServiceAccount is defined by the pool
+            template).
+          example: "agent-finance-sa"
+
         volumes:
           type: array
           description: |


### PR DESCRIPTION
## Summary
- Enable each sandbox to bind its own Kubernetes ServiceAccount at creation, giving agents per-sandbox cloud identity (Workload Identity → cloud managed identity) with least-privilege external access.
- Resolution priority: per-request `serviceAccountName` > global `kubernetes.service_account` config > namespace `default`. The field is an optional RFC 1123 DNS label.
- Pool-based creation (`extensions.poolRef`) rejects a per-request value since the pool template owns the ServiceAccount.

## Changes
- **spec**: add `serviceAccountName` to `CreateSandboxRequest`
- **server**: thread SA through schema, both k8s providers (batchsandbox, agent-sandbox), workload provider, and config default
- **sdk**: propagate through Python (async+sync), JavaScript, Go, Kotlin, and C# handwritten layers; regenerate Python/JS/Kotlin API models
- **tests**: server + all five SDKs cover set/omit and pool rejection

## Test plan
- [x] Server unit tests (batchsandbox / agent-sandbox / schema)
- [x] Python / JavaScript / Go / Kotlin / C# SDK unit tests
- [x] Real AKS + Workload Identity E2E: `create(serviceAccountName=X)` → `Pod.spec.serviceAccountName=X` → WI env injection → cloud token exchange (managed-identity access token acquired in-pod)
- [x] Negative: pool mode + `serviceAccountName` → 422 rejection
- [x] Negative: omit `serviceAccountName` → falls back to namespace `default`