### PR TITLE
feat(chart/opensandbox-server): add tolerations, affinity and imagePullSecrets to ingress-gateway

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -66,6 +66,18 @@ spec:
         app.kubernetes.io/part-of: opensandbox
     spec:
       serviceAccountName: {{ include "opensandbox-server.ingressGatewayFullname" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: main
           image: {{ include "opensandbox-server.ingressGatewayImage" . }}

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -72,6 +72,10 @@ server:
       # List of signing keys. Each entry: { key_id: "a", key: "<base64-secret>" }.
       # key_id must be exactly one character in [0-9a-z].
       keys: []
+    # -- Tolerations for the ingress gateway pod.
+    tolerations: []
+    # -- Affinity for the ingress gateway pod.
+    affinity: {}
 
 # -- Server config (TOML). Mounted at /etc/opensandbox/config.toml.
 configToml: |


### PR DESCRIPTION
## Summary

The `ingress-gateway` Deployment in the `opensandbox-server` chart was missing `tolerations`, `affinity` and `imagePullSecrets` — fields that are already present in the **server** Deployment. This makes it impossible to schedule the ingress-gateway pod on nodes with taints without patching the chart.

Fixes #1231

## Changes

**`values.yaml`** — add fields under `server.gateway`:
```yaml
server:
  gateway:
    # -- Tolerations for the ingress gateway pod.
    tolerations: []
    # -- Affinity for the ingress gateway pod.
    affinity: {}
```

**`ingress-gateway.yaml`** — render them in the Deployment spec:
```yaml
spec:
  serviceAccountName: ...
  {{- with .Values.imagePullSecrets }}
  imagePullSecrets:
    {{- toYaml . | nindent 8 }}
  {{- end }}
  {{- with .Values.server.gateway.tolerations }}
  tolerations:
    {{- toYaml . | nindent 8 }}
  {{- end }}
  {{- with .Values.server.gateway.affinity }}
  affinity:
    {{- toYaml . | nindent 8 }}
  {{- end }}
  containers:
    ...
```

## Behaviour

- **No breaking change** — defaults are empty (`[]` / `{}`), existing deployments are unaffected.
- Consistent with how `server.tolerations` and `server.affinity` are already handled for the server Deployment (`server.yaml`).

## Use case

On GKE clusters with node taints (dedicated sandbox node pools), both the server and the ingress-gateway need matching tolerations to be schedulable. Without this fix, the ingress-gateway pod stays `Pending` even when the server pod is running.