### PR TITLE
feat(chart/opensandbox-server): add tolerations and affinity to ingress-gateway Deployment

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -92,6 +92,14 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: main
           image: {{ include "opensandbox-server.ingressGatewayImage" . }}

--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -137,14 +137,6 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.server.gateway.resources | nindent 12 }}
-      {{- with .Values.server.gateway.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.server.gateway.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -137,6 +137,14 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.server.gateway.resources | nindent 12 }}
+      {{- with .Values.server.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -100,6 +100,10 @@ server:
     priorityClassName: ""
     # -- Topology spread constraints for the ingress gateway pod.
     topologySpreadConstraints: []
+    # -- Tolerations for the ingress gateway pod.
+    tolerations: []
+    # -- Affinity for the ingress gateway pod.
+    affinity: {}
 
 # -- Server config (TOML). Mounted at /etc/opensandbox/config.toml.
 configToml: |


### PR DESCRIPTION
## Summary

The `ingress-gateway` Deployment was missing `tolerations` and `affinity` fields that are already present in the **server** Deployment.

Fixes #1233

## Changes

**`values.yaml`** — add under `server.gateway`:
```yaml
server:
  gateway:
    tolerations: []
    affinity: {}
```

**`ingress-gateway.yaml`** — render in the Deployment spec:
```yaml
{{- with .Values.server.gateway.tolerations }}
tolerations:
  {{- toYaml . | nindent 8 }}
{{- end }}
{{- with .Values.server.gateway.affinity }}
affinity:
  {{- toYaml . | nindent 8 }}
{{- end }}
```

## Notes
- Consistent with `server.tolerations` / `server.affinity` in `server.yaml`.
- Defaults empty — no breaking change.