### PR TITLE
feat(chart/opensandbox-server): add env, volumeMounts, volumes and configurable imagePullPolicy to ingress-gateway

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -69,7 +69,11 @@ spec:
       containers:
         - name: main
           image: {{ include "opensandbox-server.ingressGatewayImage" . }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.server.gateway.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.server.gateway.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - "--namespace={{ .Values.server.gateway.dataplaneNamespace }}"
             - "--port={{ .Values.server.gateway.port }}"
@@ -99,6 +103,14 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.server.gateway.resources | nindent 12 }}
+          {{- with .Values.server.gateway.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.server.gateway.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -72,6 +72,14 @@ server:
       # List of signing keys. Each entry: { key_id: "a", key: "<base64-secret>" }.
       # key_id must be exactly one character in [0-9a-z].
       keys: []
+    # -- Image pull policy for the ingress gateway container.
+    pullPolicy: IfNotPresent
+    # -- Extra environment variables for the ingress gateway container.
+    env: []
+    # -- Extra volume mounts for the ingress gateway container.
+    volumeMounts: []
+    # -- Extra volumes for the ingress gateway pod.
+    volumes: []
 
 # -- Server config (TOML). Mounted at /etc/opensandbox/config.toml.
 configToml: |


### PR DESCRIPTION
Fixes #1238. Adds parity with server Deployment: env, volumeMounts, volumes and configurable pullPolicy for the ingress-gateway. All default to empty — no breaking change.