### PR TITLE
feat(server): add configurable port range for Docker bridge-mode sand…

### DIFF
--- a/server/configuration.md
+++ b/server/configuration.md
@@ -108,6 +108,8 @@ Example files in this repository:
 | `no_new_privileges` | boolean | `true` | Sets `no-new-privileges` to block privilege escalation. |
 | `seccomp_profile` | string \| omitted | `null` | Seccomp profile name or **absolute path**; empty uses Docker default seccomp. |
 | `pids_limit` | integer \| null | `4096` | Max PIDs per sandbox container; set to **`null`** to disable the limit. |
+| `port_range_min` | integer | `40000` | Lower bound of the host port range used by bridge-mode sandbox port allocation. Must be less than `port_range_max`. Each sandbox needs 2–3 host ports (2 without egress, 3 with egress sidecar). Narrow this range to match your firewall policy — e.g., 100 concurrent sandboxes ≈ 300 ports. |
+| `port_range_max` | integer | `60000` | Upper bound of the host port range. Range must span ≥ 100 ports for reliable allocation. |
 
 ---
 

--- a/server/docker-compose.example.yaml
+++ b/server/docker-compose.example.yaml
@@ -22,6 +22,8 @@ configs:
       # When server runs in a container, set host_ip to the host's IP or hostname so bridge-mode endpoints are reachable (e.g. host.docker.internal or the host LAN IP).
       # It's required when server deployed with docker container under host.
       host_ip = "host.docker.internal"
+      port_range_min = 40000
+      port_range_max = 60000
       drop_capabilities = ["AUDIT_WRITE", "MKNOD", "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_MODULE", "SYS_PTRACE", "SYS_TIME", "SYS_TTY_CONFIG"]
       no_new_privileges = true
       # TODO: For production environments, it is recommended to set this to '4096' or higher to avoid

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -834,11 +834,44 @@ class DockerConfig(BaseModel):
             "Optional seccomp profile name or path applied to sandbox containers. Leave unset to use Docker's default profile."
         ),
     )
+    port_range_min: int = Field(
+        default=40000,
+        ge=1024,
+        le=65535,
+        description=(
+            "Lower bound of the host port range for bridge-mode sandbox port allocation. "
+            "Must be less than port_range_max. Narrow the range to match your firewall policy."
+        ),
+    )
+    port_range_max: int = Field(
+        default=60000,
+        ge=1024,
+        le=65535,
+        description=(
+            "Upper bound of the host port range for bridge-mode sandbox port allocation. "
+            "Range must span at least 100 ports for reliable allocation. "
+            "Each sandbox needs 2–3 host ports (2 without egress, 3 with egress sidecar)."
+        ),
+    )
     pids_limit: Optional[int] = Field(
         default=4096,
         ge=1,
         description="Maximum number of processes allowed per sandbox container. Set to null to disable the limit.",
     )
+
+    @model_validator(mode="after")
+    def validate_port_range(self) -> "DockerConfig":
+        if self.port_range_min >= self.port_range_max:
+            raise ValueError(
+                f"docker.port_range_min ({self.port_range_min}) must be less than "
+                f"docker.port_range_max ({self.port_range_max})."
+            )
+        if self.port_range_max - self.port_range_min < 100:
+            raise ValueError(
+                f"Port range ({self.port_range_min}-{self.port_range_max}) is too narrow. "
+                f"Need at least 100 ports for reliable allocation."
+            )
+        return self
 
 
 class StoreConfig(BaseModel):

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -49,6 +49,11 @@ path = "~/.opensandbox/opensandbox.db"
 
 [docker]
 network_mode = "bridge"
+# Host port range for bridge-mode sandbox port allocation.
+# Each sandbox needs 2–3 host ports (2 without egress, 3 with egress sidecar).
+# Narrow the range to match your firewall policy — e.g., 100 concurrent sandboxes ≈ 300 ports.
+port_range_min = 40000
+port_range_max = 60000
 # Drop dangerous capabilities and block privilege escalation
 drop_capabilities = ["AUDIT_WRITE", "MKNOD", "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_MODULE", "SYS_PTRACE", "SYS_TIME", "SYS_TTY_CONFIG"]
 no_new_privileges = true

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -47,6 +47,11 @@ path = "~/.opensandbox/opensandbox.db"
 [docker]
 # Supported values for network_mode: "host", "bridge"
 network_mode = "bridge"
+# Bridge 模式下沙箱端口映射的宿主机端口范围。
+# 每个沙箱需要 2–3 个宿主机端口（无 egress 需要 2 个，有 egress sidecar 需要 3 个）。
+# 可根据防火墙策略缩小范围 — 例如 100 个并发沙箱 ≈ 需要 300 个端口。
+port_range_min = 40000
+port_range_max = 60000
 # Drop dangerous capabilities and block privilege escalation
 drop_capabilities = ["AUDIT_WRITE", "MKNOD", "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_MODULE", "SYS_PTRACE", "SYS_TIME", "SYS_TTY_CONFIG"]
 no_new_privileges = true

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -893,7 +893,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
 
                 egress_token = generate_egress_token()
                 labels[SANDBOX_EGRESS_AUTH_TOKEN_METADATA_KEY] = egress_token
-                sidecar_port_bindings = allocate_port_bindings([*exposed_ports, "18080"])
+                sidecar_port_bindings = allocate_port_bindings([*exposed_ports, "18080"], min_port=self.app_config.docker.port_range_min, max_port=self.app_config.docker.port_range_max)
                 host_execd_port = sidecar_port_bindings["44772"][1]
                 host_http_port = sidecar_port_bindings["8080"][1]
                 egress_api_binding = sidecar_port_bindings.get("18080")
@@ -936,7 +936,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     gpu_count=effective_gpu_count,
                 )
                 if self.network_mode != HOST_NETWORK_MODE:
-                    port_bindings = allocate_port_bindings(exposed_ports)
+                    port_bindings = allocate_port_bindings(exposed_ports, min_port=self.app_config.docker.port_range_min, max_port=self.app_config.docker.port_range_max)
                     host_execd_port = port_bindings["44772"][1]
                     host_http_port = port_bindings["8080"][1]
                     host_config_kwargs["port_bindings"] = normalize_port_bindings(port_bindings)

--- a/server/opensandbox_server/services/docker/port_allocator.py
+++ b/server/opensandbox_server/services/docker/port_allocator.py
@@ -74,13 +74,15 @@ def allocate_host_port(
 
 def allocate_port_bindings(
     container_ports: list[str],
+    min_port: int = 40000,
+    max_port: int = 60000,
 ) -> Dict[str, tuple[str, int]]:
     """Allocate distinct random host ports for each container port spec."""
     allocated_ports: set[int] = set()
     bindings: Dict[str, tuple[str, int]] = {}
     for container_port in container_ports:
         while True:
-            host_port = allocate_host_port()
+            host_port = allocate_host_port(min_port=min_port, max_port=max_port)
             if host_port is None:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/server/tests/test_docker_port_allocator.py
+++ b/server/tests/test_docker_port_allocator.py
@@ -49,8 +49,44 @@ def test_allocate_host_port_probes_docker_publish_address(monkeypatch) -> None:
 
 
 def test_allocate_port_bindings_keep_docker_publish_host(monkeypatch) -> None:
-    monkeypatch.setattr(port_allocator, "allocate_host_port", lambda: 45678)
+    monkeypatch.setattr(port_allocator, "allocate_host_port", lambda min_port=40000, max_port=60000, attempts=50: 45678)
 
     bindings = port_allocator.allocate_port_bindings(["8080"])
 
     assert bindings == {"8080": (port_allocator.DOCKER_PUBLISH_HOST, 45678)}
+
+
+def test_allocate_host_port_respects_custom_range(monkeypatch) -> None:
+    """allocate_host_port uses passed min/max instead of defaults."""
+    monkeypatch.setattr(port_allocator.random, "randint", lambda a, b: 41000)
+    bound_addresses: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        port_allocator.socket,
+        "socket",
+        lambda family, sock_type: _FakeSocket(bound_addresses),
+    )
+
+    port = port_allocator.allocate_host_port(min_port=41000, max_port=41100, attempts=1)
+
+    assert port == 41000
+    assert bound_addresses == [(port_allocator.PORT_PROBE_HOST, 41000)]
+
+
+def test_allocate_port_bindings_passes_custom_range(monkeypatch) -> None:
+    """allocate_port_bindings forwards custom range to allocate_host_port."""
+    calls: list[tuple[int, int]] = []
+
+    def tracked_allocate(min_port=40000, max_port=60000, attempts=50):
+        calls.append((min_port, max_port))
+        return 41000
+
+    monkeypatch.setattr(port_allocator, "allocate_host_port", tracked_allocate)
+
+    bindings = port_allocator.allocate_port_bindings(
+        ["8080"],
+        min_port=41000,
+        max_port=41100,
+    )
+
+    assert calls == [(41000, 41100)]
+    assert bindings == {"8080": (port_allocator.DOCKER_PUBLISH_HOST, 41000)}


### PR DESCRIPTION
…box allocation

Add port_range_min/port_range_max fields to [docker] config section, allowing users to narrow the host port range for bridge-mode sandbox port allocation. Defaults remain 40000-60000 for backward compatibility.

This addresses the issue where host-mode sandboxes share the fixed execd port 44772, causing SDK requests to always route to the first sandbox's execd. Bridge mode with configurable port ranges resolves this, and the narrower range helps with firewall/security policies.

# Summary
- What is changing and why?

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [ ] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [ ] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Security impact considered
- [ ] Backward compatibility considered
