### PR TITLE
[SECURITY] egress: reject ambiguous path segments before credential injection

### DIFF
--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -173,6 +173,9 @@ def _request_path(flow: http.HTTPFlow) -> str:
     return path.split("?", 1)[0] or "/"
 
 
+_DOT_SEGMENT_RE = re.compile(r"/\.\.(/|$)")
+
+
 def _path_is_ambiguous(raw_path: str) -> bool:
     """Return True if the raw request path contains dot-segment traversal sequences.
 
@@ -181,19 +184,29 @@ def _path_is_ambiguous(raw_path: str) -> bool:
     path-based authorization checks (the canonical path seen by the upstream
     server would differ from the raw prefix matched here).
     """
-    # Strip query string for the check (consistent with _request_path).
     path = raw_path.split("?", 1)[0]
-    # Check raw path for literal dot segments.
-    if "/.." in path:
+
+    # Only match ``..`` as a complete path segment (/../ or trailing /..).
+    if _DOT_SEGMENT_RE.search(path):
         return True
-    # Percent-decode and re-check to catch %2e%2e, %2E%2e, etc.
-    decoded = unquote(path)
-    if "/.." in decoded:
+
+    # Iteratively decode to catch nested encodings like %252e%252e.
+    decoded = path
+    for _ in range(10):
+        next_decoded = unquote(decoded)
+        if next_decoded == decoded:
+            break
+        decoded = next_decoded
+    if _DOT_SEGMENT_RE.search(decoded):
         return True
-    # Reject encoded forward-slash (%2f / %2F) which can confuse path routing.
+
+    # Reject encoded separators (%2f, %5c) and raw backslashes.
     lower = path.lower()
-    if "%2f" in lower:
+    if "%2f" in lower or "%5c" in lower:
         return True
+    if "\\" in path:
+        return True
+
     return False
 
 

--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -45,6 +45,7 @@ import re
 import socket
 import time
 from typing import Any
+from urllib.parse import unquote
 
 from mitmproxy import ctx, http
 from mitmproxy.tls import ClientHelloData
@@ -172,6 +173,30 @@ def _request_path(flow: http.HTTPFlow) -> str:
     return path.split("?", 1)[0] or "/"
 
 
+def _path_is_ambiguous(raw_path: str) -> bool:
+    """Return True if the raw request path contains dot-segment traversal sequences.
+
+    Legitimate HTTP clients resolve dot segments before sending. Raw ``..``
+    or percent-encoded variants on the wire indicate an attempt to confuse
+    path-based authorization checks (the canonical path seen by the upstream
+    server would differ from the raw prefix matched here).
+    """
+    # Strip query string for the check (consistent with _request_path).
+    path = raw_path.split("?", 1)[0]
+    # Check raw path for literal dot segments.
+    if "/.." in path:
+        return True
+    # Percent-decode and re-check to catch %2e%2e, %2E%2e, etc.
+    decoded = unquote(path)
+    if "/.." in decoded:
+        return True
+    # Reject encoded forward-slash (%2f / %2F) which can confuse path routing.
+    lower = path.lower()
+    if "%2f" in lower:
+        return True
+    return False
+
+
 def _host_matches(host: str, pattern: str) -> tuple[bool, int]:
     pattern = pattern.rstrip(".").lower()
     if pattern.startswith("*."):
@@ -240,6 +265,23 @@ def _select_binding(flow: http.HTTPFlow, vault: ActiveVault) -> dict[str, Any] |
 def request(flow: http.HTTPFlow) -> None:
     vault = _load_active_vault()
     if vault is None:
+        return
+
+    # Reject requests with ambiguous path segments before credential injection.
+    # Raw dot-segments or encoded variants on the wire are not produced by
+    # legitimate HTTP clients and can trick prefix-based path matching into
+    # injecting credentials for a scope the canonical path does not belong to.
+    raw_path = flow.request.path or "/"
+    if _path_is_ambiguous(raw_path):
+        flow.response = http.Response.make(
+            403,
+            b"request path contains ambiguous segments\n",
+            {"content-type": "text/plain"},
+        )
+        ctx.log.warn(
+            "credential proxy: rejected request with ambiguous path: "
+            f"{flow.request.method} {_request_host(flow)}{_request_path(flow)}"
+        )
         return
 
     binding = _select_binding(flow, vault)

--- a/components/egress/tests/test_mitmscripts_system.py
+++ b/components/egress/tests/test_mitmscripts_system.py
@@ -345,6 +345,58 @@ class SystemAddonPathTraversalTest(unittest.TestCase):
 
         self.assertNotIn("Private-Token", flow.request.headers._values)
 
+    def test_dot_dot_substring_not_rejected(self) -> None:
+        """'..' not as a complete segment (e.g. '/.../') must NOT be blocked."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/.../data"
+        system.request(flow)
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_dot_dot_metadata_path_not_rejected(self) -> None:
+        """``/..metadata`` is not a traversal segment."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/..metadata"
+        system.request(flow)
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_encoded_backslash_rejected(self) -> None:
+        """%5c encoded backslash must be rejected."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/%5c..%5c456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_raw_backslash_rejected(self) -> None:
+        """Raw backslash in path must be rejected."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123\\..\\456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_double_encoded_dot_dot_rejected(self) -> None:
+        """Double percent-encoded traversal (%252e%252e) must be rejected."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/%252e%252e/456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
     def test_no_vault_active_allows_dot_dot_through(self) -> None:
         """When no vault is active, ambiguous paths are not blocked (no credential risk)."""
         system = _load_system_module()

--- a/components/egress/tests/test_mitmscripts_system.py
+++ b/components/egress/tests/test_mitmscripts_system.py
@@ -102,7 +102,15 @@ class _Flow:
 def _load_system_module() -> Any:
     mitmproxy = types.ModuleType("mitmproxy")
     mitmproxy.ctx = types.SimpleNamespace(log=_Log(), options=types.SimpleNamespace(ignore_hosts=[]))
-    mitmproxy.http = types.SimpleNamespace(HTTPFlow=object, Response=types.SimpleNamespace(make=lambda *args: None))
+    def _make_response(status: int, body: bytes = b"", headers: dict | None = None):
+        resp = _Response()
+        resp.status_code = status
+        resp.body = body.decode("utf-8") if isinstance(body, bytes) else body
+        if headers:
+            resp.headers = _Headers(headers)
+        return resp
+
+    mitmproxy.http = types.SimpleNamespace(HTTPFlow=object, Response=types.SimpleNamespace(make=_make_response))
     mitmproxy_tls = types.ModuleType("mitmproxy.tls")
     mitmproxy_tls.ClientHelloData = object
 
@@ -234,6 +242,121 @@ class SystemAddonRedactionTest(unittest.TestCase):
         system.responseheaders(flow)
 
         self.assertEqual("[REDACTED]", flow.response.headers.get("x-token-echo"))
+
+
+class SystemAddonPathTraversalTest(unittest.TestCase):
+    """Regression tests for CVE-like path traversal credential injection bypass."""
+
+    def _make_system_with_vault(self):
+        system = _load_system_module()
+        system._load_active_vault = lambda: system.ActiveVault(
+            1,
+            [
+                {
+                    "name": "gitlab-api",
+                    "match": {
+                        "hosts": ["code.example.com"],
+                        "methods": ["GET"],
+                        "paths": ["/api/v8/projects/123/*"],
+                    },
+                    "headers": [{"name": "Private-Token", "value": "secret-token"}],
+                }
+            ],
+            ["secret-token"],
+        )
+        return system
+
+    def test_dot_dot_traversal_rejected(self) -> None:
+        """Raw .. traversal escaping path scope must be rejected with 403."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/../456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_encoded_dot_dot_traversal_rejected(self) -> None:
+        """%2e%2e encoded traversal must be rejected with 403."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/%2e%2e/456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_mixed_case_encoded_dot_dot_rejected(self) -> None:
+        """%2E%2e mixed-case encoded traversal must be rejected."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/%2E%2e/456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_encoded_slash_rejected(self) -> None:
+        """%2f encoded path separator must be rejected."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123%2f..%2f456/variables"
+
+        system.request(flow)
+
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(403, flow.response.status_code)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_dot_dot_in_query_string_not_rejected(self) -> None:
+        """.. in query string is harmless and should not trigger rejection."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/variables?ref=../../main"
+
+        system.request(flow)
+
+        # Should inject credential normally (path matches the binding).
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_normal_path_within_scope_injects_credential(self) -> None:
+        """Normal path within scope still receives credential injection."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/variables"
+
+        system.request(flow)
+
+        self.assertEqual("secret-token", flow.request.headers.get("Private-Token"))
+
+    def test_normal_path_outside_scope_no_injection(self) -> None:
+        """Normal path outside scope does not receive credential injection."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/456/variables"
+
+        system.request(flow)
+
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_no_vault_active_allows_dot_dot_through(self) -> None:
+        """When no vault is active, ambiguous paths are not blocked (no credential risk)."""
+        system = _load_system_module()
+        system._load_active_vault = lambda: None
+        flow = _Flow()
+        flow.request.path = "/api/v8/projects/123/../456/variables"
+
+        system.request(flow)
+
+        # No response set means the request passes through unmodified.
+        # (flow.response is the pre-initialized _Response, not a 403)
+        self.assertNotIn("Private-Token", flow.request.headers._values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Credential Vault path matching uses raw prefix comparison for wildcard bindings. A sandbox workload can craft requests with dot-segment traversal (`/../` or `%2e%2e`) that pass the prefix check but resolve to a different canonical path on the upstream server, escaping the intended credential scope.

## Fix

When a vault is active, reject requests whose path contains raw dot-segments, percent-encoded dot-segments, or encoded path separators (`%2f`) with HTTP 403 **before** any binding match occurs.

This is safe because legitimate HTTP clients resolve dot segments before sending; their presence on the wire is a strong signal of evasion. When no vault is active, requests pass through unmodified (no credential risk to protect against).

## Changes

- `components/egress/mitmscripts/system.py`: Add `_path_is_ambiguous()` check and early 403 rejection in `request()` hook
- `components/egress/tests/test_mitmscripts_system.py`: Add 8 regression tests covering:
  - Raw `../` traversal → 403
  - `%2e%2e` encoded traversal → 403
  - `%2E%2e` mixed-case encoding → 403
  - `%2f` encoded path separator → 403
  - `..` in query string → not rejected (false-positive check)
  - Normal path within scope → credential injected
  - Normal path outside scope → no injection
  - No vault active → ambiguous paths pass through

## Testing

```
$ python3 -m unittest discover -s tests -p "test_mitmscripts_system.py" -v
Ran 12 tests in 0.038s
OK
```
