### PR TITLE
fix(chart/opensandbox-server): ingress-gateway Deployment missing imagePullSecrets

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -66,6 +66,10 @@ spec:
         app.kubernetes.io/part-of: opensandbox
     spec:
       serviceAccountName: {{ include "opensandbox-server.ingressGatewayFullname" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: main
           image: {{ include "opensandbox-server.ingressGatewayImage" . }}


### PR DESCRIPTION
## Summary

The `ingress-gateway` Deployment did not render `imagePullSecrets` from values, causing `ImagePullBackOff` when deploying against a private registry. The server Deployment already has this block.

Fixes #1234

## Change

**`ingress-gateway.yaml`** — add the missing block:
```yaml
{{- with .Values.imagePullSecrets }}
imagePullSecrets:
  {{- toYaml . | nindent 8 }}
{{- end }}
```

## Notes
- Uses the existing top-level `imagePullSecrets` value — no new field needed.
- No breaking change — renders nothing when `imagePullSecrets` is empty.