### PR TITLE
fix(chart/opensandbox-controller): guard volumeMounts and volumes keys when extraVolumeMounts/extraVolumes are empty

### DIFF
--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -115,15 +115,15 @@ spec:
         env:
         {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
-        volumeMounts:
         {{- with .Values.extraVolumeMounts }}
+        volumeMounts:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.extraContainers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      volumes:
       {{- with .Values.extraVolumes }}
+      volumes:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}


### PR DESCRIPTION
## Summary

The controller `deployment.yaml` always renders `volumeMounts:` and `volumes:` keys even when `extraVolumeMounts` and `extraVolumes` are empty (the default). This produces bare keys with a null value, which `helm lint --strict` flags.

Fixes #1240

## Root cause

```yaml
# Current (always rendered):
volumeMounts:
{{- with .Values.extraVolumeMounts }}
{{- toYaml . | nindent 8 }}
{{- end }}

volumes:
{{- with .Values.extraVolumes }}
{{- toYaml . | nindent 6 }}
{{- end }}
```

When the values are empty, this produces `volumeMounts:` and `volumes:` with no content — technically `null`. Compare with `env:` in the same template which correctly guards the key:

```yaml
{{- if .Values.extraEnv }}
env:
{{- toYaml .Values.extraEnv | nindent 8 }}
{{- end }}
```

## Changes

Move the `volumeMounts:` and `volumes:` keys inside their respective `with` blocks:

```yaml
{{- with .Values.extraVolumeMounts }}
volumeMounts:
{{- toYaml . | nindent 8 }}
{{- end }}

{{- with .Values.extraVolumes }}
volumes:
{{- toYaml . | nindent 6 }}
{{- end }}
```

## Notes
- No breaking change — behaviour with non-empty values is identical.
- Consistent with the `extraEnv` pattern already used in the same template.