### PR TITLE
feat: add multi-tenancy provider with file and HTTP backends

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -35,6 +35,8 @@ from opensandbox_server.api import lifecycle
 from opensandbox_server.api.schema import Endpoint
 from opensandbox_server.middleware.auth import SANDBOX_API_KEY_HEADER
 from opensandbox_server.services.constants import OPEN_SANDBOX_EGRESS_AUTH_HEADER, OPEN_SANDBOX_SECURE_ACCESS_HEADER
+from opensandbox_server.tenants.context import set_current_tenant
+from opensandbox_server.tenants.provider import TenantProviderUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +167,44 @@ def _schedule_proxy_renew(request: Request | WebSocket, sandbox_id: str) -> None
     proxy_renew = getattr(request.app.state, "proxy_renew_coordinator", None)
     if proxy_renew is not None:
         proxy_renew.schedule(sandbox_id)
+
+
+async def _authenticate_websocket_tenant(websocket: WebSocket) -> bool:
+    """Authenticate WebSocket connections in multi-tenant mode.
+
+    BaseHTTPMiddleware only intercepts HTTP requests, so WebSocket
+    connections must be authenticated here to establish tenant context.
+    Returns True if the request is authorized (or single-tenant mode).
+    """
+    import asyncio
+
+    provider = getattr(websocket.app.state, "tenant_provider", None)
+    if provider is None:
+        return True
+
+    api_key = websocket.headers.get(SANDBOX_API_KEY_HEADER)
+    if not api_key:
+        await _fail_client_websocket(
+            websocket, status.WS_1008_POLICY_VIOLATION, "missing API key"
+        )
+        return False
+
+    try:
+        tenant = await asyncio.to_thread(provider.lookup, api_key)
+    except TenantProviderUnavailable:
+        await _fail_client_websocket(
+            websocket, status.WS_1011_INTERNAL_ERROR, "tenant provider unavailable"
+        )
+        return False
+
+    if tenant is None:
+        await _fail_client_websocket(
+            websocket, status.WS_1008_POLICY_VIOLATION, "invalid API key"
+        )
+        return False
+
+    set_current_tenant(tenant)
+    return True
 
 
 async def _stream_backend_response(resp: httpx.Response) -> AsyncIterator[bytes]:
@@ -359,6 +399,9 @@ async def _proxy_websocket_request(
     port: int,
     full_path: str,
 ) -> None:
+    if not await _authenticate_websocket_tenant(websocket):
+        return
+
     try:
         endpoint = lifecycle.sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
     except HTTPException as exc:
@@ -386,7 +429,6 @@ async def _proxy_websocket_request(
         return
 
     _schedule_proxy_renew(websocket, sandbox_id)
-
     query_string = websocket.url.query or ""
     target_url = _build_proxy_target_url(
         endpoint,

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -897,6 +897,43 @@ class StoreConfig(BaseModel):
     )
 
 
+class TenantsConfig(BaseModel):
+    """Multi-tenant provider configuration."""
+
+    provider: Literal["file", "http"] = Field(
+        default="file",
+        description="Tenant provider type: 'file' (tenants.toml) or 'http' (remote endpoint).",
+    )
+    endpoint: Optional[str] = Field(
+        default=None,
+        description="HTTP tenant provider endpoint URL. Required when provider='http'.",
+    )
+    max_stale_seconds: float = Field(
+        default=300.0,
+        ge=0,
+        description="Maximum seconds to serve stale cache when HTTP endpoint is unreachable.",
+    )
+    timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description="HTTP request timeout in seconds.",
+    )
+    auth_header: Optional[str] = Field(
+        default=None,
+        description="Optional header name for provider-level authentication to HTTP endpoint.",
+    )
+    auth_token: Optional[str] = Field(
+        default=None,
+        description="Optional token value for provider-level authentication to HTTP endpoint.",
+    )
+
+    @model_validator(mode="after")
+    def require_endpoint_for_http(self) -> "TenantsConfig":
+        if self.provider == "http" and not self.endpoint:
+            raise ValueError("[tenants] endpoint must be set when provider='http'.")
+        return self
+
+
 class AppConfig(BaseModel):
     """Root application configuration model."""
 
@@ -904,6 +941,10 @@ class AppConfig(BaseModel):
     log: LogConfig = Field(
         default_factory=LogConfig,
         description="Logging configuration (level, file output, rotation).",
+    )
+    tenants: Optional[TenantsConfig] = Field(
+        default=None,
+        description="Multi-tenant configuration. When present, enables multi-tenant mode.",
     )
     renew_intent: RenewIntentConfig = Field(
         default_factory=RenewIntentConfig,

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -34,10 +34,37 @@ from opensandbox_server.config import load_config
 from opensandbox_server.integrations.renew_intent import start_renew_intent_consumer
 from opensandbox_server.logging_config import configure_logging
 from opensandbox_server.startup_guard import api_key_confirm
+from opensandbox_server.tenants import validate_tenant_config, TenantProvider
 
 # Load configuration before initializing routers/middleware
 app_config = load_config()
 _log_config = configure_logging(app_config.log)
+validate_tenant_config(app_config)
+
+
+def _build_tenant_provider(config) -> TenantProvider | None:
+    if config.tenants is None:
+        return None
+    if config.tenants.provider == "http":
+        from opensandbox_server.tenants.http_provider import (
+            HTTPTenantProvider,
+            HTTPTenantProviderConfig,
+        )
+
+        http_cfg = HTTPTenantProviderConfig(
+            endpoint=config.tenants.endpoint,
+            max_stale_seconds=config.tenants.max_stale_seconds,
+            timeout_seconds=config.tenants.timeout_seconds,
+            auth_header=config.tenants.auth_header,
+            auth_token=config.tenants.auth_token,
+        )
+        return HTTPTenantProvider(http_cfg)
+    from opensandbox_server.tenants.file_provider import FileTenantProvider
+
+    return FileTenantProvider()
+
+
+tenant_provider: TenantProvider | None = _build_tenant_provider(app_config)
 
 from opensandbox_server.api.devops import router as devops_router  # noqa: E402
 from opensandbox_server.api.pool import router as pool_router  # noqa: E402
@@ -55,11 +82,16 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    try:
-        api_key_confirm(configured_api_key=app_config.server.api_key)
-    except Exception as exc:
-        logger.error("API key startup confirmation failed: %s", exc)
-        os._exit(1)
+    if tenant_provider is None:
+        try:
+            api_key_confirm(configured_api_key=app_config.server.api_key)
+        except Exception as exc:
+            logger.error("API key startup confirmation failed: %s", exc)
+            os._exit(1)
+
+    if tenant_provider is not None:
+        tenant_provider.start()
+        sandbox_service.set_tenant_provider(tenant_provider)
 
     from anyio.to_thread import current_default_thread_limiter
 
@@ -114,6 +146,8 @@ async def lifespan(app: FastAPI):
     if consumer is not None:
         await consumer.stop()
     snapshot_service.close()
+    if tenant_provider is not None:
+        tenant_provider.close()
     await app.state.http_client.aclose()
 
 
@@ -133,7 +167,7 @@ app.state.config = app_config
 
 # Middleware run in reverse order of addition: last added = first to run (outermost).
 # Add auth and CORS first so they run after RequestIdMiddleware.
-app.add_middleware(AuthMiddleware, config=app_config)
+app.add_middleware(AuthMiddleware, config=app_config, tenant_provider=tenant_provider)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -164,6 +164,7 @@ app = FastAPI(
 
 # Attach global config for runtime access
 app.state.config = app_config
+app.state.tenant_provider = tenant_provider
 
 # Middleware run in reverse order of addition: last added = first to run (outermost).
 # Add auth and CORS first so they run after RequestIdMiddleware.

--- a/server/opensandbox_server/middleware/auth.py
+++ b/server/opensandbox_server/middleware/auth.py
@@ -79,7 +79,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if any(request.url.path.startswith(path) for path in self.EXEMPT_PATHS):
             return await call_next(request)
 
-        if self._is_proxy_path(request.url.path):
+        if self._is_proxy_path(request.url.path) and not self._is_multi_tenant:
             return await call_next(request)
 
         # If no API keys configured AND no tenant provider → skip auth

--- a/server/opensandbox_server/middleware/auth.py
+++ b/server/opensandbox_server/middleware/auth.py
@@ -15,10 +15,12 @@
 """
 Authentication middleware for OpenSandbox Lifecycle API.
 
-This module implements API Key authentication as specified in the OpenAPI spec.
-API keys are configured via config.toml and validated against the OPEN-SANDBOX-API-KEY header.
+Supports two modes:
+- Single-tenant: validates against server.api_key (legacy)
+- Multi-tenant: delegates to a TenantProvider for key→tenant resolution
 """
 
+import logging
 import re
 from typing import Callable, Optional
 
@@ -27,6 +29,10 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from opensandbox_server.config import AppConfig, get_config
+from opensandbox_server.tenants.context import set_current_tenant
+from opensandbox_server.tenants.provider import TenantProvider, TenantProviderUnavailable
+
+logger = logging.getLogger(__name__)
 
 SANDBOX_API_KEY_HEADER = "OPEN-SANDBOX-API-KEY"
 
@@ -53,61 +59,35 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return False
         return bool(AuthMiddleware._PROXY_PATH_RE.match(path))
 
-    def __init__(self, app, config: Optional[AppConfig] = None):
-        """
-        Initialize authentication middleware.
-
-        Args:
-            app: FastAPI application instance
-            config: Optional application configuration (for dependency injection)
-        """
+    def __init__(self, app, config: Optional[AppConfig] = None, tenant_provider: Optional[TenantProvider] = None):
         super().__init__(app)
         self.config = config or get_config()
-        # Read the API key directly from config; suitable for dev/test usage
+        self.tenant_provider = tenant_provider
         self.valid_api_keys = self._load_api_keys()
 
     def _load_api_keys(self) -> set:
-        """
-        Load valid API keys from configuration.
-
-        Returns:
-            set: Set of valid API keys
-        """
-        # Supports a single API key from config; extend later for secret managers
         api_key = self.config.server.api_key
-        # Treat empty string as no key configured
         if api_key and api_key.strip():
             return {api_key}
         return set()
 
+    @property
+    def _is_multi_tenant(self) -> bool:
+        return self.tenant_provider is not None
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
-        """
-        Process each request and validate authentication.
-
-        Args:
-            request: Incoming HTTP request
-            call_next: Next middleware or route handler
-
-        Returns:
-            Response: HTTP response
-        """
-        # Skip authentication for exempt paths
         if any(request.url.path.startswith(path) for path in self.EXEMPT_PATHS):
             return await call_next(request)
 
-        # Skip authentication only for the exact proxy-to-sandbox route shape
-        # (no path traversal, no loose substring match)
         if self._is_proxy_path(request.url.path):
             return await call_next(request)
 
-        # If no API keys are configured, skip authentication
-        if not self.valid_api_keys:
+        # If no API keys configured AND no tenant provider → skip auth
+        if not self._is_multi_tenant and not self.valid_api_keys:
             return await call_next(request)
 
-        # Extract API key from header
         api_key = request.headers.get(SANDBOX_API_KEY_HEADER)
 
-        # Validate API key
         if not api_key:
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -118,7 +98,46 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 },
             )
 
-        # Enforce strict comparison whenever API keys are configured
+        if self._is_multi_tenant:
+            return await self._authenticate_multi_tenant(api_key, request, call_next)
+        else:
+            return await self._authenticate_single_tenant(api_key, request, call_next)
+
+    async def _authenticate_multi_tenant(
+        self, api_key: str, request: Request, call_next: Callable
+    ) -> Response:
+        import asyncio
+
+        try:
+            tenant = await asyncio.to_thread(self.tenant_provider.lookup, api_key)
+        except TenantProviderUnavailable as e:
+            logger.error("Tenant provider unavailable: %s", e)
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "code": "TENANT_PROVIDER_UNAVAILABLE",
+                    "message": "Tenant authentication service is temporarily unavailable.",
+                },
+            )
+
+        if tenant is None:
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content={
+                    "code": "INVALID_API_KEY",
+                    "message": "Authentication credentials are invalid. "
+                              "Check your API key and try again.",
+                },
+            )
+
+        set_current_tenant(tenant)
+        request.state.tenant = tenant
+        response = await call_next(request)
+        return response
+
+    async def _authenticate_single_tenant(
+        self, api_key: str, request: Request, call_next: Callable
+    ) -> Response:
         if self.valid_api_keys and api_key not in self.valid_api_keys:
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -129,6 +148,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 },
             )
 
-        # Authentication successful, proceed to next middleware/handler
+        set_current_tenant(None)
         response = await call_next(request)
         return response

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -101,7 +101,7 @@ class SQLiteSnapshotRepository:
         clauses: list[str] = []
         params: list[object] = []
 
-        if query.namespace:
+        if query.namespace is not None:
             clauses.append("namespace = ?")
             params.append(query.namespace)
 

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -264,6 +264,7 @@ class SQLiteSnapshotRepository:
                 """
             )
             self._migrate_add_namespace(conn)
+            self._migrate_namespace_nullable(conn)
 
     @staticmethod
     def _migrate_add_namespace(conn: sqlite3.Connection) -> None:
@@ -274,6 +275,42 @@ class SQLiteSnapshotRepository:
             conn.execute(
                 "ALTER TABLE snapshots ADD COLUMN namespace TEXT DEFAULT NULL"
             )
+
+    @staticmethod
+    def _migrate_namespace_nullable(conn: sqlite3.Connection) -> None:
+        """Convert namespace from NOT NULL to nullable for non-tenant mode."""
+        rows = conn.execute("PRAGMA table_info(snapshots)").fetchall()
+        for row in rows:
+            if row["name"] == "namespace" and row["notnull"]:
+                conn.executescript(
+                    """
+                    CREATE TABLE snapshots_tmp AS SELECT * FROM snapshots;
+                    DROP TABLE snapshots;
+                    CREATE TABLE snapshots (
+                        id TEXT PRIMARY KEY,
+                        source_sandbox_id TEXT NOT NULL,
+                        namespace TEXT DEFAULT NULL,
+                        name TEXT,
+                        description TEXT,
+                        restore_config TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        reason TEXT,
+                        message TEXT,
+                        last_transition_at TEXT,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+                    INSERT INTO snapshots SELECT * FROM snapshots_tmp;
+                    DROP TABLE snapshots_tmp;
+                    CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id
+                        ON snapshots(source_sandbox_id);
+                    CREATE INDEX IF NOT EXISTS idx_snapshots_state
+                        ON snapshots(state);
+                    CREATE INDEX IF NOT EXISTS idx_snapshots_created_at
+                        ON snapshots(created_at DESC);
+                    """
+                )
+                break
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self._db_path)

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -57,6 +57,7 @@ class SQLiteSnapshotRepository:
                 INSERT INTO snapshots (
                     id,
                     source_sandbox_id,
+                    namespace,
                     name,
                     description,
                     restore_config,
@@ -66,7 +67,7 @@ class SQLiteSnapshotRepository:
                     last_transition_at,
                     created_at,
                     updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._to_db_tuple(record),
             )
@@ -79,6 +80,7 @@ class SQLiteSnapshotRepository:
                 SELECT
                     id,
                     source_sandbox_id,
+                    namespace,
                     name,
                     description,
                     restore_config,
@@ -98,6 +100,10 @@ class SQLiteSnapshotRepository:
     def list(self, query: SnapshotListQuery) -> SnapshotListResult:
         clauses: list[str] = []
         params: list[object] = []
+
+        if query.namespace:
+            clauses.append("namespace = ?")
+            params.append(query.namespace)
 
         if query.source_sandbox_id:
             clauses.append("source_sandbox_id = ?")
@@ -124,6 +130,7 @@ class SQLiteSnapshotRepository:
                 SELECT
                     id,
                     source_sandbox_id,
+                    namespace,
                     name,
                     description,
                     restore_config,
@@ -153,6 +160,7 @@ class SQLiteSnapshotRepository:
                 UPDATE snapshots
                 SET
                     source_sandbox_id = ?,
+                    namespace = ?,
                     name = ?,
                     description = ?,
                     restore_config = ?,
@@ -166,6 +174,7 @@ class SQLiteSnapshotRepository:
                 """,
                 (
                     record.source_sandbox_id,
+                    record.namespace,
                     record.name,
                     record.description,
                     json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
@@ -191,6 +200,7 @@ class SQLiteSnapshotRepository:
                 UPDATE snapshots
                 SET
                     source_sandbox_id = ?,
+                    namespace = ?,
                     name = ?,
                     description = ?,
                     restore_config = ?,
@@ -204,6 +214,7 @@ class SQLiteSnapshotRepository:
                 """,
                 (
                     record.source_sandbox_id,
+                    record.namespace,
                     record.name,
                     record.description,
                     json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
@@ -230,6 +241,7 @@ class SQLiteSnapshotRepository:
                 CREATE TABLE IF NOT EXISTS snapshots (
                     id TEXT PRIMARY KEY,
                     source_sandbox_id TEXT NOT NULL,
+                    namespace TEXT NOT NULL DEFAULT 'default',
                     name TEXT,
                     description TEXT,
                     restore_config TEXT NOT NULL,
@@ -251,6 +263,17 @@ class SQLiteSnapshotRepository:
                     ON snapshots(created_at DESC);
                 """
             )
+            self._migrate_add_namespace(conn)
+
+    @staticmethod
+    def _migrate_add_namespace(conn: sqlite3.Connection) -> None:
+        """Add namespace column if missing (added for multi-tenant isolation)."""
+        rows = conn.execute("PRAGMA table_info(snapshots)").fetchall()
+        columns = {row["name"] for row in rows}
+        if "namespace" not in columns:
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default'"
+            )
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self._db_path)
@@ -263,6 +286,7 @@ class SQLiteSnapshotRepository:
         return (
             record.id,
             record.source_sandbox_id,
+            record.namespace,
             record.name,
             record.description,
             json.dumps(self._restore_config_to_dict(record.restore_config), sort_keys=True),
@@ -290,6 +314,7 @@ class SQLiteSnapshotRepository:
         return SnapshotRecord(
             id=row["id"],
             source_sandbox_id=row["source_sandbox_id"],
+            namespace=row["namespace"],
             name=row["name"],
             description=row["description"],
             restore_config=SnapshotRestoreConfig(

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -241,7 +241,7 @@ class SQLiteSnapshotRepository:
                 CREATE TABLE IF NOT EXISTS snapshots (
                     id TEXT PRIMARY KEY,
                     source_sandbox_id TEXT NOT NULL,
-                    namespace TEXT NOT NULL DEFAULT 'default',
+                    namespace TEXT DEFAULT NULL,
                     name TEXT,
                     description TEXT,
                     restore_config TEXT NOT NULL,
@@ -272,7 +272,7 @@ class SQLiteSnapshotRepository:
         columns = {row["name"] for row in rows}
         if "namespace" not in columns:
             conn.execute(
-                "ALTER TABLE snapshots ADD COLUMN namespace TEXT NOT NULL DEFAULT 'default'"
+                "ALTER TABLE snapshots ADD COLUMN namespace TEXT DEFAULT NULL"
             )
 
     def _connect(self) -> sqlite3.Connection:

--- a/server/opensandbox_server/repositories/snapshots/sqlite.py
+++ b/server/opensandbox_server/repositories/snapshots/sqlite.py
@@ -284,9 +284,7 @@ class SQLiteSnapshotRepository:
             if row["name"] == "namespace" and row["notnull"]:
                 conn.executescript(
                     """
-                    CREATE TABLE snapshots_tmp AS SELECT * FROM snapshots;
-                    DROP TABLE snapshots;
-                    CREATE TABLE snapshots (
+                    CREATE TABLE snapshots_new (
                         id TEXT PRIMARY KEY,
                         source_sandbox_id TEXT NOT NULL,
                         namespace TEXT DEFAULT NULL,
@@ -300,8 +298,17 @@ class SQLiteSnapshotRepository:
                         created_at TEXT NOT NULL,
                         updated_at TEXT NOT NULL
                     );
-                    INSERT INTO snapshots SELECT * FROM snapshots_tmp;
-                    DROP TABLE snapshots_tmp;
+                    INSERT INTO snapshots_new (
+                        id, source_sandbox_id, namespace, name, description,
+                        restore_config, state, reason, message,
+                        last_transition_at, created_at, updated_at
+                    ) SELECT
+                        id, source_sandbox_id, namespace, name, description,
+                        restore_config, state, reason, message,
+                        last_transition_at, created_at, updated_at
+                    FROM snapshots;
+                    DROP TABLE snapshots;
+                    ALTER TABLE snapshots_new RENAME TO snapshots;
                     CREATE INDEX IF NOT EXISTS idx_snapshots_source_sandbox_id
                         ON snapshots(source_sandbox_id);
                     CREATE INDEX IF NOT EXISTS idx_snapshots_state

--- a/server/opensandbox_server/services/docker/snapshot_runtime.py
+++ b/server/opensandbox_server/services/docker/snapshot_runtime.py
@@ -56,13 +56,15 @@ class DockerSnapshotRuntime:
         self,
         snapshot_id: str,
         sandbox_id: str,
+        *,
+        namespace: str = "default",
     ) -> Optional[SnapshotRuntimeStatus]:
         return self._create_snapshot(snapshot_id, sandbox_id)
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
         image_ref = image or build_snapshot_image_ref(snapshot_id)
         try:
             self._docker_client.images.remove(image=image_ref)
@@ -89,7 +91,7 @@ class DockerSnapshotRuntime:
                 f"Failed to delete snapshot image {image_ref}: {exc}"
             ) from exc
 
-    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> SnapshotRuntimeStatus:
+    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         image_ref = image or build_snapshot_image_ref(snapshot_id)
         try:
             self._docker_client.images.get(image_ref)

--- a/server/opensandbox_server/services/docker/snapshot_runtime.py
+++ b/server/opensandbox_server/services/docker/snapshot_runtime.py
@@ -57,14 +57,14 @@ class DockerSnapshotRuntime:
         snapshot_id: str,
         sandbox_id: str,
         *,
-        namespace: str = "default",
+        namespace: str | None = None,
     ) -> Optional[SnapshotRuntimeStatus]:
         return self._create_snapshot(snapshot_id, sandbox_id)
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         image_ref = image or build_snapshot_image_ref(snapshot_id)
         try:
             self._docker_client.images.remove(image=image_ref)

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -98,8 +98,22 @@ from opensandbox_server.services.k8s.client import (
 )
 from opensandbox_server.services.k8s.provider_factory import create_workload_provider
 from opensandbox_server.services.snapshot_restore import resolve_sandbox_image_from_request
+from opensandbox_server.tenants.context import get_current_tenant
+from opensandbox_server.tenants.provider import TenantProvider
 
 logger = logging.getLogger(__name__)
+
+
+def _is_namespace_not_found(exc: Exception) -> bool:
+    """True when a K8s ApiException indicates the target namespace does not exist."""
+    try:
+        from kubernetes.client import ApiException
+
+        if not isinstance(exc, ApiException):
+            return False
+        return exc.status == 404 and "namespace" in str(exc).lower()
+    except Exception:
+        return False
 
 
 class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionService):
@@ -132,6 +146,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
         self.namespace = self.app_config.kubernetes.namespace
         self.execd_image = runtime_config.execd_image
+        self._tenant_provider: Optional[TenantProvider] = None
 
         try:
             self.k8s_client = K8sClient(self.app_config.kubernetes)
@@ -171,7 +186,53 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             self.namespace,
             self.execd_image,
         )
-    
+
+    def set_tenant_provider(self, provider: object) -> None:
+        self._tenant_provider = provider  # type: ignore[assignment]
+
+    def _resolve_namespace(self) -> str:
+        tenant = get_current_tenant()
+        return tenant.namespace if tenant else self.namespace
+
+    def _find_sandbox_namespace(self, sandbox_id: str) -> Optional[str]:
+        """Try to locate a sandbox across all known namespaces.
+
+        Used as fallback when ContextVar has no tenant context (background
+        renew workers, proxy path). Returns the namespace or None.
+        """
+        workload = self.workload_provider.get_workload(
+            sandbox_id=sandbox_id, namespace=self.namespace
+        )
+        if workload:
+            return self.namespace
+
+        if self._tenant_provider is not None:
+            for entry in self._tenant_provider.list_tenants():
+                if entry.namespace == self.namespace:
+                    continue
+                try:
+                    workload = self.workload_provider.get_workload(
+                        sandbox_id=sandbox_id, namespace=entry.namespace
+                    )
+                    if workload:
+                        return entry.namespace
+                except Exception:
+                    continue
+
+        return None
+
+    def _resolve_namespace_for_lookup(self, sandbox_id: str) -> str:
+        """Resolve namespace with cross-namespace fallback for background tasks.
+
+        When ContextVar has no tenant (renew workers, proxy path), try to
+        locate the sandbox across all known namespaces.
+        """
+        tenant = get_current_tenant()
+        if tenant:
+            return tenant.namespace
+        found = self._find_sandbox_namespace(sandbox_id)
+        return found if found else self.namespace
+
     async def _wait_for_sandbox_ready(
         self,
         sandbox_id: str,
@@ -205,9 +266,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 workload = await asyncio.to_thread(
                     self.workload_provider.get_workload,
                     sandbox_id=sandbox_id,
-                    namespace=self.namespace,
+                    namespace=self._resolve_namespace(),
                 )
-                
+
                 if not workload:
                     logger.debug(f"Workload not found yet for sandbox {sandbox_id}")
                     await asyncio.sleep(poll_interval_seconds)
@@ -319,7 +380,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             pool = self.k8s_client.get_custom_object(
                 group=OPENSANDBOX_API_GROUP,
                 version=OPENSANDBOX_API_VERSION,
-                namespace=self.namespace,
+                namespace=self._resolve_namespace(),
                 plural=POOL_PLURAL,
                 name=pool_ref,
             )
@@ -413,7 +474,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             if claim_name in existing_cache:
                 continue
             try:
-                existing = self.k8s_client.get_pvc(self.namespace, claim_name)
+                existing = self.k8s_client.get_pvc(self._resolve_namespace(), claim_name)
             except ApiException as e:
                 if e.status == 403:
                     # Fail closed: without read access the ownership pre-pass
@@ -455,7 +516,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             existing = existing_cache.get(claim_name)
             if existing is not None:
                 # Ownership already validated by the pre-pass above.
-                logger.debug(f"PVC '{claim_name}' already exists in namespace '{self.namespace}'")
+                logger.debug(f"PVC '{claim_name}' already exists in namespace '{self._resolve_namespace()}'")
                 continue
 
             storage = vol.pvc.storage or default_size
@@ -471,7 +532,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             pvc_body = V1PersistentVolumeClaim(
                 metadata=V1ObjectMeta(
                     name=claim_name,
-                    namespace=self.namespace,
+                    namespace=self._resolve_namespace(),
                     labels=pvc_labels or None,
                 ),
                 spec={
@@ -483,10 +544,10 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 pvc_body.spec["storageClassName"] = storage_class
 
             try:
-                self.k8s_client.create_pvc(self.namespace, pvc_body)
+                self.k8s_client.create_pvc(self._resolve_namespace(), pvc_body)
                 logger.info(
                     f"Auto-created PVC '{claim_name}' (size={storage}, class={storage_class or '<default>'}) "
-                    f"in namespace '{self.namespace}'"
+                    f"in namespace '{self._resolve_namespace()}'"
                 )
                 if is_managed:
                     managed_pvcs.append(claim_name)
@@ -501,7 +562,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     # confirm ownership and silently proceeding risks the
                     # exact live-data-loss case the guard exists for.
                     try:
-                        racer = self.k8s_client.get_pvc(self.namespace, claim_name)
+                        racer = self.k8s_client.get_pvc(self._resolve_namespace(), claim_name)
                     except Exception as fetch_ex:
                         logger.error(
                             f"PVC '{claim_name}' lost create race and the "
@@ -642,7 +703,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
         for name in claim_names:
             try:
-                self.k8s_client.patch_pvc(self.namespace, name, patch_body)
+                self.k8s_client.patch_pvc(self._resolve_namespace(), name, patch_body)
                 logger.debug(
                     f"sandbox={owner_name} | attached ownerReference {owner_kind}/{owner_name} to PVC '{name}'"
                 )
@@ -765,7 +826,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 workload_info = await asyncio.to_thread(
                     self.workload_provider.create_workload,
                     sandbox_id=sandbox_id,
-                    namespace=self.namespace,
+                    namespace=self._resolve_namespace(),
                     image_spec=request.image,
                     entrypoint=request.entrypoint,
                     env=context.sandbox_env,
@@ -800,7 +861,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     await asyncio.to_thread(
                         self.workload_provider.delete_workload,
                         sandbox_id,
-                        self.namespace,
+                        self._resolve_namespace(),
                     )
                     logger.info(
                         f"Rolled back partial workload for sandbox {sandbox_id} "
@@ -888,7 +949,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                     await asyncio.to_thread(
                         self.workload_provider.delete_workload,
                         sandbox_id,
-                        self.namespace,
+                        self._resolve_namespace(),
                     )
                     workload_left_alive = False
                 except Exception as cleanup_ex:
@@ -918,6 +979,14 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 },
             ) from e
         except Exception as e:
+            if _is_namespace_not_found(e):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "code": SandboxErrorCodes.INVALID_PARAMETER,
+                        "message": f"Namespace not found: {e}",
+                    },
+                ) from e
             logger.error(f"Error creating sandbox: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -965,13 +1034,14 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             HTTPException: If sandbox not found
         """
         try:
+            ns = self._resolve_namespace_for_lookup(sandbox_id)
             workload = _get_workload_or_404(
                 self.workload_provider,
-                self.namespace,
+                ns,
                 sandbox_id,
             )
             return _build_sandbox_from_workload(workload, self.workload_provider)
-            
+
         except HTTPException:
             raise
         except Exception as e:
@@ -991,7 +1061,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         try:
             label_selector = SANDBOX_ID_LABEL
             workloads = self.workload_provider.list_workloads(
-                namespace=self.namespace,
+                namespace=self._resolve_namespace(),
                 label_selector=label_selector,
             )
             sandboxes = [
@@ -1024,7 +1094,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         try:
             _delete_workload_or_404(
                 self.workload_provider,
-                self.namespace,
+                self._resolve_namespace(),
                 sandbox_id,
             )
             logger.info(f"Deleted sandbox: {sandbox_id}")
@@ -1063,7 +1133,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             f"{SANDBOX_ID_LABEL}={sandbox_id}"
         )
         try:
-            pvcs = self.k8s_client.list_pvcs(self.namespace, label_selector=selector)
+            pvcs = self.k8s_client.list_pvcs(self._resolve_namespace(), label_selector=selector)
         except ApiException as e:
             if e.status == 403:
                 logger.debug(
@@ -1086,9 +1156,9 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             if not name:
                 continue
             try:
-                self.k8s_client.delete_pvc(self.namespace, name)
+                self.k8s_client.delete_pvc(self._resolve_namespace(), name)
                 logger.info(
-                    f"sandbox={sandbox_id} | deleted managed PVC '{name}' in namespace '{self.namespace}'"
+                    f"sandbox={sandbox_id} | deleted managed PVC '{name}' in namespace '{self._resolve_namespace()}'"
                 )
             except ApiException as e:
                 if e.status == 403:
@@ -1109,7 +1179,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         Pause sandbox by delegating to the workload provider.
         """
         try:
-            self.workload_provider.pause_sandbox(sandbox_id, self.namespace)
+            self.workload_provider.pause_sandbox(sandbox_id, self._resolve_namespace())
         except NotImplementedError:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1150,7 +1220,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         Resume sandbox by delegating to the workload provider.
         """
         try:
-            self.workload_provider.resume_sandbox(sandbox_id, self.namespace)
+            self.workload_provider.resume_sandbox(sandbox_id, self._resolve_namespace())
         except NotImplementedError:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1187,9 +1257,10 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             )
 
     def get_access_renew_extend_seconds(self, sandbox_id: str) -> Optional[int]:
+        ns = self._resolve_namespace_for_lookup(sandbox_id)
         workload = self.workload_provider.get_workload(
             sandbox_id=sandbox_id,
-            namespace=self.namespace,
+            namespace=ns,
         )
         if not workload:
             return None
@@ -1228,11 +1299,12 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             HTTPException: If renewal fails
         """
         new_expiration = ensure_future_expiration(request.expires_at)
-        
+
         try:
+            ns = self._resolve_namespace_for_lookup(sandbox_id)
             workload = _get_workload_or_404(
                 self.workload_provider,
-                self.namespace,
+                ns,
                 sandbox_id,
             )
 
@@ -1248,7 +1320,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
             self.workload_provider.update_expiration(
                 sandbox_id=sandbox_id,
-                namespace=self.namespace,
+                namespace=ns,
                 expires_at=new_expiration,
             )
             
@@ -1270,7 +1342,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         """Patch sandbox metadata via JSON Merge Patch (RFC 7396). Does not restart the sandbox."""
         workload = _get_workload_or_404(
             self.workload_provider,
-            self.namespace,
+            self._resolve_namespace(),
             sandbox_id,
         )
 
@@ -1295,7 +1367,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         try:
             updated = self.workload_provider.patch_labels(
                 name=name,
-                namespace=self.namespace,
+                namespace=self._resolve_namespace(),
                 labels=label_patch,
             )
         except Exception as e:
@@ -1357,9 +1429,10 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                 )
 
         try:
+            ns = self._resolve_namespace_for_lookup(sandbox_id)
             workload = _get_workload_or_404(
                 self.workload_provider,
-                self.namespace,
+                ns,
                 sandbox_id,
             )
 

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -74,6 +74,7 @@ class KubernetesSnapshotRuntime:
         self._namespace = namespace
         self._wait_timeout_seconds = wait_timeout_seconds
         self._poll_interval_seconds = poll_interval_seconds
+        self._snapshot_namespaces: dict[str, str] = {}
 
     def supports_create_snapshot(self) -> bool:
         return True
@@ -85,16 +86,19 @@ class KubernetesSnapshotRuntime:
         self,
         snapshot_id: str,
         sandbox_id: str,
+        *,
+        namespace: str = "default",
     ) -> Optional[SnapshotRuntimeStatus]:
         snapshot_name = build_public_snapshot_name(snapshot_id)
-        body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name)
+        self._snapshot_namespaces[snapshot_id] = namespace
+        body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=namespace)
         should_validate_existing_source = False
 
         try:
             self._k8s_client.create_custom_object(
                 group=_GROUP,
                 version=_VERSION,
-                namespace=self._namespace,
+                namespace=namespace,
                 plural=_PLURAL,
                 body=body,
             )
@@ -117,7 +121,7 @@ class KubernetesSnapshotRuntime:
 
         if should_validate_existing_source:
             try:
-                current = self._get_snapshot_cr(snapshot_name)
+                current = self._get_snapshot_cr(snapshot_name, namespace=namespace)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Failed to inspect existing Kubernetes SandboxSnapshot %s after create conflict: %s",
@@ -129,18 +133,20 @@ class KubernetesSnapshotRuntime:
                 if conflict is not None:
                     return conflict
 
-        return self._wait_for_terminal_snapshot(snapshot_id)
+        return self._wait_for_terminal_snapshot(snapshot_id, namespace=namespace)
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
-        return self.inspect_snapshot(snapshot_id)
+        ns = self._snapshot_namespaces.get(snapshot_id)
+        return self.inspect_snapshot(snapshot_id, namespace=ns)
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
         snapshot_name = build_public_snapshot_name(snapshot_id)
+        ns = self._snapshot_namespaces.pop(snapshot_id, namespace)
         try:
             self._k8s_client.delete_custom_object(
                 group=_GROUP,
                 version=_VERSION,
-                namespace=self._namespace,
+                namespace=ns,
                 plural=_PLURAL,
                 name=snapshot_name,
             )
@@ -150,10 +156,11 @@ class KubernetesSnapshotRuntime:
                 return
             raise RuntimeError(f"Failed to delete Kubernetes SandboxSnapshot {snapshot_name}: {exc}") from exc
 
-    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> SnapshotRuntimeStatus:
+    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         snapshot_name = build_public_snapshot_name(snapshot_id)
+        ns = namespace or self._snapshot_namespaces.get(snapshot_id)
         try:
-            snapshot = self._get_snapshot_cr(snapshot_name)
+            snapshot = self._get_snapshot_cr(snapshot_name, namespace=ns)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to inspect Kubernetes SandboxSnapshot %s: %s", snapshot_name, exc)
             return SnapshotRuntimeStatus(
@@ -171,13 +178,13 @@ class KubernetesSnapshotRuntime:
 
         return self._snapshot_status_from_cr(snapshot)
 
-    def _build_snapshot_body(self, snapshot_id: str, sandbox_id: str, snapshot_name: str) -> dict:
+    def _build_snapshot_body(self, snapshot_id: str, sandbox_id: str, snapshot_name: str, *, namespace: str = "default") -> dict:
         return {
             "apiVersion": f"{_GROUP}/{_VERSION}",
             "kind": "SandboxSnapshot",
             "metadata": {
                 "name": snapshot_name,
-                "namespace": self._namespace,
+                "namespace": namespace,
                 "labels": {
                     PUBLIC_SNAPSHOT_ID_LABEL: snapshot_id,
                     PUBLIC_SNAPSHOT_SOURCE_SANDBOX_ID_LABEL: sandbox_id,
@@ -189,11 +196,11 @@ class KubernetesSnapshotRuntime:
             },
         }
 
-    def _get_snapshot_cr(self, snapshot_name: str) -> Optional[dict]:
+    def _get_snapshot_cr(self, snapshot_name: str, *, namespace: str | None = None) -> Optional[dict]:
         return self._k8s_client.get_custom_object(
             group=_GROUP,
             version=_VERSION,
-            namespace=self._namespace,
+            namespace=namespace or self._namespace,
             plural=_PLURAL,
             name=snapshot_name,
         )
@@ -219,10 +226,10 @@ class KubernetesSnapshotRuntime:
             ),
         )
 
-    def _wait_for_terminal_snapshot(self, snapshot_id: str) -> SnapshotRuntimeStatus:
+    def _wait_for_terminal_snapshot(self, snapshot_id: str, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         deadline = time.monotonic() + self._wait_timeout_seconds
         while True:
-            runtime_status = self.inspect_snapshot(snapshot_id)
+            runtime_status = self.inspect_snapshot(snapshot_id, namespace=namespace)
             if runtime_status.state in (SnapshotState.READY, SnapshotState.FAILED):
                 return runtime_status
 

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -87,10 +87,10 @@ class KubernetesSnapshotRuntime:
         snapshot_id: str,
         sandbox_id: str,
         *,
-        namespace: str = "default",
+        namespace: str | None = None,
     ) -> Optional[SnapshotRuntimeStatus]:
         snapshot_name = build_public_snapshot_name(snapshot_id)
-        ns = namespace if namespace != "default" else self._namespace
+        ns = namespace if namespace is not None else self._namespace
         self._snapshot_namespaces[snapshot_id] = ns
         body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=ns)
         should_validate_existing_source = False
@@ -140,9 +140,9 @@ class KubernetesSnapshotRuntime:
         ns = self._snapshot_namespaces.get(snapshot_id)
         return self.inspect_snapshot(snapshot_id, namespace=ns)
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         snapshot_name = build_public_snapshot_name(snapshot_id)
-        fallback = namespace if namespace != "default" else self._namespace
+        fallback = namespace if namespace is not None else self._namespace
         ns = self._snapshot_namespaces.pop(snapshot_id, fallback)
         try:
             self._k8s_client.delete_custom_object(
@@ -202,7 +202,7 @@ class KubernetesSnapshotRuntime:
         return self._k8s_client.get_custom_object(
             group=_GROUP,
             version=_VERSION,
-            namespace=namespace or self._namespace,
+            namespace=namespace if namespace is not None else self._namespace,
             plural=_PLURAL,
             name=snapshot_name,
         )

--- a/server/opensandbox_server/services/k8s/snapshot_runtime.py
+++ b/server/opensandbox_server/services/k8s/snapshot_runtime.py
@@ -90,15 +90,16 @@ class KubernetesSnapshotRuntime:
         namespace: str = "default",
     ) -> Optional[SnapshotRuntimeStatus]:
         snapshot_name = build_public_snapshot_name(snapshot_id)
-        self._snapshot_namespaces[snapshot_id] = namespace
-        body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=namespace)
+        ns = namespace if namespace != "default" else self._namespace
+        self._snapshot_namespaces[snapshot_id] = ns
+        body = self._build_snapshot_body(snapshot_id, sandbox_id, snapshot_name, namespace=ns)
         should_validate_existing_source = False
 
         try:
             self._k8s_client.create_custom_object(
                 group=_GROUP,
                 version=_VERSION,
-                namespace=namespace,
+                namespace=ns,
                 plural=_PLURAL,
                 body=body,
             )
@@ -121,7 +122,7 @@ class KubernetesSnapshotRuntime:
 
         if should_validate_existing_source:
             try:
-                current = self._get_snapshot_cr(snapshot_name, namespace=namespace)
+                current = self._get_snapshot_cr(snapshot_name, namespace=ns)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Failed to inspect existing Kubernetes SandboxSnapshot %s after create conflict: %s",
@@ -133,7 +134,7 @@ class KubernetesSnapshotRuntime:
                 if conflict is not None:
                     return conflict
 
-        return self._wait_for_terminal_snapshot(snapshot_id, namespace=namespace)
+        return self._wait_for_terminal_snapshot(snapshot_id, namespace=ns)
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         ns = self._snapshot_namespaces.get(snapshot_id)
@@ -141,7 +142,8 @@ class KubernetesSnapshotRuntime:
 
     def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
         snapshot_name = build_public_snapshot_name(snapshot_id)
-        ns = self._snapshot_namespaces.pop(snapshot_id, namespace)
+        fallback = namespace if namespace != "default" else self._namespace
+        ns = self._snapshot_namespaces.pop(snapshot_id, fallback)
         try:
             self._k8s_client.delete_custom_object(
                 group=_GROUP,

--- a/server/opensandbox_server/services/sandbox_service.py
+++ b/server/opensandbox_server/services/sandbox_service.py
@@ -46,6 +46,9 @@ class SandboxService(ABC):
     Implementations should handle creating, managing, and destroying sandboxes.
     """
 
+    def set_tenant_provider(self, provider: object) -> None:
+        """Inject tenant provider (no-op for non-K8s implementations)."""
+
     @staticmethod
     def generate_sandbox_id() -> str:
         """

--- a/server/opensandbox_server/services/snapshot_models.py
+++ b/server/opensandbox_server/services/snapshot_models.py
@@ -69,6 +69,7 @@ class SnapshotRecord:
 
     id: str
     source_sandbox_id: str
+    namespace: str = "default"
     name: str | None = None
     description: str | None = None
     restore_config: SnapshotRestoreConfig = field(default_factory=SnapshotRestoreConfig)

--- a/server/opensandbox_server/services/snapshot_models.py
+++ b/server/opensandbox_server/services/snapshot_models.py
@@ -69,7 +69,7 @@ class SnapshotRecord:
 
     id: str
     source_sandbox_id: str
-    namespace: str = "default"
+    namespace: str | None = None
     name: str | None = None
     description: str | None = None
     restore_config: SnapshotRestoreConfig = field(default_factory=SnapshotRestoreConfig)

--- a/server/opensandbox_server/services/snapshot_repository.py
+++ b/server/opensandbox_server/services/snapshot_repository.py
@@ -32,6 +32,7 @@ class SnapshotListQuery:
     page_size: int = 20
     source_sandbox_id: str | None = None
     states: list[str] = field(default_factory=list)
+    namespace: str | None = None
 
 
 @dataclass(slots=True)

--- a/server/opensandbox_server/services/snapshot_restore.py
+++ b/server/opensandbox_server/services/snapshot_restore.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException, status
 from opensandbox_server.api.schema import CreateSandboxRequest, ImageSpec
 from opensandbox_server.repositories.snapshots.factory import create_snapshot_repository
 from opensandbox_server.services.snapshot_models import SnapshotState
+from opensandbox_server.tenants.context import get_current_tenant
 
 DEFAULT_SNAPSHOT_RESTORE_ENTRYPOINT = ["tail", "-f", "/dev/null"]
 
@@ -52,6 +53,16 @@ def resolve_sandbox_image_from_request(request: CreateSandboxRequest) -> CreateS
     snapshot_repository = create_snapshot_repository()
     snapshot = snapshot_repository.get(snapshot_id)
     if snapshot is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "SNAPSHOT::NOT_FOUND",
+                "message": f"Snapshot {snapshot_id} not found",
+            },
+        )
+
+    tenant = get_current_tenant()
+    if tenant is not None and snapshot.namespace != tenant.namespace:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={

--- a/server/opensandbox_server/services/snapshot_restore.py
+++ b/server/opensandbox_server/services/snapshot_restore.py
@@ -62,7 +62,7 @@ def resolve_sandbox_image_from_request(request: CreateSandboxRequest) -> CreateS
         )
 
     tenant = get_current_tenant()
-    if tenant is not None and snapshot.namespace != tenant.namespace:
+    if tenant is not None and snapshot.namespace is not None and snapshot.namespace != tenant.namespace:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={

--- a/server/opensandbox_server/services/snapshot_restore.py
+++ b/server/opensandbox_server/services/snapshot_restore.py
@@ -62,7 +62,7 @@ def resolve_sandbox_image_from_request(request: CreateSandboxRequest) -> CreateS
         )
 
     tenant = get_current_tenant()
-    if tenant is not None and snapshot.namespace is not None and snapshot.namespace != tenant.namespace:
+    if tenant is not None and (snapshot.namespace is None or snapshot.namespace != tenant.namespace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={

--- a/server/opensandbox_server/services/snapshot_runtime.py
+++ b/server/opensandbox_server/services/snapshot_runtime.py
@@ -51,6 +51,8 @@ class SnapshotRuntime(Protocol):
         self,
         snapshot_id: str,
         sandbox_id: str,
+        *,
+        namespace: str = "default",
     ) -> Optional[SnapshotRuntimeStatus]:
         """
         Create a snapshot for a sandbox and return the final runtime status.
@@ -61,12 +63,12 @@ class SnapshotRuntime(Protocol):
         Return the most recent runtime view for a snapshot if known.
         """
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
         """
         Delete runtime-managed artifacts for a snapshot.
         """
 
-    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> SnapshotRuntimeStatus:
+    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         """
         Inspect runtime-managed artifacts for startup recovery.
         """
@@ -87,16 +89,18 @@ class NoopSnapshotRuntime:
         self,
         snapshot_id: str,
         sandbox_id: str,
+        *,
+        namespace: str = "default",
     ) -> Optional[SnapshotRuntimeStatus]:
         raise NotImplementedError(self.create_snapshot_unsupported_message())
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
         return None
 
-    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None) -> SnapshotRuntimeStatus:
+    def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         return SnapshotRuntimeStatus(
             state=SnapshotState.FAILED,
             reason="snapshot_recovery_not_supported",

--- a/server/opensandbox_server/services/snapshot_runtime.py
+++ b/server/opensandbox_server/services/snapshot_runtime.py
@@ -52,7 +52,7 @@ class SnapshotRuntime(Protocol):
         snapshot_id: str,
         sandbox_id: str,
         *,
-        namespace: str = "default",
+        namespace: str | None = None,
     ) -> Optional[SnapshotRuntimeStatus]:
         """
         Create a snapshot for a sandbox and return the final runtime status.
@@ -63,7 +63,7 @@ class SnapshotRuntime(Protocol):
         Return the most recent runtime view for a snapshot if known.
         """
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         """
         Delete runtime-managed artifacts for a snapshot.
         """
@@ -90,14 +90,14 @@ class NoopSnapshotRuntime:
         snapshot_id: str,
         sandbox_id: str,
         *,
-        namespace: str = "default",
+        namespace: str | None = None,
     ) -> Optional[SnapshotRuntimeStatus]:
         raise NotImplementedError(self.create_snapshot_unsupported_message())
 
     def get_snapshot_status(self, snapshot_id: str) -> Optional[SnapshotRuntimeStatus]:
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str = "default") -> None:
+    def delete_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> None:
         return None
 
     def inspect_snapshot(self, snapshot_id: str, image: Optional[str] = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -57,6 +57,7 @@ from opensandbox_server.services.snapshot_repository import (
     SnapshotListQuery,
     SnapshotRepository,
 )
+from opensandbox_server.tenants.context import get_current_tenant
 
 logger = logging.getLogger(__name__)
 SNAPSHOT_RECOVERY_PAGE_SIZE = 200
@@ -131,6 +132,7 @@ class PersistedSnapshotService(SnapshotService):
         record = SnapshotRecord(
             id=str(uuid4()),
             source_sandbox_id=sandbox_id,
+            namespace=self._get_tenant_namespace(),
             name=request.name,
             restore_config=self._default_restore_config(),
             status=SnapshotStatusRecord(
@@ -152,12 +154,14 @@ class PersistedSnapshotService(SnapshotService):
 
     def list_snapshots(self, request: ListSnapshotsRequest) -> ListSnapshotsResponse:
         pagination = request.pagination or self._default_pagination()
+        tenant = get_current_tenant()
         result = self._snapshot_repository.list(
             SnapshotListQuery(
                 page=pagination.page,
                 page_size=pagination.page_size,
                 source_sandbox_id=request.filter.sandbox_id,
                 states=request.filter.state or [],
+                namespace=tenant.namespace if tenant else None,
             )
         )
 
@@ -183,6 +187,7 @@ class PersistedSnapshotService(SnapshotService):
                     "message": f"Snapshot {snapshot_id} not found",
                 },
             )
+        self._verify_tenant_access(record)
         return self._to_snapshot_response(record)
 
     def delete_snapshot(self, snapshot_id: str) -> None:
@@ -195,6 +200,7 @@ class PersistedSnapshotService(SnapshotService):
                     "message": f"Snapshot {snapshot_id} not found",
                 },
             )
+        self._verify_tenant_access(record)
 
         if record.status.state == SnapshotState.CREATING:
             raise HTTPException(
@@ -213,6 +219,7 @@ class PersistedSnapshotService(SnapshotService):
         self._snapshot_runtime.delete_snapshot(
             snapshot_id,
             image=record.restore_config.image,
+            namespace=record.namespace,
         )
         self._snapshot_repository.delete(snapshot_id)
 
@@ -232,11 +239,31 @@ class PersistedSnapshotService(SnapshotService):
 
         return PaginationRequest()
 
+    @staticmethod
+    def _get_tenant_namespace() -> str:
+        tenant = get_current_tenant()
+        return tenant.namespace if tenant else "default"
+
+    @staticmethod
+    def _verify_tenant_access(record: SnapshotRecord) -> None:
+        tenant = get_current_tenant()
+        if tenant is None:
+            return
+        if record.namespace != tenant.namespace:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "code": "SNAPSHOT::NOT_FOUND",
+                    "message": f"Snapshot {record.id} not found",
+                },
+            )
+
     def _mark_snapshot_deleting(self, record: SnapshotRecord) -> SnapshotRecord | None:
         now = datetime.now(timezone.utc)
         deleting_record = SnapshotRecord(
             id=record.id,
             source_sandbox_id=record.source_sandbox_id,
+            namespace=record.namespace,
             name=record.name,
             description=record.description,
             restore_config=record.restore_config,
@@ -274,6 +301,7 @@ class PersistedSnapshotService(SnapshotService):
             runtime_status = self._snapshot_runtime.create_snapshot(
                 record.id,
                 record.source_sandbox_id,
+                namespace=record.namespace,
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
@@ -308,11 +336,11 @@ class PersistedSnapshotService(SnapshotService):
     def _complete_snapshot(self, record: SnapshotRecord, runtime_status) -> None:
         current_record = self._snapshot_repository.get(record.id)
         if current_record is None:
-            self._cleanup_runtime_artifact(record.id, runtime_status.image)
+            self._cleanup_runtime_artifact(record.id, runtime_status.image, record.namespace)
             return
 
         if current_record.status.state == SnapshotState.DELETING:
-            self._cleanup_runtime_artifact(current_record.id, runtime_status.image)
+            self._cleanup_runtime_artifact(current_record.id, runtime_status.image, current_record.namespace)
             self._snapshot_repository.delete(current_record.id)
             return
 
@@ -372,6 +400,7 @@ class PersistedSnapshotService(SnapshotService):
             runtime_status = self._snapshot_runtime.inspect_snapshot(
                 record.id,
                 image=record.restore_config.image,
+                namespace=record.namespace,
             )
             if runtime_status.state == SnapshotState.CREATING:
                 future = self._snapshot_executor.submit(
@@ -388,6 +417,7 @@ class PersistedSnapshotService(SnapshotService):
                 self._snapshot_runtime.delete_snapshot(
                     record.id,
                     image=record.restore_config.image,
+                    namespace=record.namespace,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
@@ -414,6 +444,7 @@ class PersistedSnapshotService(SnapshotService):
                 return SnapshotRecord(
                     id=record.id,
                     source_sandbox_id=record.source_sandbox_id,
+                    namespace=record.namespace,
                     name=record.name,
                     description=record.description,
                     restore_config=record.restore_config,
@@ -430,6 +461,7 @@ class PersistedSnapshotService(SnapshotService):
             return SnapshotRecord(
                 id=record.id,
                 source_sandbox_id=record.source_sandbox_id,
+                namespace=record.namespace,
                 name=record.name,
                 description=record.description,
                 restore_config=SnapshotRestoreConfig(image=runtime_status.image),
@@ -447,6 +479,7 @@ class PersistedSnapshotService(SnapshotService):
             return SnapshotRecord(
                 id=record.id,
                 source_sandbox_id=record.source_sandbox_id,
+                namespace=record.namespace,
                 name=record.name,
                 description=record.description,
                 restore_config=record.restore_config,
@@ -462,12 +495,12 @@ class PersistedSnapshotService(SnapshotService):
 
         return None
 
-    def _cleanup_runtime_artifact(self, snapshot_id: str, image: str | None) -> None:
+    def _cleanup_runtime_artifact(self, snapshot_id: str, image: str | None, namespace: str = "default") -> None:
         if not image:
             return
 
         try:
-            self._snapshot_runtime.delete_snapshot(snapshot_id, image=image)
+            self._snapshot_runtime.delete_snapshot(snapshot_id, image=image, namespace=namespace)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Failed to cleanup snapshot artifact for %s: %s",

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -249,7 +249,7 @@ class PersistedSnapshotService(SnapshotService):
         tenant = get_current_tenant()
         if tenant is None:
             return
-        if record.namespace is not None and record.namespace != tenant.namespace:
+        if record.namespace is None or record.namespace != tenant.namespace:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={

--- a/server/opensandbox_server/services/snapshot_service.py
+++ b/server/opensandbox_server/services/snapshot_service.py
@@ -240,16 +240,16 @@ class PersistedSnapshotService(SnapshotService):
         return PaginationRequest()
 
     @staticmethod
-    def _get_tenant_namespace() -> str:
+    def _get_tenant_namespace() -> str | None:
         tenant = get_current_tenant()
-        return tenant.namespace if tenant else "default"
+        return tenant.namespace if tenant else None
 
     @staticmethod
     def _verify_tenant_access(record: SnapshotRecord) -> None:
         tenant = get_current_tenant()
         if tenant is None:
             return
-        if record.namespace != tenant.namespace:
+        if record.namespace is not None and record.namespace != tenant.namespace:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={

--- a/server/opensandbox_server/tenants/__init__.py
+++ b/server/opensandbox_server/tenants/__init__.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opensandbox_server.tenants.context import get_current_tenant, set_current_tenant
+from opensandbox_server.tenants.file_provider import (
+    DEFAULT_TENANTS_CONFIG_PATH,
+    TENANTS_CONFIG_ENV_VAR,
+    FileTenantProvider,
+    resolve_tenants_path,
+)
+from opensandbox_server.tenants.http_provider import (
+    HTTPTenantProvider,
+    HTTPTenantProviderConfig,
+)
+from opensandbox_server.tenants.models import TenantEntry
+from opensandbox_server.tenants.provider import TenantProvider, TenantProviderUnavailable
+
+
+def validate_tenant_config(app_config) -> None:
+    """Validate tenant configuration against runtime and auth settings.
+
+    Raises ValueError if:
+    - runtime is docker (multi-tenancy requires Kubernetes namespaces)
+    - server.api_key is set (conflicts with tenant-managed keys)
+    """
+    if app_config.tenants is None:
+        return
+    if app_config.runtime.type == "docker":
+        raise ValueError(
+            "[tenants] configured but runtime.type='docker'. "
+            "Multi-tenancy requires Kubernetes namespaces."
+        )
+    api_key = getattr(app_config.server, "api_key", None)
+    if api_key and api_key.strip():
+        raise ValueError(
+            "server.api_key must be removed from server.toml when using [tenants]. "
+            "Tenant API keys are managed by the tenant provider."
+        )
+
+
+__all__ = [
+    "TenantEntry",
+    "TenantProvider",
+    "TenantProviderUnavailable",
+    "FileTenantProvider",
+    "HTTPTenantProvider",
+    "HTTPTenantProviderConfig",
+    "DEFAULT_TENANTS_CONFIG_PATH",
+    "TENANTS_CONFIG_ENV_VAR",
+    "get_current_tenant",
+    "set_current_tenant",
+    "resolve_tenants_path",
+    "validate_tenant_config",
+]

--- a/server/opensandbox_server/tenants/context.py
+++ b/server/opensandbox_server/tenants/context.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Optional
+
+from opensandbox_server.tenants.models import TenantEntry
+
+_current_tenant: ContextVar[Optional[TenantEntry]] = ContextVar("current_tenant", default=None)
+
+
+def get_current_tenant() -> Optional[TenantEntry]:
+    return _current_tenant.get()
+
+
+def set_current_tenant(tenant: Optional[TenantEntry]) -> None:
+    _current_tenant.set(tenant)

--- a/server/opensandbox_server/tenants/file_provider.py
+++ b/server/opensandbox_server/tenants/file_provider.py
@@ -54,6 +54,9 @@ def _parse_tenants_file(path: Path) -> List[TenantEntry]:
         namespace = raw["namespace"]
         api_keys = raw["api_keys"]
 
+        if not namespace or not isinstance(namespace, str):
+            raise ValueError(f"Tenant '{name}' namespace must be a non-empty string.")
+
         if not isinstance(api_keys, list):
             raise ValueError(f"Tenant '{name}' api_keys must be a list, got {type(api_keys).__name__}.")
 

--- a/server/opensandbox_server/tenants/file_provider.py
+++ b/server/opensandbox_server/tenants/file_provider.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from opensandbox_server.tenants.models import TenantEntry
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[import]
+
+logger = logging.getLogger(__name__)
+
+TENANTS_CONFIG_ENV_VAR = "SANDBOX_TENANTS_CONFIG_PATH"
+DEFAULT_TENANTS_CONFIG_PATH = Path.home() / ".opensandbox" / "tenants.toml"
+
+
+def resolve_tenants_path(path: Optional[str | Path] = None) -> Path:
+    if path:
+        return Path(path)
+    env = os.environ.get(TENANTS_CONFIG_ENV_VAR)
+    if env:
+        return Path(env)
+    return DEFAULT_TENANTS_CONFIG_PATH
+
+
+def _parse_tenants_file(path: Path) -> List[TenantEntry]:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    entries: List[TenantEntry] = []
+    seen_keys: Dict[str, str] = {}
+
+    for raw in data.get("tenants", []):
+        name = raw["name"]
+        namespace = raw["namespace"]
+        api_keys = raw["api_keys"]
+
+        if not api_keys:
+            raise ValueError(f"Tenant '{name}' has no api_keys configured.")
+
+        for key in api_keys:
+            if key in seen_keys:
+                raise ValueError(
+                    f"Duplicate api_key across tenants: '{name}' and '{seen_keys[key]}'."
+                )
+            seen_keys[key] = name
+
+        entries.append(TenantEntry(name=name, namespace=namespace, api_keys=tuple(api_keys)))
+
+    return entries
+
+
+def _build_lookup_dict(entries: List[TenantEntry]) -> Dict[str, TenantEntry]:
+    result: Dict[str, TenantEntry] = {}
+    for entry in entries:
+        for key in entry.api_keys:
+            result[key] = entry
+    return result
+
+
+class FileTenantProvider:
+    """TenantProvider backed by a local tenants.toml file with hot-reload via filesystem polling."""
+
+    def __init__(self, path: Optional[str | Path] = None) -> None:
+        self._path = resolve_tenants_path(path)
+        self._lock = threading.Lock()
+        self._lookup: Dict[str, TenantEntry] = {}
+        self._entries: List[TenantEntry] = []
+        self._ready = False
+        self._callbacks: List[Callable[[List[TenantEntry]], None]] = []
+        self._watcher_stop = threading.Event()
+        self._watcher_thread: Optional[threading.Thread] = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def lookup(self, api_key: str) -> Optional[TenantEntry]:
+        with self._lock:
+            return self._lookup.get(api_key)
+
+    def list_tenants(self) -> List[TenantEntry]:
+        with self._lock:
+            return list(self._entries)
+
+    def ready(self) -> bool:
+        return self._ready
+
+    def start(self) -> None:
+        self._load()
+        self._watcher_thread = threading.Thread(
+            target=self._watch_loop, daemon=True, name="tenant-file-watcher"
+        )
+        self._watcher_thread.start()
+
+    def close(self) -> None:
+        self._watcher_stop.set()
+        if self._watcher_thread and self._watcher_thread.is_alive():
+            self._watcher_thread.join(timeout=5)
+
+    def on_reload(self, callback: Callable[[List[TenantEntry]], None]) -> None:
+        self._callbacks.append(callback)
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            raise FileNotFoundError(f"Tenants config not found: {self._path}")
+
+        entries = _parse_tenants_file(self._path)
+        lookup = _build_lookup_dict(entries)
+
+        with self._lock:
+            self._entries = entries
+            self._lookup = lookup
+            self._ready = True
+
+        logger.info("Loaded %d tenant(s) from %s", len(entries), self._path)
+
+    def _reload(self) -> None:
+        try:
+            entries = _parse_tenants_file(self._path)
+            lookup = _build_lookup_dict(entries)
+
+            with self._lock:
+                self._entries = entries
+                self._lookup = lookup
+
+            logger.info("Reloaded %d tenant(s) from %s", len(entries), self._path)
+            for cb in self._callbacks:
+                try:
+                    cb(entries)
+                except Exception:
+                    logger.exception("Tenant reload callback failed")
+
+        except FileNotFoundError:
+            with self._lock:
+                self._entries = []
+                self._lookup = {}
+            logger.warning("Tenants config deleted: %s — all tenant keys invalidated", self._path)
+
+        except Exception:
+            logger.exception("Failed to reload tenants config — keeping previous state")
+
+    def _watch_loop(self) -> None:
+        last_mtime: Optional[float] = None
+        try:
+            last_mtime = self._path.stat().st_mtime
+        except OSError:
+            pass
+
+        while not self._watcher_stop.wait(timeout=2.0):
+            try:
+                current_mtime = self._path.stat().st_mtime
+            except OSError:
+                if last_mtime is not None:
+                    self._reload()
+                    last_mtime = None
+                continue
+
+            if last_mtime is None or current_mtime != last_mtime:
+                last_mtime = current_mtime
+                self._reload()

--- a/server/opensandbox_server/tenants/file_provider.py
+++ b/server/opensandbox_server/tenants/file_provider.py
@@ -35,10 +35,10 @@ DEFAULT_TENANTS_CONFIG_PATH = Path.home() / ".opensandbox" / "tenants.toml"
 
 def resolve_tenants_path(path: Optional[str | Path] = None) -> Path:
     if path:
-        return Path(path)
+        return Path(path).expanduser()
     env = os.environ.get(TENANTS_CONFIG_ENV_VAR)
     if env:
-        return Path(env)
+        return Path(env).expanduser()
     return DEFAULT_TENANTS_CONFIG_PATH
 
 

--- a/server/opensandbox_server/tenants/file_provider.py
+++ b/server/opensandbox_server/tenants/file_provider.py
@@ -64,6 +64,8 @@ def _parse_tenants_file(path: Path) -> List[TenantEntry]:
             raise ValueError(f"Tenant '{name}' has no api_keys configured.")
 
         for key in api_keys:
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError(f"Tenant '{name}' has a blank or non-string api_key.")
             if key in seen_keys:
                 raise ValueError(
                     f"Duplicate api_key across tenants: '{name}' and '{seen_keys[key]}'."

--- a/server/opensandbox_server/tenants/file_provider.py
+++ b/server/opensandbox_server/tenants/file_provider.py
@@ -54,6 +54,9 @@ def _parse_tenants_file(path: Path) -> List[TenantEntry]:
         namespace = raw["namespace"]
         api_keys = raw["api_keys"]
 
+        if not isinstance(api_keys, list):
+            raise ValueError(f"Tenant '{name}' api_keys must be a list, got {type(api_keys).__name__}.")
+
         if not api_keys:
             raise ValueError(f"Tenant '{name}' has no api_keys configured.")
 

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -72,6 +72,13 @@ class _CacheEntry:
     ttl: float
 
 
+class _FlightEvent(threading.Event):
+    """Event with attached result/error for singleflight propagation."""
+
+    result: Optional[TenantEntry] = None
+    error: Optional[Exception] = None
+
+
 class HTTPTenantProvider:
     """TenantProvider backed by a remote HTTP endpoint with per-key TTL cache.
 
@@ -84,9 +91,7 @@ class HTTPTenantProvider:
         self._config = config
         self._lock = threading.Lock()
         self._cache: Dict[str, _CacheEntry] = {}
-        self._inflight: Dict[str, threading.Event] = {}
-        self._inflight_result: Dict[str, Optional[TenantEntry]] = {}
-        self._inflight_error: Dict[str, Exception] = {}
+        self._inflight: Dict[str, _FlightEvent] = {}
         self._ready = False
         self._callbacks: List[Callable[[List[TenantEntry]], None]] = []
         self._client: Optional[httpx.Client] = None
@@ -165,37 +170,33 @@ class HTTPTenantProvider:
         provider outages / 5xx errors don't masquerade as invalid credentials.
         """
         with self._lock:
-            event = self._inflight.get(api_key)
-            if event is not None:
+            flight = self._inflight.get(api_key)
+            if flight is not None:
                 is_leader = False
             else:
-                event = threading.Event()
-                self._inflight[api_key] = event
-                self._inflight_result[api_key] = None
-                self._inflight_error.pop(api_key, None)
+                flight = _FlightEvent()
+                self._inflight[api_key] = flight
                 is_leader = True
 
         if not is_leader:
-            event.wait(timeout=self._config.timeout_seconds)
+            flight.wait(timeout=self._config.timeout_seconds)
+            if flight.error is not None:
+                raise flight.error
             with self._lock:
                 cached = self._cache.get(api_key)
-                error = self._inflight_error.get(api_key)
             if cached:
                 return cached.tenant
-            if error is not None:
-                raise error
             raise TenantProviderUnavailable("Timed out waiting for in-flight tenant lookup")
 
         try:
             return self._do_fetch(api_key, now)
         except Exception as e:
-            with self._lock:
-                self._inflight_error[api_key] = e
+            flight.error = e
             raise
         finally:
             with self._lock:
                 self._inflight.pop(api_key, None)
-            event.set()
+            flight.set()
 
     def _do_fetch(self, api_key: str, now: float) -> Optional[TenantEntry]:
         """GET the endpoint for a single api_key. Returns TenantEntry or raises."""

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -214,7 +214,9 @@ class HTTPTenantProvider:
         resp.raise_for_status()
 
         data = resp.json()
-        namespace = data["namespace"]
+        namespace = (data.get("namespace") or "").strip()
+        if not namespace:
+            raise ValueError("HTTP tenant endpoint returned empty namespace for key")
         ttl = float(data.get("ttl", 30))
 
         entry = TenantEntry(

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP-based TenantProvider with per-key in-memory TTL cache.
+
+Endpoint contract:
+    GET {endpoint}
+    Header: OPEN-SANDBOX-API-KEY: <api_key>
+
+    200 OK:
+        {
+            "namespace": "ns-a",
+            "ttl": 60
+        }
+        - namespace: target K8s namespace for this key
+        - ttl: suggested cache duration in seconds
+
+    401 Unauthorized:
+        {
+            "code": "UNAUTHORIZED",
+            "message": "..."
+        }
+
+Cache strategy:
+    - Per-key cache entry with server-suggested TTL
+    - lookup hit + within TTL → return cached
+    - lookup hit + TTL expired → sync GET → refresh or serve stale within max_stale
+    - lookup miss → sync GET → 200: cache + return; 401: return None
+    - Network failure + beyond max_stale → raise TenantProviderUnavailable
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+import httpx
+
+from opensandbox_server.tenants.models import TenantEntry
+from opensandbox_server.tenants.provider import TenantProviderUnavailable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HTTPTenantProviderConfig:
+    endpoint: str
+    max_stale_seconds: float = 300.0
+    timeout_seconds: float = 5.0
+    auth_header: Optional[str] = None
+    auth_token: Optional[str] = None
+
+
+@dataclass
+class _CacheEntry:
+    tenant: TenantEntry
+    fetched_at: float
+    ttl: float
+
+
+class HTTPTenantProvider:
+    """TenantProvider backed by a remote HTTP endpoint with per-key TTL cache.
+
+    Each lookup that misses or expires in cache triggers a sync GET to the
+    remote endpoint. The server response includes a suggested TTL for caching.
+    Uses per-key locks to prevent thundering herd on TTL expiry.
+    """
+
+    def __init__(self, config: HTTPTenantProviderConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._cache: Dict[str, _CacheEntry] = {}
+        self._inflight: Dict[str, threading.Event] = {}
+        self._inflight_result: Dict[str, Optional[TenantEntry]] = {}
+        self._inflight_error: Dict[str, Exception] = {}
+        self._ready = False
+        self._callbacks: List[Callable[[List[TenantEntry]], None]] = []
+        self._client: Optional[httpx.Client] = None
+
+    def lookup(self, api_key: str) -> Optional[TenantEntry]:
+        now = time.monotonic()
+
+        with self._lock:
+            cached = self._cache.get(api_key)
+
+        if cached is not None:
+            age = now - cached.fetched_at
+            if age <= cached.ttl:
+                return cached.tenant
+
+            # TTL expired — sync refresh
+            try:
+                return self._fetch_and_cache(api_key, now)
+            except _Unauthorized:
+                with self._lock:
+                    self._cache.pop(api_key, None)
+                return None
+            except Exception:
+                if age > self._config.max_stale_seconds:
+                    raise TenantProviderUnavailable(
+                        f"HTTP tenant endpoint unreachable and cache stale "
+                        f"beyond {self._config.max_stale_seconds}s"
+                    )
+                logger.warning("HTTP tenant fetch failed, serving stale entry (age=%.1fs)", age)
+                return cached.tenant
+
+        # Cache miss — sync fetch
+        try:
+            return self._fetch_and_cache(api_key, now)
+        except _Unauthorized:
+            return None
+        except Exception as e:
+            raise TenantProviderUnavailable(f"HTTP tenant endpoint unreachable: {e}") from e
+
+    def list_tenants(self) -> List[TenantEntry]:
+        with self._lock:
+            seen = {}
+            for entry in self._cache.values():
+                seen[entry.tenant.name] = entry.tenant
+            return list(seen.values())
+
+    def ready(self) -> bool:
+        return self._ready
+
+    def start(self) -> None:
+        if self._config.endpoint and not self._config.endpoint.startswith("https://"):
+            logger.warning(
+                "HTTP tenant endpoint is not HTTPS (%s). "
+                "API keys will be transmitted in cleartext.",
+                self._config.endpoint,
+            )
+        self._client = httpx.Client(timeout=self._config.timeout_seconds)
+        self._ready = True
+        logger.info("HTTP tenant provider started, endpoint=%s", self._config.endpoint)
+
+    def close(self) -> None:
+        with self._lock:
+            self._cache.clear()
+            self._ready = False
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def on_reload(self, callback: Callable[[List[TenantEntry]], None]) -> None:
+        self._callbacks.append(callback)
+
+    def _fetch_and_cache(self, api_key: str, now: float) -> Optional[TenantEntry]:
+        """Singleflight GET: only one fetch per key at a time, others wait.
+
+        Propagates leader result (entry or exception) to all waiters so
+        provider outages / 5xx errors don't masquerade as invalid credentials.
+        """
+        with self._lock:
+            event = self._inflight.get(api_key)
+            if event is not None:
+                is_leader = False
+            else:
+                event = threading.Event()
+                self._inflight[api_key] = event
+                self._inflight_result[api_key] = None
+                self._inflight_error.pop(api_key, None)
+                is_leader = True
+
+        if not is_leader:
+            event.wait(timeout=self._config.timeout_seconds)
+            with self._lock:
+                cached = self._cache.get(api_key)
+                error = self._inflight_error.get(api_key)
+            if cached:
+                return cached.tenant
+            if error is not None:
+                raise error
+            raise TenantProviderUnavailable("Timed out waiting for in-flight tenant lookup")
+
+        try:
+            return self._do_fetch(api_key, now)
+        except Exception as e:
+            with self._lock:
+                if api_key in self._inflight:
+                    self._inflight_error[api_key] = e
+            raise
+        finally:
+            with self._lock:
+                self._inflight.pop(api_key, None)
+            event.set()
+
+    def _do_fetch(self, api_key: str, now: float) -> Optional[TenantEntry]:
+        """GET the endpoint for a single api_key. Returns TenantEntry or raises."""
+        assert self._client is not None
+
+        headers: Dict[str, str] = {"OPEN-SANDBOX-API-KEY": api_key}
+        if self._config.auth_header and self._config.auth_token:
+            headers[self._config.auth_header] = self._config.auth_token
+
+        resp = self._client.get(self._config.endpoint, headers=headers)
+
+        if resp.status_code == 401:
+            raise _Unauthorized()
+
+        resp.raise_for_status()
+
+        data = resp.json()
+        namespace = data["namespace"]
+        ttl = float(data.get("ttl", 30))
+
+        entry = TenantEntry(
+            name=namespace,
+            namespace=namespace,
+            api_keys=(api_key,),
+        )
+
+        with self._lock:
+            self._cache[api_key] = _CacheEntry(tenant=entry, fetched_at=now, ttl=ttl)
+
+        return entry
+
+
+class _Unauthorized(Exception):
+    pass

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -196,9 +196,6 @@ class HTTPTenantProvider:
             with self._lock:
                 self._inflight.pop(api_key, None)
             event.set()
-            with self._lock:
-                self._inflight_result.pop(api_key, None)
-                self._inflight_error.pop(api_key, None)
 
     def _do_fetch(self, api_key: str, now: float) -> Optional[TenantEntry]:
         """GET the endpoint for a single api_key. Returns TenantEntry or raises."""

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -110,7 +110,7 @@ class HTTPTenantProvider:
                     self._cache.pop(api_key, None)
                 return None
             except Exception:
-                if age > self._config.max_stale_seconds:
+                if age > cached.ttl + self._config.max_stale_seconds:
                     raise TenantProviderUnavailable(
                         f"HTTP tenant endpoint unreachable and cache stale "
                         f"beyond {self._config.max_stale_seconds}s"

--- a/server/opensandbox_server/tenants/http_provider.py
+++ b/server/opensandbox_server/tenants/http_provider.py
@@ -190,13 +190,15 @@ class HTTPTenantProvider:
             return self._do_fetch(api_key, now)
         except Exception as e:
             with self._lock:
-                if api_key in self._inflight:
-                    self._inflight_error[api_key] = e
+                self._inflight_error[api_key] = e
             raise
         finally:
             with self._lock:
                 self._inflight.pop(api_key, None)
             event.set()
+            with self._lock:
+                self._inflight_result.pop(api_key, None)
+                self._inflight_error.pop(api_key, None)
 
     def _do_fetch(self, api_key: str, now: float) -> Optional[TenantEntry]:
         """GET the endpoint for a single api_key. Returns TenantEntry or raises."""

--- a/server/opensandbox_server/tenants/models.py
+++ b/server/opensandbox_server/tenants/models.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class TenantEntry:
+    name: str
+    namespace: str
+    api_keys: Tuple[str, ...] = field(default_factory=tuple)

--- a/server/opensandbox_server/tenants/provider.py
+++ b/server/opensandbox_server/tenants/provider.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Protocol, runtime_checkable
+
+from opensandbox_server.tenants.models import TenantEntry
+
+
+@runtime_checkable
+class TenantProvider(Protocol):
+    """Abstraction for tenant resolution.
+
+    Auth middleware depends only on this interface, not on any specific
+    config source. Implementations may be backed by a local file, an
+    HTTP endpoint, a Kubernetes Secret, or any other tenant store.
+    """
+
+    def lookup(self, api_key: str) -> Optional[TenantEntry]:
+        """Resolve an API key to a tenant entry.
+
+        Returns None if the key is not recognized.
+        Raises TenantProviderUnavailable if the provider cannot serve lookups.
+        """
+        ...
+
+    def list_tenants(self) -> List[TenantEntry]:
+        """Return all known tenant entries (used for startup validation)."""
+        ...
+
+    def ready(self) -> bool:
+        """True once the provider has loaded initial state and can serve lookups."""
+        ...
+
+    def start(self) -> None:
+        """Start background resources (watchers, pollers). Called once at server startup."""
+        ...
+
+    def close(self) -> None:
+        """Release resources (threads, connections). Called on server shutdown."""
+        ...
+
+    def on_reload(self, callback: Callable[[List[TenantEntry]], None]) -> None:
+        """Register a callback invoked when tenant data changes.
+
+        The callback receives the new full list of tenant entries.
+        Not all providers support change notification; those that don't
+        may silently ignore this call.
+        """
+        ...
+
+
+class TenantProviderUnavailable(Exception):
+    """Raised when a provider cannot serve lookups (e.g. remote unreachable + cache expired)."""

--- a/server/tests/test_auth_middleware.py
+++ b/server/tests/test_auth_middleware.py
@@ -115,6 +115,35 @@ def test_auth_middleware_requires_key_for_malformed_proxy_port():
     assert response.json()["code"] == "MISSING_API_KEY"
 
 
+def test_auth_middleware_proxy_requires_auth_in_multi_tenant_mode():
+    """In multi-tenant mode, proxy paths must require auth to establish tenant context."""
+    from unittest.mock import MagicMock
+
+    from opensandbox_server.tenants.models import TenantEntry
+
+    app = FastAPI()
+    config = _app_config_with_api_key()
+    mock_provider = MagicMock()
+    tenant = TenantEntry(name="tenant-a", namespace="ns-a", api_keys=["key-a"])
+    mock_provider.lookup.return_value = tenant
+    app.add_middleware(AuthMiddleware, config=config, tenant_provider=mock_provider)
+
+    @app.get("/sandboxes/{sandbox_id}/proxy/{port}/{full_path:path}")
+    def proxy_echo(sandbox_id: str, port: int, full_path: str):
+        return {"proxied": True}
+
+    client = TestClient(app)
+
+    response = client.get("/sandboxes/abc/proxy/8080/foo")
+    assert response.status_code == 401, "proxy must require auth in multi-tenant mode"
+
+    response = client.get(
+        "/sandboxes/abc/proxy/8080/foo",
+        headers={"OPEN-SANDBOX-API-KEY": "key-a"},
+    )
+    assert response.status_code == 200
+
+
 def test_auth_middleware_is_proxy_path_rejects_traversal():
     """Paths containing '..' are never considered proxy (no auth bypass)."""
     assert AuthMiddleware._is_proxy_path("/sandboxes/abc/proxy/8080/../other") is False

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -89,17 +89,17 @@ class StubSnapshotRuntime:
     def create_snapshot_unsupported_message(self) -> str:
         return ""
 
-    def create_snapshot(self, snapshot_id: str, sandbox_id: str):
+    def create_snapshot(self, snapshot_id: str, sandbox_id: str, *, namespace: str = "default"):
         self.calls.append((snapshot_id, sandbox_id))
         return None
 
     def get_snapshot_status(self, snapshot_id: str):
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: str | None = None) -> None:
+    def delete_snapshot(self, snapshot_id: str, image: str | None = None, *, namespace: str = "default") -> None:
         self.delete_calls.append((snapshot_id, image))
 
-    def inspect_snapshot(self, snapshot_id: str, image: str | None = None) -> SnapshotRuntimeStatus:
+    def inspect_snapshot(self, snapshot_id: str, image: str | None = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:
         return self.inspect_status_by_snapshot_id.get(
             snapshot_id,
             SnapshotRuntimeStatus(
@@ -206,7 +206,7 @@ def test_snapshot_service_marks_snapshot_ready_from_worker(tmp_path) -> None:
         message="Docker snapshot image created successfully.",
     )
 
-    def create_snapshot(snapshot_id: str, sandbox_id: str):
+    def create_snapshot(snapshot_id: str, sandbox_id: str, **kwargs):
         runtime.calls.append((snapshot_id, sandbox_id))
         return ready_status
 
@@ -238,7 +238,7 @@ def test_snapshot_service_marks_snapshot_failed_from_worker(tmp_path) -> None:
         message="Docker snapshot creation timed out after 45 seconds.",
     )
 
-    def create_snapshot(snapshot_id: str, sandbox_id: str):
+    def create_snapshot(snapshot_id: str, sandbox_id: str, **kwargs):
         runtime.calls.append((snapshot_id, sandbox_id))
         return failed_status
 
@@ -377,11 +377,11 @@ def test_snapshot_service_deletes_runtime_artifact_before_metadata(tmp_path) -> 
         message="Docker snapshot image created successfully.",
     )
 
-    def create_snapshot(snapshot_id: str, sandbox_id: str):
+    def create_snapshot(snapshot_id: str, sandbox_id: str, **kwargs):
         runtime.calls.append((snapshot_id, sandbox_id))
         return ready_status
 
-    def delete_snapshot(snapshot_id: str, image: str | None = None) -> None:
+    def delete_snapshot(snapshot_id: str, image: str | None = None, **kwargs) -> None:
         stored = repo.get(snapshot_id)
         assert stored is not None
         assert stored.status.state == SnapshotState.DELETING
@@ -413,7 +413,7 @@ def test_snapshot_service_propagates_snapshot_delete_conflict(tmp_path) -> None:
     )
     repo.create(record)
 
-    def delete_snapshot(snapshot_id: str, image: str | None = None) -> None:
+    def delete_snapshot(snapshot_id: str, image: str | None = None, **kwargs) -> None:
         raise HTTPException(
             status_code=409,
             detail={
@@ -489,7 +489,7 @@ def test_snapshot_service_worker_cleans_up_snapshot_deleted_during_creation(tmp_
         message="Docker snapshot image created successfully.",
     )
 
-    def create_snapshot(snapshot_id: str, sandbox_id: str):
+    def create_snapshot(snapshot_id: str, sandbox_id: str, **kwargs):
         runtime.calls.append((snapshot_id, sandbox_id))
         return ready_status
 
@@ -520,7 +520,7 @@ def test_snapshot_service_worker_does_not_overwrite_transitioned_snapshot(tmp_pa
         message="Docker snapshot image created successfully.",
     )
 
-    def create_snapshot(snapshot_id: str, sandbox_id: str):
+    def create_snapshot(snapshot_id: str, sandbox_id: str, **kwargs):
         runtime.calls.append((snapshot_id, sandbox_id))
         return ready_status
 

--- a/server/tests/test_snapshot_service.py
+++ b/server/tests/test_snapshot_service.py
@@ -89,14 +89,14 @@ class StubSnapshotRuntime:
     def create_snapshot_unsupported_message(self) -> str:
         return ""
 
-    def create_snapshot(self, snapshot_id: str, sandbox_id: str, *, namespace: str = "default"):
+    def create_snapshot(self, snapshot_id: str, sandbox_id: str, *, namespace: str | None = None):
         self.calls.append((snapshot_id, sandbox_id))
         return None
 
     def get_snapshot_status(self, snapshot_id: str):
         return None
 
-    def delete_snapshot(self, snapshot_id: str, image: str | None = None, *, namespace: str = "default") -> None:
+    def delete_snapshot(self, snapshot_id: str, image: str | None = None, *, namespace: str | None = None) -> None:
         self.delete_calls.append((snapshot_id, image))
 
     def inspect_snapshot(self, snapshot_id: str, image: str | None = None, *, namespace: str | None = None) -> SnapshotRuntimeStatus:

--- a/server/tests/test_tenants.py
+++ b/server/tests/test_tenants.py
@@ -1,0 +1,496 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the tenants package: file provider, HTTP provider, context, and validation."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from opensandbox_server.tenants import validate_tenant_config
+from opensandbox_server.tenants.context import get_current_tenant, set_current_tenant
+from opensandbox_server.tenants.file_provider import (
+    FileTenantProvider,
+    _build_lookup_dict,
+    _parse_tenants_file,
+    resolve_tenants_path,
+)
+from opensandbox_server.tenants.http_provider import (
+    HTTPTenantProvider,
+    HTTPTenantProviderConfig,
+)
+from opensandbox_server.tenants.models import TenantEntry
+from opensandbox_server.tenants.provider import TenantProviderUnavailable
+
+
+SAMPLE_TOML = """\
+[[tenants]]
+name = "team-alpha"
+namespace = "ns-alpha"
+api_keys = ["key-alpha-1", "key-alpha-2"]
+
+[[tenants]]
+name = "team-beta"
+namespace = "ns-beta"
+api_keys = ["key-beta-1"]
+"""
+
+DUPLICATE_KEY_TOML = """\
+[[tenants]]
+name = "team-a"
+namespace = "ns-a"
+api_keys = ["shared-key"]
+
+[[tenants]]
+name = "team-b"
+namespace = "ns-b"
+api_keys = ["shared-key"]
+"""
+
+EMPTY_KEYS_TOML = """\
+[[tenants]]
+name = "team-empty"
+namespace = "ns-empty"
+api_keys = []
+"""
+
+
+# --- context tests ---
+
+
+def test_context_default_is_none():
+    assert get_current_tenant() is None
+
+
+def test_context_set_and_get():
+    entry = TenantEntry(name="t", namespace="ns-t", api_keys=("k",))
+    set_current_tenant(entry)
+    assert get_current_tenant() is entry
+    set_current_tenant(None)
+    assert get_current_tenant() is None
+
+
+# --- resolve_tenants_path ---
+
+
+def test_resolve_tenants_path_explicit():
+    p = resolve_tenants_path("/etc/tenants.toml")
+    assert p == Path("/etc/tenants.toml")
+
+
+def test_resolve_tenants_path_env(monkeypatch):
+    monkeypatch.setenv("SANDBOX_TENANTS_CONFIG_PATH", "/tmp/custom.toml")
+    assert resolve_tenants_path() == Path("/tmp/custom.toml")
+
+
+def test_resolve_tenants_path_default(monkeypatch):
+    monkeypatch.delenv("SANDBOX_TENANTS_CONFIG_PATH", raising=False)
+    p = resolve_tenants_path()
+    assert p == Path.home() / ".opensandbox" / "tenants.toml"
+
+
+# --- _parse_tenants_file / _build_lookup_dict ---
+
+
+def test_parse_tenants_file(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    entries = _parse_tenants_file(f)
+    assert len(entries) == 2
+    assert entries[0].name == "team-alpha"
+    assert entries[0].namespace == "ns-alpha"
+    assert entries[0].api_keys == ("key-alpha-1", "key-alpha-2")
+    assert entries[1].name == "team-beta"
+
+
+def test_parse_tenants_file_duplicate_key(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(DUPLICATE_KEY_TOML)
+    with pytest.raises(ValueError, match="Duplicate api_key"):
+        _parse_tenants_file(f)
+
+
+def test_parse_tenants_file_empty_keys(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(EMPTY_KEYS_TOML)
+    with pytest.raises(ValueError, match="no api_keys"):
+        _parse_tenants_file(f)
+
+
+def test_build_lookup_dict():
+    entries = [
+        TenantEntry(name="a", namespace="ns-a", api_keys=("k1", "k2")),
+        TenantEntry(name="b", namespace="ns-b", api_keys=("k3",)),
+    ]
+    lookup = _build_lookup_dict(entries)
+    assert lookup["k1"].name == "a"
+    assert lookup["k2"].name == "a"
+    assert lookup["k3"].name == "b"
+    assert "k4" not in lookup
+
+
+# --- FileTenantProvider ---
+
+
+def test_file_provider_start_and_lookup(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    try:
+        assert provider.ready()
+        result = provider.lookup("key-alpha-1")
+        assert result is not None
+        assert result.namespace == "ns-alpha"
+        assert provider.lookup("nonexistent") is None
+    finally:
+        provider.close()
+
+
+def test_file_provider_list_tenants(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    try:
+        tenants = provider.list_tenants()
+        assert len(tenants) == 2
+        names = {t.name for t in tenants}
+        assert names == {"team-alpha", "team-beta"}
+    finally:
+        provider.close()
+
+
+def test_file_provider_start_file_not_found(tmp_path):
+    provider = FileTenantProvider(tmp_path / "missing.toml")
+    with pytest.raises(FileNotFoundError):
+        provider.start()
+
+
+def test_file_provider_hot_reload(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    try:
+        assert provider.lookup("key-new") is None
+        # Modify file
+        time.sleep(0.05)
+        f.write_text("""\
+[[tenants]]
+name = "team-new"
+namespace = "ns-new"
+api_keys = ["key-new"]
+""")
+        provider._reload()
+        assert provider.lookup("key-new") is not None
+        assert provider.lookup("key-new").namespace == "ns-new"
+        assert provider.lookup("key-alpha-1") is None
+    finally:
+        provider.close()
+
+
+def test_file_provider_reload_bad_file_keeps_previous(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    try:
+        f.write_text("invalid toml [[[")
+        provider._reload()
+        # Should keep previous state
+        assert provider.lookup("key-alpha-1") is not None
+    finally:
+        provider.close()
+
+
+def test_file_provider_reload_deleted_clears(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    try:
+        f.unlink()
+        provider._reload()
+        assert provider.lookup("key-alpha-1") is None
+        assert provider.list_tenants() == []
+    finally:
+        provider.close()
+
+
+def test_file_provider_on_reload_callback(tmp_path):
+    f = tmp_path / "tenants.toml"
+    f.write_text(SAMPLE_TOML)
+    provider = FileTenantProvider(f)
+    provider.start()
+    calls = []
+    provider.on_reload(lambda entries: calls.append(entries))
+    try:
+        f.write_text(SAMPLE_TOML)
+        provider._reload()
+        assert len(calls) == 1
+        assert len(calls[0]) == 2
+    finally:
+        provider.close()
+
+
+# --- HTTPTenantProvider ---
+
+
+def test_http_provider_start_close():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    assert not provider.ready()
+    provider.start()
+    assert provider.ready()
+    provider.close()
+    assert not provider.ready()
+
+
+def test_http_provider_lookup_cache_hit():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        # Manually inject a cache entry
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        entry = TenantEntry(name="cached", namespace="ns-cached", api_keys=("key-c",))
+        provider._cache["key-c"] = _CacheEntry(
+            tenant=entry, fetched_at=time.monotonic(), ttl=300
+        )
+        result = provider.lookup("key-c")
+        assert result is not None
+        assert result.namespace == "ns-cached"
+    finally:
+        provider.close()
+
+
+def test_http_provider_lookup_cache_miss_fetch(monkeypatch):
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"namespace": "ns-fetched", "ttl": 60}
+        mock_response.raise_for_status = MagicMock()
+
+        provider._client.get = MagicMock(return_value=mock_response)
+        result = provider.lookup("key-fetch")
+        assert result is not None
+        assert result.namespace == "ns-fetched"
+        assert "key-fetch" in provider._cache
+    finally:
+        provider.close()
+
+
+def test_http_provider_lookup_401_returns_none(monkeypatch):
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        provider._client.get = MagicMock(return_value=mock_response)
+        result = provider.lookup("bad-key")
+        assert result is None
+    finally:
+        provider.close()
+
+
+def test_http_provider_lookup_network_error_raises_unavailable():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        provider._client.get = MagicMock(side_effect=Exception("connection refused"))
+        with pytest.raises(TenantProviderUnavailable):
+            provider.lookup("any-key")
+    finally:
+        provider.close()
+
+
+def test_http_provider_stale_cache_served_on_error():
+    cfg = HTTPTenantProviderConfig(
+        endpoint="http://localhost:9999/tenants",
+        max_stale_seconds=300.0,
+    )
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        entry = TenantEntry(name="stale", namespace="ns-stale", api_keys=("key-s",))
+        # TTL expired (fetched 10s ago, TTL=1s) but within max_stale
+        provider._cache["key-s"] = _CacheEntry(
+            tenant=entry, fetched_at=time.monotonic() - 10, ttl=1
+        )
+        provider._client.get = MagicMock(side_effect=Exception("timeout"))
+        result = provider.lookup("key-s")
+        assert result is not None
+        assert result.namespace == "ns-stale"
+    finally:
+        provider.close()
+
+
+def test_http_provider_stale_beyond_max_stale_raises():
+    cfg = HTTPTenantProviderConfig(
+        endpoint="http://localhost:9999/tenants",
+        max_stale_seconds=5.0,
+    )
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        entry = TenantEntry(name="old", namespace="ns-old", api_keys=("key-o",))
+        # Fetched 100s ago, TTL=1, max_stale=5 → way past stale
+        provider._cache["key-o"] = _CacheEntry(
+            tenant=entry, fetched_at=time.monotonic() - 100, ttl=1
+        )
+        provider._client.get = MagicMock(side_effect=Exception("timeout"))
+        with pytest.raises(TenantProviderUnavailable):
+            provider.lookup("key-o")
+    finally:
+        provider.close()
+
+
+def test_http_provider_list_tenants():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        e1 = TenantEntry(name="t1", namespace="ns-1", api_keys=("k1",))
+        e2 = TenantEntry(name="t2", namespace="ns-2", api_keys=("k2",))
+        provider._cache["k1"] = _CacheEntry(tenant=e1, fetched_at=time.monotonic(), ttl=60)
+        provider._cache["k2"] = _CacheEntry(tenant=e2, fetched_at=time.monotonic(), ttl=60)
+        tenants = provider.list_tenants()
+        names = {t.name for t in tenants}
+        assert names == {"t1", "t2"}
+    finally:
+        provider.close()
+
+
+def test_http_provider_expired_cache_refresh_success():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        entry = TenantEntry(name="old", namespace="ns-old", api_keys=("key-r",))
+        provider._cache["key-r"] = _CacheEntry(
+            tenant=entry, fetched_at=time.monotonic() - 100, ttl=1
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"namespace": "ns-refreshed", "ttl": 60}
+        mock_response.raise_for_status = MagicMock()
+        provider._client.get = MagicMock(return_value=mock_response)
+
+        result = provider.lookup("key-r")
+        assert result is not None
+        assert result.namespace == "ns-refreshed"
+    finally:
+        provider.close()
+
+
+def test_http_provider_expired_401_clears_cache():
+    cfg = HTTPTenantProviderConfig(endpoint="http://localhost:9999/tenants")
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        from opensandbox_server.tenants.http_provider import _CacheEntry
+
+        entry = TenantEntry(name="revoked", namespace="ns-r", api_keys=("key-rev",))
+        provider._cache["key-rev"] = _CacheEntry(
+            tenant=entry, fetched_at=time.monotonic() - 100, ttl=1
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        provider._client.get = MagicMock(return_value=mock_response)
+
+        result = provider.lookup("key-rev")
+        assert result is None
+        assert "key-rev" not in provider._cache
+    finally:
+        provider.close()
+
+
+def test_http_provider_auth_header():
+    cfg = HTTPTenantProviderConfig(
+        endpoint="http://localhost:9999/tenants",
+        auth_header="X-Service-Token",
+        auth_token="secret-123",
+    )
+    provider = HTTPTenantProvider(cfg)
+    provider.start()
+    try:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"namespace": "ns-auth", "ttl": 30}
+        mock_response.raise_for_status = MagicMock()
+        provider._client.get = MagicMock(return_value=mock_response)
+
+        provider.lookup("key-auth")
+        call_kwargs = provider._client.get.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert headers["X-Service-Token"] == "secret-123"
+        assert headers["OPEN-SANDBOX-API-KEY"] == "key-auth"
+    finally:
+        provider.close()
+
+
+# --- validate_tenant_config ---
+
+
+def test_validate_tenant_config_no_tenants():
+    cfg = MagicMock()
+    cfg.tenants = None
+    validate_tenant_config(cfg)
+
+
+def test_validate_tenant_config_docker_raises():
+    cfg = MagicMock()
+    cfg.tenants = MagicMock()
+    cfg.runtime.type = "docker"
+    with pytest.raises(ValueError, match="docker"):
+        validate_tenant_config(cfg)
+
+
+def test_validate_tenant_config_api_key_raises():
+    cfg = MagicMock()
+    cfg.tenants = MagicMock()
+    cfg.runtime.type = "kubernetes"
+    cfg.server.api_key = "some-key"
+    with pytest.raises(ValueError, match="api_key"):
+        validate_tenant_config(cfg)
+
+
+def test_validate_tenant_config_ok():
+    cfg = MagicMock()
+    cfg.tenants = MagicMock()
+    cfg.runtime.type = "kubernetes"
+    cfg.server.api_key = None
+    validate_tenant_config(cfg)

--- a/server/tests/test_tenants.py
+++ b/server/tests/test_tenants.py
@@ -361,7 +361,7 @@ def test_http_provider_stale_beyond_max_stale_raises():
         from opensandbox_server.tenants.http_provider import _CacheEntry
 
         entry = TenantEntry(name="old", namespace="ns-old", api_keys=("key-o",))
-        # Fetched 100s ago, TTL=1, max_stale=5 → way past stale
+        # Fetched 100s ago, TTL=1, max_stale=5 → age(100) > ttl(1)+max_stale(5) → reject
         provider._cache["key-o"] = _CacheEntry(
             tenant=entry, fetched_at=time.monotonic() - 100, ttl=1
         )


### PR DESCRIPTION
## Summary
- Adds tenant isolation via Kubernetes namespaces with two provider backends: file (TOML with mtime hot-reload) and HTTP (per-key TTL cache + singleflight)
- ContextVar-based per-request tenant propagation through auth middleware
- Namespace-scoped sandbox and snapshot operations with tenant access verification
- closes #972 
- closes #497 

## Changes
- New `opensandbox_server/tenants/` package (models, provider protocol, context, file_provider, http_provider)
- `config.py`: TenantsConfig model with file/http provider settings
- `middleware/auth.py`: multi-tenant authentication path with 503 on provider unavailable
- `services/k8s/kubernetes_service.py`: `_resolve_namespace()` / `_resolve_namespace_for_lookup()` for tenant-aware namespace resolution
- `services/snapshot_*`: namespace column, tenant access checks, namespace propagation through runtime
- `main.py`: provider initialization, startup validation, lifecycle wiring

## Test plan
- [x] All 1222 existing tests pass
- [x] ruff check clean
- [ ] E2E with file provider (tenants.toml) on Kubernetes cluster
- [ ] E2E with HTTP provider endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)