### PR TITLE
refactor(python-sdk): unify logging to use f-strings

### DIFF
--- a/sdks/code-interpreter/python/src/code_interpreter/adapters/code_adapter.py
+++ b/sdks/code-interpreter/python/src/code_interpreter/adapters/code_adapter.py
@@ -216,7 +216,9 @@ class CodesAdapter(Codes):
             )
             handle_api_error(response_obj, "List code contexts")
             parsed_list = require_parsed(response_obj, list, "List code contexts")
-            return [CodeExecutionConverter.from_api_code_context(c) for c in parsed_list]
+            return [
+                CodeExecutionConverter.from_api_code_context(c) for c in parsed_list
+            ]
         except Exception as e:
             logger.error("Failed to list contexts", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -269,7 +271,11 @@ class CodesAdapter(Codes):
             raise InvalidArgumentException("Code cannot be empty")
 
         try:
-            if context is not None and language is not None and context.language != language:
+            if (
+                context is not None
+                and language is not None
+                and context.language != language
+            ):
                 raise InvalidArgumentException(
                     f"language '{language}' must match context.language '{context.language}'"
                 )
@@ -299,9 +305,7 @@ class CodesAdapter(Codes):
                     await response.aread()
                     error_body = response.text
                     logger.error(
-                        "Failed to run code. Status: %s, Body: %s",
-                        response.status_code,
-                        error_body,
+                        f"Failed to run code. Status: {response.status_code}, Body: {error_body}"
                     )
                     raise SandboxApiException(
                         message=f"Failed to run code. Status code: {response.status_code}",
@@ -325,18 +329,16 @@ class CodesAdapter(Codes):
                         event_node = EventNode(**event_dict)
                         await dispatcher.dispatch(event_node)
                     except json.JSONDecodeError:
-                        logger.debug("Failed to parse SSE line: %s", line)
+                        logger.debug(f"Failed to parse SSE line: {line}")
                         continue
                     except Exception as e:
-                        logger.error("Error processing event: %s", data, exc_info=e)
+                        logger.error(f"Error processing event: {data}", exc_info=e)
                         continue
 
             return execution
 
         except Exception as e:
-            logger.error(
-                "Failed to run code (length: %s)", len(code), exc_info=e
-            )
+            logger.error(f"Failed to run code (length: {len(code)})", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def interrupt(self, execution_id: str) -> None:

--- a/sdks/code-interpreter/python/src/code_interpreter/code_interpreter.py
+++ b/sdks/code-interpreter/python/src/code_interpreter/code_interpreter.py
@@ -196,17 +196,20 @@ class CodeInterpreter:
         if sandbox is None:
             raise InvalidArgumentException("Sandbox instance must be provided")
 
-        logger.info("Creating code interpreter from sandbox: %s", sandbox.id)
+        logger.info(f"Creating code interpreter from sandbox: {sandbox.id}")
 
         factory = AdapterFactory(sandbox.connection_config)
 
         try:
             # Connect to the execd daemon endpoint for code execution services
             from opensandbox.constants import DEFAULT_EXECD_PORT
-            code_interpreter_endpoint = await sandbox.get_endpoint(DEFAULT_EXECD_PORT)
-            code_execution_service = factory.create_code_execution_service(code_interpreter_endpoint)
 
-            logger.info("Code interpreter %s created successfully", sandbox.id)
+            code_interpreter_endpoint = await sandbox.get_endpoint(DEFAULT_EXECD_PORT)
+            code_execution_service = factory.create_code_execution_service(
+                code_interpreter_endpoint
+            )
+
+            logger.info(f"Code interpreter {sandbox.id} created successfully")
 
             return cls(sandbox, code_execution_service)
         except Exception as e:

--- a/sdks/code-interpreter/python/src/code_interpreter/sync/adapters/code_adapter.py
+++ b/sdks/code-interpreter/python/src/code_interpreter/sync/adapters/code_adapter.py
@@ -304,15 +304,15 @@ class CodesAdapterSync(CodesSync):
                         event_node = EventNode(**event_dict)
                         dispatcher.dispatch(event_node)
                     except json.JSONDecodeError:
-                        logger.debug("Failed to parse SSE line: %s", line)
+                        logger.debug(f"Failed to parse SSE line: {line}")
                         continue
                     except Exception as e:
-                        logger.error("Error processing event: %s", data, exc_info=e)
+                        logger.error(f"Error processing event: {data}", exc_info=e)
                         continue
 
             return execution
         except Exception as e:
-            logger.error("Failed to run code (length: %s)", len(code), exc_info=e)
+            logger.error(f"Failed to run code (length: {len(code)})", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def interrupt(self, execution_id: str) -> None:

--- a/sdks/code-interpreter/python/src/code_interpreter/sync/code_interpreter.py
+++ b/sdks/code-interpreter/python/src/code_interpreter/sync/code_interpreter.py
@@ -165,14 +165,16 @@ class CodeInterpreterSync:
         if sandbox is None:
             raise InvalidArgumentException("Sandbox instance must be provided")
 
-        logger.info("Creating code interpreter from sandbox: %s", sandbox.id)
+        logger.info(f"Creating code interpreter from sandbox: {sandbox.id}")
         factory = AdapterFactorySync(sandbox.connection_config)
         try:
             endpoint = sandbox.get_endpoint(DEFAULT_EXECD_PORT)
             code_service = factory.create_code_execution_service(endpoint)
-            logger.info("Code interpreter %s created successfully", sandbox.id)
+            logger.info(f"Code interpreter {sandbox.id} created successfully")
             return cls(sandbox, code_service)
         except Exception as e:
             if isinstance(e, SandboxException):
                 raise
-            raise SandboxInternalException(f"Failed to create code interpreter: {e}", cause=e) from e
+            raise SandboxInternalException(
+                f"Failed to create code interpreter: {e}", cause=e
+            ) from e

--- a/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_async_pool_reconciler.py
@@ -47,7 +47,7 @@ async def run_async_reconcile_tick(
     ttl = config.primary_lock_ttl
 
     if not await state_store.try_acquire_primary_lock(pool_name, owner_id, ttl):
-        logger.debug("Async reconcile skip (not primary): pool_name=%s", pool_name)
+        logger.debug(f"Async reconcile skip (not primary): pool_name={pool_name}")
         return
     await _run_primary_replenish_once(
         config=config,
@@ -116,9 +116,7 @@ async def _run_primary_replenish_once(
             for orphaned_id in created_ids[index:]:
                 await _discard(on_discard_sandbox, orphaned_id)
             logger.warning(
-                "Async reconcile lost primary lock before put_idle; dropped %s newly created sandbox(es): pool_name=%s",
-                len(created_ids) - index,
-                pool_name,
+                f"Async reconcile lost primary lock before put_idle; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name}"
             )
             return
         try:
@@ -134,14 +132,13 @@ async def _run_primary_replenish_once(
                     pass
                 await _discard(on_discard_sandbox, orphaned_id)
             logger.warning(
-                "Async reconcile put_idle failed; dropped %s newly created sandbox(es): pool_name=%s error=%s",
-                len(created_ids) - index,
-                pool_name,
-                exc,
+                f"Async reconcile put_idle failed; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name} error={exc}"
             )
             return
     if created > 0:
-        logger.debug("Async reconcile created %s sandboxes: pool_name=%s", created, pool_name)
+        logger.debug(
+            f"Async reconcile created {created} sandboxes: pool_name={pool_name}"
+        )
 
 
 async def _shrink_excess_idle(
@@ -157,9 +154,7 @@ async def _shrink_excess_idle(
     for _ in range(to_remove):
         if not await state_store.renew_primary_lock(pool_name, owner_id, ttl):
             logger.warning(
-                "Async reconcile lost primary lock before shrinking idle: pool_name=%s removed=%s",
-                pool_name,
-                removed,
+                f"Async reconcile lost primary lock before shrinking idle: pool_name={pool_name} removed={removed}"
             )
             return
         sandbox_id = await state_store.try_take_idle(pool_name)
@@ -169,7 +164,9 @@ async def _shrink_excess_idle(
         removed += 1
 
     await state_store.renew_primary_lock(pool_name, owner_id, ttl)
-    logger.debug("Async reconcile shrunk %s idle sandbox(es): pool_name=%s", removed, pool_name)
+    logger.debug(
+        f"Async reconcile shrunk {removed} idle sandbox(es): pool_name={pool_name}"
+    )
 
 
 async def _discard(
@@ -179,7 +176,5 @@ async def _discard(
         await on_discard_sandbox(sandbox_id)
     except Exception as exc:
         logger.warning(
-            "Async reconcile sandbox cleanup failed: sandbox_id=%s error=%s",
-            sandbox_id,
-            exc,
+            f"Async reconcile sandbox cleanup failed: sandbox_id={sandbox_id} error={exc}"
         )

--- a/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
+++ b/sdks/sandbox/python/src/opensandbox/_pool_reconciler.py
@@ -76,7 +76,10 @@ class ReconcileState:
         until = self.backoff_until
         if until is None:
             return False
-        return self.state == PoolState.DEGRADED and (now or datetime.now(timezone.utc)) < until
+        return (
+            self.state == PoolState.DEGRADED
+            and (now or datetime.now(timezone.utc)) < until
+        )
 
 
 def run_reconcile_tick(
@@ -93,7 +96,7 @@ def run_reconcile_tick(
     ttl = config.primary_lock_ttl
 
     if not state_store.try_acquire_primary_lock(pool_name, owner_id, ttl):
-        logger.debug("Reconcile skip (not primary): pool_name=%s", pool_name)
+        logger.debug(f"Reconcile skip (not primary): pool_name={pool_name}")
         return
     _run_primary_replenish_once(
         config=config,
@@ -166,9 +169,7 @@ def _run_primary_replenish_once(
             for orphaned_id in created_ids[index:]:
                 _discard(on_discard_sandbox, orphaned_id)
             logger.warning(
-                "Reconcile lost primary lock before put_idle; dropped %s newly created sandbox(es): pool_name=%s",
-                len(created_ids) - index,
-                pool_name,
+                f"Reconcile lost primary lock before put_idle; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name}"
             )
             return
         try:
@@ -184,14 +185,11 @@ def _run_primary_replenish_once(
                     pass
                 _discard(on_discard_sandbox, orphaned_id)
             logger.warning(
-                "Reconcile put_idle failed; dropped %s newly created sandbox(es): pool_name=%s error=%s",
-                len(created_ids) - index,
-                pool_name,
-                exc,
+                f"Reconcile put_idle failed; dropped {len(created_ids) - index} newly created sandbox(es): pool_name={pool_name} error={exc}"
             )
             return
     if created > 0:
-        logger.debug("Reconcile created %s sandboxes: pool_name=%s", created, pool_name)
+        logger.debug(f"Reconcile created {created} sandboxes: pool_name={pool_name}")
 
 
 def _shrink_excess_idle(
@@ -207,9 +205,7 @@ def _shrink_excess_idle(
     for _ in range(to_remove):
         if not state_store.renew_primary_lock(pool_name, owner_id, ttl):
             logger.warning(
-                "Reconcile lost primary lock before shrinking idle: pool_name=%s removed=%s",
-                pool_name,
-                removed,
+                f"Reconcile lost primary lock before shrinking idle: pool_name={pool_name} removed={removed}"
             )
             return
         sandbox_id = state_store.try_take_idle(pool_name)
@@ -219,7 +215,7 @@ def _shrink_excess_idle(
         removed += 1
 
     state_store.renew_primary_lock(pool_name, owner_id, ttl)
-    logger.debug("Reconcile shrunk %s idle sandbox(es): pool_name=%s", removed, pool_name)
+    logger.debug(f"Reconcile shrunk {removed} idle sandbox(es): pool_name={pool_name}")
 
 
 def _discard(on_discard_sandbox: Callable[[str], None], sandbox_id: str) -> None:
@@ -227,5 +223,5 @@ def _discard(on_discard_sandbox: Callable[[str], None], sandbox_id: str) -> None
         on_discard_sandbox(sandbox_id)
     except Exception as exc:
         logger.warning(
-            "Reconcile sandbox cleanup failed: sandbox_id=%s error=%s", sandbox_id, exc
+            f"Reconcile sandbox cleanup failed: sandbox_id={sandbox_id} error={exc}"
         )

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -65,9 +65,7 @@ def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
         if timeout_ms < 0:
             raise InvalidArgumentException("timeout must be positive")
         return timeout_ms
-    raise InvalidArgumentException(
-        "timeout must be a datetime.timedelta or None"
-    )
+    raise InvalidArgumentException("timeout must be a datetime.timedelta or None")
 
 
 def _infer_foreground_exit_code(execution: Execution) -> int | None:
@@ -117,7 +115,7 @@ def _decode_sse_event_line(line: str) -> EventNode | None:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error("Failed to parse SSE line: %s", line, exc_info=e)
+        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
         return None
 
 
@@ -232,10 +230,7 @@ class CommandsAdapter(Commands):
                 await response.aread()
                 error_body = response.text
                 logger.error(
-                    "%s. Status: %s, Body: %s",
-                    failure_message,
-                    response.status_code,
-                    error_body,
+                    f"{failure_message}. Status: {response.status_code}, Body: {error_body}"
                 )
                 raise SandboxApiException(
                     message=f"{failure_message}. Status code: {response.status_code}",
@@ -283,11 +278,7 @@ class CommandsAdapter(Commands):
             )
 
         except Exception as e:
-            logger.error(
-                "Failed to run command (length: %s)",
-                len(command),
-                exc_info=e,
-            )
+            logger.error(f"Failed to run command (length: {len(command)})", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def interrupt(self, execution_id: str) -> None:
@@ -321,7 +312,9 @@ class CommandsAdapter(Commands):
             )
 
             handle_api_error(response_obj, "Get command status")
-            parsed = require_parsed(response_obj, CommandStatusResponse, "Get command status")
+            parsed = require_parsed(
+                response_obj, CommandStatusResponse, "Get command status"
+            )
             return to_command_status(parsed)
         except Exception as e:
             logger.error("Failed to get command status", exc_info=e)
@@ -371,9 +364,7 @@ class CommandsAdapter(Commands):
         from opensandbox.api.execd.types import UNSET
 
         body = (
-            CreateSessionRequest(cwd=working_directory)
-            if working_directory
-            else UNSET
+            CreateSessionRequest(cwd=working_directory) if working_directory else UNSET
         )
         try:
             client = await self._get_client()
@@ -434,9 +425,7 @@ class CommandsAdapter(Commands):
 
         try:
             client = await self._get_client()
-            parsed = await delete_session_asyncio(
-                client=client, session_id=session_id
-            )
+            parsed = await delete_session_asyncio(client=client, session_id=session_id)
             if parsed is not None:
                 handle_api_error(parsed, "delete_session")
         except Exception as e:

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/exception_converter.py
@@ -248,7 +248,7 @@ def _parse_error_body(body: Any) -> SandboxError | None:
         return None
 
     except Exception as ex:
-        logger.debug("Failed to parse error body: %s", ex)
+        logger.debug(f"Failed to parse error body: {ex}")
         return None
 
 

--- a/sdks/sandbox/python/src/opensandbox/adapters/diagnostics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/diagnostics_adapter.py
@@ -82,12 +82,16 @@ class DiagnosticsAdapter(Diagnostics):
             )
             from opensandbox.api.diagnostic.models import DiagnosticContentResponse
 
-            response_obj = await get_sandboxes_sandbox_id_diagnostics_logs.asyncio_detailed(
-                sandbox_id=sandbox_id,
-                client=await self._get_client(),
-                scope=scope,
+            response_obj = (
+                await get_sandboxes_sandbox_id_diagnostics_logs.asyncio_detailed(
+                    sandbox_id=sandbox_id,
+                    client=await self._get_client(),
+                    scope=scope,
+                )
             )
-            handle_api_error(response_obj, f"Get diagnostic logs for sandbox {sandbox_id}")
+            handle_api_error(
+                response_obj, f"Get diagnostic logs for sandbox {sandbox_id}"
+            )
             parsed = require_parsed(
                 response_obj,
                 DiagnosticContentResponse,
@@ -95,7 +99,9 @@ class DiagnosticsAdapter(Diagnostics):
             )
             return DiagnosticModelConverter.to_diagnostic_content(parsed)
         except Exception as e:
-            logger.error("Failed to get diagnostic logs for sandbox %s", sandbox_id, exc_info=e)
+            logger.error(
+                f"Failed to get diagnostic logs for sandbox {sandbox_id}", exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_events(
@@ -109,12 +115,16 @@ class DiagnosticsAdapter(Diagnostics):
             )
             from opensandbox.api.diagnostic.models import DiagnosticContentResponse
 
-            response_obj = await get_sandboxes_sandbox_id_diagnostics_events.asyncio_detailed(
-                sandbox_id=sandbox_id,
-                client=await self._get_client(),
-                scope=scope,
+            response_obj = (
+                await get_sandboxes_sandbox_id_diagnostics_events.asyncio_detailed(
+                    sandbox_id=sandbox_id,
+                    client=await self._get_client(),
+                    scope=scope,
+                )
             )
-            handle_api_error(response_obj, f"Get diagnostic events for sandbox {sandbox_id}")
+            handle_api_error(
+                response_obj, f"Get diagnostic events for sandbox {sandbox_id}"
+            )
             parsed = require_parsed(
                 response_obj,
                 DiagnosticContentResponse,
@@ -122,5 +132,7 @@ class DiagnosticsAdapter(Diagnostics):
             )
             return DiagnosticModelConverter.to_diagnostic_content(parsed)
         except Exception as e:
-            logger.error("Failed to get diagnostic events for sandbox %s", sandbox_id, exc_info=e)
+            logger.error(
+                f"Failed to get diagnostic events for sandbox {sandbox_id}", exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/adapters/egress_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/egress_adapter.py
@@ -165,8 +165,7 @@ class EgressAdapter(Egress):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to create credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to create credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -181,8 +180,7 @@ class EgressAdapter(Egress):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -213,8 +211,7 @@ class EgressAdapter(Egress):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to patch credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to patch credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -228,8 +225,7 @@ class EgressAdapter(Egress):
             )
         except Exception as e:
             logger.error(
-                "Failed to delete credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to delete credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -244,8 +240,7 @@ class EgressAdapter(Egress):
             return CredentialListResponse.model_validate(payload).credentials
         except Exception as e:
             logger.error(
-                "Failed to list credential vault credentials via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to list credential vault credentials via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -260,8 +255,7 @@ class EgressAdapter(Egress):
             return CredentialMetadata.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault credential via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault credential via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -276,8 +270,7 @@ class EgressAdapter(Egress):
             return CredentialBindingListResponse.model_validate(payload).bindings
         except Exception as e:
             logger.error(
-                "Failed to list credential vault bindings via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to list credential vault bindings via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -292,8 +285,7 @@ class EgressAdapter(Egress):
             return CredentialBindingMetadata.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault binding via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault binding via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -322,8 +314,7 @@ class EgressAdapter(Egress):
             return NetworkPolicy.model_validate(policy.to_dict())
         except Exception as e:
             logger.error(
-                "Failed to get egress policy from endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get egress policy from endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -351,8 +342,7 @@ class EgressAdapter(Egress):
             handle_api_error(response_obj, "Patch egress rules")
         except Exception as e:
             logger.error(
-                "Failed to patch egress policy via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to patch egress policy via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -368,8 +358,7 @@ class EgressAdapter(Egress):
             handle_api_error(response_obj, "Delete egress rules")
         except Exception as e:
             logger.error(
-                "Failed to delete egress rules via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to delete egress rules via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
@@ -60,7 +60,7 @@ def _decode_sse_event_line(line: str) -> EventNode | None:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error("Failed to parse SSE line: %s", line, exc_info=e)
+        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
         return None
 
 
@@ -108,7 +108,9 @@ class IsolationSessionHandle(IsolationSession):
         opts: IsolatedRunOpts | None = None,
         handlers: ExecutionHandlers | None = None,
     ) -> Execution:
-        return await self._adapter._run(self._info.session_id, code, opts=opts, handlers=handlers)
+        return await self._adapter._run(
+            self._info.session_id, code, opts=opts, handlers=handlers
+        )
 
     async def get(self) -> IsolatedSessionState:
         return await self._adapter._get(self._info.session_id)
@@ -194,9 +196,7 @@ class IsolatedSessionsAdapter(IsolationService):
         if not (session_id and session_id.strip()):
             raise InvalidArgumentException("session_id cannot be empty")
         try:
-            url = self._get_url(
-                self.SESSION_PATH.format(session_id=session_id)
-            )
+            url = self._get_url(self.SESSION_PATH.format(session_id=session_id))
             response = await self._httpx_client.get(url)
             if response.status_code != 200:
                 raise SandboxApiException(
@@ -232,9 +232,7 @@ class IsolatedSessionsAdapter(IsolationService):
         url = self._get_url(self.RUN_PATH.format(session_id=session_id))
 
         try:
-            execution = Execution(
-                id=None, execution_count=None, result=[], error=None
-            )
+            execution = Execution(id=None, execution_count=None, result=[], error=None)
             client = self._sse_client
 
             async with client.stream("POST", url, json=json_body) as response:
@@ -262,9 +260,7 @@ class IsolatedSessionsAdapter(IsolationService):
         if not (session_id and session_id.strip()):
             raise InvalidArgumentException("session_id cannot be empty")
         try:
-            url = self._get_url(
-                self.SESSION_PATH.format(session_id=session_id)
-            )
+            url = self._get_url(self.SESSION_PATH.format(session_id=session_id))
             response = await self._httpx_client.delete(url)
             if response.status_code not in (200, 204):
                 raise SandboxApiException(

--- a/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sandboxes_adapter.py
@@ -144,8 +144,7 @@ class SandboxesAdapter(Sandboxes):
     ) -> SandboxCreateResponse:
         """Create a new sandbox instance with the specified configuration."""
         logger.info(
-            "Creating sandbox with startup source: %s",
-            spec.image if spec is not None else snapshot_id,
+            f"Creating sandbox with startup source: {spec.image if spec is not None else snapshot_id}"
         )
 
         try:
@@ -187,9 +186,7 @@ class SandboxesAdapter(Sandboxes):
 
         except Exception as e:
             logger.warning(
-                "Failed to create sandbox with startup source %s: %s",
-                spec.image if spec is not None else snapshot_id,
-                e,
+                f"Failed to create sandbox with startup source {spec.image if spec is not None else snapshot_id}: {e}"
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -214,7 +211,7 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_sandbox_info(parsed)
 
         except Exception as e:
-            logger.warning("Failed to get sandbox info %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to get sandbox info {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -254,7 +251,7 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
 
         except Exception as e:
-            logger.warning("Failed to list sandboxes: %s", e)
+            logger.warning(f"Failed to list sandboxes: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def patch_sandbox_metadata(
@@ -283,7 +280,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.warning("Failed to patch sandbox %s metadata: %s", sandbox_id, e)
+            logger.warning(f"Failed to patch sandbox {sandbox_id} metadata: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def create_snapshot(
@@ -307,7 +304,7 @@ class SandboxesAdapter(Sandboxes):
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
             logger.debug(
-                "Failed to create snapshot for sandbox %s", sandbox_id, exc_info=e
+                f"Failed to create snapshot for sandbox {sandbox_id}", exc_info=e
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -329,7 +326,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.warning("Failed to get snapshot info %s: %s", snapshot_id, e)
+            logger.warning(f"Failed to get snapshot info {snapshot_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -356,7 +353,7 @@ class SandboxesAdapter(Sandboxes):
             )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.warning("Failed to list snapshots: %s", e)
+            logger.warning(f"Failed to list snapshots: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def delete_snapshot(self, snapshot_id: str) -> None:
@@ -372,7 +369,7 @@ class SandboxesAdapter(Sandboxes):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.warning("Failed to delete snapshot %s: %s", snapshot_id, e)
+            logger.warning(f"Failed to delete snapshot {snapshot_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def get_sandbox_endpoint(
@@ -421,9 +418,7 @@ class SandboxesAdapter(Sandboxes):
 
         except Exception as e:
             logger.warning(
-                "Failed to retrieve sandbox endpoint for sandbox %s: %s",
-                sandbox_id,
-                e,
+                f"Failed to retrieve sandbox endpoint for sandbox {sandbox_id}: {e}"
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -470,9 +465,7 @@ class SandboxesAdapter(Sandboxes):
 
         except Exception as e:
             logger.warning(
-                "Failed to retrieve signed sandbox endpoint for sandbox %s: %s",
-                sandbox_id,
-                e,
+                f"Failed to retrieve signed sandbox endpoint for sandbox {sandbox_id}: {e}"
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -496,7 +489,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated pause for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.warning("Failed to initiate pause sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to initiate pause sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def resume_sandbox(self, sandbox_id: str) -> None:
@@ -519,7 +512,7 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Initiated resume for sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.warning("Failed to resume sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to resume sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def renew_sandbox_expiration(
@@ -558,14 +551,12 @@ class SandboxesAdapter(Sandboxes):
             )
             renew_response = SandboxModelConverter.to_sandbox_renew_response(parsed)
             logger.info(
-                "Successfully renewed sandbox %s expiration to %s",
-                sandbox_id,
-                renew_response.expires_at,
+                f"Successfully renewed sandbox {sandbox_id} expiration to {renew_response.expires_at}"
             )
             return renew_response
 
         except Exception as e:
-            logger.warning("Failed to renew sandbox %s expiration: %s", sandbox_id, e)
+            logger.warning(f"Failed to renew sandbox {sandbox_id} expiration: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     async def kill_sandbox(self, sandbox_id: str) -> None:
@@ -588,5 +579,5 @@ class SandboxesAdapter(Sandboxes):
             logger.info(f"Successfully terminated sandbox: {sandbox_id}")
 
         except Exception as e:
-            logger.warning("Failed to terminate sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to terminate sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/manager.py
+++ b/sdks/sandbox/python/src/opensandbox/manager.py
@@ -100,9 +100,10 @@ class SandboxManager:
         """
         self._sandbox_service = sandbox_service
         self._connection_config = connection_config
-        self._diagnostics_service = diagnostics_service or AdapterFactory(
-            connection_config
-        ).create_diagnostics_service()
+        self._diagnostics_service = (
+            diagnostics_service
+            or AdapterFactory(connection_config).create_diagnostics_service()
+        )
 
     @property
     def connection_config(self) -> ConnectionConfig:
@@ -196,7 +197,7 @@ class SandboxManager:
 
         String values add or replace keys; None deletes keys.
         """
-        logger.info("Patching metadata for sandbox: %s", sandbox_id)
+        logger.info(f"Patching metadata for sandbox: {sandbox_id}")
         return await self._sandbox_service.patch_sandbox_metadata(sandbox_id, patch)
 
     async def kill_sandbox(self, sandbox_id: str) -> None:
@@ -213,7 +214,9 @@ class SandboxManager:
         await self._sandbox_service.kill_sandbox(sandbox_id)
         logger.info(f"Successfully terminated sandbox: {sandbox_id}")
 
-    async def renew_sandbox(self, sandbox_id: str, timeout: timedelta) -> SandboxRenewResponse:
+    async def renew_sandbox(
+        self, sandbox_id: str, timeout: timedelta
+    ) -> SandboxRenewResponse:
         """
         Renew expiration time for a single sandbox.
 
@@ -293,8 +296,7 @@ class SandboxManager:
             await self._connection_config.close_transport_if_owned()
         except Exception as e:
             logger.warning(
-                f"Error closing resources for sandbox manager: {e}",
-                exc_info=True
+                f"Error closing resources for sandbox manager: {e}", exc_info=True
             )
 
     async def __aenter__(self) -> "SandboxManager":

--- a/sdks/sandbox/python/src/opensandbox/pool_async.py
+++ b/sdks/sandbox/python/src/opensandbox/pool_async.py
@@ -269,10 +269,7 @@ class SandboxPoolAsync:
                     await manager.kill_sandbox(sandbox_id)
                 except Exception as exc:
                     logger.warning(
-                        "release_all_idle: failed to kill sandbox: pool_name=%s sandbox_id=%s error=%s",
-                        pool_name,
-                        sandbox_id,
-                        exc,
+                        f"release_all_idle: failed to kill sandbox: pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
                     )
         finally:
             if temporary_manager is not None:
@@ -319,10 +316,7 @@ class SandboxPoolAsync:
         drained = await self._await_in_flight_drain(self._config.drain_timeout)
         if not drained:
             logger.warning(
-                "Async pool graceful shutdown timed out waiting in-flight operations: pool_name=%s in_flight=%s timeout_ms=%s",
-                self._config.pool_name,
-                self._in_flight,
-                int(self._config.drain_timeout.total_seconds() * 1000),
+                f"Async pool graceful shutdown timed out waiting in-flight operations: pool_name={self._config.pool_name} in_flight={self._in_flight} timeout_ms={int(self._config.drain_timeout.total_seconds() * 1000)}"
             )
         async with self._lifecycle_lock:
             self._lifecycle_state = PoolLifecycleState.STOPPED
@@ -382,8 +376,7 @@ class SandboxPoolAsync:
                 )
             except Exception as exc:
                 logger.error(
-                    "Async pool reconcile tick failed unexpectedly: pool_name=%s",
-                    self._config.pool_name,
+                    f"Async pool reconcile tick failed unexpectedly: pool_name={self._config.pool_name}",
                     exc_info=exc,
                 )
             finally:
@@ -567,10 +560,7 @@ class SandboxPoolAsync:
             return True
         except Exception as exc:
             logger.warning(
-                "Async pool sandbox cleanup failed: pool_name=%s sandbox_id=%s error=%s",
-                self._config.pool_name,
-                sandbox_id,
-                exc,
+                f"Async pool sandbox cleanup failed: pool_name={self._config.pool_name} sandbox_id={sandbox_id} error={exc}"
             )
             return False
 
@@ -594,10 +584,7 @@ class SandboxPoolAsync:
             # No running loop / loop is closed — fall back to inline cleanup so the work is
             # not silently dropped. The await here is safe because we are inside `acquire()`.
             logger.debug(
-                "Discarded-alive kill scheduling failed, running inline: pool_name=%s count=%d error=%s",
-                pool_name,
-                len(sandbox_ids),
-                exc,
+                f"Discarded-alive kill scheduling failed, running inline: pool_name={pool_name} count={len(sandbox_ids)} error={exc}"
             )
             # Caller is in an async function, so this is awaited via the original
             # `_kill_discarded_alive` directly by the caller. Since `_schedule_kill_discarded_alive`
@@ -627,10 +614,7 @@ class SandboxPoolAsync:
         for sandbox_id, killed in zip(sandbox_ids, results, strict=True):
             if killed:
                 logger.debug(
-                    "Killed near-expiry idle sandbox: pool_name=%s sandbox_id=%s source=%s",
-                    pool_name,
-                    sandbox_id,
-                    source,
+                    f"Killed near-expiry idle sandbox: pool_name={pool_name} sandbox_id={sandbox_id} source={source}"
                 )
 
     async def _begin_operation(self) -> None:
@@ -693,10 +677,7 @@ class SandboxPoolAsync:
             )
         except Exception as exc:
             logger.warning(
-                "Async pool primary lock release failed: pool_name=%s owner_id=%s error=%s",
-                self._config.pool_name,
-                self._config.owner_id,
-                exc,
+                f"Async pool primary lock release failed: pool_name={self._config.pool_name} owner_id={self._config.owner_id} error={exc}"
             )
 
     async def _close_provider(self) -> None:
@@ -708,10 +689,7 @@ class SandboxPoolAsync:
         if self._config.primary_lock_ttl > self._config.warmup_ready_timeout:
             return
         logger.warning(
-            "Async pool primary lock TTL may expire during warmup: pool_name=%s primary_lock_ttl_ms=%s warmup_ready_timeout_ms=%s",
-            self._config.pool_name,
-            int(self._config.primary_lock_ttl.total_seconds() * 1000),
-            int(self._config.warmup_ready_timeout.total_seconds() * 1000),
+            f"Async pool primary lock TTL may expire during warmup: pool_name={self._config.pool_name} primary_lock_ttl_ms={int(self._config.primary_lock_ttl.total_seconds() * 1000)} warmup_ready_timeout_ms={int(self._config.warmup_ready_timeout.total_seconds() * 1000)}"
         )
 
 

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -138,9 +138,10 @@ class Sandbox:
         self._metrics_service = metrics_service
         self._egress_service = egress_service
         self._connection_config = connection_config
-        self._diagnostics_service = diagnostics_service or AdapterFactory(
-            connection_config
-        ).create_diagnostics_service()
+        self._diagnostics_service = (
+            diagnostics_service
+            or AdapterFactory(connection_config).create_diagnostics_service()
+        )
         self._custom_health_check = custom_health_check
         self._isolated_service = isolated_service
 
@@ -148,9 +149,7 @@ class Sandbox:
     def isolation(self) -> IsolationService:
         """Provides access to namespace-isolated session operations (OSEP-0013)."""
         if self._isolated_service is None:
-            raise SandboxInternalException(
-                "isolated service not initialized"
-            )
+            raise SandboxInternalException("isolated service not initialized")
         return self._isolated_service
 
     @property
@@ -296,7 +295,9 @@ class Sandbox:
         logger.info(
             f"Renewing sandbox {self.id} timeout, estimated expiration: {new_expiration}"
         )
-        return await self._sandbox_service.renew_sandbox_expiration(self.id, new_expiration)
+        return await self._sandbox_service.renew_sandbox_expiration(
+            self.id, new_expiration
+        )
 
     async def patch_metadata(self, patch: dict[str, str | None]) -> SandboxInfo:
         """
@@ -389,8 +390,7 @@ class Sandbox:
             logger.debug(f"Closed resources for sandbox {self.id}")
         except Exception as e:
             logger.warning(
-                f"Error closing resources for sandbox {self.id}: {e}",
-                exc_info=True
+                f"Error closing resources for sandbox {self.id}: {e}", exc_info=True
             )
 
     async def is_healthy(self) -> bool:
@@ -557,11 +557,11 @@ class Sandbox:
             image = SandboxImageSpec(image=image)
 
         startup_source = image.image if image is not None else snapshot_id
-        timeout_log = "manual-cleanup" if timeout is None else f"{timeout.total_seconds()}s"
+        timeout_log = (
+            "manual-cleanup" if timeout is None else f"{timeout.total_seconds()}s"
+        )
         logger.info(
-            "Creating sandbox with startup source: %s (timeout: %s)",
-            startup_source,
-            timeout_log,
+            f"Creating sandbox with startup source: {startup_source} (timeout: {timeout_log})"
         )
         factory = AdapterFactory(config)
         sandbox_id: str | None = None
@@ -603,18 +603,19 @@ class Sandbox:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
 
             if not skip_health_check:
                 await sandbox.check_ready(ready_timeout, health_check_polling_interval)
-                logger.info("Sandbox %s is ready", sandbox.id)
+                logger.info(f"Sandbox {sandbox.id} is ready")
             else:
                 logger.info(
-                    "Sandbox %s created (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox.id,
+                    f"Sandbox {sandbox.id} created (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
             return sandbox
@@ -622,14 +623,12 @@ class Sandbox:
             if sandbox_id and sandbox_service:
                 try:
                     logger.warning(
-                        "Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: %s",
-                        sandbox_id,
+                        f"Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: {sandbox_id}"
                     )
                     await sandbox_service.kill_sandbox(sandbox_id)
                 except Exception as cleanup_ex:
                     logger.error(
-                        "Failed to clean up sandbox %s after creation failure",
-                        sandbox_id,
+                        f"Failed to clean up sandbox {sandbox_id} after creation failure",
                         exc_info=cleanup_ex,
                     )
 
@@ -701,20 +700,23 @@ class Sandbox:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
 
             if not skip_health_check:
-                await sandbox.check_ready(connect_timeout, health_check_polling_interval)
+                await sandbox.check_ready(
+                    connect_timeout, health_check_polling_interval
+                )
             else:
                 logger.info(
-                    "Connected to sandbox %s (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox_id,
+                    f"Connected to sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
-            logger.info("Connected to sandbox %s", sandbox_id)
+            logger.info(f"Connected to sandbox {sandbox_id}")
             return sandbox
         except Exception as e:
             await config.close_transport_if_owned()
@@ -725,13 +727,13 @@ class Sandbox:
 
     @classmethod
     async def resume(
-            cls,
-            sandbox_id: str,
-            connection_config: ConnectionConfig | None = None,
-            health_check: Callable[["Sandbox"], Awaitable[bool]] | None = None,
-            resume_timeout: timedelta = timedelta(seconds=30),
-            health_check_polling_interval: timedelta = timedelta(milliseconds=200),
-            skip_health_check: bool = False,
+        cls,
+        sandbox_id: str,
+        connection_config: ConnectionConfig | None = None,
+        health_check: Callable[["Sandbox"], Awaitable[bool]] | None = None,
+        resume_timeout: timedelta = timedelta(seconds=30),
+        health_check_polling_interval: timedelta = timedelta(milliseconds=200),
+        skip_health_check: bool = False,
     ) -> "Sandbox":
         """
         Resume a paused sandbox by ID and return a new, usable Sandbox instance.
@@ -755,7 +757,7 @@ class Sandbox:
 
         config = (connection_config or ConnectionConfig()).with_transport_if_missing()
 
-        logger.info("Resuming sandbox: %s", sandbox_id)
+        logger.info(f"Resuming sandbox: {sandbox_id}")
         factory = AdapterFactory(config)
 
         try:
@@ -778,7 +780,9 @@ class Sandbox:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -787,8 +791,7 @@ class Sandbox:
                 await sandbox.check_ready(resume_timeout, health_check_polling_interval)
             else:
                 logger.info(
-                    "Resumed sandbox %s (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox_id,
+                    f"Resumed sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
             return sandbox

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -60,9 +60,7 @@ def _resolve_run_in_session_timeout(timeout: timedelta | None) -> int | None:
         if timeout_ms < 0:
             raise InvalidArgumentException("timeout must be positive")
         return timeout_ms
-    raise InvalidArgumentException(
-        "timeout must be a datetime.timedelta or None"
-    )
+    raise InvalidArgumentException("timeout must be a datetime.timedelta or None")
 
 
 def _infer_foreground_exit_code(execution: Execution) -> int | None:
@@ -112,7 +110,7 @@ def _decode_sse_event_line(line: str) -> EventNode | None:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error("Failed to parse SSE line: %s", line, exc_info=e)
+        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
         return None
 
 
@@ -128,7 +126,9 @@ class CommandsAdapterSync(CommandsSync):
     SESSION_PATH = "/session"
     RUN_IN_SESSION_PATH = "/session/{session_id}/run"
 
-    def __init__(self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint) -> None:
+    def __init__(
+        self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint
+    ) -> None:
         """
         Initialize the command adapter (sync).
 
@@ -180,7 +180,9 @@ class CommandsAdapterSync(CommandsSync):
 
     def _get_execd_url(self, path: str) -> str:
         """Build URL for execd endpoint."""
-        return f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        return (
+            f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        )
 
     def _execute_streaming_request(
         self,
@@ -237,7 +239,7 @@ class CommandsAdapterSync(CommandsSync):
             )
 
         except Exception as e:
-            logger.error("Failed to run command (length: %s)", len(command), exc_info=e)
+            logger.error(f"Failed to run command (length: {len(command)})", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def interrupt(self, execution_id: str) -> None:
@@ -250,7 +252,9 @@ class CommandsAdapterSync(CommandsSync):
         try:
             from opensandbox.api.execd.api.command import interrupt_command
 
-            response_obj = interrupt_command.sync_detailed(client=self._client, id=execution_id)
+            response_obj = interrupt_command.sync_detailed(
+                client=self._client, id=execution_id
+            )
             handle_api_error(response_obj, "Interrupt command")
         except Exception as e:
             logger.error("Failed to interrupt command", exc_info=e)
@@ -271,7 +275,9 @@ class CommandsAdapterSync(CommandsSync):
                 id=execution_id,
             )
             handle_api_error(response_obj, "Get command status")
-            parsed = require_parsed(response_obj, CommandStatusResponse, "Get command status")
+            parsed = require_parsed(
+                response_obj, CommandStatusResponse, "Get command status"
+            )
             return to_command_status(parsed)
         except Exception as e:
             logger.error("Failed to get command status", exc_info=e)
@@ -318,9 +324,7 @@ class CommandsAdapterSync(CommandsSync):
         from opensandbox.api.execd.types import UNSET
 
         body = (
-            CreateSessionRequest(cwd=working_directory)
-            if working_directory
-            else UNSET
+            CreateSessionRequest(cwd=working_directory) if working_directory else UNSET
         )
         try:
             parsed = create_session_sync(client=self._client, body=body)
@@ -379,9 +383,7 @@ class CommandsAdapterSync(CommandsSync):
         )
 
         try:
-            parsed = delete_session_sync(
-                client=self._client, session_id=session_id
-            )
+            parsed = delete_session_sync(client=self._client, session_id=session_id)
             if parsed is not None:
                 handle_api_error(parsed, "delete_session")
         except Exception as e:

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/diagnostics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/diagnostics_adapter.py
@@ -87,7 +87,9 @@ class DiagnosticsAdapterSync(DiagnosticsSync):
                 client=self._get_client(),
                 scope=scope,
             )
-            handle_api_error(response_obj, f"Get diagnostic logs for sandbox {sandbox_id}")
+            handle_api_error(
+                response_obj, f"Get diagnostic logs for sandbox {sandbox_id}"
+            )
             parsed = require_parsed(
                 response_obj,
                 DiagnosticContentResponse,
@@ -95,7 +97,9 @@ class DiagnosticsAdapterSync(DiagnosticsSync):
             )
             return DiagnosticModelConverter.to_diagnostic_content(parsed)
         except Exception as e:
-            logger.error("Failed to get diagnostic logs for sandbox %s", sandbox_id, exc_info=e)
+            logger.error(
+                f"Failed to get diagnostic logs for sandbox {sandbox_id}", exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_events(
@@ -114,7 +118,9 @@ class DiagnosticsAdapterSync(DiagnosticsSync):
                 client=self._get_client(),
                 scope=scope,
             )
-            handle_api_error(response_obj, f"Get diagnostic events for sandbox {sandbox_id}")
+            handle_api_error(
+                response_obj, f"Get diagnostic events for sandbox {sandbox_id}"
+            )
             parsed = require_parsed(
                 response_obj,
                 DiagnosticContentResponse,
@@ -122,5 +128,7 @@ class DiagnosticsAdapterSync(DiagnosticsSync):
             )
             return DiagnosticModelConverter.to_diagnostic_content(parsed)
         except Exception as e:
-            logger.error("Failed to get diagnostic events for sandbox %s", sandbox_id, exc_info=e)
+            logger.error(
+                f"Failed to get diagnostic events for sandbox {sandbox_id}", exc_info=e
+            )
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/egress_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/egress_adapter.py
@@ -165,8 +165,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to create credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to create credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -181,8 +180,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -213,8 +211,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialVaultState.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to patch credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to patch credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -228,8 +225,7 @@ class EgressAdapterSync(EgressSync):
             )
         except Exception as e:
             logger.error(
-                "Failed to delete credential vault via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to delete credential vault via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -244,8 +240,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialListResponse.model_validate(payload).credentials
         except Exception as e:
             logger.error(
-                "Failed to list credential vault credentials via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to list credential vault credentials via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -260,8 +255,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialMetadata.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault credential via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault credential via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -276,8 +270,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialBindingListResponse.model_validate(payload).bindings
         except Exception as e:
             logger.error(
-                "Failed to list credential vault bindings via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to list credential vault bindings via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -292,8 +285,7 @@ class EgressAdapterSync(EgressSync):
             return CredentialBindingMetadata.model_validate(payload)
         except Exception as e:
             logger.error(
-                "Failed to get credential vault binding via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get credential vault binding via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -322,8 +314,7 @@ class EgressAdapterSync(EgressSync):
             return NetworkPolicy.model_validate(policy.to_dict())
         except Exception as e:
             logger.error(
-                "Failed to get egress policy from endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to get egress policy from endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -351,8 +342,7 @@ class EgressAdapterSync(EgressSync):
             handle_api_error(response_obj, "Patch egress rules")
         except Exception as e:
             logger.error(
-                "Failed to patch egress policy via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to patch egress policy via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -368,8 +358,7 @@ class EgressAdapterSync(EgressSync):
             handle_api_error(response_obj, "Delete egress rules")
         except Exception as e:
             logger.error(
-                "Failed to delete egress rules via endpoint %s",
-                self.endpoint.endpoint,
+                f"Failed to delete egress rules via endpoint {self.endpoint.endpoint}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/filesystem_adapter.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 def _multipart_header_filename(filename: str) -> str:
     return (
         filename.replace("\\", "\\\\")
-        .replace('"', r'\"')
+        .replace('"', r"\"")
         .replace("\r", "_")
         .replace("\n", "_")
     )
@@ -68,6 +68,8 @@ def _rewind_seekable_stream(stream: IOBase) -> None:
     if not stream.seekable():
         return
     stream.seek(0)
+
+
 class _DownloadRequest(TypedDict):
     url: str
     params: dict[str, str]
@@ -78,7 +80,9 @@ class FilesystemAdapterSync(FilesystemSync):
     FILESYSTEM_UPLOAD_PATH = "/files/upload"
     FILESYSTEM_DOWNLOAD_PATH = "/files/download"
 
-    def __init__(self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint) -> None:
+    def __init__(
+        self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint
+    ) -> None:
         self.connection_config = connection_config
         self.execd_endpoint = execd_endpoint
         from opensandbox.api.execd import Client
@@ -105,7 +109,9 @@ class FilesystemAdapterSync(FilesystemSync):
         return f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}"
 
     def _get_execd_url(self, path: str) -> str:
-        return f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        return (
+            f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        )
 
     def _build_download_request(
         self,
@@ -135,7 +141,9 @@ class FilesystemAdapterSync(FilesystemSync):
         offset: int | None = None,
         limit: int | None = None,
     ) -> str:
-        content = self.read_bytes(path, range_header=range_header, offset=offset, limit=limit)
+        content = self.read_bytes(
+            path, range_header=range_header, offset=offset, limit=limit
+        )
         return content.decode(encoding)
 
     def read_bytes(
@@ -146,9 +154,11 @@ class FilesystemAdapterSync(FilesystemSync):
         offset: int | None = None,
         limit: int | None = None,
     ) -> bytes:
-        logger.debug("Reading file as bytes: %s", path)
+        logger.debug(f"Reading file as bytes: {path}")
         try:
-            request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
+            request_data = self._build_download_request(
+                path, range_header, offset=offset, limit=limit
+            )
             response = self._httpx_client.get(
                 request_data["url"],
                 headers=request_data["headers"],
@@ -157,7 +167,7 @@ class FilesystemAdapterSync(FilesystemSync):
             response.raise_for_status()
             return response.content
         except Exception as e:
-            logger.error("Failed to read file %s", path, exc_info=e)
+            logger.error(f"Failed to read file {path}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def read_bytes_stream(
@@ -169,8 +179,10 @@ class FilesystemAdapterSync(FilesystemSync):
         offset: int | None = None,
         limit: int | None = None,
     ) -> Iterator[bytes]:
-        logger.debug("Streaming file as bytes: %s (chunk_size=%s)", path, chunk_size)
-        request_data = self._build_download_request(path, range_header, offset=offset, limit=limit)
+        logger.debug(f"Streaming file as bytes: {path} (chunk_size={chunk_size})")
+        request_data = self._build_download_request(
+            path, range_header, offset=offset, limit=limit
+        )
         url = request_data["url"]
         params = request_data["params"]
         headers = request_data["headers"]
@@ -211,7 +223,7 @@ class FilesystemAdapterSync(FilesystemSync):
         """
         if not entries:
             return
-        logger.debug("Writing %s files", len(entries))
+        logger.debug(f"Writing {len(entries)} files")
         try:
             url = self._get_execd_url(self.FILESYSTEM_UPLOAD_PATH)
 
@@ -222,7 +234,7 @@ class FilesystemAdapterSync(FilesystemSync):
 
             response.raise_for_status()
         except Exception as e:
-            logger.error("Failed to write %s files", len(entries), exc_info=e)
+            logger.error(f"Failed to write {len(entries)} files", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def _write_files_with_content_length(
@@ -331,7 +343,9 @@ class FilesystemAdapterSync(FilesystemSync):
                 yield metadata_json.encode()
                 yield b"\r\n"
 
-                filename = _multipart_header_filename(os.path.basename(entry.path) or "file")
+                filename = _multipart_header_filename(
+                    os.path.basename(entry.path) or "file"
+                )
                 yield f"--{boundary}\r\n".encode()
                 yield (
                     f'Content-Disposition: form-data; name="file"; '
@@ -370,7 +384,9 @@ class FilesystemAdapterSync(FilesystemSync):
         owner: str | None = None,
         group: str | None = None,
     ) -> None:
-        entry = WriteEntry(path=path, data=data, mode=mode, owner=owner, group=group, encoding=encoding)
+        entry = WriteEntry(
+            path=path, data=data, mode=mode, owner=owner, group=group, encoding=encoding
+        )
         self.write_files([entry])
 
     def create_directories(self, entries: list[WriteEntry]) -> None:
@@ -393,7 +409,7 @@ class FilesystemAdapterSync(FilesystemSync):
             response_obj = remove_files.sync_detailed(client=self._client, path=paths)
             handle_api_error(response_obj, "Delete files")
         except Exception as e:
-            logger.error("Failed to delete %s files", len(paths), exc_info=e)
+            logger.error(f"Failed to delete {len(paths)} files", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def delete_directories(self, paths: list[str]) -> None:
@@ -403,7 +419,7 @@ class FilesystemAdapterSync(FilesystemSync):
             response_obj = remove_dirs.sync_detailed(client=self._client, path=paths)
             handle_api_error(response_obj, "Delete directories")
         except Exception as e:
-            logger.error("Failed to delete %s directories", len(paths), exc_info=e)
+            logger.error(f"Failed to delete {len(paths)} directories", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def move_files(self, entries: list[MoveEntry]) -> None:
@@ -411,7 +427,9 @@ class FilesystemAdapterSync(FilesystemSync):
             from opensandbox.api.execd.api.filesystem import rename_files
 
             rename_items = FilesystemModelConverter.to_api_rename_file_items(entries)
-            response_obj = rename_files.sync_detailed(client=self._client, body=rename_items)
+            response_obj = rename_files.sync_detailed(
+                client=self._client, body=rename_items
+            )
             handle_api_error(response_obj, "Move files")
         except Exception as e:
             logger.error("Failed to move files", exc_info=e)
@@ -448,7 +466,9 @@ class FilesystemAdapterSync(FilesystemSync):
             logger.error("Failed to replace contents", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
-    def replace_contents_detailed(self, entries: list[ContentReplaceEntry]) -> list[ContentReplaceResult]:
+    def replace_contents_detailed(
+        self, entries: list[ContentReplaceEntry]
+    ) -> list[ContentReplaceResult]:
         try:
             from opensandbox.api.execd.api.filesystem import replace_content
 
@@ -479,7 +499,9 @@ class FilesystemAdapterSync(FilesystemSync):
             parsed = response_obj.parsed
             if not parsed:
                 return []
-            if isinstance(parsed, list) and all(isinstance(x, FileInfo) for x in parsed):
+            if isinstance(parsed, list) and all(
+                isinstance(x, FileInfo) for x in parsed
+            ):
                 return FilesystemModelConverter.to_entry_info_list(parsed)
             raise SandboxApiException(
                 message="Search files failed: unexpected response type",
@@ -504,7 +526,9 @@ class FilesystemAdapterSync(FilesystemSync):
             parsed = response_obj.parsed
             if not parsed:
                 return []
-            if isinstance(parsed, list) and all(isinstance(x, FileInfo) for x in parsed):
+            if isinstance(parsed, list) and all(
+                isinstance(x, FileInfo) for x in parsed
+            ):
                 return FilesystemModelConverter.to_entry_info_list(parsed)
             raise SandboxApiException(
                 message="List directory failed: unexpected response type",
@@ -524,5 +548,5 @@ class FilesystemAdapterSync(FilesystemSync):
                 return {}
             return FilesystemModelConverter.to_entry_info_map(response_obj.parsed)
         except Exception as e:
-            logger.error("Failed to get file info for %s paths", len(paths), exc_info=e)
+            logger.error(f"Failed to get file info for {len(paths)} paths", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/health_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/health_adapter.py
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class HealthAdapterSync(HealthSync):
-    def __init__(self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint) -> None:
+    def __init__(
+        self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint
+    ) -> None:
         self.connection_config = connection_config
         self.execd_endpoint = execd_endpoint
         from opensandbox.api.execd import Client
@@ -60,5 +62,5 @@ class HealthAdapterSync(HealthSync):
             handle_api_error(response_obj, "Ping")
             return True
         except Exception as e:
-            logger.debug("Health check failed for sandbox %s: %s", sandbox_id, e)
+            logger.debug(f"Health check failed for sandbox {sandbox_id}: {e}")
             return False

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
@@ -60,7 +60,7 @@ def _decode_sse_event_line(line: str) -> EventNode | None:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error("Failed to parse SSE line: %s", line, exc_info=e)
+        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
         return None
 
 
@@ -78,7 +78,9 @@ def _infer_exit_code(execution: Execution) -> int | None:
 class IsolationSessionHandleSync(IsolationSessionSync):
     """Sync handle to a single isolated session."""
 
-    def __init__(self, info: IsolatedSessionInfo, adapter: "IsolatedSessionsAdapterSync"):
+    def __init__(
+        self, info: IsolatedSessionInfo, adapter: "IsolatedSessionsAdapterSync"
+    ):
         self._info = info
         self._adapter = adapter
         self._files = None
@@ -97,6 +99,7 @@ class IsolationSessionHandleSync(IsolationSessionSync):
             from opensandbox.sync.adapters.isolated_filesystem_adapter import (
                 IsolatedFilesystemAdapterSync,
             )
+
             self._files = IsolatedFilesystemAdapterSync(
                 self._adapter.connection_config,
                 self._adapter.execd_endpoint,
@@ -111,7 +114,9 @@ class IsolationSessionHandleSync(IsolationSessionSync):
         opts: IsolatedRunOpts | None = None,
         handlers: ExecutionHandlersSync | None = None,
     ) -> Execution:
-        return self._adapter._run(self._info.session_id, code, opts=opts, handlers=handlers)
+        return self._adapter._run(
+            self._info.session_id, code, opts=opts, handlers=handlers
+        )
 
     def get(self) -> IsolatedSessionState:
         return self._adapter._get(self._info.session_id)
@@ -170,7 +175,9 @@ class IsolatedSessionsAdapterSync(IsolationServiceSync):
         )
 
     def _get_url(self, path: str) -> str:
-        return f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        return (
+            f"{self.connection_config.protocol}://{self.execd_endpoint.endpoint}{path}"
+        )
 
     def create(
         self, request: CreateIsolatedSessionRequest

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/metrics_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/metrics_adapter.py
@@ -39,7 +39,9 @@ logger = logging.getLogger(__name__)
 
 
 class MetricsAdapterSync(MetricsSync):
-    def __init__(self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint) -> None:
+    def __init__(
+        self, connection_config: ConnectionConfigSync, execd_endpoint: SandboxEndpoint
+    ) -> None:
         self.connection_config = connection_config
         self.execd_endpoint = execd_endpoint
         from opensandbox.api.execd import Client
@@ -71,5 +73,5 @@ class MetricsAdapterSync(MetricsSync):
             parsed = require_parsed(response_obj, Metrics, "Get metrics")
             return MetricsModelConverter.to_sandbox_metrics(parsed)
         except Exception as e:
-            logger.error("Failed to get metrics for sandbox %s", sandbox_id, exc_info=e)
+            logger.error(f"Failed to get metrics for sandbox {sandbox_id}", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/sandboxes_adapter.py
@@ -120,8 +120,7 @@ class SandboxesAdapterSync(SandboxesSync):
         resource_requests: dict[str, str] | None = None,
     ) -> SandboxCreateResponse:
         logger.info(
-            "Creating sandbox with startup source: %s",
-            spec.image if spec is not None else snapshot_id,
+            f"Creating sandbox with startup source: {spec.image if spec is not None else snapshot_id}"
         )
         try:
             from opensandbox.api.lifecycle.api.sandboxes import post_sandboxes
@@ -156,9 +155,7 @@ class SandboxesAdapterSync(SandboxesSync):
             return SandboxModelConverter.to_sandbox_create_response(parsed)
         except Exception as e:
             logger.warning(
-                "Failed to create sandbox with startup source %s: %s",
-                spec.image if spec is not None else snapshot_id,
-                e,
+                f"Failed to create sandbox with startup source {spec.image if spec is not None else snapshot_id}: {e}"
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -177,7 +174,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.warning("Failed to get sandbox info %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to get sandbox info {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_sandboxes(self, filter: SandboxFilter) -> PagedSandboxInfos:
@@ -217,7 +214,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_paged_sandbox_infos(parsed)
         except Exception as e:
-            logger.warning("Failed to list sandboxes: %s", e)
+            logger.warning(f"Failed to list sandboxes: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def patch_sandbox_metadata(
@@ -243,7 +240,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_info(parsed)
         except Exception as e:
-            logger.warning("Failed to patch sandbox %s metadata: %s", sandbox_id, e)
+            logger.warning(f"Failed to patch sandbox {sandbox_id} metadata: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_sandbox_endpoint(
@@ -281,9 +278,7 @@ class SandboxesAdapterSync(SandboxesSync):
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
         except Exception as e:
             logger.warning(
-                "Failed to retrieve sandbox endpoint for sandbox %s: %s",
-                sandbox_id,
-                e,
+                f"Failed to retrieve sandbox endpoint for sandbox {sandbox_id}: {e}"
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
@@ -320,8 +315,7 @@ class SandboxesAdapterSync(SandboxesSync):
             return SandboxModelConverter.to_sandbox_endpoint(parsed)
         except Exception as e:
             logger.debug(
-                "Failed to retrieve signed sandbox endpoint for sandbox %s",
-                sandbox_id,
+                f"Failed to retrieve signed sandbox endpoint for sandbox {sandbox_id}",
                 exc_info=e,
             )
             raise ExceptionConverter.to_sandbox_exception(e) from e
@@ -337,7 +331,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Pause sandbox {sandbox_id}")
         except Exception as e:
-            logger.warning("Failed to pause sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to pause sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def resume_sandbox(self, sandbox_id: str) -> None:
@@ -351,7 +345,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Resume sandbox {sandbox_id}")
         except Exception as e:
-            logger.warning("Failed to resume sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to resume sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def renew_sandbox_expiration(
@@ -381,9 +375,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_sandbox_renew_response(parsed)
         except Exception as e:
-            logger.debug(
-                "Failed to renew sandbox %s expiration", sandbox_id, exc_info=e
-            )
+            logger.debug(f"Failed to renew sandbox {sandbox_id} expiration", exc_info=e)
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def kill_sandbox(self, sandbox_id: str) -> None:
@@ -397,7 +389,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Kill sandbox {sandbox_id}")
         except Exception as e:
-            logger.warning("Failed to kill sandbox %s: %s", sandbox_id, e)
+            logger.warning(f"Failed to kill sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def create_snapshot(
@@ -418,9 +410,7 @@ class SandboxesAdapterSync(SandboxesSync):
             parsed = require_parsed(response_obj, ApiSnapshot, "Create snapshot")
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.warning(
-                "Failed to create snapshot for sandbox %s: %s", sandbox_id, e
-            )
+            logger.warning(f"Failed to create snapshot for sandbox {sandbox_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def get_snapshot(self, snapshot_id: str) -> SnapshotInfo:
@@ -440,7 +430,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_snapshot_info(parsed)
         except Exception as e:
-            logger.warning("Failed to get snapshot info %s: %s", snapshot_id, e)
+            logger.warning(f"Failed to get snapshot info {snapshot_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def list_snapshots(self, filter: SnapshotFilter) -> PagedSnapshotInfos:
@@ -468,7 +458,7 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             return SandboxModelConverter.to_paged_snapshot_infos(parsed)
         except Exception as e:
-            logger.warning("Failed to list snapshots: %s", e)
+            logger.warning(f"Failed to list snapshots: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e
 
     def delete_snapshot(self, snapshot_id: str) -> None:
@@ -483,5 +473,5 @@ class SandboxesAdapterSync(SandboxesSync):
             )
             handle_api_error(response_obj, f"Delete snapshot {snapshot_id}")
         except Exception as e:
-            logger.warning("Failed to delete snapshot %s: %s", snapshot_id, e)
+            logger.warning(f"Failed to delete snapshot {snapshot_id}: {e}")
             raise ExceptionConverter.to_sandbox_exception(e) from e

--- a/sdks/sandbox/python/src/opensandbox/sync/manager.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/manager.py
@@ -81,9 +81,10 @@ class SandboxManagerSync:
         """
         self._sandbox_service = sandbox_service
         self._connection_config = connection_config
-        self._diagnostics_service = diagnostics_service or AdapterFactorySync(
-            connection_config
-        ).create_diagnostics_service()
+        self._diagnostics_service = (
+            diagnostics_service
+            or AdapterFactorySync(connection_config).create_diagnostics_service()
+        )
 
     @property
     def connection_config(self) -> ConnectionConfigSync:
@@ -91,7 +92,9 @@ class SandboxManagerSync:
         return self._connection_config
 
     @classmethod
-    def create(cls, connection_config: ConnectionConfigSync | None = None) -> "SandboxManagerSync":
+    def create(
+        cls, connection_config: ConnectionConfigSync | None = None
+    ) -> "SandboxManagerSync":
         """
         Create a SandboxManagerSync instance with the provided configuration (blocking).
 
@@ -102,7 +105,9 @@ class SandboxManagerSync:
         Returns:
             Configured sandbox manager instance
         """
-        config = (connection_config or ConnectionConfigSync()).with_transport_if_missing()
+        config = (
+            connection_config or ConnectionConfigSync()
+        ).with_transport_if_missing()
         factory = AdapterFactorySync(config)
         sandbox_service = factory.create_sandbox_service()
         diagnostics_service = factory.create_diagnostics_service()
@@ -136,7 +141,7 @@ class SandboxManagerSync:
         Raises:
             SandboxException: if the operation fails
         """
-        logger.debug("Getting info for sandbox: %s", sandbox_id)
+        logger.debug(f"Getting info for sandbox: {sandbox_id}")
         return self._sandbox_service.get_sandbox_info(sandbox_id)
 
     def get_diagnostic_logs(
@@ -175,7 +180,7 @@ class SandboxManagerSync:
 
         String values add or replace keys; None deletes keys.
         """
-        logger.info("Patching metadata for sandbox: %s", sandbox_id)
+        logger.info(f"Patching metadata for sandbox: {sandbox_id}")
         return self._sandbox_service.patch_sandbox_metadata(sandbox_id, patch)
 
     def kill_sandbox(self, sandbox_id: str) -> None:
@@ -188,11 +193,13 @@ class SandboxManagerSync:
         Raises:
             SandboxException: if the operation fails
         """
-        logger.info("Terminating sandbox: %s", sandbox_id)
+        logger.info(f"Terminating sandbox: {sandbox_id}")
         self._sandbox_service.kill_sandbox(sandbox_id)
-        logger.info("Successfully terminated sandbox: %s", sandbox_id)
+        logger.info(f"Successfully terminated sandbox: {sandbox_id}")
 
-    def renew_sandbox(self, sandbox_id: str, timeout: timedelta) -> SandboxRenewResponse:
+    def renew_sandbox(
+        self, sandbox_id: str, timeout: timedelta
+    ) -> SandboxRenewResponse:
         """
         Renew expiration time for a single sandbox.
 
@@ -207,8 +214,10 @@ class SandboxManagerSync:
         """
         # Use timezone-aware UTC datetime to avoid cross-timezone ambiguity.
         new_expiration = datetime.now(timezone.utc) + timeout
-        logger.info("Renew expiration for sandbox %s to %s", sandbox_id, new_expiration)
-        return self._sandbox_service.renew_sandbox_expiration(sandbox_id, new_expiration)
+        logger.info(f"Renew expiration for sandbox {sandbox_id} to {new_expiration}")
+        return self._sandbox_service.renew_sandbox_expiration(
+            sandbox_id, new_expiration
+        )
 
     def pause_sandbox(self, sandbox_id: str) -> None:
         """
@@ -220,7 +229,7 @@ class SandboxManagerSync:
         Raises:
             SandboxException: if the operation fails
         """
-        logger.info("Pausing sandbox: %s", sandbox_id)
+        logger.info(f"Pausing sandbox: {sandbox_id}")
         self._sandbox_service.pause_sandbox(sandbox_id)
 
     def resume_sandbox(self, sandbox_id: str) -> None:
@@ -233,7 +242,7 @@ class SandboxManagerSync:
         Raises:
             SandboxException: if the operation fails
         """
-        logger.info("Resuming sandbox: %s", sandbox_id)
+        logger.info(f"Resuming sandbox: {sandbox_id}")
         self._sandbox_service.resume_sandbox(sandbox_id)
 
     def create_snapshot(self, sandbox_id: str, name: str | None = None) -> SnapshotInfo:
@@ -266,7 +275,9 @@ class SandboxManagerSync:
         try:
             self._connection_config.close_transport_if_owned()
         except Exception as e:
-            logger.warning("Error closing resources for sandbox manager: %s", e, exc_info=True)
+            logger.warning(
+                f"Error closing resources for sandbox manager: {e}", exc_info=True
+            )
 
     def __enter__(self) -> "SandboxManagerSync":
         """Sync context manager entry."""

--- a/sdks/sandbox/python/src/opensandbox/sync/pool.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/pool.py
@@ -276,10 +276,7 @@ class SandboxPoolSync:
                     manager.kill_sandbox(sandbox_id)
                 except Exception as exc:
                     logger.warning(
-                        "release_all_idle: failed to kill sandbox: pool_name=%s sandbox_id=%s error=%s",
-                        pool_name,
-                        sandbox_id,
-                        exc,
+                        f"release_all_idle: failed to kill sandbox: pool_name={pool_name} sandbox_id={sandbox_id} error={exc}"
                     )
         finally:
             if temporary_manager is not None:
@@ -326,10 +323,7 @@ class SandboxPoolSync:
         drained = self._await_in_flight_drain(self._config.drain_timeout)
         if not drained:
             logger.warning(
-                "Pool graceful shutdown timed out waiting in-flight operations: pool_name=%s in_flight=%s timeout_ms=%s",
-                self._config.pool_name,
-                self._in_flight,
-                int(self._config.drain_timeout.total_seconds() * 1000),
+                f"Pool graceful shutdown timed out waiting in-flight operations: pool_name={self._config.pool_name} in_flight={self._in_flight} timeout_ms={int(self._config.drain_timeout.total_seconds() * 1000)}"
             )
         with self._lifecycle_lock:
             self._lifecycle_state = PoolLifecycleState.STOPPED
@@ -374,8 +368,7 @@ class SandboxPoolSync:
             )
         except Exception as exc:
             logger.error(
-                "Pool reconcile tick failed unexpectedly: pool_name=%s",
-                self._config.pool_name,
+                f"Pool reconcile tick failed unexpectedly: pool_name={self._config.pool_name}",
                 exc_info=exc,
             )
         finally:
@@ -556,10 +549,7 @@ class SandboxPoolSync:
             return True
         except Exception as exc:
             logger.warning(
-                "Pool sandbox cleanup failed: pool_name=%s sandbox_id=%s error=%s",
-                self._config.pool_name,
-                sandbox_id,
-                exc,
+                f"Pool sandbox cleanup failed: pool_name={self._config.pool_name} sandbox_id={sandbox_id} error={exc}"
             )
             return False
 
@@ -583,10 +573,7 @@ class SandboxPoolSync:
             executor.submit(self._kill_discarded_alive, pool_name, sandbox_ids, source)
         except Exception as exc:
             logger.debug(
-                "Discarded-alive kill submit rejected, running inline: pool_name=%s count=%d error=%s",
-                pool_name,
-                len(sandbox_ids),
-                exc,
+                f"Discarded-alive kill submit rejected, running inline: pool_name={pool_name} count={len(sandbox_ids)} error={exc}"
             )
             self._kill_discarded_alive(pool_name, sandbox_ids, source)
 
@@ -605,10 +592,7 @@ class SandboxPoolSync:
         for sandbox_id in sandbox_ids:
             if self._kill_sandbox_best_effort(sandbox_id):
                 logger.debug(
-                    "Killed near-expiry idle sandbox: pool_name=%s sandbox_id=%s source=%s",
-                    pool_name,
-                    sandbox_id,
-                    source,
+                    f"Killed near-expiry idle sandbox: pool_name={pool_name} sandbox_id={sandbox_id} source={source}"
                 )
 
     def _begin_operation(self) -> None:
@@ -678,10 +662,7 @@ class SandboxPoolSync:
             )
         except Exception as exc:
             logger.warning(
-                "Pool primary lock release failed: pool_name=%s owner_id=%s error=%s",
-                self._config.pool_name,
-                self._config.owner_id,
-                exc,
+                f"Pool primary lock release failed: pool_name={self._config.pool_name} owner_id={self._config.owner_id} error={exc}"
             )
 
     def _close_provider(self) -> None:
@@ -693,8 +674,5 @@ class SandboxPoolSync:
         if self._config.primary_lock_ttl > self._config.warmup_ready_timeout:
             return
         logger.warning(
-            "Pool primary lock TTL may expire during warmup: pool_name=%s primary_lock_ttl_ms=%s warmup_ready_timeout_ms=%s",
-            self._config.pool_name,
-            int(self._config.primary_lock_ttl.total_seconds() * 1000),
-            int(self._config.warmup_ready_timeout.total_seconds() * 1000),
+            f"Pool primary lock TTL may expire during warmup: pool_name={self._config.pool_name} primary_lock_ttl_ms={int(self._config.primary_lock_ttl.total_seconds() * 1000)} warmup_ready_timeout_ms={int(self._config.warmup_ready_timeout.total_seconds() * 1000)}"
         )

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -144,9 +144,10 @@ class SandboxSync:
         self._metrics_service = metrics_service
         self._egress_service = egress_service
         self._connection_config = connection_config
-        self._diagnostics_service = diagnostics_service or AdapterFactorySync(
-            connection_config
-        ).create_diagnostics_service()
+        self._diagnostics_service = (
+            diagnostics_service
+            or AdapterFactorySync(connection_config).create_diagnostics_service()
+        )
         self._custom_health_check = custom_health_check
         self._isolated_service = isolated_service
 
@@ -154,9 +155,7 @@ class SandboxSync:
     def isolation(self) -> IsolationServiceSync:
         """Provides access to namespace-isolated session operations (OSEP-0013)."""
         if self._isolated_service is None:
-            raise SandboxInternalException(
-                "isolated service not initialized"
-            )
+            raise SandboxInternalException("isolated service not initialized")
         return self._isolated_service
 
     @property
@@ -300,9 +299,7 @@ class SandboxSync:
         # Use timezone-aware UTC datetime to avoid cross-timezone ambiguity.
         new_expiration = datetime.now(timezone.utc) + timeout
         logger.info(
-            "Renewing sandbox %s timeout, estimated expiration: %s",
-            self.id,
-            new_expiration,
+            f"Renewing sandbox {self.id} timeout, estimated expiration: {new_expiration}"
         )
         return self._sandbox_service.renew_sandbox_expiration(self.id, new_expiration)
 
@@ -360,7 +357,7 @@ class SandboxSync:
         Raises:
             SandboxException: if pause operation fails
         """
-        logger.info("Pausing sandbox: %s", self.id)
+        logger.info(f"Pausing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
         self._sandbox_service.pause_sandbox(self.id)
 
@@ -376,7 +373,7 @@ class SandboxSync:
         Raises:
             SandboxException: if termination fails
         """
-        logger.info("Killing sandbox: %s", self.id)
+        logger.info(f"Killing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
         self._sandbox_service.kill_sandbox(self.id)
 
@@ -393,9 +390,11 @@ class SandboxSync:
         """
         try:
             self._connection_config.close_transport_if_owned()
-            logger.debug("Closed resources for sandbox %s", self.id)
+            logger.debug(f"Closed resources for sandbox {self.id}")
         except Exception as e:
-            logger.warning("Error closing resources for sandbox %s: %s", self.id, e, exc_info=True)
+            logger.warning(
+                f"Error closing resources for sandbox {self.id}: {e}", exc_info=True
+            )
 
     def is_healthy(self) -> bool:
         """
@@ -424,9 +423,7 @@ class SandboxSync:
             SandboxException: if health check fails
         """
         logger.info(
-            "Waiting for sandbox %s to pass health check (timeout: %ss)",
-            self.id,
-            timeout.total_seconds(),
+            f"Waiting for sandbox {self.id} to pass health check (timeout: {timeout.total_seconds()}s)"
         )
 
         deadline = time.time() + timeout.total_seconds()
@@ -435,13 +432,11 @@ class SandboxSync:
 
         while time.time() < deadline:
             attempt += 1
-            logger.debug("Health check attempt #%s for sandbox %s", attempt, self.id)
+            logger.debug(f"Health check attempt #{attempt} for sandbox {self.id}")
             try:
                 if self.is_healthy():
                     logger.info(
-                        "Sandbox %s passed health check after %s attempts",
-                        self.id,
-                        attempt,
+                        f"Sandbox {self.id} passed health check after {attempt} attempts"
                     )
                     return
                 last_exception = None
@@ -535,7 +530,9 @@ class SandboxSync:
                 "Exactly one of image or snapshot_id must be specified"
             )
 
-        config = (connection_config or ConnectionConfigSync()).with_transport_if_missing()
+        config = (
+            connection_config or ConnectionConfigSync()
+        ).with_transport_if_missing()
         entrypoint = entrypoint or ["tail", "-f", "/dev/null"]
         env = env or {}
         metadata = metadata or {}
@@ -546,11 +543,11 @@ class SandboxSync:
             image = SandboxImageSpec(image=image)
 
         startup_source = image.image if image is not None else snapshot_id
-        timeout_log = "manual-cleanup" if timeout is None else f"{timeout.total_seconds()}s"
+        timeout_log = (
+            "manual-cleanup" if timeout is None else f"{timeout.total_seconds()}s"
+        )
         logger.info(
-            "Creating sandbox with startup source: %s (timeout: %s)",
-            startup_source,
-            timeout_log,
+            f"Creating sandbox with startup source: {startup_source} (timeout: {timeout_log})"
         )
         factory = AdapterFactorySync(config)
         sandbox_id: str | None = None
@@ -591,18 +588,19 @@ class SandboxSync:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
 
             if not skip_health_check:
                 sandbox.check_ready(ready_timeout, health_check_polling_interval)
-                logger.info("Sandbox %s is ready", sandbox.id)
+                logger.info(f"Sandbox {sandbox.id} is ready")
             else:
                 logger.info(
-                    "Sandbox %s created (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox.id,
+                    f"Sandbox {sandbox.id} created (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
             return sandbox
@@ -610,8 +608,7 @@ class SandboxSync:
             if sandbox_id and sandbox_service:
                 try:
                     logger.warning(
-                        "Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: %s",
-                        sandbox_id,
+                        f"Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: {sandbox_id}"
                     )
                     sandbox_service.kill_sandbox(sandbox_id)
                 except Exception:
@@ -619,7 +616,9 @@ class SandboxSync:
             config.close_transport_if_owned()
             if isinstance(e, SandboxException):
                 raise
-            raise SandboxInternalException(f"Internal exception when creating sandbox: {e}") from e
+            raise SandboxInternalException(
+                f"Internal exception when creating sandbox: {e}"
+            ) from e
 
     @classmethod
     def connect(
@@ -654,8 +653,10 @@ class SandboxSync:
         # Accept any string identifier.
         sandbox_id = str(sandbox_id)
 
-        config = (connection_config or ConnectionConfigSync()).with_transport_if_missing()
-        logger.info("Connecting to sandbox: %s", sandbox_id)
+        config = (
+            connection_config or ConnectionConfigSync()
+        ).with_transport_if_missing()
+        logger.info(f"Connecting to sandbox: {sandbox_id}")
         factory = AdapterFactorySync(config)
 
         try:
@@ -676,7 +677,9 @@ class SandboxSync:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -685,11 +688,10 @@ class SandboxSync:
                 sandbox.check_ready(connect_timeout, health_check_polling_interval)
             else:
                 logger.info(
-                    "Connected to sandbox %s (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox_id,
+                    f"Connected to sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
-            logger.info("Connected to sandbox %s", sandbox_id)
+            logger.info(f"Connected to sandbox {sandbox_id}")
             return sandbox
         except Exception as e:
             config.close_transport_if_owned()
@@ -699,13 +701,13 @@ class SandboxSync:
 
     @classmethod
     def resume(
-            cls,
-            sandbox_id: str,
-            connection_config: ConnectionConfigSync | None = None,
-            health_check: Callable[["SandboxSync"], bool] | None = None,
-            resume_timeout: timedelta = timedelta(seconds=30),
-            health_check_polling_interval: timedelta = timedelta(milliseconds=200),
-            skip_health_check: bool = False,
+        cls,
+        sandbox_id: str,
+        connection_config: ConnectionConfigSync | None = None,
+        health_check: Callable[["SandboxSync"], bool] | None = None,
+        resume_timeout: timedelta = timedelta(seconds=30),
+        health_check_polling_interval: timedelta = timedelta(milliseconds=200),
+        skip_health_check: bool = False,
     ) -> "SandboxSync":
         """
         Resume a paused sandbox by ID and return a new, usable SandboxSync instance.
@@ -728,9 +730,11 @@ class SandboxSync:
         # Accept any string identifier.
         sandbox_id = str(sandbox_id)
 
-        config = (connection_config or ConnectionConfigSync()).with_transport_if_missing()
+        config = (
+            connection_config or ConnectionConfigSync()
+        ).with_transport_if_missing()
 
-        logger.info("Resuming sandbox: %s", sandbox_id)
+        logger.info(f"Resuming sandbox: {sandbox_id}")
         factory = AdapterFactorySync(config)
 
         try:
@@ -753,7 +757,9 @@ class SandboxSync:
                 metrics_service=factory.create_metrics_service(execd_endpoint),
                 egress_service=factory.create_egress_service(egress_endpoint),
                 diagnostics_service=factory.create_diagnostics_service(),
-                isolated_service=factory.create_isolated_session_service(execd_endpoint),
+                isolated_service=factory.create_isolated_session_service(
+                    execd_endpoint
+                ),
                 connection_config=config,
                 custom_health_check=health_check,
             )
@@ -762,8 +768,7 @@ class SandboxSync:
                 sandbox.check_ready(resume_timeout, health_check_polling_interval)
             else:
                 logger.info(
-                    "Resumed sandbox %s (skip_health_check=true, sandbox may not be ready yet)",
-                    sandbox_id,
+                    f"Resumed sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
             return sandbox
@@ -772,7 +777,6 @@ class SandboxSync:
             if isinstance(e, SandboxException):
                 raise
             raise SandboxInternalException(f"Failed to resume sandbox: {e}") from e
-
 
     def __enter__(self) -> "SandboxSync":
         """Sync context manager entry."""


### PR DESCRIPTION
## Summary
- Convert all `logger.X("msg %s", arg)` calls to `logger.X(f"msg {arg}")` across sandbox and code-interpreter Python SDKs
- 26 files modified, achieving consistent f-string usage in all logging statements
- Auto-generated API code (`api/` directory) and URL template `.format()` calls left untouched
- Formatted with `ruff format` per project config

## Test plan
- [x] All 330 Python SDK source files compile clean (`py_compile`)
- [x] Zero remaining `%s`-style logger calls (verified via grep)
- [x] `ruff format` applied — no style violations