### PR TITLE
[SECURITY] server: enforce secure-access token validation on proxy route

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -16,6 +16,7 @@
 HTTP and WebSocket proxy routes for reaching services inside sandboxes via the lifecycle API.
 """
 
+import hmac
 import logging
 from collections.abc import AsyncIterator, Mapping
 from typing import Optional
@@ -54,6 +55,7 @@ SENSITIVE_HEADERS = {
     "authorization",
     "cookie",
     SANDBOX_API_KEY_HEADER.lower(),
+    OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower(),
 }
 
 FORWARDED_HEADERS = {
@@ -180,14 +182,47 @@ async def _stream_backend_response(resp: httpx.Response) -> AsyncIterator[bytes]
         await resp.aclose()
 
 
+def _verify_secure_access(endpoint: Endpoint, caller_headers: Mapping[str, str]) -> None:
+    """Enforce OpenSandbox-Secure-Access validation on server-proxy requests.
+
+    When endpoint resolution returns a secure-access token, the caller must
+    supply the same header value.  Raises 401 for missing or mismatched tokens.
+    Uses constant-time comparison to avoid timing side-channels.
+    """
+    if not endpoint.headers:
+        return
+    expected_token = endpoint.headers.get(OPEN_SANDBOX_SECURE_ACCESS_HEADER)
+    if not expected_token:
+        return
+    caller_token = None
+    for key, value in caller_headers.items():
+        if key.lower() == OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower():
+            caller_token = value
+            break
+    if not caller_token or not hmac.compare_digest(
+        caller_token.encode(), expected_token.encode()
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "MISSING_OR_INVALID_SECURE_ACCESS",
+                "message": (
+                    "This sandbox requires the "
+                    f"{OPEN_SANDBOX_SECURE_ACCESS_HEADER} header for access."
+                ),
+            },
+        )
+
+
 async def _proxy_http_request(
     request: Request,
     sandbox_id: str,
     port: int,
     full_path: str,
 ) -> StreamingResponse:
-    _schedule_proxy_renew(request, sandbox_id)
     endpoint = lifecycle.sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
+    _verify_secure_access(endpoint, request.headers)
+    _schedule_proxy_renew(request, sandbox_id)
     query_string = request.url.query
     target_url = _build_proxy_target_url(endpoint, full_path, query_string, websocket=False)
     client: httpx.AsyncClient = request.app.state.http_client
@@ -324,8 +359,6 @@ async def _proxy_websocket_request(
     port: int,
     full_path: str,
 ) -> None:
-    _schedule_proxy_renew(websocket, sandbox_id)
-
     try:
         endpoint = lifecycle.sandbox_service.get_endpoint(sandbox_id, port, resolve_internal=True)
     except HTTPException as exc:
@@ -341,6 +374,18 @@ async def _proxy_websocket_request(
             str(exc.detail) if exc.detail else "",
         )
         return
+
+    try:
+        _verify_secure_access(endpoint, dict(websocket.headers))
+    except HTTPException:
+        await _fail_client_websocket(
+            websocket,
+            status.WS_1008_POLICY_VIOLATION,
+            "Missing or invalid secure-access token",
+        )
+        return
+
+    _schedule_proxy_renew(websocket, sandbox_id)
 
     query_string = websocket.url.query or ""
     target_url = _build_proxy_target_url(

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -248,11 +248,12 @@ def test_proxy_root_path_forwards_endpoint_headers_and_query(
     assert lowered_headers["x-trace"] == "trace-root"
 
 
-def test_proxy_does_not_auto_inject_secure_access_header(
+def test_proxy_rejects_missing_secure_access_header(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
 ) -> None:
+    """Regression test: requests without the required secure-access token are rejected."""
     class StubService:
         @staticmethod
         def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
@@ -279,19 +280,16 @@ def test_proxy_does_not_auto_inject_secure_access_header(
         headers={**auth_headers, "X-Trace": "trace-root"},
     )
 
-    assert response.status_code == 200
-    lowered_headers = {
-        key.lower(): value for key, value in fake_client.built["headers"].items()
-    }
-    assert lowered_headers["opensandbox-ingress-to"] == "sbx-123-44772"
-    assert OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower() not in lowered_headers
+    assert response.status_code == 401
+    assert fake_client.built is None  # request was never forwarded
 
 
-def test_proxy_forwards_client_supplied_secure_access_header(
+def test_proxy_rejects_mismatched_secure_access_header(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
 ) -> None:
+    """Regression test: requests with a wrong secure-access token are rejected."""
     class StubService:
         @staticmethod
         def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
@@ -316,7 +314,45 @@ def test_proxy_forwards_client_supplied_secure_access_header(
         "/v1/sandboxes/sbx-123/proxy/44772",
         headers={
             **auth_headers,
-            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "client-token",
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "wrong-token",
+        },
+    )
+
+    assert response.status_code == 401
+    assert fake_client.built is None  # request was never forwarded
+
+
+def test_proxy_allows_valid_secure_access_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    """Valid secure-access token passes; header is stripped from forwarded request."""
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert sandbox_id == "sbx-123"
+            assert port == 44772
+            assert resolve_internal is True
+            return Endpoint(
+                endpoint="10.57.1.91:40109/base",
+                headers={
+                    OPEN_SANDBOX_INGRESS_HEADER: "sbx-123-44772",
+                    OPEN_SANDBOX_SECURE_ACCESS_HEADER: "server-side-token",
+                },
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(chunks=[b"root-ok"])
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772",
+        headers={
+            **auth_headers,
+            OPEN_SANDBOX_SECURE_ACCESS_HEADER: "server-side-token",
         },
     )
 
@@ -324,7 +360,10 @@ def test_proxy_forwards_client_supplied_secure_access_header(
     lowered_headers = {
         key.lower(): value for key, value in fake_client.built["headers"].items()
     }
-    assert lowered_headers[OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower()] == "client-token"
+    # Token is stripped from forwarded headers — sandbox app should not receive it
+    assert OPEN_SANDBOX_SECURE_ACCESS_HEADER.lower() not in lowered_headers
+    # Other endpoint headers are still forwarded
+    assert lowered_headers["opensandbox-ingress-to"] == "sbx-123-44772"
 
 
 def test_proxy_forwards_get_request_with_query_params(


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the lifecycle server proxy route
`/sandboxes/{sandboxId}/proxy/{port}/...` bypassed `secureAccess` enforcement.

**Root cause:**
1. `AuthMiddleware` exempts proxy-shaped paths from API-key validation
2. `_proxy_http_request()` resolves an internal Pod IP via `resolve_internal=True` (bypassing ingress)
3. The proxy never verified the caller-supplied `OpenSandbox-Secure-Access` header against the server-side token

**Impact:** An unauthenticated network client who knows a sandbox ID and port can reach `secureAccess: true` sandbox services without the lifecycle API key or per-sandbox token.

## Fix

- Add `_verify_secure_access()` — when endpoint resolution returns a secure-access token, require the incoming request to supply a matching header value (constant-time `hmac.compare_digest`). Return 401 on missing/mismatch.
- Enforce in both HTTP and WebSocket proxy paths.
- Add `OpenSandbox-Secure-Access` to `SENSITIVE_HEADERS` so the token is stripped from forwarded headers after validation (sandbox apps should not receive infrastructure tokens).

## Tests

- `test_proxy_rejects_missing_secure_access_header` — missing token → 401
- `test_proxy_rejects_mismatched_secure_access_header` — wrong token → 401
- `test_proxy_allows_valid_secure_access_header` — correct token → 200, token stripped from forwarded headers

All 1225 tests pass (694 unit + 531 k8s), lint clean.

## Security

CVSSv3.1 ~7.5 (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N — access to protected sandbox services without credentials)