### PR TITLE
fix(ingress): use dedicated ServeMux instead of http.DefaultServeMux

### DIFF
--- a/components/ingress/main.go
+++ b/components/ingress/main.go
@@ -103,10 +103,11 @@ func main() {
 
 	// Create reverse proxy with sandbox provider
 	reverseProxy := proxy.NewProxy(ctx, sandboxProvider, proxy.Mode(flag.Mode), renewPublisher, secure)
-	http.Handle("/", reverseProxy)
-	http.HandleFunc("/status.ok", proxy.Healthz)
+	mux := http.NewServeMux()
+	mux.Handle("/", reverseProxy)
+	mux.HandleFunc("/status.ok", proxy.Healthz)
 
-	if err := http.ListenAndServe(fmt.Sprintf(":%v", flag.Port), nil); err != nil {
+	if err := http.ListenAndServe(fmt.Sprintf(":%v", flag.Port), mux); err != nil {
 		log.Panicf("Error starting http server: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Replace `http.DefaultServeMux` with an explicit `http.ServeMux` in the ingress HTTP server
- `DefaultServeMux` is a global singleton — any transitive dependency can silently register routes via `init()`, potentially exposing unintended endpoints (e.g. `net/http/pprof`, `expvar`)
- Using a dedicated mux ensures only intentionally registered routes (`/` and `/status.ok`) are reachable

## Test plan

- [x] Full `pkg/proxy/` test suite passes (28/28)
- [ ] Deploy to staging and verify ingress routing works as before
- [ ] Confirm `/debug/pprof/` returns 404 instead of pprof output

🤖 Generated with [Claude Code](https://claude.com/claude-code)