### PR TITLE
Update repository links after GitHub org migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Any Questions or Suggestions?
-    url: https://github.com/alibaba/OpenSandbox/issues
+    url: https://github.com/opensandbox-group/OpenSandbox/issues
     about: Please ask and answer questions here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ OpenSandbox adheres to a [Code of Conduct](CODE_OF_CONDUCT.md) that we expect al
 
 There are many ways to contribute to OpenSandbox:
 
-- **Report Bugs**: Submit detailed bug reports through [GitHub Issues](https://github.com/alibaba/OpenSandbox/issues)
+- **Report Bugs**: Submit detailed bug reports through [GitHub Issues](https://github.com/opensandbox-group/OpenSandbox/issues)
 - **Suggest Features**: Propose new features or improvements
 - **Write Code**: Fix bugs, implement features, or improve performance
 - **Improve Documentation**: Enhance README files, write tutorials, or fix typos

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </p>
 
 <p align="center">
-  <a href="https://github.com/opensandbox-group/OpenSandbox"><img src="https://img.shields.io/badge/Stars-11.6k-181717?style=flat-square&logo=github&logoColor=white" alt="Stars" /></a>
+  <a href="https://github.com/opensandbox-group/OpenSandbox"><img src="https://img.shields.io/github/stars/opensandbox-group/OpenSandbox?style=flat-square&logo=github&logoColor=white&label=Stars&color=181717" alt="Stars" /></a>
   <a href="https://www.bestpractices.dev/projects/12588"><img src="https://img.shields.io/badge/OpenSSF-Best-4C566A?style=flat-square" alt="OpenSSF Best Practices" /></a>
   <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox"><img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4?style=flat-square" alt="CNCF Landscape" /></a>
   <a href="https://discord.gg/g7FuPs8YeD"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>

--- a/README.md
+++ b/README.md
@@ -4,33 +4,17 @@
   <h1>OpenSandbox</h1>
 
   <p align="center">
-    <a href="https://trendshift.io/repositories/21828" target="_blank">
-      <img src="https://trendshift.io/api/badge/repositories/21828" alt="alibaba%2FOpenSandbox | Trendshift" style="width: 320px; height: 70px;" width="320" height="70" />
-    </a>
+    <a href="https://trendshift.io/repositories/21828" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21828" alt="opensandbox-group%2FOpenSandbox | Trendshift" style="width: 320px; height: 70px;" width="320" height="70" /></a>
   </p>
 
 <p align="center">
-  <a href="https://github.com/alibaba/OpenSandbox">
-    <img src="https://img.shields.io/badge/Stars-11.6k-181717?style=flat-square&logo=github&logoColor=white" alt="Stars" />
-  </a>
-  <a href="https://www.bestpractices.dev/projects/12588">
-    <img src="https://img.shields.io/badge/OpenSSF-Best-4C566A?style=flat-square" alt="OpenSSF Best Practices" />
-  </a>
-  <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox">
-    <img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4?style=flat-square" alt="CNCF Landscape" />
-  </a>
-  <a href="https://discord.gg/g7FuPs8YeD">
-    <img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" />
-  </a>
-  <a href="https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11">
-    <img src="https://img.shields.io/badge/DingTalk-Join-0089FF?style=flat-square" alt="DingTalk" />
-  </a>
-  <a href="https://github.com/alibaba/OpenSandbox/actions">
-    <img src="https://img.shields.io/github/actions/workflow/status/opensandbox-group/OpenSandbox/real-e2e.yml?branch=main&label=TEST&style=flat-square&logo=github&logoColor=white" alt="E2E Status" />
-  </a>
-  <a href="https://github.com/alibaba/OpenSandbox/actions">
-    <img src="https://img.shields.io/github/actions/workflow/status/opensandbox-group/OpenSandbox/kubernetes-nightly-build.yml?branch=main&label=K8S&style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes nightly build status" />
-  </a>
+  <a href="https://github.com/opensandbox-group/OpenSandbox"><img src="https://img.shields.io/badge/Stars-11.6k-181717?style=flat-square&logo=github&logoColor=white" alt="Stars" /></a>
+  <a href="https://www.bestpractices.dev/projects/12588"><img src="https://img.shields.io/badge/OpenSSF-Best-4C566A?style=flat-square" alt="OpenSSF Best Practices" /></a>
+  <a href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--opensandbox"><img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4?style=flat-square" alt="CNCF Landscape" /></a>
+  <a href="https://discord.gg/g7FuPs8YeD"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11"><img src="https://img.shields.io/badge/DingTalk-Join-0089FF?style=flat-square" alt="DingTalk" /></a>
+  <a href="https://github.com/opensandbox-group/OpenSandbox/actions"><img src="https://img.shields.io/github/actions/workflow/status/opensandbox-group/OpenSandbox/real-e2e.yml?branch=main&label=TEST&style=flat-square&logo=github&logoColor=white" alt="E2E Status" /></a>
+  <a href="https://github.com/opensandbox-group/OpenSandbox/actions"><img src="https://img.shields.io/github/actions/workflow/status/opensandbox-group/OpenSandbox/kubernetes-nightly-build.yml?branch=main&label=K8S&style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes nightly build status" /></a>
 </p>
 
   <hr />
@@ -313,4 +297,4 @@ and how roadmap items are managed.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/OpenSandbox&type=date&legend=top-left)](https://www.star-history.com/#alibaba/OpenSandbox&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=opensandbox-group/OpenSandbox&type=date&legend=top-left)](https://www.star-history.com/#opensandbox-group/OpenSandbox&type=date&legend=top-left)

--- a/docs/community/release-verification.md
+++ b/docs/community/release-verification.md
@@ -51,19 +51,19 @@ infrastructure.
 
 Expected identity values:
 
-- Repository: `alibaba/OpenSandbox`
+- Repository: `opensandbox-group/OpenSandbox`
 - OIDC issuer: `https://token.actions.githubusercontent.com`
-- Source release workflow: `alibaba/OpenSandbox/.github/workflows/release-generic.yml`
-- Component image workflow: `alibaba/OpenSandbox/.github/workflows/publish-components.yml`
-- Server image workflow: `alibaba/OpenSandbox/.github/workflows/publish-server.yml`
-- CLI package workflow: `alibaba/OpenSandbox/.github/workflows/publish-cli.yml`
-- Python package workflow: `alibaba/OpenSandbox/.github/workflows/publish-python-sdks.yml`
-- JavaScript package workflow: `alibaba/OpenSandbox/.github/workflows/publish-js-sdks.yml`
-- C# package workflow: `alibaba/OpenSandbox/.github/workflows/publish-csharp-sdks.yml`
-- Helm chart workflow: `alibaba/OpenSandbox/.github/workflows/publish-helm-chart.yml`
+- Source release workflow: `opensandbox-group/OpenSandbox/.github/workflows/release-generic.yml`
+- Component image workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-components.yml`
+- Server image workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-server.yml`
+- CLI package workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-cli.yml`
+- Python package workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-python-sdks.yml`
+- JavaScript package workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-js-sdks.yml`
+- C# package workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-csharp-sdks.yml`
+- Helm chart workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-helm-chart.yml`
 
 If you run the release workflows from a downstream fork, replace
-`alibaba/OpenSandbox` in the verification commands with that fork's
+`opensandbox-group/OpenSandbox` in the verification commands with that fork's
 `owner/repository` identity.
 
 Private signing material is not stored in GitHub Releases, Docker Hub, ACR,
@@ -83,7 +83,7 @@ Download the signed source archive and checksum file:
 
 ```bash
 gh release download "$TAG" \
-  --repo alibaba/OpenSandbox \
+  --repo opensandbox-group/OpenSandbox \
   --pattern "opensandbox-${SAFE_TAG}.tar.gz" \
   --pattern "SHA256SUMS"
 ```
@@ -98,16 +98,16 @@ Verify the source archive attestation:
 
 ```bash
 gh attestation verify "opensandbox-${SAFE_TAG}.tar.gz" \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/release-generic.yml
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/release-generic.yml
 ```
 
 Verify the checksum file attestation:
 
 ```bash
 gh attestation verify SHA256SUMS \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/release-generic.yml
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/release-generic.yml
 ```
 
 The Generic Release workflow is started with `workflow_dispatch`, so its
@@ -138,9 +138,9 @@ Verify the registry provenance attestation:
 
 ```bash
 gh attestation verify "oci://${IMAGE_REF}" \
-  --repo alibaba/OpenSandbox \
+  --repo opensandbox-group/OpenSandbox \
   --bundle-from-oci \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-components.yml
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-components.yml
 ```
 
 For the server image, use `docker.io/opensandbox/server` and the server workflow:
@@ -173,8 +173,8 @@ Python and CLI packages:
 ```bash
 python -m pip download opensandbox-server==0.1.13 --no-deps
 gh attestation verify opensandbox_server-0.1.13*.whl \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-server.yml \
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-server.yml \
   --source-ref refs/tags/server/v0.1.13
 ```
 
@@ -183,8 +183,8 @@ JavaScript packages:
 ```bash
 npm pack @alibaba-group/opensandbox@0.1.7
 gh attestation verify alibaba-group-opensandbox-0.1.7.tgz \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-js-sdks.yml \
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-js-sdks.yml \
   --source-ref refs/tags/js/sandbox/v0.1.7
 ```
 
@@ -192,8 +192,8 @@ C# packages:
 
 ```bash
 gh attestation verify Alibaba.OpenSandbox.1.0.0.nupkg \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-csharp-sdks.yml \
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-csharp-sdks.yml \
   --source-ref refs/tags/csharp/sandbox/v1.0.0
 ```
 
@@ -201,11 +201,11 @@ Helm charts:
 
 ```bash
 gh release download helm/opensandbox/0.1.0 \
-  --repo alibaba/OpenSandbox \
+  --repo opensandbox-group/OpenSandbox \
   --pattern 'opensandbox-*.tgz'
 gh attestation verify opensandbox-*.tgz \
-  --repo alibaba/OpenSandbox \
-  --signer-workflow alibaba/OpenSandbox/.github/workflows/publish-helm-chart.yml
+  --repo opensandbox-group/OpenSandbox \
+  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-helm-chart.yml
 ```
 
 When Helm charts are released through `workflow_dispatch`, their provenance

--- a/docs/community/release-verification.md
+++ b/docs/community/release-verification.md
@@ -131,7 +131,7 @@ Verify the cosign keyless signature:
 ```bash
 cosign verify "$IMAGE_REF" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github.com/alibaba/OpenSandbox/.github/workflows/publish-components.yml@refs/tags/(docker|k8s)/[^/]+/v?[0-9].*$'
+  --certificate-identity-regexp '^https://github.com/opensandbox-group/OpenSandbox/.github/workflows/publish-components.yml@refs/tags/(docker|k8s)/[^/]+/v?[0-9].*$'
 ```
 
 Verify the registry provenance attestation:
@@ -153,7 +153,7 @@ IMAGE_REF="${IMAGE}@${DIGEST}"
 
 cosign verify "$IMAGE_REF" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github.com/alibaba/OpenSandbox/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$'
+  --certificate-identity-regexp '^https://github.com/opensandbox-group/OpenSandbox/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$'
 ```
 
 ACR images use the same digest and identity checks with the ACR image name, for

--- a/docs/community/release-verification.md
+++ b/docs/community/release-verification.md
@@ -62,6 +62,23 @@ Expected identity values:
 - C# package workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-csharp-sdks.yml`
 - Helm chart workflow: `opensandbox-group/OpenSandbox/.github/workflows/publish-helm-chart.yml`
 
+Set the repository identity for the release you are verifying:
+
+```bash
+REPOSITORY="opensandbox-group/OpenSandbox"
+WORKFLOW_REPOSITORY="${REPOSITORY}"
+WORKFLOW_REPOSITORY_URL="https://github.com/${WORKFLOW_REPOSITORY}"
+```
+
+For releases produced before the GitHub organization migration, use the
+historical identity instead:
+
+```bash
+REPOSITORY="alibaba/OpenSandbox"
+WORKFLOW_REPOSITORY="${REPOSITORY}"
+WORKFLOW_REPOSITORY_URL="https://github.com/${WORKFLOW_REPOSITORY}"
+```
+
 If you run the release workflows from a downstream fork, replace
 `opensandbox-group/OpenSandbox` in the verification commands with that fork's
 `owner/repository` identity.
@@ -83,7 +100,7 @@ Download the signed source archive and checksum file:
 
 ```bash
 gh release download "$TAG" \
-  --repo opensandbox-group/OpenSandbox \
+  --repo "$REPOSITORY" \
   --pattern "opensandbox-${SAFE_TAG}.tar.gz" \
   --pattern "SHA256SUMS"
 ```
@@ -98,16 +115,16 @@ Verify the source archive attestation:
 
 ```bash
 gh attestation verify "opensandbox-${SAFE_TAG}.tar.gz" \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/release-generic.yml
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/release-generic.yml"
 ```
 
 Verify the checksum file attestation:
 
 ```bash
 gh attestation verify SHA256SUMS \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/release-generic.yml
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/release-generic.yml"
 ```
 
 The Generic Release workflow is started with `workflow_dispatch`, so its
@@ -131,16 +148,16 @@ Verify the cosign keyless signature:
 ```bash
 cosign verify "$IMAGE_REF" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github.com/opensandbox-group/OpenSandbox/.github/workflows/publish-components.yml@refs/tags/(docker|k8s)/[^/]+/v?[0-9].*$'
+  --certificate-identity-regexp "^${WORKFLOW_REPOSITORY_URL}/.github/workflows/publish-components.yml@refs/tags/(docker|k8s)/[^/]+/v?[0-9].*$"
 ```
 
 Verify the registry provenance attestation:
 
 ```bash
 gh attestation verify "oci://${IMAGE_REF}" \
-  --repo opensandbox-group/OpenSandbox \
+  --repo "$REPOSITORY" \
   --bundle-from-oci \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-components.yml
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/publish-components.yml"
 ```
 
 For the server image, use `docker.io/opensandbox/server` and the server workflow:
@@ -153,7 +170,7 @@ IMAGE_REF="${IMAGE}@${DIGEST}"
 
 cosign verify "$IMAGE_REF" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github.com/opensandbox-group/OpenSandbox/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$'
+  --certificate-identity-regexp "^${WORKFLOW_REPOSITORY_URL}/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$"
 ```
 
 ACR images use the same digest and identity checks with the ACR image name, for
@@ -173,8 +190,8 @@ Python and CLI packages:
 ```bash
 python -m pip download opensandbox-server==0.1.13 --no-deps
 gh attestation verify opensandbox_server-0.1.13*.whl \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-server.yml \
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/publish-server.yml" \
   --source-ref refs/tags/server/v0.1.13
 ```
 
@@ -183,8 +200,8 @@ JavaScript packages:
 ```bash
 npm pack @alibaba-group/opensandbox@0.1.7
 gh attestation verify alibaba-group-opensandbox-0.1.7.tgz \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-js-sdks.yml \
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/publish-js-sdks.yml" \
   --source-ref refs/tags/js/sandbox/v0.1.7
 ```
 
@@ -192,8 +209,8 @@ C# packages:
 
 ```bash
 gh attestation verify Alibaba.OpenSandbox.1.0.0.nupkg \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-csharp-sdks.yml \
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/publish-csharp-sdks.yml" \
   --source-ref refs/tags/csharp/sandbox/v1.0.0
 ```
 
@@ -201,11 +218,11 @@ Helm charts:
 
 ```bash
 gh release download helm/opensandbox/0.1.0 \
-  --repo opensandbox-group/OpenSandbox \
+  --repo "$REPOSITORY" \
   --pattern 'opensandbox-*.tgz'
 gh attestation verify opensandbox-*.tgz \
-  --repo opensandbox-group/OpenSandbox \
-  --signer-workflow opensandbox-group/OpenSandbox/.github/workflows/publish-helm-chart.yml
+  --repo "$REPOSITORY" \
+  --signer-workflow "${WORKFLOW_REPOSITORY}/.github/workflows/publish-helm-chart.yml"
 ```
 
 When Helm charts are released through `workflow_dispatch`, their provenance

--- a/kubernetes/charts/opensandbox-controller/Chart.yaml
+++ b/kubernetes/charts/opensandbox-controller/Chart.yaml
@@ -13,15 +13,15 @@ keywords:
   - batch-sandbox
   - task-orchestration
 
-home: https://github.com/alibaba/OpenSandbox
+home: https://github.com/opensandbox-group/OpenSandbox
 sources:
-  - https://github.com/alibaba/OpenSandbox/tree/main/kubernetes
+  - https://github.com/opensandbox-group/OpenSandbox/tree/main/kubernetes
 
 maintainers:
   - name: OpenSandbox Team
     email: opensandbox@example.com
 
-icon: https://raw.githubusercontent.com/alibaba/OpenSandbox/main/kubernetes/images/logo.png
+icon: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/kubernetes/images/logo.png
 
 # Kubernetes version constraints
 kubeVersion: ">=1.21.1-0"
@@ -39,6 +39,6 @@ annotations:
     - url: https://github.com/kubernetes-sigs/kind
   artifacthub.io/links: |
     - name: Documentation
-      url: https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/README.md
+      url: https://github.com/opensandbox-group/OpenSandbox/blob/main/kubernetes/README.md
     - name: Support
-      url: https://github.com/alibaba/OpenSandbox/issues
+      url: https://github.com/opensandbox-group/OpenSandbox/issues

--- a/kubernetes/charts/opensandbox-controller/README.md
+++ b/kubernetes/charts/opensandbox-controller/README.md
@@ -264,11 +264,11 @@ kubectl auth can-i --as=system:serviceaccount:opensandbox-system:opensandbox-con
 
 ## Additional Resources
 
-- [OpenSandbox GitHub](https://github.com/alibaba/OpenSandbox)
-- [Documentation](https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/README.md)
+- [OpenSandbox GitHub](https://github.com/opensandbox-group/OpenSandbox)
+- [Documentation](https://github.com/opensandbox-group/OpenSandbox/blob/main/kubernetes/README.md)
 - [Pause and Resume Guide](https://github.com/opensandbox-group/OpenSandbox/blob/main/docs/guides/pause-resume.md)
-- [Server Configuration Reference](https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md)
-- [Examples](https://github.com/alibaba/OpenSandbox/tree/main/kubernetes/config/samples)
+- [Server Configuration Reference](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md)
+- [Examples](https://github.com/opensandbox-group/OpenSandbox/tree/main/kubernetes/config/samples)
 
 ## License
 

--- a/kubernetes/charts/opensandbox-controller/templates/NOTES.txt
+++ b/kubernetes/charts/opensandbox-controller/templates/NOTES.txt
@@ -70,13 +70,13 @@ To learn more about the release, try:
 
 📖 Documentation:
 
-  GitHub: https://github.com/alibaba/OpenSandbox
-  Docs:   https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/README.md
+  GitHub: https://github.com/opensandbox-group/OpenSandbox
+  Docs:   https://github.com/opensandbox-group/OpenSandbox/blob/main/kubernetes/README.md
 
 💡 Examples:
 
   Check out example configurations in the repository:
-  https://github.com/alibaba/OpenSandbox/tree/main/kubernetes/config/samples
+  https://github.com/opensandbox-group/OpenSandbox/tree/main/kubernetes/config/samples
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/kubernetes/charts/opensandbox-server/Chart.yaml
+++ b/kubernetes/charts/opensandbox-server/Chart.yaml
@@ -29,10 +29,10 @@ keywords:
   - ingress
   - gateway
 
-home: https://github.com/alibaba/OpenSandbox
+home: https://github.com/opensandbox-group/OpenSandbox
 sources:
-  - https://github.com/alibaba/OpenSandbox/tree/main/server
-  - https://github.com/alibaba/OpenSandbox/tree/main/components/ingress
+  - https://github.com/opensandbox-group/OpenSandbox/tree/main/server
+  - https://github.com/opensandbox-group/OpenSandbox/tree/main/components/ingress
 
 maintainers:
   - name: OpenSandbox Team

--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -76,5 +76,5 @@ helm uninstall opensandbox-server -n opensandbox-system
 
 ## References
 
-- [OpenSandbox](https://github.com/alibaba/OpenSandbox)
+- [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox)
 - [Helm deployment docs](../../docs/HELM-DEPLOYMENT.md)

--- a/kubernetes/charts/opensandbox-server/templates/NOTES.txt
+++ b/kubernetes/charts/opensandbox-server/templates/NOTES.txt
@@ -29,4 +29,4 @@ Port-forward to access locally:
 Then use the API at http://localhost:8080 (set api_key in config if required).
 {{- end }}
 
-Documentation: https://github.com/alibaba/OpenSandbox
+Documentation: https://github.com/opensandbox-group/OpenSandbox

--- a/kubernetes/charts/opensandbox/Chart.yaml
+++ b/kubernetes/charts/opensandbox/Chart.yaml
@@ -27,9 +27,9 @@ keywords:
   - lifecycle
   - batchsandbox
 
-home: https://github.com/alibaba/OpenSandbox
+home: https://github.com/opensandbox-group/OpenSandbox
 sources:
-  - https://github.com/alibaba/OpenSandbox/tree/main/kubernetes
+  - https://github.com/opensandbox-group/OpenSandbox/tree/main/kubernetes
 
 maintainers:
   - name: OpenSandbox Team
@@ -52,6 +52,6 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/links: |
     - name: Documentation
-      url: https://github.com/alibaba/OpenSandbox/blob/main/kubernetes/README.md
+      url: https://github.com/opensandbox-group/OpenSandbox/blob/main/kubernetes/README.md
     - name: Support
-      url: https://github.com/alibaba/OpenSandbox/issues
+      url: https://github.com/opensandbox-group/OpenSandbox/issues

--- a/kubernetes/docs/BUILD-IMAGES.md
+++ b/kubernetes/docs/BUILD-IMAGES.md
@@ -43,7 +43,7 @@ COMPONENT=task-executor TAG=v0.1.0 ./build.sh
 
 ### Manually Trigger the Workflow
 
-1. Open the [Actions page](https://github.com/alibaba/OpenSandbox/actions)
+1. Open the [Actions page](https://github.com/opensandbox-group/OpenSandbox/actions)
 2. Select the "Publish Components Image" workflow
 3. Click "Run workflow"
 4. Select the component and image tag:

--- a/kubernetes/docs/HELM-DEPLOYMENT.md
+++ b/kubernetes/docs/HELM-DEPLOYMENT.md
@@ -17,7 +17,7 @@ Download and install the published chart package directly:
 ```bash
 # Install the latest version (0.1.0)
 helm install opensandbox-controller \
-  https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
+  https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
   --namespace opensandbox-system \
   --create-namespace
 ```
@@ -26,7 +26,7 @@ To use a custom image:
 
 ```bash
 helm install opensandbox-controller \
-  https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
+  https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz \
   --set controller.image.repository=<your-registry>/controller \
   --set controller.image.tag=v0.0.1 \
   --namespace opensandbox-system \
@@ -89,7 +89,7 @@ helm list -n opensandbox-system
 ### View Available Versions
 
 Visit GitHub Releases to see all available versions:
-https://github.com/alibaba/OpenSandbox/releases
+https://github.com/opensandbox-group/OpenSandbox/releases
 
 Look for tags starting with `helm/opensandbox-controller/`, such as `helm/opensandbox-controller/0.1.0`
 
@@ -98,7 +98,7 @@ Look for tags starting with `helm/opensandbox-controller/`, such as `helm/opensa
 ```bash
 # Upgrade directly from GitHub Release
 helm upgrade opensandbox-controller \
-  https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.2.0/opensandbox-controller-0.2.0.tgz \
+  https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/opensandbox-controller/0.2.0/opensandbox-controller-0.2.0.tgz \
   --namespace opensandbox-system
 ```
 
@@ -197,7 +197,7 @@ Upgrade from GitHub Release:
 ```bash
 # Upgrade to a specific version
 helm upgrade opensandbox-controller \
-  https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.2.0/opensandbox-controller-0.2.0.tgz \
+  https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/opensandbox-controller/0.2.0/opensandbox-controller-0.2.0.tgz \
   --namespace opensandbox-system
 ```
 
@@ -476,12 +476,12 @@ Important versioning note:
 After publishing, users can access the Helm Chart at:
 
 ```
-https://github.com/alibaba/OpenSandbox/releases/download/helm/{COMPONENT}/{VERSION}/{COMPONENT}-{VERSION}.tgz
+https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/{COMPONENT}/{VERSION}/{COMPONENT}-{VERSION}.tgz
 ```
 
 Example:
 ```
-https://github.com/alibaba/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz
+https://github.com/opensandbox-group/OpenSandbox/releases/download/helm/opensandbox-controller/0.1.0/opensandbox-controller-0.1.0.tgz
 ```
 
 ### Adding a New Helm Chart Component

--- a/sandboxes/code-interpreter/README.md
+++ b/sandboxes/code-interpreter/README.md
@@ -241,7 +241,7 @@ This project is part of the OpenSandbox suite. See the main [LICENSE](../../LICE
 
 For issues and questions:
 
-- GitHub Issues: [OpenSandbox Issues](https://github.com/alibaba/OpenSandbox/issues)
+- GitHub Issues: [OpenSandbox Issues](https://github.com/opensandbox-group/OpenSandbox/issues)
 
 ## Related Projects
 

--- a/sandboxes/code-interpreter/README_zh.md
+++ b/sandboxes/code-interpreter/README_zh.md
@@ -231,7 +231,7 @@ code-interpreter/
 
 问题和疑问：
 
-- GitHub Issues: [OpenSandbox Issues](https://github.com/alibaba/OpenSandbox/issues)
+- GitHub Issues: [OpenSandbox Issues](https://github.com/opensandbox-group/OpenSandbox/issues)
 
 ## 相关项目
 

--- a/sdks/sandbox/go/README.md
+++ b/sdks/sandbox/go/README.md
@@ -1,6 +1,6 @@
 # OpenSandbox Go SDK
 
-Go client library for the [OpenSandbox](https://github.com/alibaba/OpenSandbox) API.
+Go client library for the [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox) API.
 
 Covers all three OpenAPI specs:
 - **Lifecycle** — Create, manage, and destroy sandbox instances

--- a/server/TROUBLESHOOTING.md
+++ b/server/TROUBLESHOOTING.md
@@ -35,7 +35,7 @@ If the client reports:
 opensandbox.exceptions.sandbox.SandboxReadyTimeoutException: Sandbox health check timed out after 30.0s (2 attempts). Health check returned false continuously
 ```
 
-when the server runs on a cloud VM (e.g. [Alibaba Cloud ECS](https://github.com/alibaba/OpenSandbox/issues/297)), the client is likely trying to reach the sandbox at an address it cannot access. The server may be returning a bind address such as `127.0.0.1` or an internal LAN IP in the endpoint URL, so the health check from the client side fails.
+when the server runs on a cloud VM (e.g. [Alibaba Cloud ECS](https://github.com/opensandbox-group/OpenSandbox/issues/297)), the client is likely trying to reach the sandbox at an address it cannot access. The server may be returning a bind address such as `127.0.0.1` or an internal LAN IP in the endpoint URL, so the health check from the client side fails.
 
 **Solution:** Set the bound public IP so that the server returns a reachable address in the sandbox endpoint API. In your config (e.g. `~/.sandbox.toml`), under `[server]`, set `eip` to the VM’s public IP (or the hostname that clients use to reach the server):
 

--- a/server/docker-compose.example.yaml
+++ b/server/docker-compose.example.yaml
@@ -28,7 +28,7 @@ configs:
       no_new_privileges = true
       # TODO: For production environments, it is recommended to set this to '4096' or higher to avoid
       # "can't start new thread" errors when multiple sandboxes are running concurrently.
-      # See: https://github.com/alibaba/OpenSandbox/issues/447
+      # See: https://github.com/opensandbox-group/OpenSandbox/issues/447
       pids_limit = 4096
 
       [ingress]

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -14,7 +14,7 @@
 
 # Example Kubernetes Runtime Configuration for OpenSandbox Server
 #
-# Full configuration reference: https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md
+# Full configuration reference: https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md
 
 [server]
 host = "0.0.0.0"

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -14,7 +14,7 @@
 
 # Example Kubernetes Runtime Configuration for OpenSandbox Server
 #
-# 完整配置参考：https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md
+# 完整配置参考：https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md
 
 [server]
 host = "0.0.0.0"

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -14,7 +14,7 @@
 
 # Example Docker Runtime Configuration for OpenSandbox Server
 #
-# Full configuration reference: https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md
+# Full configuration reference: https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md
 
 [server]
 host = "127.0.0.1"

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -14,7 +14,7 @@
 
 # Example Docker Runtime Configuration for OpenSandbox Server
 #
-# 完整配置参考：https://github.com/alibaba/OpenSandbox/blob/main/server/configuration.md
+# 完整配置参考：https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md
 
 [server]
 host = "127.0.0.1"

--- a/server/opensandbox_server/startup_guard.py
+++ b/server/opensandbox_server/startup_guard.py
@@ -87,7 +87,7 @@ def api_key_confirm(
                 "SECURITY WARNING: server.api_key is empty; API authentication is disabled. "
                 "Type 'YES' to continue startup without API key. "
                 "Strongly recommend setting server.api_key. "
-                "See: https://github.com/alibaba/OpenSandbox/issues/750 "
+                "See: https://github.com/opensandbox-group/OpenSandbox/issues/750 "
                 ": "
                 f"{ANSI_RESET}",
                 input_func,
@@ -97,7 +97,7 @@ def api_key_confirm(
             raise RuntimeError(
                 "Startup aborted: confirmation timed out waiting for YES. "
                 "Strongly recommend setting server.api_key. "
-                "See: https://github.com/alibaba/OpenSandbox/issues/750"
+                "See: https://github.com/opensandbox-group/OpenSandbox/issues/750"
             ) from exc
         if confirmation == ALLOW_NO_API_KEY_CONFIRMATION:
             logger.warning(
@@ -107,12 +107,12 @@ def api_key_confirm(
         raise RuntimeError(
             "Startup aborted: missing explicit confirmation for empty server.api_key. "
             "Strongly recommend setting server.api_key. "
-            "See: https://github.com/alibaba/OpenSandbox/issues/750"
+            "See: https://github.com/opensandbox-group/OpenSandbox/issues/750"
         )
 
     raise RuntimeError(
         "Startup blocked: server.api_key is empty in non-interactive mode. "
         f"Set {INSECURE_SERVER_ENV_VAR}={ALLOW_NO_API_KEY_CONFIRMATION} to acknowledge the risk. "
         "Strongly recommend setting server.api_key. "
-        "See: https://github.com/alibaba/OpenSandbox/issues/750"
+        "See: https://github.com/opensandbox-group/OpenSandbox/issues/750"
     )

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -18,7 +18,7 @@ info:
 
   contact:
     name: OpenSandbox Team
-    url: https://github.com/alibaba/OpenSandbox
+    url: https://github.com/opensandbox-group/OpenSandbox
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
## Summary

- Update user-facing GitHub links from `alibaba/OpenSandbox` to `opensandbox-group/OpenSandbox` across README, docs, Helm chart metadata, server examples, and issue templates.
- Fix README badge anchors so GitHub does not render stray blue underlines between badges.
- Leave Go module/import paths and historical OSEP/release-note/test references unchanged for separate review.

## Validation

- Ran targeted `rg` scans for old user-facing repository URLs in the touched areas.
- Checked README badge anchors no longer contain newline whitespace inside `<a>...</a>`.
- Attempted `pnpm docs:build`; it failed before build because pnpm blocked dependency build scripts: `Ignored build scripts: esbuild@0.21.5` and requested `pnpm approve-builds`. No generated files are included in this PR.