### PR TITLE
feat(otel): rename attribute keys, switch to delta temporality, remove redundant metrics

### DIFF
--- a/components/ingress/docs/opentelemetry.md
+++ b/components/ingress/docs/opentelemetry.md
@@ -6,17 +6,17 @@ Meter: `opensandbox/ingress` · Service name: `opensandbox-ingress-<version>`
 
 | Metric | Type | Unit | Attributes | Description |
 |---|---|---|---|---|
-| `ingress.http.request.count` | Counter | — | `http.method`, `http.status_code`, `proxy_type` | Request count (QPS derivable) |
-| `ingress.http.request.duration` | Histogram | `ms` | `http.method`, `http.status_code`, `proxy_type` | Full request duration |
-| `ingress.routing.resolutions.count` | Counter | — | `routing.result` | Routing resolution count |
-| `ingress.routing.resolution.duration` | Histogram | `ms` | `routing.result` | Routing resolution latency |
-| `ingress.proxy.http.requests_total` | Counter | — | — | HTTP proxy requests |
-| `ingress.proxy.websocket.connections_total` | Counter | — | — | WebSocket connections |
+| `ingress.http.request.count` | Counter | — | `http_method`, `http_status_code`, `proxy_type` | Request count (QPS derivable) |
+| `ingress.http.request.duration` | Histogram | `ms` | `http_method`, `http_status_code`, `proxy_type` | Full request duration |
+| `ingress.routing.resolutions.count` | Counter | — | `routing_result` | Routing resolution count |
+| `ingress.routing.resolution.duration` | Histogram | `ms` | `routing_result` | Routing resolution latency |
 | `ingress.connections.active` | Observable Gauge | — | — | TCP ESTABLISHED connections (from `/proc/net/tcp`) |
 | `ingress.system.cpu.usage` | Observable Gauge | `1` | — | CPU busy ratio `[0,1]` (Linux only) |
 | `ingress.system.memory.usage_bytes` | Observable Gauge | `By` | — | Memory used bytes (Linux only) |
 
-**Attribute values:** `proxy_type`: `http` | `websocket`. `routing.result`: `success` | `not_found` | `not_ready` | `error`.
+**Attribute values:** `proxy_type`: `http` | `websocket`. `routing_result`: `success` | `not_found` | `not_ready` | `error`.
+
+**Temporality:** Delta.
 
 ## Configuration
 

--- a/components/ingress/pkg/proxy/proxy.go
+++ b/components/ingress/pkg/proxy/proxy.go
@@ -135,7 +135,6 @@ func (p *Proxy) serve(w http.ResponseWriter, r *http.Request) {
 				r.URL.Scheme = "http"
 			}
 		}
-		telemetry.RecordProxyHTTP()
 		NewHTTPProxy().ServeHTTP(w, r)
 	}
 }

--- a/components/ingress/pkg/proxy/websocket.go
+++ b/components/ingress/pkg/proxy/websocket.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/alibaba/opensandbox/ingress/pkg/telemetry"
 	slogger "github.com/alibaba/opensandbox/internal/logger"
 	"github.com/gorilla/websocket"
 )
@@ -199,7 +198,6 @@ func (w *WebSocketProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer connPub.Close()
-	telemetry.RecordProxyWebSocket()
 
 	errClient := make(chan error, 1)
 	errBackend := make(chan error, 1)

--- a/components/ingress/pkg/telemetry/metrics.go
+++ b/components/ingress/pkg/telemetry/metrics.go
@@ -30,9 +30,6 @@ var (
 
 	routingResolutions        metric.Int64Counter
 	routingResolutionDuration metric.Float64Histogram
-
-	proxyHTTPTotal      metric.Int64Counter
-	proxyWebSocketTotal metric.Int64Counter
 )
 
 func registerIngressMetrics() error {
@@ -68,22 +65,6 @@ func registerIngressMetrics() error {
 		"ingress.routing.resolution.duration",
 		metric.WithDescription("Routing resolution duration"),
 		metric.WithUnit("ms"),
-	)
-	if err != nil {
-		return err
-	}
-
-	proxyHTTPTotal, err = meter.Int64Counter(
-		"ingress.proxy.http.requests_total",
-		metric.WithDescription("HTTP proxy request count"),
-	)
-	if err != nil {
-		return err
-	}
-
-	proxyWebSocketTotal, err = meter.Int64Counter(
-		"ingress.proxy.websocket.connections_total",
-		metric.WithDescription("WebSocket proxy connection count"),
 	)
 	if err != nil {
 		return err
@@ -131,8 +112,8 @@ func RecordHTTPRequest(method string, statusCode int, proxyType string, duration
 		return
 	}
 	attrs := metric.WithAttributes(
-		attribute.String("http.method", method),
-		attribute.Int("http.status_code", statusCode),
+		attribute.String("http_method", method),
+		attribute.Int("http_status_code", statusCode),
 		attribute.String("proxy_type", proxyType),
 	)
 	httpRequestCount.Add(context.Background(), 1, attrs)
@@ -143,21 +124,9 @@ func RecordRouting(result string, durationMs float64) {
 	if routingResolutions == nil {
 		return
 	}
-	attrs := metric.WithAttributes(attribute.String("routing.result", result))
+	attrs := metric.WithAttributes(attribute.String("routing_result", result))
 	routingResolutions.Add(context.Background(), 1, attrs)
 	routingResolutionDuration.Record(context.Background(), durationMs, attrs)
 }
 
-func RecordProxyHTTP() {
-	if proxyHTTPTotal == nil {
-		return
-	}
-	proxyHTTPTotal.Add(context.Background(), 1)
-}
 
-func RecordProxyWebSocket() {
-	if proxyWebSocketTotal == nil {
-		return
-	}
-	proxyWebSocketTotal.Add(context.Background(), 1)
-}

--- a/components/ingress/pkg/telemetry/metrics.go
+++ b/components/ingress/pkg/telemetry/metrics.go
@@ -128,5 +128,3 @@ func RecordRouting(result string, durationMs float64) {
 	routingResolutions.Add(context.Background(), 1, attrs)
 	routingResolutionDuration.Record(context.Background(), durationMs, attrs)
 }
-
-

--- a/components/internal/telemetry/init.go
+++ b/components/internal/telemetry/init.go
@@ -177,8 +177,7 @@ func firstEndpoint(primary, fallback string) string {
 func deltaTemporalitySelector(kind sdkmetric.InstrumentKind) metricdata.Temporality {
 	switch kind {
 	case sdkmetric.InstrumentKindCounter,
-		sdkmetric.InstrumentKindHistogram,
-		sdkmetric.InstrumentKindObservableCounter:
+		sdkmetric.InstrumentKindHistogram:
 		return metricdata.DeltaTemporality
 	default:
 		return metricdata.CumulativeTemporality

--- a/components/internal/telemetry/init.go
+++ b/components/internal/telemetry/init.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
@@ -67,7 +68,10 @@ func Init(ctx context.Context, cfg Config) (shutdown func(context.Context) error
 	)
 
 	if metricsEnabled() {
-		mexp, err := otlpmetrichttp.New(ctx, metricsClientOptions()...)
+		opts := append(metricsClientOptions(),
+			otlpmetrichttp.WithTemporalitySelector(deltaTemporalitySelector),
+		)
+		mexp, err := otlpmetrichttp.New(ctx, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -165,4 +169,18 @@ func firstEndpoint(primary, fallback string) string {
 		return s
 	}
 	return strings.TrimSpace(fallback)
+}
+
+// deltaTemporalitySelector returns delta temporality for monotonic instruments
+// (Counter, Histogram, ObservableCounter). Gauges and UpDownCounters keep
+// the default cumulative semantics.
+func deltaTemporalitySelector(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	switch kind {
+	case sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindHistogram,
+		sdkmetric.InstrumentKindObservableCounter:
+		return metricdata.DeltaTemporality
+	default:
+		return metricdata.CumulativeTemporality
+	}
 }


### PR DESCRIPTION
## Changes

1. **Normalize attribute keys: `.` → `_`**
   - `http.method` → `http_method`
   - `http.status_code` → `http_status_code`
   - `routing.result` → `routing_result`

2. **Switch to delta temporality**
   - OTLP HTTP exporter now uses delta export for Counter / Histogram / ObservableCounter
   - Change is in the shared `components/internal/telemetry/init.go`, covers ingress, execd, and egress in one place

3. **Remove redundant metrics**
   - Remove `ingress.proxy.http.requests_total` and `ingress.proxy.websocket.connections_total`
   - Remove corresponding `RecordProxyHTTP()` / `RecordProxyWebSocket()` functions, call sites, and imports

## Files

| File | Description |
|---|---|
| `components/internal/telemetry/init.go` | Add `deltaTemporalitySelector`, apply to OTLP exporter |
| `components/ingress/pkg/telemetry/metrics.go` | Rename attribute keys, remove redundant metric definitions and recording functions |
| `components/ingress/pkg/proxy/proxy.go` | Remove `telemetry.RecordProxyHTTP()` call |
| `components/ingress/pkg/proxy/websocket.go` | Remove `telemetry.RecordProxyWebSocket()` call and unused import |
| `components/ingress/docs/opentelemetry.md` | Update docs accordingly |