### PR TITLE
fix(python-sdk): demote handled adapter errors

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -186,10 +186,10 @@ class SandboxesAdapter(Sandboxes):
             return response
 
         except Exception as e:
-            logger.debug(
-                "Failed to create sandbox with startup source: %s",
+            logger.warning(
+                "Failed to create sandbox with startup source %s: %s",
                 spec.image if spec is not None else snapshot_id,
-                exc_info=e,
+                e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -214,7 +214,7 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_sandbox_info(parsed)
 
         except Exception as e:
-            logger.debug(f"Failed to get sandbox info: {sandbox_id}", exc_info=e)
+            logger.warning("Failed to get sandbox info %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -254,7 +254,7 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
 
         except Exception as e:
-            logger.debug("Failed to list sandboxes", exc_info=e)
+            logger.warning("Failed to list sandboxes: %s", e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def patch_sandbox_metadata(
@@ -283,7 +283,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.debug("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
+            logger.warning("Failed to patch sandbox %s metadata: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def create_snapshot(
@@ -329,7 +329,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.debug("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
+            logger.warning("Failed to get snapshot info %s: %s", snapshot_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -356,7 +356,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.debug("Failed to list snapshots", exc_info=e)
+            logger.warning("Failed to list snapshots: %s", e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def delete_snapshot(self, snapshot_id: str) -> None:
@@ -372,7 +372,7 @@ class SandboxesAdapter(Sandboxes):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.debug("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
+            logger.warning("Failed to delete snapshot %s: %s", snapshot_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_sandbox_endpoint(
@@ -420,9 +420,10 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
 
         except Exception as e:
-            logger.debug(
-                f"Failed to retrieve sandbox endpoint for sandbox {sandbox_id}",
-                exc_info=e,
+            logger.warning(
+                "Failed to retrieve sandbox endpoint for sandbox %s: %s",
+                sandbox_id,
+                e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -468,9 +469,10 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
 
         except Exception as e:
-            logger.debug(
-                f"Failed to retrieve signed sandbox endpoint for sandbox {sandbox_id}",
-                exc_info=e,
+            logger.warning(
+                "Failed to retrieve signed sandbox endpoint for sandbox %s: %s",
+                sandbox_id,
+                e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -494,7 +496,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated pause for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.debug(f"Failed to initiate pause sandbox: {sandbox_id}", exc_info=e)
+            logger.warning("Failed to initiate pause sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def resume_sandbox(self, sandbox_id: str) -> None:
@@ -517,7 +519,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated resume for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.debug(f"Failed initiate resume sandbox: {sandbox_id}", exc_info=e)
+            logger.warning("Failed to resume sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def renew_sandbox_expiration(
@@ -563,7 +565,7 @@ class SandboxesAdapter(Sandboxes):
             return renew_response
 
         except Exception as e:
-            logger.debug(f"Failed to renew sandbox {sandbox_id} expiration", exc_info=e)
+            logger.warning("Failed to renew sandbox %s expiration: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def kill_sandbox(self, sandbox_id: str) -> None:
@@ -586,5 +588,5 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Successfully terminated sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.debug(f"Failed to terminate sandbox: {sandbox_id}", exc_info=e)
+            logger.warning("Failed to terminate sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -177,13 +177,16 @@ class SandboxesAdapter(Sandboxes):
             handle_api_error(response_obj, "Create sandbox")
 
             from opensandbox.api.lifecycle.models import CreateSandboxResponse
-            parsed = require_parsed(response_obj, CreateSandboxResponse, "Create sandbox")
+
+            parsed = require_parsed(
+                response_obj, CreateSandboxResponse, "Create sandbox"
+            )
             response = SandboxModelConverter.to_sandbox_create_response(parsed)
             logger.info(f"Successfully created sandbox: {response.id}")
             return response
 
         except Exception as e:
-            logger.error(
+            logger.debug(
                 "Failed to create sandbox with startup source: %s",
                 spec.image if spec is not None else snapshot_id,
                 exc_info=e,
@@ -206,11 +209,12 @@ class SandboxesAdapter(Sandboxes):
             handle_api_error(response_obj, f"Get sandbox {sandbox_id}")
 
             from opensandbox.api.lifecycle.models import Sandbox
+
             parsed = require_parsed(response_obj, Sandbox, f"Get sandbox {sandbox_id}")
             return SandboxModelConverter.to_sandbox_info(parsed)
 
         except Exception as e:
-            logger.error(f"Failed to get sandbox info: {sandbox_id}", exc_info=e)
+            logger.debug(f"Failed to get sandbox info: {sandbox_id}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -220,7 +224,6 @@ class SandboxesAdapter(Sandboxes):
         # Prepare metadata parameter similar to Kotlin SDK
         metadata = UNSET
         if filter.metadata:
-
             metadata_parts: list[str] = []
             for key, value in filter.metadata.items():
                 metadata_parts.append(f"{key}={value}")
@@ -236,17 +239,22 @@ class SandboxesAdapter(Sandboxes):
                 state=filter.states if filter.states else API_UNSET,
                 metadata=metadata,
                 page=filter.page if filter.page is not None else API_UNSET,
-                page_size=filter.page_size if filter.page_size is not None else API_UNSET,
+                page_size=filter.page_size
+                if filter.page_size is not None
+                else API_UNSET,
             )
 
             handle_api_error(response_obj, "List sandboxes")
 
             from opensandbox.api.lifecycle.models import ListSandboxesResponse
-            parsed = require_parsed(response_obj, ListSandboxesResponse, "List sandboxes")
+
+            parsed = require_parsed(
+                response_obj, ListSandboxesResponse, "List sandboxes"
+            )
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
 
         except Exception as e:
-            logger.error("Failed to list sandboxes", exc_info=e)
+            logger.debug("Failed to list sandboxes", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def patch_sandbox_metadata(
@@ -275,7 +283,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.error("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
+            logger.debug("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def create_snapshot(
@@ -298,7 +306,9 @@ class SandboxesAdapter(Sandboxes):
             parsed = require_parsed(response_obj, Snapshot, "Create snapshot")
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.error("Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e)
+            logger.debug(
+                "Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_snapshot(self, snapshot_id: str) -> SnapshotInfo:
@@ -314,10 +324,12 @@ class SandboxesAdapter(Sandboxes):
                 snapshot_id=snapshot_id,
             )
             handle_api_error(response_obj, f"Get snapshot {snapshot_id}")
-            parsed = require_parsed(response_obj, Snapshot, f"Get snapshot {snapshot_id}")
+            parsed = require_parsed(
+                response_obj, Snapshot, f"Get snapshot {snapshot_id}"
+            )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.error("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
+            logger.debug("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -329,16 +341,22 @@ class SandboxesAdapter(Sandboxes):
             client = await self._get_client()
             response_obj = await get_snapshots.asyncio_detailed(
                 client=client,
-                sandbox_id=filter.sandbox_id if filter.sandbox_id is not None else API_UNSET,
+                sandbox_id=filter.sandbox_id
+                if filter.sandbox_id is not None
+                else API_UNSET,
                 state=filter.states if filter.states else API_UNSET,
                 page=filter.page if filter.page is not None else API_UNSET,
-                page_size=filter.page_size if filter.page_size is not None else API_UNSET,
+                page_size=filter.page_size
+                if filter.page_size is not None
+                else API_UNSET,
             )
             handle_api_error(response_obj, "List snapshots")
-            parsed = require_parsed(response_obj, ListSnapshotsResponse, "List snapshots")
+            parsed = require_parsed(
+                response_obj, ListSnapshotsResponse, "List snapshots"
+            )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.error("Failed to list snapshots", exc_info=e)
+            logger.debug("Failed to list snapshots", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def delete_snapshot(self, snapshot_id: str) -> None:
@@ -354,7 +372,7 @@ class SandboxesAdapter(Sandboxes):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.error("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
+            logger.debug("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_sandbox_endpoint(
@@ -365,7 +383,9 @@ class SandboxesAdapter(Sandboxes):
             key = (sandbox_id, port, use_server_proxy)
             return await self._endpoint_cache.get_or_fetch(
                 key,
-                lambda: self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy),
+                lambda: self._fetch_sandbox_endpoint(
+                    sandbox_id, port, use_server_proxy
+                ),
             )
         return await self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy)
 
@@ -395,11 +415,12 @@ class SandboxesAdapter(Sandboxes):
             )
 
             from opensandbox.api.lifecycle.models import Endpoint
+
             parsed = require_parsed(response_obj, Endpoint, "Get endpoint")
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
 
         except Exception as e:
-            logger.error(
+            logger.debug(
                 f"Failed to retrieve sandbox endpoint for sandbox {sandbox_id}",
                 exc_info=e,
             )
@@ -411,7 +432,10 @@ class SandboxesAdapter(Sandboxes):
             self._endpoint_cache.invalidate(sandbox_id)
 
     async def get_signed_sandbox_endpoint(
-        self, sandbox_id: str, port: int, expires: int,
+        self,
+        sandbox_id: str,
+        port: int,
+        expires: int,
         use_server_proxy: bool = False,
     ) -> SandboxEndpoint:
         """Get signed sandbox endpoint with an OSEP-0011 route token."""
@@ -434,15 +458,17 @@ class SandboxesAdapter(Sandboxes):
             )
 
             handle_api_error(
-                response_obj, f"Get signed endpoint for sandbox {sandbox_id} port {port}"
+                response_obj,
+                f"Get signed endpoint for sandbox {sandbox_id} port {port}",
             )
 
             from opensandbox.api.lifecycle.models import Endpoint
+
             parsed = require_parsed(response_obj, Endpoint, "Get signed endpoint")
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
 
         except Exception as e:
-            logger.error(
+            logger.debug(
                 f"Failed to retrieve signed sandbox endpoint for sandbox {sandbox_id}",
                 exc_info=e,
             )
@@ -468,7 +494,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated pause for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.error(f"Failed to initiate pause sandbox: {sandbox_id}", exc_info=e)
+            logger.debug(f"Failed to initiate pause sandbox: {sandbox_id}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def resume_sandbox(self, sandbox_id: str) -> None:
@@ -491,7 +517,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated resume for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.error(f"Failed initiate resume sandbox: {sandbox_id}", exc_info=e)
+            logger.debug(f"Failed initiate resume sandbox: {sandbox_id}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def renew_sandbox_expiration(
@@ -537,7 +563,7 @@ class SandboxesAdapter(Sandboxes):
             return renew_response
 
         except Exception as e:
-            logger.error(f"Failed to renew sandbox {sandbox_id} expiration", exc_info=e)
+            logger.debug(f"Failed to renew sandbox {sandbox_id} expiration", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def kill_sandbox(self, sandbox_id: str) -> None:
@@ -560,5 +586,5 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Successfully terminated sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.error(f"Failed to terminate sandbox: {sandbox_id}", exc_info=e)
+            logger.debug(f"Failed to terminate sandbox: {sandbox_id}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -155,10 +155,10 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_create_response(parsed)
         except Exception as e:
-            logger.debug(
-                "Failed to create sandbox with startup source: %s",
+            logger.warning(
+                "Failed to create sandbox with startup source %s: %s",
                 spec.image if spec is not None else snapshot_id,
-                exc_info=e,
+                e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -177,7 +177,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.debug("Failed to get sandbox info: %s", sandbox_id, exc_info=e)
+            logger.warning("Failed to get sandbox info %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -217,7 +217,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
         except Exception as e:
-            logger.debug("Failed to list sandboxes", exc_info=e)
+            logger.warning("Failed to list sandboxes: %s", e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def patch_sandbox_metadata(
@@ -243,7 +243,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.debug("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
+            logger.warning("Failed to patch sandbox %s metadata: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_sandbox_endpoint(
@@ -280,10 +280,10 @@ class SandboxesAdapterSync(SandboxesSync):
             parsed = require_parsed(response_obj, ApiEndpoint, "Get endpoint")
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
         except Exception as e:
-            logger.debug(
-                "Failed to retrieve sandbox endpoint for sandbox %s",
+            logger.warning(
+                "Failed to retrieve sandbox endpoint for sandbox %s: %s",
                 sandbox_id,
-                exc_info=e,
+                e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -337,7 +337,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Pause sandbox {sandbox_id}")
         except Exception as e:
-            logger.debug("Failed to pause sandbox: %s", sandbox_id, exc_info=e)
+            logger.warning("Failed to pause sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def resume_sandbox(self, sandbox_id: str) -> None:
@@ -351,7 +351,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Resume sandbox {sandbox_id}")
         except Exception as e:
-            logger.debug("Failed to resume sandbox: %s", sandbox_id, exc_info=e)
+            logger.warning("Failed to resume sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def renew_sandbox_expiration(
@@ -397,7 +397,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Kill sandbox {sandbox_id}")
         except Exception as e:
-            logger.debug("Failed to kill sandbox: %s", sandbox_id, exc_info=e)
+            logger.warning("Failed to kill sandbox %s: %s", sandbox_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def create_snapshot(
@@ -418,8 +418,8 @@ class SandboxesAdapterSync(SandboxesSync):
             parsed = require_parsed(response_obj, ApiSnapshot, "Create snapshot")
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.debug(
-                "Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e
+            logger.warning(
+                "Failed to create snapshot for sandbox %s: %s", sandbox_id, e
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -440,7 +440,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.debug("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
+            logger.warning("Failed to get snapshot info %s: %s", snapshot_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -468,7 +468,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.debug("Failed to list snapshots", exc_info=e)
+            logger.warning("Failed to list snapshots: %s", e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def delete_snapshot(self, snapshot_id: str) -> None:
@@ -483,5 +483,5 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.debug("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
+            logger.warning("Failed to delete snapshot %s: %s", snapshot_id, e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -145,13 +145,17 @@ class SandboxesAdapterSync(SandboxesSync):
                 snapshot_id=snapshot_id,
                 resource_requests=resource_requests,
             )
-            response_obj = post_sandboxes.sync_detailed(client=self._get_client(), body=create_request)
+            response_obj = post_sandboxes.sync_detailed(
+                client=self._get_client(), body=create_request
+            )
             handle_api_error(response_obj, "Create sandbox")
 
-            parsed = require_parsed(response_obj, ApiCreateSandboxResponse, "Create sandbox")
+            parsed = require_parsed(
+                response_obj, ApiCreateSandboxResponse, "Create sandbox"
+            )
             return SandboxModelConverter.to_sandbox_create_response(parsed)
         except Exception as e:
-            logger.error(
+            logger.debug(
                 "Failed to create sandbox with startup source: %s",
                 spec.image if spec is not None else snapshot_id,
                 exc_info=e,
@@ -168,10 +172,12 @@ class SandboxesAdapterSync(SandboxesSync):
                 sandbox_id=sandbox_id,
             )
             handle_api_error(response_obj, f"Get sandbox {sandbox_id}")
-            parsed = require_parsed(response_obj, ApiSandbox, f"Get sandbox {sandbox_id}")
+            parsed = require_parsed(
+                response_obj, ApiSandbox, f"Get sandbox {sandbox_id}"
+            )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.error("Failed to get sandbox info: %s", sandbox_id, exc_info=e)
+            logger.debug("Failed to get sandbox info: %s", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -201,13 +207,17 @@ class SandboxesAdapterSync(SandboxesSync):
                 state=filter.states if filter.states else API_UNSET,
                 metadata=metadata,
                 page=filter.page if filter.page is not None else API_UNSET,
-                page_size=filter.page_size if filter.page_size is not None else API_UNSET,
+                page_size=filter.page_size
+                if filter.page_size is not None
+                else API_UNSET,
             )
             handle_api_error(response_obj, "List sandboxes")
-            parsed = require_parsed(response_obj, ApiListSandboxesResponse, "List sandboxes")
+            parsed = require_parsed(
+                response_obj, ApiListSandboxesResponse, "List sandboxes"
+            )
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
         except Exception as e:
-            logger.error("Failed to list sandboxes", exc_info=e)
+            logger.debug("Failed to list sandboxes", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def patch_sandbox_metadata(
@@ -233,7 +243,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.error("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
+            logger.debug("Failed to patch sandbox %s metadata", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_sandbox_endpoint(
@@ -243,7 +253,9 @@ class SandboxesAdapterSync(SandboxesSync):
             key = (sandbox_id, port, use_server_proxy)
             return self._endpoint_cache.get_or_fetch(
                 key,
-                lambda: self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy),
+                lambda: self._fetch_sandbox_endpoint(
+                    sandbox_id, port, use_server_proxy
+                ),
             )
         return self._fetch_sandbox_endpoint(sandbox_id, port, use_server_proxy)
 
@@ -262,11 +274,17 @@ class SandboxesAdapterSync(SandboxesSync):
                 client=self._get_client(),
                 use_server_proxy=use_server_proxy,
             )
-            handle_api_error(response_obj, f"Get endpoint for sandbox {sandbox_id} port {port}")
+            handle_api_error(
+                response_obj, f"Get endpoint for sandbox {sandbox_id} port {port}"
+            )
             parsed = require_parsed(response_obj, ApiEndpoint, "Get endpoint")
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
         except Exception as e:
-            logger.error("Failed to retrieve sandbox endpoint for sandbox %s", sandbox_id, exc_info=e)
+            logger.debug(
+                "Failed to retrieve sandbox endpoint for sandbox %s",
+                sandbox_id,
+                exc_info=e,
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def invalidate_endpoint_cache(self, sandbox_id: str) -> None:
@@ -275,7 +293,10 @@ class SandboxesAdapterSync(SandboxesSync):
             self._endpoint_cache.invalidate(sandbox_id)
 
     def get_signed_sandbox_endpoint(
-        self, sandbox_id: str, port: int, expires: int,
+        self,
+        sandbox_id: str,
+        port: int,
+        expires: int,
         use_server_proxy: bool = False,
     ) -> SandboxEndpoint:
         try:
@@ -291,11 +312,18 @@ class SandboxesAdapterSync(SandboxesSync):
                 use_server_proxy=use_server_proxy,
                 expires=str(expires),
             )
-            handle_api_error(response_obj, f"Get signed endpoint for sandbox {sandbox_id} port {port}")
+            handle_api_error(
+                response_obj,
+                f"Get signed endpoint for sandbox {sandbox_id} port {port}",
+            )
             parsed = require_parsed(response_obj, ApiEndpoint, "Get signed endpoint")
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
         except Exception as e:
-            logger.error("Failed to retrieve signed sandbox endpoint for sandbox %s", sandbox_id, exc_info=e)
+            logger.debug(
+                "Failed to retrieve signed sandbox endpoint for sandbox %s",
+                sandbox_id,
+                exc_info=e,
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def pause_sandbox(self, sandbox_id: str) -> None:
@@ -309,7 +337,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Pause sandbox {sandbox_id}")
         except Exception as e:
-            logger.error("Failed to pause sandbox: %s", sandbox_id, exc_info=e)
+            logger.debug("Failed to pause sandbox: %s", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def resume_sandbox(self, sandbox_id: str) -> None:
@@ -323,7 +351,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Resume sandbox {sandbox_id}")
         except Exception as e:
-            logger.error("Failed to resume sandbox: %s", sandbox_id, exc_info=e)
+            logger.debug("Failed to resume sandbox: %s", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def renew_sandbox_expiration(
@@ -337,7 +365,9 @@ class SandboxesAdapterSync(SandboxesSync):
                 RenewSandboxExpirationResponse,
             )
 
-            renew_request = SandboxModelConverter.to_api_renew_request(new_expiration_time)
+            renew_request = SandboxModelConverter.to_api_renew_request(
+                new_expiration_time
+            )
             response_obj = post_sandboxes_sandbox_id_renew_expiration.sync_detailed(
                 client=self._get_client(),
                 sandbox_id=sandbox_id,
@@ -351,7 +381,9 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_renew_response(parsed)
         except Exception as e:
-            logger.error("Failed to renew sandbox %s expiration", sandbox_id, exc_info=e)
+            logger.debug(
+                "Failed to renew sandbox %s expiration", sandbox_id, exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def kill_sandbox(self, sandbox_id: str) -> None:
@@ -365,7 +397,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Kill sandbox {sandbox_id}")
         except Exception as e:
-            logger.error("Failed to kill sandbox: %s", sandbox_id, exc_info=e)
+            logger.debug("Failed to kill sandbox: %s", sandbox_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def create_snapshot(
@@ -386,7 +418,9 @@ class SandboxesAdapterSync(SandboxesSync):
             parsed = require_parsed(response_obj, ApiSnapshot, "Create snapshot")
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.error("Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e)
+            logger.debug(
+                "Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_snapshot(self, snapshot_id: str) -> SnapshotInfo:
@@ -401,10 +435,12 @@ class SandboxesAdapterSync(SandboxesSync):
                 snapshot_id=snapshot_id,
             )
             handle_api_error(response_obj, f"Get snapshot {snapshot_id}")
-            parsed = require_parsed(response_obj, ApiSnapshot, f"Get snapshot {snapshot_id}")
+            parsed = require_parsed(
+                response_obj, ApiSnapshot, f"Get snapshot {snapshot_id}"
+            )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.error("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
+            logger.debug("Failed to get snapshot info: %s", snapshot_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -417,16 +453,22 @@ class SandboxesAdapterSync(SandboxesSync):
 
             response_obj = get_snapshots.sync_detailed(
                 client=self._get_client(),
-                sandbox_id=filter.sandbox_id if filter.sandbox_id is not None else API_UNSET,
+                sandbox_id=filter.sandbox_id
+                if filter.sandbox_id is not None
+                else API_UNSET,
                 state=filter.states if filter.states else API_UNSET,
                 page=filter.page if filter.page is not None else API_UNSET,
-                page_size=filter.page_size if filter.page_size is not None else API_UNSET,
+                page_size=filter.page_size
+                if filter.page_size is not None
+                else API_UNSET,
             )
             handle_api_error(response_obj, "List snapshots")
-            parsed = require_parsed(response_obj, ApiListSnapshotsResponse, "List snapshots")
+            parsed = require_parsed(
+                response_obj, ApiListSnapshotsResponse, "List snapshots"
+            )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.error("Failed to list snapshots", exc_info=e)
+            logger.debug("Failed to list snapshots", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def delete_snapshot(self, snapshot_id: str) -> None:
@@ -441,5 +483,5 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.error("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
+            logger.debug("Failed to delete snapshot: %s", snapshot_id, exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
@@ -540,7 +540,7 @@ async def test_snapshot_lifecycle_calls_openapi(
     ]
 
 
-async def test_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
+async def test_get_sandbox_endpoint_logs_warning_and_not_error_on_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     async def _boom(*, client, sandbox_id, port, use_server_proxy=False):
@@ -553,13 +553,15 @@ async def test_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
 
     adapter = SandboxesAdapter(ConnectionConfig())
 
-    with caplog.at_level("DEBUG", logger="opensandbox.adapters.sandboxes_adapter"):
+    with caplog.at_level("WARNING", logger="opensandbox.adapters.sandboxes_adapter"):
         with pytest.raises(Exception) as exc_info:
             await adapter.get_sandbox_endpoint("sbx-1", 8080)
 
     assert "endpoint exploded" in str(exc_info.value)
     assert not [r for r in caplog.records if r.levelname == "ERROR"]
-    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    debug_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
     assert any(
         "Failed to retrieve sandbox endpoint for sandbox sbx-1" in msg
         for msg in debug_messages
@@ -567,7 +569,7 @@ async def test_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
 
 
 @pytest.mark.asyncio
-async def test_resume_sandbox_logs_debug_and_not_error_on_failure(
+async def test_resume_sandbox_logs_warning_and_not_error_on_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     async def _boom(*, client, sandbox_id):
@@ -580,11 +582,17 @@ async def test_resume_sandbox_logs_debug_and_not_error_on_failure(
 
     adapter = SandboxesAdapter(ConnectionConfig())
 
-    with caplog.at_level("DEBUG", logger="opensandbox.adapters.sandboxes_adapter"):
+    with caplog.at_level("WARNING", logger="opensandbox.adapters.sandboxes_adapter"):
         with pytest.raises(Exception) as exc_info:
             await adapter.resume_sandbox("sbx-2")
 
     assert "resume exploded" in str(exc_info.value)
     assert not [r for r in caplog.records if r.levelname == "ERROR"]
-    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
-    assert any("Failed initiate resume sandbox: sbx-2" in msg for msg in debug_messages)
+    debug_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert any(
+        "Failed to resume sandbox sbx-2: resume exploded" in msg
+        for msg in debug_messages
+    )
+    assert all(r.exc_info is None for r in caplog.records if r.levelname == "WARNING")

--- a/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_service_adapter_lifecycle.py
@@ -147,14 +147,23 @@ async def test_create_sandbox_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(out.id, str)
     assert "image" in called["body"].to_dict()
     assert called["body"].to_dict()["secureAccess"] is True
-    assert called["body"].to_dict()["extensions"] == {"storage.id": "abc123", "debug": "true"}
+    assert called["body"].to_dict()["extensions"] == {
+        "storage.id": "abc123",
+        "debug": "true",
+    }
+    assert called["body"].to_dict()["extensions"] == {
+        "storage.id": "abc123",
+        "debug": "true",
+    }
     network_policy = called["body"].to_dict()["networkPolicy"]
     assert network_policy["defaultAction"] == "deny"
     assert network_policy["egress"] == [{"action": "allow", "target": "pypi.org"}]
 
 
 @pytest.mark.asyncio
-async def test_create_sandbox_manual_cleanup_preserves_null_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_sandbox_manual_cleanup_preserves_null_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     called = {}
 
     async def _fake_asyncio_detailed(*, client, body):
@@ -184,7 +193,9 @@ async def test_create_sandbox_manual_cleanup_preserves_null_timeout(monkeypatch:
 
 
 @pytest.mark.asyncio
-async def test_create_sandbox_restore_from_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_sandbox_restore_from_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     called = {}
 
     async def _fake_asyncio_detailed(*, client, body):
@@ -302,7 +313,9 @@ async def test_create_sandbox_unexpected_status_preserves_fastapi_detail_payload
 
 
 @pytest.mark.asyncio
-async def test_create_sandbox_empty_response_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_sandbox_empty_response_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _fake_asyncio_detailed(*, client, body):
         return _Resp(status_code=200, parsed=None)
 
@@ -328,7 +341,9 @@ async def test_create_sandbox_empty_response_raises(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-async def test_list_sandboxes_metadata_double_encoded(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_list_sandboxes_metadata_double_encoded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from opensandbox.api.lifecycle.types import UNSET as API_UNSET
 
     captured = {}
@@ -391,7 +406,9 @@ async def test_pause_resume_kill_call_openapi(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio
-async def test_patch_sandbox_metadata_sends_metadata_body(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_patch_sandbox_metadata_sends_metadata_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     sbx_id = str(uuid4())
     captured = {}
 
@@ -419,7 +436,9 @@ async def test_patch_sandbox_metadata_sends_metadata_body(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
-async def test_renew_sandbox_expiration_sends_timezone_aware(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_renew_sandbox_expiration_sends_timezone_aware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured = {}
 
     async def _fake_asyncio_detailed(*, client, sandbox_id, body):
@@ -445,7 +464,9 @@ async def test_renew_sandbox_expiration_sends_timezone_aware(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
-async def test_snapshot_lifecycle_calls_openapi(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_snapshot_lifecycle_calls_openapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[tuple[str, object]] = []
 
     async def _create_snapshot(*, client, sandbox_id, body):
@@ -499,7 +520,9 @@ async def test_snapshot_lifecycle_calls_openapi(monkeypatch: pytest.MonkeyPatch)
     )
 
     adapter = SandboxesAdapter(ConnectionConfig())
-    created = await adapter.create_snapshot("sbx-1", CreateSnapshotRequest(name="before-upgrade"))
+    created = await adapter.create_snapshot(
+        "sbx-1", CreateSnapshotRequest(name="before-upgrade")
+    )
     loaded = await adapter.get_snapshot("snap-1")
     listed = await adapter.list_snapshots(
         SnapshotFilter(sandbox_id="sbx-1", states=["Ready"], page=1, page_size=10)
@@ -515,3 +538,53 @@ async def test_snapshot_lifecycle_calls_openapi(monkeypatch: pytest.MonkeyPatch)
         ("list", ("sbx-1", ["Ready"], 1, 10)),
         ("delete", "snap-1"),
     ]
+
+
+async def test_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def _boom(*, client, sandbox_id, port, use_server_proxy=False):
+        raise RuntimeError("endpoint exploded")
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.get_sandboxes_sandbox_id_endpoints_port.asyncio_detailed",
+        _boom,
+    )
+
+    adapter = SandboxesAdapter(ConnectionConfig())
+
+    with caplog.at_level("DEBUG", logger="opensandbox.adapters.sandboxes_adapter"):
+        with pytest.raises(Exception) as exc_info:
+            await adapter.get_sandbox_endpoint("sbx-1", 8080)
+
+    assert "endpoint exploded" in str(exc_info.value)
+    assert not [r for r in caplog.records if r.levelname == "ERROR"]
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any(
+        "Failed to retrieve sandbox endpoint for sandbox sbx-1" in msg
+        for msg in debug_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_sandbox_logs_debug_and_not_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def _boom(*, client, sandbox_id):
+        raise RuntimeError("resume exploded")
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.post_sandboxes_sandbox_id_resume.asyncio_detailed",
+        _boom,
+    )
+
+    adapter = SandboxesAdapter(ConnectionConfig())
+
+    with caplog.at_level("DEBUG", logger="opensandbox.adapters.sandboxes_adapter"):
+        with pytest.raises(Exception) as exc_info:
+            await adapter.resume_sandbox("sbx-2")
+
+    assert "resume exploded" in str(exc_info.value)
+    assert not [r for r in caplog.records if r.levelname == "ERROR"]
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("Failed initiate resume sandbox: sbx-2" in msg for msg in debug_messages)

--- a/sdks/sandbox/python/tests/test_sandbox_sync_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_service_adapter_lifecycle.py
@@ -21,7 +21,7 @@ from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.sync.adapters.sandboxes_adapter import SandboxesAdapterSync
 
 
-def test_sync_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
+def test_sync_get_sandbox_endpoint_logs_warning_and_not_error_on_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     def _boom(*, sandbox_id, port, client, use_server_proxy=False):
@@ -34,20 +34,24 @@ def test_sync_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
 
     adapter = SandboxesAdapterSync(ConnectionConfigSync())
 
-    with caplog.at_level("DEBUG", logger="opensandbox.sync.adapters.sandboxes_adapter"):
+    with caplog.at_level(
+        "WARNING", logger="opensandbox.sync.adapters.sandboxes_adapter"
+    ):
         with pytest.raises(Exception) as exc_info:
             adapter.get_sandbox_endpoint("sbx-1", 8080)
 
     assert "endpoint exploded" in str(exc_info.value)
     assert not [r for r in caplog.records if r.levelname == "ERROR"]
-    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    debug_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
     assert any(
         "Failed to retrieve sandbox endpoint for sandbox sbx-1" in msg
         for msg in debug_messages
     )
 
 
-def test_sync_resume_sandbox_logs_debug_and_not_error_on_failure(
+def test_sync_resume_sandbox_logs_warning_and_not_error_on_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     def _boom(*, client, sandbox_id):
@@ -60,11 +64,19 @@ def test_sync_resume_sandbox_logs_debug_and_not_error_on_failure(
 
     adapter = SandboxesAdapterSync(ConnectionConfigSync())
 
-    with caplog.at_level("DEBUG", logger="opensandbox.sync.adapters.sandboxes_adapter"):
+    with caplog.at_level(
+        "WARNING", logger="opensandbox.sync.adapters.sandboxes_adapter"
+    ):
         with pytest.raises(Exception) as exc_info:
             adapter.resume_sandbox("sbx-2")
 
     assert "resume exploded" in str(exc_info.value)
     assert not [r for r in caplog.records if r.levelname == "ERROR"]
-    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
-    assert any("Failed to resume sandbox: sbx-2" in msg for msg in debug_messages)
+    debug_messages = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert any(
+        "Failed to resume sandbox sbx-2: resume exploded" in msg
+        for msg in debug_messages
+    )
+    assert all(r.exc_info is None for r in caplog.records if r.levelname == "WARNING")

--- a/sdks/sandbox/python/tests/test_sandbox_sync_service_adapter_lifecycle.py
+++ b/sdks/sandbox/python/tests/test_sandbox_sync_service_adapter_lifecycle.py
@@ -1,0 +1,70 @@
+#
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import pytest
+
+from opensandbox.config.connection_sync import ConnectionConfigSync
+from opensandbox.sync.adapters.sandboxes_adapter import SandboxesAdapterSync
+
+
+def test_sync_get_sandbox_endpoint_logs_debug_and_not_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _boom(*, sandbox_id, port, client, use_server_proxy=False):
+        raise RuntimeError("endpoint exploded")
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.get_sandboxes_sandbox_id_endpoints_port.sync_detailed",
+        _boom,
+    )
+
+    adapter = SandboxesAdapterSync(ConnectionConfigSync())
+
+    with caplog.at_level("DEBUG", logger="opensandbox.sync.adapters.sandboxes_adapter"):
+        with pytest.raises(Exception) as exc_info:
+            adapter.get_sandbox_endpoint("sbx-1", 8080)
+
+    assert "endpoint exploded" in str(exc_info.value)
+    assert not [r for r in caplog.records if r.levelname == "ERROR"]
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any(
+        "Failed to retrieve sandbox endpoint for sandbox sbx-1" in msg
+        for msg in debug_messages
+    )
+
+
+def test_sync_resume_sandbox_logs_debug_and_not_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _boom(*, client, sandbox_id):
+        raise RuntimeError("resume exploded")
+
+    monkeypatch.setattr(
+        "opensandbox.api.lifecycle.api.sandboxes.post_sandboxes_sandbox_id_resume.sync_detailed",
+        _boom,
+    )
+
+    adapter = SandboxesAdapterSync(ConnectionConfigSync())
+
+    with caplog.at_level("DEBUG", logger="opensandbox.sync.adapters.sandboxes_adapter"):
+        with pytest.raises(Exception) as exc_info:
+            adapter.resume_sandbox("sbx-2")
+
+    assert "resume exploded" in str(exc_info.value)
+    assert not [r for r in caplog.records if r.levelname == "ERROR"]
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("Failed to resume sandbox: sbx-2" in msg for msg in debug_messages)


### PR DESCRIPTION
## Summary
- demote sandboxes adapter log-then-raise failures from ERROR to DEBUG in the Python SDK
- keep the raised `SandboxException` behavior unchanged for callers
- add focused async/sync regression tests for `get_sandbox_endpoint()` and `resume_sandbox()` failure paths

Closes #1203.

## Testing
- `cd sdks/sandbox/python && uv sync --group dev`
- `cd sdks/sandbox/python && uv run pytest tests/test_sandbox_service_adapter_lifecycle.py -k 'logs_debug_and_not_error_on_failure or pause_resume_kill_call_openapi' -q`
- `cd sdks/sandbox/python && uv run pytest tests/test_sandbox_sync_service_adapter_lifecycle.py -q`
- `cd sdks/sandbox/python && uv run ruff format src/opensandbox/adapters/sandboxes_adapter.py src/opensandbox/sync/adapters/sandboxes_adapter.py tests/test_sandbox_service_adapter_lifecycle.py tests/test_sandbox_sync_service_adapter_lifecycle.py`
- `cd sdks/sandbox/python && uv run ruff check src/opensandbox/adapters/sandboxes_adapter.py src/opensandbox/sync/adapters/sandboxes_adapter.py tests/test_sandbox_service_adapter_lifecycle.py tests/test_sandbox_sync_service_adapter_lifecycle.py`
