### PR TITLE
refactor(egress): introduce CredentialSource provider interface

### DIFF
--- a/components/egress/credential_vault_handler_test.go
+++ b/components/egress/credential_vault_handler_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -43,11 +44,8 @@ func testCredentialVaultRequest() credentialvault.CreateRequest {
 	return credentialvault.CreateRequest{
 		Credentials: []credentialvault.Credential{
 			{
-				Name: "gitlab-token",
-				Source: credentialvault.InlineCredentialSource{
-					Type:  "inline",
-					Value: "secret-token",
-				},
+				Name:   "gitlab-token",
+				Source: json.RawMessage(`{"type":"inline","value":"secret-token"}`),
 			},
 		},
 		Bindings: []credentialvault.Binding{

--- a/components/egress/pkg/credentialvault/source.go
+++ b/components/egress/pkg/credentialvault/source.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentialvault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// CredentialSource resolves credential material from a configured source.
+// Implementations must be safe for concurrent use.
+type CredentialSource interface {
+	// Type returns the source discriminator (e.g. "inline").
+	Type() string
+	// Resolve returns the plaintext credential value.
+	// Context allows future providers to perform network calls with
+	// timeout/cancellation support.
+	Resolve(ctx context.Context) (string, error)
+}
+
+// CredentialSourceFactory creates a CredentialSource from raw JSON source
+// configuration. The raw bytes are the full "source" object from the API
+// request (including the "type" field).
+type CredentialSourceFactory func(raw json.RawMessage) (CredentialSource, error)
+
+// SourceRegistry maps source type discriminators to their factories.
+type SourceRegistry struct {
+	factories map[string]CredentialSourceFactory
+}
+
+// NewSourceRegistry creates a registry with the built-in inline provider
+// pre-registered.
+func NewSourceRegistry() *SourceRegistry {
+	r := &SourceRegistry{
+		factories: make(map[string]CredentialSourceFactory),
+	}
+	r.Register("inline", inlineSourceFactory)
+	return r
+}
+
+// Register adds a factory for the given source type. Panics if the type is
+// already registered.
+func (r *SourceRegistry) Register(sourceType string, factory CredentialSourceFactory) {
+	if _, exists := r.factories[sourceType]; exists {
+		panic(fmt.Sprintf("credential source type %q already registered", sourceType))
+	}
+	r.factories[sourceType] = factory
+}
+
+// Create extracts the "type" discriminator from raw JSON and delegates to the
+// matching factory. Returns an error for unknown or missing types.
+func (r *SourceRegistry) Create(raw json.RawMessage) (CredentialSource, error) {
+	sourceType, err := extractSourceType(raw)
+	if err != nil {
+		return nil, err
+	}
+	factory, ok := r.factories[sourceType]
+	if !ok {
+		return nil, fmt.Errorf("unsupported credential source type %q", sourceType)
+	}
+	return factory(raw)
+}
+
+// SupportedTypes returns all registered source type names.
+func (r *SourceRegistry) SupportedTypes() []string {
+	types := make([]string, 0, len(r.factories))
+	for t := range r.factories {
+		types = append(types, t)
+	}
+	return types
+}
+
+func extractSourceType(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "inline", nil
+	}
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return "", fmt.Errorf("parse credential source: %w", err)
+	}
+	if envelope.Type == "" {
+		return "inline", nil
+	}
+	return envelope.Type, nil
+}

--- a/components/egress/pkg/credentialvault/source_inline.go
+++ b/components/egress/pkg/credentialvault/source_inline.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentialvault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type inlineSource struct {
+	value string
+}
+
+func (s *inlineSource) Type() string                              { return "inline" }
+func (s *inlineSource) Resolve(_ context.Context) (string, error) { return s.value, nil }
+
+// inlineSourceFactory creates an inlineSource from the raw JSON "source"
+// object. Expected shape: {"type": "inline", "value": "<secret>"}.
+func inlineSourceFactory(raw json.RawMessage) (CredentialSource, error) {
+	var src struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &src); err != nil {
+		return nil, fmt.Errorf("parse inline credential source: %w", err)
+	}
+	if src.Value == "" {
+		return nil, fmt.Errorf("inline credential value cannot be empty")
+	}
+	return &inlineSource{value: src.Value}, nil
+}

--- a/components/egress/pkg/credentialvault/source_inline.go
+++ b/components/egress/pkg/credentialvault/source_inline.go
@@ -15,6 +15,7 @@
 package credentialvault
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,12 +30,16 @@ func (s *inlineSource) Resolve(_ context.Context) (string, error) { return s.val
 
 // inlineSourceFactory creates an inlineSource from the raw JSON "source"
 // object. Expected shape: {"type": "inline", "value": "<secret>"}.
+// Unknown fields are rejected to match the OpenAPI additionalProperties: false
+// contract.
 func inlineSourceFactory(raw json.RawMessage) (CredentialSource, error) {
 	var src struct {
 		Type  string `json:"type"`
 		Value string `json:"value"`
 	}
-	if err := json.Unmarshal(raw, &src); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&src); err != nil {
 		return nil, fmt.Errorf("parse inline credential source: %w", err)
 	}
 	if src.Value == "" {

--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -72,12 +72,13 @@ type Store struct {
 	interceptPorts map[int]struct{}
 	mitmGate       *mitmproxy.HealthGate
 	requireToken   func() bool
+	sources        *SourceRegistry
 }
 
 type record struct {
 	Name       string
 	SourceType string
-	Value      string
+	Source     CredentialSource
 	Revision   int64
 }
 
@@ -105,13 +106,8 @@ type BindingMutationSet struct {
 }
 
 type Credential struct {
-	Name   string                 `json:"name"`
-	Source InlineCredentialSource `json:"source"`
-}
-
-type InlineCredentialSource struct {
-	Type  string `json:"type"`
-	Value string `json:"value"`
+	Name   string          `json:"name"`
+	Source json.RawMessage `json:"source"`
 }
 
 type Binding struct {
@@ -192,12 +188,22 @@ type InjectionHeader struct {
 }
 
 func NewStore(mitmGate *mitmproxy.HealthGate, requireToken func() bool) *Store {
+	return NewStoreWithRegistry(mitmGate, requireToken, nil)
+}
+
+// NewStoreWithRegistry creates a Store with a custom SourceRegistry. If
+// registry is nil, the default registry (with inline pre-registered) is used.
+func NewStoreWithRegistry(mitmGate *mitmproxy.HealthGate, requireToken func() bool, registry *SourceRegistry) *Store {
+	if registry == nil {
+		registry = NewSourceRegistry()
+	}
 	return &Store{
 		credentials:    make(map[string]record),
 		bindings:       make(map[string]Binding),
 		interceptPorts: map[int]struct{}{80: {}, 443: {}},
 		mitmGate:       mitmGate,
 		requireToken:   requireToken,
+		sources:        registry,
 	}
 }
 
@@ -211,7 +217,7 @@ func (v *Store) Create(req CreateRequest, pol *policy.NetworkPolicy) (State, err
 	credentials := make(map[string]record, len(req.Credentials))
 	bindings := make(map[string]Binding, len(req.Bindings))
 	for _, c := range req.Credentials {
-		rec, err := normalizeCredential(c, 1)
+		rec, err := v.normalizeCredential(c, 1)
 		if err != nil {
 			return State{}, err
 		}
@@ -255,7 +261,7 @@ func (v *Store) Patch(req MutationRequest, pol *policy.NetworkPolicy) (State, er
 	credentials := cloneCredentialRecords(v.credentials)
 	bindings := cloneCredentialBindings(v.bindings)
 
-	if err := applyCredentialMutations(credentials, req.Credentials, nextRevision); err != nil {
+	if err := v.applyCredentialMutations(credentials, req.Credentials, nextRevision); err != nil {
 		return State{}, err
 	}
 	if err := applyBindingMutations(bindings, req.Bindings); err != nil {
@@ -320,6 +326,10 @@ func (v *Store) sanitizedLocked() State {
 }
 
 func (v *Store) ActiveSnapshot() (ActiveSnapshot, error) {
+	return v.ActiveSnapshotWithContext(context.Background())
+}
+
+func (v *Store) ActiveSnapshotWithContext(ctx context.Context) (ActiveSnapshot, error) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	if !v.exists {
@@ -337,7 +347,7 @@ func (v *Store) ActiveSnapshot() (ActiveSnapshot, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		b := v.bindings[name]
-		headers, values, err := renderInjectionHeaders(b.Auth, v.credentials)
+		headers, values, err := renderInjectionHeaders(ctx, b.Auth, v.credentials)
 		if err != nil {
 			return ActiveSnapshot{}, err
 		}
@@ -425,22 +435,16 @@ func (v *Store) validateBindingPolicy(b Binding, pol *policy.NetworkPolicy) erro
 	return nil
 }
 
-func normalizeCredential(c Credential, revision int64) (record, error) {
+func (v *Store) normalizeCredential(c Credential, revision int64) (record, error) {
 	name := strings.TrimSpace(c.Name)
 	if name == "" {
 		return record{}, fmt.Errorf("credential name cannot be blank")
 	}
-	sourceType := strings.TrimSpace(c.Source.Type)
-	if sourceType == "" {
-		sourceType = "inline"
+	source, err := v.sources.Create(c.Source)
+	if err != nil {
+		return record{}, fmt.Errorf("credential %q: %w", name, err)
 	}
-	if sourceType != "inline" {
-		return record{}, fmt.Errorf("unsupported credential source type %q", sourceType)
-	}
-	if c.Source.Value == "" {
-		return record{}, fmt.Errorf("credential %q inline value cannot be empty", name)
-	}
-	return record{Name: name, SourceType: sourceType, Value: c.Source.Value, Revision: revision}, nil
+	return record{Name: name, SourceType: source.Type(), Source: source, Revision: revision}, nil
 }
 
 func normalizeBinding(b Binding) (Binding, error) {
@@ -589,13 +593,13 @@ func credentialRefsForAuth(auth Auth) []string {
 	return []string{auth.Credential}
 }
 
-func renderInjectionHeaders(auth Auth, credentials map[string]record) ([]InjectionHeader, []string, error) {
+func renderInjectionHeaders(ctx context.Context, auth Auth, credentials map[string]record) ([]InjectionHeader, []string, error) {
 	valueFor := func(name string) (string, error) {
 		c, ok := credentials[name]
 		if !ok {
 			return "", fmt.Errorf("unknown credential %q", name)
 		}
-		return c.Value, nil
+		return c.Source.Resolve(ctx)
 	}
 	var headers []InjectionHeader
 	var redactions []string
@@ -647,7 +651,7 @@ func sanitizeAuth(auth Auth) AuthMetadata {
 	return meta
 }
 
-func applyCredentialMutations(credentials map[string]record, mutations *CredentialMutationSet, revision int64) error {
+func (v *Store) applyCredentialMutations(credentials map[string]record, mutations *CredentialMutationSet, revision int64) error {
 	if mutations == nil {
 		return nil
 	}
@@ -667,7 +671,7 @@ func applyCredentialMutations(credentials map[string]record, mutations *Credenti
 		delete(credentials, name)
 	}
 	for _, raw := range mutations.Replace {
-		rec, err := normalizeCredential(raw, revision)
+		rec, err := v.normalizeCredential(raw, revision)
 		if err != nil {
 			return err
 		}
@@ -682,7 +686,7 @@ func applyCredentialMutations(credentials map[string]record, mutations *Credenti
 	}
 	addSeen := make(map[string]struct{})
 	for _, raw := range mutations.Add {
-		rec, err := normalizeCredential(raw, revision)
+		rec, err := v.normalizeCredential(raw, revision)
 		if err != nil {
 			return err
 		}

--- a/components/egress/pkg/credentialvault/vault_test.go
+++ b/components/egress/pkg/credentialvault/vault_test.go
@@ -15,11 +15,20 @@
 package credentialvault
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/alibaba/opensandbox/egress/pkg/policy"
 	"github.com/stretchr/testify/require"
 )
+
+func mustMarshal(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
 
 func testCredentialPolicy(t *testing.T, raw string) *policy.NetworkPolicy {
 	t.Helper()
@@ -32,11 +41,8 @@ func testCredentialVaultRequest() CreateRequest {
 	return CreateRequest{
 		Credentials: []Credential{
 			{
-				Name: "gitlab-token",
-				Source: InlineCredentialSource{
-					Type:  "inline",
-					Value: "secret-token",
-				},
+				Name:   "gitlab-token",
+				Source: mustMarshal(map[string]string{"type": "inline", "value": "secret-token"}),
 			},
 		},
 		Bindings: []Binding{


### PR DESCRIPTION
## Summary
- Extract credential source resolution behind a `CredentialSource` interface and `SourceRegistry` in `components/egress/pkg/credentialvault/`
- Replace hardcoded `InlineCredentialSource` struct with `json.RawMessage` + factory-based dispatch
- Enable future secret manager integrations (HashiCorp Vault, AWS SM, etc.) by implementing the interface and calling `registry.Register()`
- No changes to API wire format, specs, or SDK models

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all green (unit + handler tests)
- [ ] Verify no regression in e2e credential vault flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)