### PR TITLE
refactor(egress): remove redundant ports field from credential vault binding match

### DIFF
--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -195,9 +195,11 @@ def _binding_matches(flow: http.HTTPFlow, binding: dict[str, Any]) -> tuple[bool
     method = (flow.request.method or "").upper()
     path = _request_path(flow)
 
-    if scheme not in (match.get("schemes") or ["https"]):
+    schemes = match.get("schemes") or ["https"]
+    if scheme not in schemes:
         return False, 0
-    if port not in (match.get("ports") or [443]):
+    allowed_ports = {443 if s == "https" else 80 for s in schemes}
+    if port not in allowed_ports:
         return False, 0
     if method not in [m.upper() for m in (match.get("methods") or ["GET", "POST", "PUT", "PATCH", "DELETE"])]:
         return False, 0

--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -198,8 +198,8 @@ def _binding_matches(flow: http.HTTPFlow, binding: dict[str, Any]) -> tuple[bool
     schemes = match.get("schemes") or ["https"]
     if scheme not in schemes:
         return False, 0
-    allowed_ports = {443 if s == "https" else 80 for s in schemes}
-    if port not in allowed_ports:
+    canonical_port = 443 if scheme == "https" else 80
+    if port != canonical_port:
         return False, 0
     if method not in [m.upper() for m in (match.get("methods") or ["GET", "POST", "PUT", "PATCH", "DELETE"])]:
         return False, 0

--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -117,6 +117,7 @@ type Binding struct {
 
 type Match struct {
 	Schemes []string `json:"schemes,omitempty"`
+	Ports   []int    `json:"ports,omitempty"` // Deprecated: ignored, port is derived from scheme.
 	Hosts   []string `json:"hosts"`
 	Methods []string `json:"methods,omitempty"`
 	Paths   []string `json:"paths,omitempty"`
@@ -474,6 +475,7 @@ func normalizeMatch(m *Match) error {
 		}
 		m.Schemes[i] = scheme
 	}
+	m.Ports = nil
 	for i, host := range m.Hosts {
 		normalized, err := normalizeCredentialHost(host)
 		if err != nil {

--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -475,7 +475,14 @@ func normalizeMatch(m *Match) error {
 		}
 		m.Schemes[i] = scheme
 	}
-	m.Ports = nil
+	if len(m.Ports) > 0 {
+		for _, port := range m.Ports {
+			if port != 80 && port != 443 {
+				return fmt.Errorf("unsupported port %d: only ports 80 and 443 are supported (derived from scheme)", port)
+			}
+		}
+		m.Ports = nil
+	}
 	for i, host := range m.Hosts {
 		normalized, err := normalizeCredentialHost(host)
 		if err != nil {

--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -64,15 +64,14 @@ var (
 )
 
 type Store struct {
-	mu             sync.RWMutex
-	exists         bool
-	revision       int64
-	credentials    map[string]record
-	bindings       map[string]Binding
-	interceptPorts map[int]struct{}
-	mitmGate       *mitmproxy.HealthGate
-	requireToken   func() bool
-	sources        *SourceRegistry
+	mu           sync.RWMutex
+	exists       bool
+	revision     int64
+	credentials  map[string]record
+	bindings     map[string]Binding
+	mitmGate     *mitmproxy.HealthGate
+	requireToken func() bool
+	sources      *SourceRegistry
 }
 
 type record struct {
@@ -118,7 +117,6 @@ type Binding struct {
 
 type Match struct {
 	Schemes []string `json:"schemes,omitempty"`
-	Ports   []int    `json:"ports,omitempty"`
 	Hosts   []string `json:"hosts"`
 	Methods []string `json:"methods,omitempty"`
 	Paths   []string `json:"paths,omitempty"`
@@ -198,12 +196,11 @@ func NewStoreWithRegistry(mitmGate *mitmproxy.HealthGate, requireToken func() bo
 		registry = NewSourceRegistry()
 	}
 	return &Store{
-		credentials:    make(map[string]record),
-		bindings:       make(map[string]Binding),
-		interceptPorts: map[int]struct{}{80: {}, 443: {}},
-		mitmGate:       mitmGate,
-		requireToken:   requireToken,
-		sources:        registry,
+		credentials:  make(map[string]record),
+		bindings:     make(map[string]Binding),
+		mitmGate:     mitmGate,
+		requireToken: requireToken,
+		sources:      registry,
 	}
 }
 
@@ -419,11 +416,6 @@ func (v *Store) validateCandidate(credentials map[string]record, bindings map[st
 }
 
 func (v *Store) validateBindingPolicy(b Binding, pol *policy.NetworkPolicy) error {
-	for _, port := range b.Match.Ports {
-		if _, ok := v.interceptPorts[port]; !ok {
-			return fmt.Errorf("binding %q port %d is not a configured transparent intercept port", b.Name, port)
-		}
-	}
 	for _, host := range b.Match.Hosts {
 		if !explicitAllowCoversHost(pol, host) {
 			return fmt.Errorf("binding %q host %q is not allowed by egress policy", b.Name, host)
@@ -465,9 +457,6 @@ func normalizeMatch(m *Match) error {
 	if len(m.Schemes) == 0 {
 		m.Schemes = []string{"https"}
 	}
-	if len(m.Ports) == 0 {
-		m.Ports = []int{443}
-	}
 	if len(m.Methods) == 0 {
 		m.Methods = []string{"GET", "POST", "PUT", "PATCH", "DELETE"}
 	}
@@ -484,11 +473,6 @@ func normalizeMatch(m *Match) error {
 			return fmt.Errorf("unsupported scheme %q", scheme)
 		}
 		m.Schemes[i] = scheme
-	}
-	for _, port := range m.Ports {
-		if port <= 0 || port > 65535 {
-			return fmt.Errorf("invalid port %d", port)
-		}
 	}
 	for i, host := range m.Hosts {
 		normalized, err := normalizeCredentialHost(host)
@@ -512,7 +496,6 @@ func normalizeMatch(m *Match) error {
 		m.Paths[i] = path
 	}
 	dedupeStringsInPlace(&m.Schemes)
-	dedupeIntsInPlace(&m.Ports)
 	dedupeStringsInPlace(&m.Hosts)
 	dedupeStringsInPlace(&m.Methods)
 	dedupeStringsInPlace(&m.Paths)
@@ -955,7 +938,6 @@ func validateBindingAmbiguity(bindings map[string]Binding) error {
 
 func bindingsAmbiguous(a, b Binding) bool {
 	if !stringSlicesOverlap(a.Match.Schemes, b.Match.Schemes) ||
-		!intSlicesOverlap(a.Match.Ports, b.Match.Ports) ||
 		!stringSlicesOverlap(a.Match.Methods, b.Match.Methods) ||
 		!pathPatternsOverlap(a.Match.Paths, b.Match.Paths) {
 		return false
@@ -1034,18 +1016,6 @@ func stringSlicesOverlap(a, b []string) bool {
 	return false
 }
 
-func intSlicesOverlap(a, b []int) bool {
-	set := make(map[int]struct{}, len(a))
-	for _, x := range a {
-		set[x] = struct{}{}
-	}
-	for _, y := range b {
-		if _, ok := set[y]; ok {
-			return true
-		}
-	}
-	return false
-}
 
 func canonicalHeaderName(name string) string {
 	return http.CanonicalHeaderKey(name)
@@ -1064,18 +1034,6 @@ func dedupeStringsInPlace(values *[]string) {
 	*values = out
 }
 
-func dedupeIntsInPlace(values *[]int) {
-	seen := make(map[int]struct{}, len(*values))
-	out := (*values)[:0]
-	for _, value := range *values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	*values = out
-}
 
 func ReadJSON(r *http.Request, dst any) error {
 	defer r.Body.Close()

--- a/components/egress/pkg/credentialvault/vault.go
+++ b/components/egress/pkg/credentialvault/vault.go
@@ -1016,7 +1016,6 @@ func stringSlicesOverlap(a, b []string) bool {
 	return false
 }
 
-
 func canonicalHeaderName(name string) string {
 	return http.CanonicalHeaderKey(name)
 }
@@ -1033,7 +1032,6 @@ func dedupeStringsInPlace(values *[]string) {
 	}
 	*values = out
 }
-
 
 func ReadJSON(r *http.Request, dst any) error {
 	defer r.Body.Close()

--- a/components/egress/pkg/credentialvault/vault_test.go
+++ b/components/egress/pkg/credentialvault/vault_test.go
@@ -144,6 +144,31 @@ func TestCredentialVaultRejectsNonFQDNBindingHosts(t *testing.T) {
 	}
 }
 
+func TestCredentialVaultRejectsNonStandardPorts(t *testing.T) {
+	for _, tc := range []struct {
+		ports   []int
+		wantErr bool
+	}{
+		{[]int{8080}, true},
+		{[]int{443, 8080}, true},
+		{[]int{80, 443}, false},
+		{[]int{443}, false},
+		{[]int{80}, false},
+		{nil, false},
+	} {
+		_, err := normalizeBinding(Binding{
+			Name:  "test",
+			Match: Match{Hosts: []string{"api.example.com"}, Ports: tc.ports},
+			Auth:  Auth{Type: "bearer", Credential: "token"},
+		})
+		if tc.wantErr {
+			require.ErrorContains(t, err, "unsupported port", "ports=%v", tc.ports)
+		} else {
+			require.NoError(t, err, "ports=%v", tc.ports)
+		}
+	}
+}
+
 func TestCredentialVaultPatchRejectsDeletingReferencedCredential(t *testing.T) {
 	store := NewStore(nil, func() bool { return true })
 	pol := testCredentialPolicy(t, `{"defaultAction":"deny","egress":[{"action":"allow","target":"code.example.com"}]}`)

--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -319,3 +319,15 @@ curl -fsS https://api.example.com/v1/projects/123/variables
   metadata.
 - Keep fake environment variables when a CLI refuses to start without a key; the
   vault-injected header is what authenticates the outbound request.
+
+## Migrating From `ports`
+
+The `match.ports` field is deprecated. Port is now derived from scheme (`https`→443, `http`→80). Only ports 80 and 443 are supported; non-standard values are rejected with a validation error.
+
+If you have existing bindings that use `ports` to narrow scope, migrate them to the equivalent `schemes` restriction:
+
+| Before | After |
+|--------|-------|
+| `schemes: ["http", "https"], ports: [443]` | `schemes: ["https"]` |
+| `schemes: ["http", "https"], ports: [80]` | `schemes: ["http"]` |
+| `schemes: ["https"], ports: [443]` | `schemes: ["https"]` (remove `ports`) |

--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -224,7 +224,6 @@ try:
                 name="anthropic-api",
                 match={
                     "schemes": ["https"],
-                    "ports": [443],
                     "hosts": [ANTHROPIC_HOST],
                     "methods": ["GET", "POST"],
                     "paths": ["/v1/*"],
@@ -271,7 +270,6 @@ CredentialBinding(
     name="git-basic",
     match={
         "schemes": ["https"],
-        "ports": [443],
         "hosts": ["git.example.com"],
         "paths": ["/org/private-repo.git*"],
     },
@@ -295,7 +293,6 @@ CredentialBinding(
     name="api-token",
     match={
         "schemes": ["https"],
-        "ports": [443],
         "hosts": ["api.example.com"],
         "methods": ["GET"],
         "paths": ["/v1/projects/123/variables"],

--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -330,7 +330,6 @@ await sandbox.credentialVault.create({
       name: "api-token",
       match: {
         schemes: ["https"],
-        ports: [443],
         hosts: ["api.example.com"],
         paths: ["/v1/*"],
       },

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -439,7 +439,6 @@ sandbox.credentialVault().create(
                     .match(
                         CredentialMatch.builder()
                             .schemes(CredentialMatch.Scheme.HTTPS)
-                            .ports(443)
                             .hosts("api.example.com")
                             .paths("/v1/*")
                             .build()

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -534,7 +534,6 @@ await sandbox.credential_vault.create(
             name="api-token",
             match={
                 "schemes": ["https"],
-                "ports": [443],
                 "hosts": ["api.example.com"],
                 "paths": ["/v1/*"],
             },

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -191,6 +191,13 @@ public class CredentialMatch
     public IReadOnlyList<string>? Schemes { get; set; }
 
     /// <summary>
+    /// Deprecated: ignored, port is derived from scheme.
+    /// </summary>
+    [JsonPropertyName("ports")]
+    [Obsolete("Ports is ignored; port is derived from Schemes (https→443, http→80).")]
+    public IReadOnlyList<int>? Ports { get; set; }
+
+    /// <summary>
     /// Gets or sets exact FQDNs or leftmost-label wildcards.
     /// </summary>
     [JsonPropertyName("hosts")]

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -191,12 +191,6 @@ public class CredentialMatch
     public IReadOnlyList<string>? Schemes { get; set; }
 
     /// <summary>
-    /// Gets or sets the request ports to match.
-    /// </summary>
-    [JsonPropertyName("ports")]
-    public IReadOnlyList<int>? Ports { get; set; }
-
-    /// <summary>
     /// Gets or sets exact FQDNs or leftmost-label wildcards.
     /// </summary>
     [JsonPropertyName("hosts")]

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/EgressAdapterCredentialVaultTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/EgressAdapterCredentialVaultTests.cs
@@ -51,7 +51,6 @@ public class EgressAdapterCredentialVaultTests
                     {
                         Hosts = ["api.example.com"],
                         Schemes = ["https"],
-                        Ports = [443],
                         Methods = ["GET"],
                         Paths = ["/v1/*"]
                     },

--- a/sdks/sandbox/go/credential_vault_test.go
+++ b/sdks/sandbox/go/credential_vault_test.go
@@ -47,7 +47,6 @@ func TestCreateCredentialVaultPayloadAndHeaders(t *testing.T) {
 					"name": "api-binding",
 					"match": map[string]any{
 						"schemes": []any{"https"},
-						"ports":   []any{float64(443)},
 						"hosts":   []any{"api.example.com"},
 						"methods": []any{"GET"},
 						"paths":   []any{"/v1/*"},
@@ -402,7 +401,6 @@ func sampleCredentialVaultCreateRequest() CredentialVaultCreateRequest {
 				Name: "api-binding",
 				Match: CredentialMatch{
 					Schemes: []CredentialScheme{CredentialSchemeHTTPS},
-					Ports:   []int{443},
 					Hosts:   []string{"api.example.com"},
 					Methods: []string{"GET"},
 					Paths:   []string{"/v1/*"},

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -310,7 +310,6 @@ const (
 // applies.
 type CredentialMatch struct {
 	Schemes []CredentialScheme `json:"schemes,omitempty"`
-	Ports   []int              `json:"ports,omitempty"`
 	Hosts   []string           `json:"hosts"`
 	Methods []string           `json:"methods,omitempty"`
 	Paths   []string           `json:"paths,omitempty"`

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -310,9 +310,11 @@ const (
 // applies.
 type CredentialMatch struct {
 	Schemes []CredentialScheme `json:"schemes,omitempty"`
-	Hosts   []string           `json:"hosts"`
-	Methods []string           `json:"methods,omitempty"`
-	Paths   []string           `json:"paths,omitempty"`
+	// Deprecated: Ports is ignored; port is derived from Schemes (https→443, http→80).
+	Ports   []int    `json:"ports,omitempty"`
+	Hosts   []string `json:"hosts"`
+	Methods []string `json:"methods,omitempty"`
+	Paths   []string `json:"paths,omitempty"`
 }
 
 // CustomHeaderEntry describes one custom header injection rule.

--- a/sdks/sandbox/javascript/README.md
+++ b/sdks/sandbox/javascript/README.md
@@ -323,7 +323,6 @@ await sandbox.credentialVault.create({
       name: "api-token",
       match: {
         schemes: ["https"],
-        ports: [443],
         hosts: ["api.example.com"],
         paths: ["/v1/*"],
       },

--- a/sdks/sandbox/javascript/src/api/egress.ts
+++ b/sdks/sandbox/javascript/src/api/egress.ts
@@ -522,6 +522,11 @@ export interface components {
              *     ]
              */
             schemes: ("https" | "http")[];
+            /**
+             * @deprecated
+             * @description Ignored. Port is derived from scheme (https→443, http→80).
+             */
+            ports?: number[];
             hosts: string[];
             /**
              * @default [

--- a/sdks/sandbox/javascript/src/api/egress.ts
+++ b/sdks/sandbox/javascript/src/api/egress.ts
@@ -164,7 +164,9 @@ export interface paths {
          * Create a sandbox-local Credential Vault
          * @description Create the initial sandbox-local Credential Vault revision and activate it
          *     in Credential Proxy. Inline credential values are write-only and are never
-         *     returned by this API.
+         *     returned by this API. The sidecar must run in `dns+nft` mode and requires
+         *     an egress policy. `defaultAction: deny` is strongly recommended;
+         *     default-allow remains temporarily supported with a security warning.
          */
         post: {
             parameters: {
@@ -520,12 +522,6 @@ export interface components {
              *     ]
              */
             schemes: ("https" | "http")[];
-            /**
-             * @default [
-             *       443
-             *     ]
-             */
-            ports: number[];
             hosts: string[];
             /**
              * @default [

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -115,7 +115,7 @@ export interface CredentialMatch extends Record<string, unknown> {
    */
   schemes?: CredentialMatchScheme[];
   /**
-   * @deprecated Ignored. Port is derived from scheme (https→443, http→80).
+   * @deprecated Port is derived from scheme (https→443, http→80). Values other than 80 or 443 are rejected by the server.
    */
   ports?: number[];
   /**

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -115,7 +115,7 @@ export interface CredentialMatch extends Record<string, unknown> {
    */
   schemes?: CredentialMatchScheme[];
   /**
-   * Destination ports to match. Defaults to 443 in the sidecar.
+   * @deprecated Ignored. Port is derived from scheme (https→443, http→80).
    */
   ports?: number[];
   /**

--- a/sdks/sandbox/kotlin/README.md
+++ b/sdks/sandbox/kotlin/README.md
@@ -429,7 +429,6 @@ sandbox.credentialVault().create(
                     .match(
                         CredentialMatch.builder()
                             .schemes(CredentialMatch.Scheme.HTTPS)
-                            .ports(443)
                             .hosts("api.example.com")
                             .paths("/v1/*")
                             .build()

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
@@ -130,6 +130,8 @@ class Credential private constructor(
  */
 class CredentialMatch private constructor(
     val schemes: List<Scheme>?,
+    @Deprecated("Ignored; port is derived from schemes (HTTPS→443, HTTP→80)")
+    val ports: List<Int>? = null,
     val hosts: List<String>,
     val methods: List<String>?,
     val paths: List<String>?,
@@ -157,6 +159,12 @@ class CredentialMatch private constructor(
         }
 
         fun schemes(vararg schemes: Scheme): Builder = schemes(schemes.toList())
+
+        @Deprecated("Ignored; port is derived from schemes")
+        fun ports(ports: List<Int>): Builder = this
+
+        @Deprecated("Ignored; port is derived from schemes")
+        fun ports(vararg ports: Int): Builder = this
 
         fun hosts(hosts: List<String>): Builder {
             require(hosts.isNotEmpty()) { "Credential match hosts cannot be empty" }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
@@ -160,11 +160,18 @@ class CredentialMatch private constructor(
 
         fun schemes(vararg schemes: Scheme): Builder = schemes(schemes.toList())
 
-        @Deprecated("Ignored; port is derived from schemes")
-        fun ports(ports: List<Int>): Builder = this
+        @Deprecated("Port is derived from schemes. Values other than 80 or 443 are rejected by the server.")
+        fun ports(ports: List<Int>): Builder {
+            ports.forEach { port ->
+                require(port == 80 || port == 443) {
+                    "Unsupported port $port: only ports 80 and 443 are supported (derived from scheme)"
+                }
+            }
+            return this
+        }
 
-        @Deprecated("Ignored; port is derived from schemes")
-        fun ports(vararg ports: Int): Builder = this
+        @Deprecated("Port is derived from schemes. Values other than 80 or 443 are rejected by the server.")
+        fun ports(vararg ports: Int): Builder = ports(ports.toList())
 
         fun hosts(hosts: List<String>): Builder {
             require(hosts.isNotEmpty()) { "Credential match hosts cannot be empty" }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/CredentialVaultModels.kt
@@ -130,7 +130,6 @@ class Credential private constructor(
  */
 class CredentialMatch private constructor(
     val schemes: List<Scheme>?,
-    val ports: List<Int>?,
     val hosts: List<String>,
     val methods: List<String>?,
     val paths: List<String>?,
@@ -147,7 +146,6 @@ class CredentialMatch private constructor(
 
     class Builder {
         private var schemes: List<Scheme>? = null
-        private var ports: List<Int>? = null
         private var hosts: List<String>? = null
         private var methods: List<String>? = null
         private var paths: List<String>? = null
@@ -159,15 +157,6 @@ class CredentialMatch private constructor(
         }
 
         fun schemes(vararg schemes: Scheme): Builder = schemes(schemes.toList())
-
-        fun ports(ports: List<Int>): Builder {
-            require(ports.isNotEmpty()) { "Credential match ports cannot be empty when provided" }
-            require(ports.all { it in 1..65535 }) { "Credential match ports must be between 1 and 65535" }
-            this.ports = ports.toList()
-            return this
-        }
-
-        fun ports(vararg ports: Int): Builder = ports(ports.toList())
 
         fun hosts(hosts: List<String>): Builder {
             require(hosts.isNotEmpty()) { "Credential match hosts cannot be empty" }
@@ -200,7 +189,6 @@ class CredentialMatch private constructor(
             val hostsValue = hosts ?: throw IllegalArgumentException("Credential match hosts must be specified")
             return CredentialMatch(
                 schemes = schemes,
-                ports = ports,
                 hosts = hostsValue,
                 methods = methods,
                 paths = paths,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
@@ -331,7 +331,6 @@ internal class EgressAdapter(
     private fun CredentialMatch.toJsonObject(): JsonObject =
         buildJsonObject {
             schemes?.let { put("schemes", it.map { scheme -> scheme.wireName() }.toStringJsonArray()) }
-            ports?.let { put("ports", JsonArray(it.map { port -> JsonPrimitive(port) })) }
             put("hosts", hosts.toStringJsonArray())
             methods?.let { put("methods", it.toStringJsonArray()) }
             paths?.let { put("paths", it.toStringJsonArray()) }
@@ -426,7 +425,6 @@ internal class EgressAdapter(
         optionalStringArray("schemes")?.let { schemes ->
             builder.schemes(schemes.map { it.toCredentialMatchScheme() })
         }
-        optionalIntArray("ports")?.let { builder.ports(it) }
         optionalStringArray("methods")?.let { builder.methods(it) }
         optionalStringArray("paths")?.let { builder.paths(it) }
         return builder.build()

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapterTest.kt
@@ -95,7 +95,6 @@ class EgressAdapterTest {
                           "revision": 1,
                           "match": {
                             "schemes": ["https"],
-                            "ports": [443],
                             "hosts": ["api.github.com"],
                             "methods": ["GET"],
                             "paths": ["/repos/*"]
@@ -111,7 +110,6 @@ class EgressAdapterTest {
         val match =
             CredentialMatch.builder()
                 .schemes(CredentialMatch.Scheme.HTTPS)
-                .ports(443)
                 .hosts("api.github.com")
                 .methods("GET")
                 .paths("/repos/*")

--- a/sdks/sandbox/python/README.md
+++ b/sdks/sandbox/python/README.md
@@ -527,7 +527,6 @@ await sandbox.credential_vault.create(
             name="api-token",
             match={
                 "schemes": ["https"],
-                "ports": [443],
                 "hosts": ["api.example.com"],
                 "paths": ["/v1/*"],
             },

--- a/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
+++ b/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
@@ -33,14 +33,12 @@ class CredentialMatch:
     Attributes:
         hosts (list[str]):
         schemes (list[CredentialMatchSchemesItem] | Unset):
-        ports (list[int] | Unset):
         methods (list[str] | Unset):
         paths (list[str] | Unset):
     """
 
     hosts: list[str]
     schemes: list[CredentialMatchSchemesItem] | Unset = UNSET
-    ports: list[int] | Unset = UNSET
     methods: list[str] | Unset = UNSET
     paths: list[str] | Unset = UNSET
 
@@ -53,10 +51,6 @@ class CredentialMatch:
             for schemes_item_data in self.schemes:
                 schemes_item = schemes_item_data.value
                 schemes.append(schemes_item)
-
-        ports: list[int] | Unset = UNSET
-        if not isinstance(self.ports, Unset):
-            ports = self.ports
 
         methods: list[str] | Unset = UNSET
         if not isinstance(self.methods, Unset):
@@ -75,8 +69,6 @@ class CredentialMatch:
         )
         if schemes is not UNSET:
             field_dict["schemes"] = schemes
-        if ports is not UNSET:
-            field_dict["ports"] = ports
         if methods is not UNSET:
             field_dict["methods"] = methods
         if paths is not UNSET:
@@ -98,8 +90,6 @@ class CredentialMatch:
 
                 schemes.append(schemes_item)
 
-        ports = cast(list[int], d.pop("ports", UNSET))
-
         methods = cast(list[str], d.pop("methods", UNSET))
 
         paths = cast(list[str], d.pop("paths", UNSET))
@@ -107,7 +97,6 @@ class CredentialMatch:
         credential_match = cls(
             hosts=hosts,
             schemes=schemes,
-            ports=ports,
             methods=methods,
             paths=paths,
         )

--- a/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
+++ b/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
@@ -33,12 +33,14 @@ class CredentialMatch:
     Attributes:
         hosts (list[str]):
         schemes (list[CredentialMatchSchemesItem] | Unset):
+        ports (list[int] | Unset): Ignored. Port is derived from scheme (https→443, http→80).
         methods (list[str] | Unset):
         paths (list[str] | Unset):
     """
 
     hosts: list[str]
     schemes: list[CredentialMatchSchemesItem] | Unset = UNSET
+    ports: list[int] | Unset = UNSET
     methods: list[str] | Unset = UNSET
     paths: list[str] | Unset = UNSET
 
@@ -51,6 +53,10 @@ class CredentialMatch:
             for schemes_item_data in self.schemes:
                 schemes_item = schemes_item_data.value
                 schemes.append(schemes_item)
+
+        ports: list[int] | Unset = UNSET
+        if not isinstance(self.ports, Unset):
+            ports = self.ports
 
         methods: list[str] | Unset = UNSET
         if not isinstance(self.methods, Unset):
@@ -69,6 +75,8 @@ class CredentialMatch:
         )
         if schemes is not UNSET:
             field_dict["schemes"] = schemes
+        if ports is not UNSET:
+            field_dict["ports"] = ports
         if methods is not UNSET:
             field_dict["methods"] = methods
         if paths is not UNSET:
@@ -90,6 +98,8 @@ class CredentialMatch:
 
                 schemes.append(schemes_item)
 
+        ports = cast(list[int], d.pop("ports", UNSET))
+
         methods = cast(list[str], d.pop("methods", UNSET))
 
         paths = cast(list[str], d.pop("paths", UNSET))
@@ -97,6 +107,7 @@ class CredentialMatch:
         credential_match = cls(
             hosts=hosts,
             schemes=schemes,
+            ports=ports,
             methods=methods,
             paths=paths,
         )

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -204,7 +204,7 @@ class CredentialMatch(BaseModel):
     """Request match for a Credential Vault binding."""
 
     schemes: list[Literal["https", "http"]] | None = Field(default=None)
-    ports: list[int] | None = Field(default=None, deprecated="Ignored. Port is derived from scheme (https→443, http→80).")
+    ports: list[int] | None = Field(default=None, deprecated="Port is derived from scheme (https→443, http→80). Values other than 80 or 443 are rejected by the server.")
     hosts: list[str] = Field(description="Exact FQDNs or leftmost-label wildcards.")
     methods: list[str] | None = Field(default=None)
     paths: list[str] | None = Field(default=None)

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -204,7 +204,7 @@ class CredentialMatch(BaseModel):
     """Request match for a Credential Vault binding."""
 
     schemes: list[Literal["https", "http"]] | None = Field(default=None)
-    ports: list[int] | None = Field(default=None)
+    ports: list[int] | None = Field(default=None, deprecated="Ignored. Port is derived from scheme (https→443, http→80).")
     hosts: list[str] = Field(description="Exact FQDNs or leftmost-label wildcards.")
     methods: list[str] | None = Field(default=None)
     paths: list[str] | None = Field(default=None)

--- a/sdks/sandbox/python/uv.lock
+++ b/sdks/sandbox/python/uv.lock
@@ -420,6 +420,7 @@ dependencies = [
 
 [package.optional-dependencies]
 pool-redis = [
+    { name = "pyjwt" },
     { name = "redis" },
 ]
 
@@ -439,6 +440,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=21.3.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "pydantic", specifier = ">=2.4.2,<3.0" },
+    { name = "pyjwt", marker = "extra == 'pool-redis'", specifier = ">=2.13.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0" },
     { name = "redis", marker = "extra == 'pool-redis'", specifier = ">=5.0,<6.0" },
 ]

--- a/specs/egress-api.yaml
+++ b/specs/egress-api.yaml
@@ -561,7 +561,7 @@ components:
           items:
             type: integer
           deprecated: true
-          description: "Ignored. Port is derived from scheme (https→443, http→80)."
+          description: "Deprecated. Port is derived from scheme (https→443, http→80). Values other than 80 or 443 are rejected with a validation error. Standard values (80/443) are accepted but ignored."
         hosts:
           type: array
           items:

--- a/specs/egress-api.yaml
+++ b/specs/egress-api.yaml
@@ -556,11 +556,6 @@ components:
             type: string
             enum: [https, http]
           default: [https]
-        ports:
-          type: array
-          items:
-            type: integer
-          default: [443]
         hosts:
           type: array
           items:

--- a/specs/egress-api.yaml
+++ b/specs/egress-api.yaml
@@ -556,6 +556,12 @@ components:
             type: string
             enum: [https, http]
           default: [https]
+        ports:
+          type: array
+          items:
+            type: integer
+          deprecated: true
+          description: "Ignored. Port is derived from scheme (https→443, http→80)."
         hosts:
           type: array
           items:

--- a/tests/csharp/OpenSandbox.E2ETests/CredentialVaultE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/CredentialVaultE2ETests.cs
@@ -275,7 +275,6 @@ public class CredentialVaultE2ETests : IClassFixture<E2ETestFixture>
             Match = new CredentialMatch
             {
                 Schemes = new[] { "http" },
-                Ports = new[] { 80 },
                 Hosts = new[] { CredentialVaultTargetHost() },
                 Methods = new[] { "GET" },
                 Paths = new[] { path }

--- a/tests/go/credential_vault_e2e_test.go
+++ b/tests/go/credential_vault_e2e_test.go
@@ -288,7 +288,6 @@ func credentialVaultBinding(name, path string, auth opensandbox.CredentialAuth) 
 		Name: name,
 		Match: opensandbox.CredentialMatch{
 			Schemes: []opensandbox.CredentialScheme{opensandbox.CredentialSchemeHTTP},
-			Ports:   []int{80},
 			Hosts:   []string{credentialVaultTargetHost()},
 			Methods: []string{"GET"},
 			Paths:   []string{path},

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CredentialVaultE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/CredentialVaultE2ETest.java
@@ -327,7 +327,6 @@ class CredentialVaultE2ETest extends BaseE2ETest {
                 .match(
                         CredentialMatch.builder()
                                 .schemes(CredentialMatch.Scheme.HTTP)
-                                .ports(80)
                                 .hosts(credentialVaultTargetHost())
                                 .methods("GET")
                                 .paths(path)

--- a/tests/javascript/tests/test_credential_vault_e2e.test.ts
+++ b/tests/javascript/tests/test_credential_vault_e2e.test.ts
@@ -234,7 +234,6 @@ function credentialVaultBinding(name: string, path: string, auth: CredentialAuth
     name,
     match: {
       schemes: ["http"],
-      ports: [80],
       hosts: [credentialVaultTargetHost()],
       methods: ["GET"],
       paths: [path],

--- a/tests/python/tests/test_credential_vault_e2e.py
+++ b/tests/python/tests/test_credential_vault_e2e.py
@@ -286,7 +286,6 @@ def _binding(name: str, path: str, auth: dict[str, object]) -> CredentialBinding
         name=name,
         match={
             "schemes": ["http"],
-            "ports": [80],
             "hosts": [TARGET_HOST],
             "methods": ["GET"],
             "paths": [path],


### PR DESCRIPTION
## Summary

- Remove `Match.Ports` field from credential vault bindings — port is now derived from scheme (https→443, http→80)
- Remove `interceptPorts` validation and related helper functions (`intSlicesOverlap`, `dedupeIntsInPlace`)
- Update mitmproxy matching script to derive allowed ports from schemes
- Regenerate Python/JavaScript/Kotlin SDK clients, update C# SDK manually

## Motivation

The intercept layer (iptables/nft) only redirects ports 80 and 443. The `interceptPorts` map hardcodes these same values. HTTP semantics bind scheme↔port (http↔80, https↔443). Exposing a `ports` field to users creates confusion ("why can't I use 8443?") with no actual flexibility. Removing it simplifies the API surface and eliminates invalid configurations.

## Test plan

- [x] `go test ./pkg/credentialvault/...` — pass
- [x] `go test ./...` (full egress component) — pass
- [x] Go SDK tests — pass
- [x] JavaScript SDK build — pass
- [ ] E2E credential vault tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)