### PR TITLE
fix(rbac): add pods/log permission to opensandbox-server ClusterRole

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- include "opensandbox-server.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/status", "events", "services", "configmaps"]
+    resources: ["pods", "pods/status", "pods/log", "events", "services", "configmaps"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
## 问题

`GET /v1/sandboxes/{id}/diagnostics/logs` 始终返回 403。

**原因**: opensandbox-server 的 ClusterRole 中已有 `pods`、`pods/status` 等权限，但缺少 `pods/log` 子资源。虽然 ClusterRole 是集群范围的，但 `pods/log` 作为子资源需要显式声明才能授权跨命名空间访问。

## 修复

`kubernetes/charts/opensandbox-server/templates/server.yaml` — 一行变更：

```diff
- resources: ["pods", "pods/status", "events", "services", "configmaps"]
+ resources: ["pods", "pods/status", "pods/log", "events", "services", "configmaps"]
```

## 影响范围

- `GET /v1/sandboxes/{id}/diagnostics/logs` — 修复
- 其他 endpoints（Events / Inspect）— 不受影响，本来就能工作

Fixes #1207