### PR TITLE
fix(server): remove service_account injection and disable SA token automount in sandbox pods

### DIFF
--- a/server/configuration.md
+++ b/server/configuration.md
@@ -119,7 +119,6 @@ If `runtime.type = "kubernetes"` and the `[kubernetes]` table is absent, the ser
 |-----|------|---------|-------------|
 | `kubeconfig_path` | string \| omitted | `null` | Path to kubeconfig (expandable, e.g. `~/.kube/config`). In-cluster configs often leave this unset and rely on in-cluster credentials. |
 | `namespace` | string \| omitted | `null` | Namespace for sandbox workloads. |
-| `service_account` | string \| omitted | `null` | ServiceAccount name bound to workload pods. |
 | `workload_provider` | string \| omitted | `null` | One of: **`batchsandbox`**, **`agent-sandbox`**. If omitted, the **first registered** provider is used (currently **`batchsandbox`**). |
 | `batchsandbox_template_file` | string \| omitted | `null` | Path to **BatchSandbox** CR YAML template when `workload_provider = "batchsandbox"`. |
 | `image_pull_policy` | string \| omitted | `"IfNotPresent"` | Image pull policy for the BatchSandbox main container. Values: **`Always`**, **`IfNotPresent`**, **`Never`**. |

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -582,10 +582,6 @@ class KubernetesRuntimeConfig(BaseModel):
         default=None,
         description="Namespace used for sandbox workloads.",
     )
-    service_account: Optional[str] = Field(
-        default=None,
-        description="Service account bound to sandbox workloads.",
-    )
     workload_provider: Optional[str] = Field(
         default=None,
         description="Workload provider type. If not specified, uses the first registered provider.",

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -89,7 +89,6 @@ class AgentSandboxProvider(WorkloadProvider):
         agent_config = app_config.agent_sandbox if app_config else None
 
         self.shutdown_policy = agent_config.shutdown_policy if agent_config else "Delete"
-        self.service_account = k8s_config.service_account if k8s_config else None
         self.template_manager = AgentSandboxTemplateManager(
             agent_config.template_file if agent_config else None
         )
@@ -170,8 +169,6 @@ class AgentSandboxProvider(WorkloadProvider):
         if volumes:
             apply_volumes_to_pod_spec(pod_spec, volumes)
 
-        if self.service_account:
-            pod_spec["serviceAccountName"] = self.service_account
         self._apply_platform_node_selector(pod_spec, platform)
 
         resource_name = self._resource_name(sandbox_id)
@@ -300,6 +297,7 @@ class AgentSandboxProvider(WorkloadProvider):
                 "emptyDir": {},
             })
         pod_spec: Dict[str, Any] = {
+            "automountServiceAccountToken": False,
             "initContainers": [_container_to_dict(init_container)],
             "containers": containers,
             "volumes": volumes,

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -196,6 +196,7 @@ class BatchSandboxProvider(WorkloadProvider):
                 "emptyDir": {}
             })
         pod_spec = {
+            "automountServiceAccountToken": False,
             "initContainers": [_container_to_dict(init_container)],
             "containers": containers,
             "volumes": pod_volumes,

--- a/server/tests/k8s/fixtures/k8s_fixtures.py
+++ b/server/tests/k8s/fixtures/k8s_fixtures.py
@@ -54,7 +54,6 @@ def k8s_runtime_config():
     return KubernetesRuntimeConfig(
         kubeconfig_path="/tmp/test-kubeconfig",
         namespace="test-namespace",
-        service_account="test-sa",
         workload_provider=PROVIDER_TYPE_BATCHSANDBOX,
     )
 
@@ -65,7 +64,6 @@ def agent_sandbox_runtime_config():
     return KubernetesRuntimeConfig(
         kubeconfig_path="/tmp/test-kubeconfig",
         namespace="test-namespace",
-        service_account="test-sa",
         workload_provider="agent-sandbox",
     )
 
@@ -89,7 +87,6 @@ spec:
     return KubernetesRuntimeConfig(
         kubeconfig_path="/tmp/test-kubeconfig",
         namespace="test-namespace",
-        service_account="test-sa",
         workload_provider=PROVIDER_TYPE_BATCHSANDBOX,
         batchsandbox_template_file=str(template_file),
     )

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -44,7 +44,6 @@ from opensandbox_server.services.constants import OPENSANDBOX_EGRESS_TOKEN
 
 def _app_config(
     shutdown_policy: str = "Delete",
-    service_account: str | None = None,
     execd_init_resources: ExecdInitResources | None = None,
     egress: EgressConfig | None = None,
 ) -> AppConfig:
@@ -53,7 +52,6 @@ def _app_config(
         runtime=RuntimeConfig(type="kubernetes", execd_image="execd:test"),
         kubernetes=KubernetesRuntimeConfig(
             namespace="test-ns",
-            service_account=service_account,
             workload_provider="agent-sandbox",
             execd_init_resources=execd_init_resources,
         ),
@@ -73,7 +71,7 @@ class TestAgentSandboxProvider:
     def test_create_workload_builds_correct_manifest_init_mode(self, mock_k8s_client):
         provider = AgentSandboxProvider(
             mock_k8s_client,
-            _app_config(shutdown_policy="Delete", service_account="agent-sa"),
+            _app_config(shutdown_policy="Delete"),
         )
         mock_k8s_client.create_custom_object.return_value = {
             "metadata": {"name": "test-id", "uid": "test-uid"}
@@ -103,7 +101,8 @@ class TestAgentSandboxProvider:
         assert body["spec"]["replicas"] == 1
         assert body["spec"]["shutdownTime"] == "2025-12-31T10:00:00+00:00"
         assert body["spec"]["shutdownPolicy"] == "Delete"
-        assert body["spec"]["podTemplate"]["spec"]["serviceAccountName"] == "agent-sa"
+        assert body["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"] is False
+        assert "serviceAccountName" not in body["spec"]["podTemplate"]["spec"]
         assert "initContainers" in body["spec"]["podTemplate"]["spec"]
         assert "containers" in body["spec"]["podTemplate"]["spec"]
         assert "volumes" in body["spec"]["podTemplate"]["spec"]

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -154,6 +154,7 @@ class TestBatchSandboxProvider:
         assert body["spec"]["replicas"] == 1
         assert body["spec"]["expireTime"] == "2025-12-31T10:00:00+00:00"
         assert "template" in body["spec"]
+        assert body["spec"]["template"]["spec"]["automountServiceAccountToken"] is False
         assert "initContainers" in body["spec"]["template"]["spec"]
         assert "containers" in body["spec"]["template"]["spec"]
         assert "volumes" in body["spec"]["template"]["spec"]

--- a/server/tests/k8s/test_provider_factory.py
+++ b/server/tests/k8s/test_provider_factory.py
@@ -74,7 +74,6 @@ spec:
         assert isinstance(provider, AgentSandboxProvider)
         assert provider.k8s_client == mock_k8s_client
         assert provider.shutdown_policy == "Retain"
-        assert provider.service_account == agent_sandbox_app_config.kubernetes.service_account
     
     def test_create_provider_case_insensitive(self, mock_k8s_client, k8s_app_config):
         provider1 = create_workload_provider("BatchSandbox", mock_k8s_client, k8s_app_config)

--- a/server/tests/test_agent_sandbox_service.py
+++ b/server/tests/test_agent_sandbox_service.py
@@ -36,7 +36,6 @@ def agent_sandbox_runtime_config():
     return KubernetesRuntimeConfig(
         kubeconfig_path="/tmp/test-kubeconfig",
         namespace="test-namespace",
-        service_account="test-sa",
         workload_provider="agent-sandbox",
     )
 

--- a/server/tests/testdata/k8s_config.toml
+++ b/server/tests/testdata/k8s_config.toml
@@ -29,5 +29,4 @@ execd_image = "ghcr.io/opensandbox/execd:test"
 [kubernetes]
 kubeconfig_path = "/tmp/test-kubeconfig"
 namespace = "test-namespace"
-service_account = "test-sa"
 workload_provider = "batchsandbox"


### PR DESCRIPTION
# Summary

Remove Kubernetes `service_account` injection and disable service account token auto-mounting in sandbox pods to reduce attack surface.

- Remove `service_account` config field from `KubernetesRuntimeConfig` and its documentation
- Remove `serviceAccountName` injection from `AgentSandboxProvider` — sandbox pods do not need Kubernetes API access, and the auto-mounted token volume was never consumed by any in-sandbox process (execd, egress, user code)
- Add `automountServiceAccountToken: false` to both `AgentSandboxProvider` and `BatchSandboxProvider` pod specs, preventing Kubernetes from injecting the default SA token volume even when a namespace default SA has automount enabled
- Update test fixtures and assertions across 6 test files

Note: the issue mentioned removing a `kube-access-api` volume — no such volume exists in the codebase. The `kube-api-access-*` projected volume was injected by Kubernetes itself as a side effect of `serviceAccountName`; removing the SA injection and disabling automount eliminates it.

Users who configured `kubernetes.service_account` in server TOML: this field is now removed. Existing config files with this field will continue to load without error (silently ignored). If you relied on the SA's `imagePullSecrets` for private image pulling with agent-sandbox, use the agent-sandbox template to set `serviceAccountName` instead.

Closes #1213

# Testing

- [x] Unit tests (`uv run pytest tests/` — 1199 passed, 0 failed)
- [x] e2e / manual verification (`make test-e2e-core`, Kind v1.22.4 — 37 passed, 0 failed)

# Breaking Changes

- [x] None

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered