### PR TITLE
fix(k8s): propagate pvc readonly flag

### DIFF
--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -60,6 +60,7 @@ from opensandbox_server.services.k8s.error_helpers import _build_k8s_api_error, 
 from opensandbox_server.services.k8s.k8s_diagnostics import K8sDiagnosticsMixin
 from opensandbox_server.services.k8s.endpoint_resolver import _attach_egress_auth_headers, _attach_secure_access_headers
 from opensandbox_server.services.k8s.list_helpers import _build_list_sandboxes_response
+from opensandbox_server.services.k8s.volume_helper import ensure_shared_pvc_read_only_policy
 from opensandbox_server.services.k8s.status_helpers import (
     _is_unschedulable_status,
     _normalize_create_status,
@@ -802,6 +803,11 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
 
             if has_pool_ref and pool_ref != POOL_AUTO_ASSIGN_REF:
                 await asyncio.to_thread(self._ensure_pool_ref_exists, pool_ref)
+
+            # Kubernetes applies PVC readOnly at the source volume level, so
+            # shared PVC mounts must agree before any auto-provisioning side effect.
+            if request.volumes:
+                ensure_shared_pvc_read_only_policy(request.volumes)
 
             # Auto-create PVCs that don't exist yet
             if request.volumes:

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -40,6 +40,7 @@ def apply_volumes_to_pod_spec(
 
     existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
     pvc_to_volume_name: Dict[str, str] = {}
+    pvc_to_read_only: Dict[str, bool] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -54,17 +55,21 @@ def apply_volumes_to_pod_spec(
             pvc_claim_name = vol.pvc.claim_name
 
             if pvc_claim_name not in pvc_to_volume_name:
-                pod_volumes.append(
-                    {
-                        "name": vol_name,
-                        "persistentVolumeClaim": {
-                            "claimName": pvc_claim_name,
-                            "readOnly": vol.read_only,
-                        },
-                    }
-                )
+                pod_volumes.append({
+                    "name": vol_name,
+                    "persistentVolumeClaim": {
+                        "claimName": pvc_claim_name,
+                        "readOnly": vol.read_only,
+                    },
+                })
                 pvc_to_volume_name[pvc_claim_name] = vol_name
+                pvc_to_read_only[pvc_claim_name] = vol.read_only
                 existing_volume_names.add(vol_name)
+            elif pvc_to_read_only[pvc_claim_name] != vol.read_only:
+                raise ValueError(
+                    f"PVC claim '{pvc_claim_name}' is mounted with mixed read_only values. "
+                    "All mounts sharing the same PVC must use the same read_only policy."
+                )
 
             mount = {
                 "name": pvc_to_volume_name[pvc_claim_name],
@@ -76,20 +81,22 @@ def apply_volumes_to_pod_spec(
             mounts.append(mount)
 
             logger.info(
-                f"Added PVC volume '{vol_name}' (claim: {pvc_claim_name}) mounted at '{vol.mount_path}' for sandbox"
+                "Added PVC volume '%s' (claim: %s, read_only=%s) mounted at '%s' for sandbox",
+                pvc_to_volume_name[pvc_claim_name],
+                pvc_claim_name,
+                vol.read_only,
+                vol.mount_path,
             )
         elif vol.host is not None:
             host_path = vol.host.path
 
-            pod_volumes.append(
-                {
-                    "name": vol_name,
-                    "hostPath": {
-                        "path": host_path,
-                        "type": "DirectoryOrCreate",
-                    },
-                }
-            )
+            pod_volumes.append({
+                "name": vol_name,
+                "hostPath": {
+                    "path": host_path,
+                    "type": "DirectoryOrCreate",
+                },
+            })
 
             mount = {
                 "name": vol_name,

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -54,12 +54,15 @@ def apply_volumes_to_pod_spec(
             pvc_claim_name = vol.pvc.claim_name
 
             if pvc_claim_name not in pvc_to_volume_name:
-                pod_volumes.append({
-                    "name": vol_name,
-                    "persistentVolumeClaim": {
-                        "claimName": pvc_claim_name,
-                    },
-                })
+                pod_volumes.append(
+                    {
+                        "name": vol_name,
+                        "persistentVolumeClaim": {
+                            "claimName": pvc_claim_name,
+                            "readOnly": vol.read_only,
+                        },
+                    }
+                )
                 pvc_to_volume_name[pvc_claim_name] = vol_name
                 existing_volume_names.add(vol_name)
 
@@ -78,13 +81,15 @@ def apply_volumes_to_pod_spec(
         elif vol.host is not None:
             host_path = vol.host.path
 
-            pod_volumes.append({
-                "name": vol_name,
-                "hostPath": {
-                    "path": host_path,
-                    "type": "DirectoryOrCreate",
-                },
-            })
+            pod_volumes.append(
+                {
+                    "name": vol_name,
+                    "hostPath": {
+                        "path": host_path,
+                        "type": "DirectoryOrCreate",
+                    },
+                }
+            )
 
             mount = {
                 "name": vol_name,

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -24,6 +24,30 @@ from opensandbox_server.api.schema import Volume
 logger = logging.getLogger(__name__)
 
 
+def _raise_mixed_pvc_read_only_policy(pvc_claim_name: str) -> None:
+    raise ValueError(
+        f"PVC claim '{pvc_claim_name}' is mounted with mixed read_only values. "
+        "All mounts sharing the same PVC must use the same read_only policy."
+    )
+
+
+def ensure_shared_pvc_read_only_policy(volumes: List[Volume]) -> None:
+    """Ensure every mount that references the same PVC uses the same read_only policy."""
+    pvc_to_read_only: Dict[str, bool] = {}
+
+    for vol in volumes:
+        if vol.pvc is None:
+            continue
+
+        pvc_claim_name = vol.pvc.claim_name
+        if pvc_claim_name in pvc_to_read_only:
+            if pvc_to_read_only[pvc_claim_name] != vol.read_only:
+                _raise_mixed_pvc_read_only_policy(pvc_claim_name)
+            continue
+
+        pvc_to_read_only[pvc_claim_name] = vol.read_only
+
+
 def apply_volumes_to_pod_spec(
     pod_spec: Dict[str, Any],
     volumes: List[Volume],
@@ -38,9 +62,10 @@ def apply_volumes_to_pod_spec(
     mounts = main_container.get("volumeMounts", [])
     pod_volumes = pod_spec.get("volumes", [])
 
+    ensure_shared_pvc_read_only_policy(volumes)
+
     existing_volume_names = {v.get("name") for v in pod_volumes if isinstance(v, dict)}
     pvc_to_volume_name: Dict[str, str] = {}
-    pvc_to_read_only: Dict[str, bool] = {}
 
     for vol in volumes:
         vol_name = vol.name
@@ -63,13 +88,7 @@ def apply_volumes_to_pod_spec(
                     },
                 })
                 pvc_to_volume_name[pvc_claim_name] = vol_name
-                pvc_to_read_only[pvc_claim_name] = vol.read_only
                 existing_volume_names.add(vol_name)
-            elif pvc_to_read_only[pvc_claim_name] != vol.read_only:
-                raise ValueError(
-                    f"PVC claim '{pvc_claim_name}' is mounted with mixed read_only values. "
-                    "All mounts sharing the same PVC must use the same read_only policy."
-                )
 
             mount = {
                 "name": pvc_to_volume_name[pvc_claim_name],

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -141,12 +141,7 @@ class TestBatchSandboxProvider:
             execd_image="execd:latest",
         )
 
-        assert result == {
-            "name": "test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
@@ -874,12 +869,7 @@ spec:
             execd_image="execd:latest",
         )
 
-        assert result == {
-            "name": "test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
     # ===== Workload List Tests =====
 
@@ -1334,12 +1324,7 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {
-            "name": "sandbox-test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
@@ -1371,12 +1356,7 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {
-            "name": "sandbox-test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
@@ -1406,12 +1386,7 @@ spec:
             extensions={"poolRef": "my-pool"},
         )
 
-        assert result == {
-            "name": "sandbox-test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
@@ -1645,9 +1620,7 @@ spec:
         task_template = body["spec"]["taskTemplate"]
         assert task_template["spec"]["process"]["env"] == [{"name": "VERSION", "value": "11"}]
 
-    def test_create_workload_poolref_none_entrypoint_no_env_omits_task_template(
-        self, mock_k8s_client
-    ):
+    def test_create_workload_poolref_none_entrypoint_no_env_omits_task_template(self, mock_k8s_client):
         """When entrypoint is None and env is empty, taskTemplate is omitted.
 
         SDK pool mode callers omit entrypoint entirely (None), expecting the pool's
@@ -2664,12 +2637,7 @@ spec:
             volumes=volumes,
         )
 
-        assert result == {
-            "name": "test-id",
-            "uid": "test-uid",
-            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
-            "kind": "BatchSandbox",
-        }
+        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
 
     def test_create_workload_poolref_rejects_platform(self, mock_k8s_client):
         provider = BatchSandboxProvider(mock_k8s_client)
@@ -3009,3 +2977,67 @@ spec:
         assert by_path["/path/to/skills"].get("subPath") == "skill-hub/publish"
         assert by_path["/path/to/draft"]["name"] == "skills"
         assert by_path["/path/to/draft"].get("subPath") == "skill-hub/draft"
+
+    def test_apply_volumes_to_pod_spec_same_pvc_multiple_mounts_readwrite(self, mock_k8s_client):
+        """Shared PVC mounts with read_only=False should keep source-level readOnly false."""
+        from opensandbox_server.api.schema import Volume, PVC
+
+        pod_spec = {
+            "containers": [{"name": "main", "volumeMounts": []}],
+            "volumes": [],
+        }
+        volumes = [
+            Volume(
+                name="skills",
+                pvc=PVC(claim_name="oss-pvc-rw"),
+                mount_path="/path/to/skills",
+                sub_path="skill-hub/publish",
+                read_only=False,
+            ),
+            Volume(
+                name="draft",
+                pvc=PVC(claim_name="oss-pvc-rw"),
+                mount_path="/path/to/draft",
+                sub_path="skill-hub/draft",
+                read_only=False,
+            ),
+        ]
+
+        apply_volumes_to_pod_spec(pod_spec, volumes)
+
+        assert len(pod_spec["volumes"]) == 1
+        shared_volume = next((v for v in pod_spec["volumes"] if v["name"] == "skills"), None)
+        assert shared_volume is not None
+        assert shared_volume["persistentVolumeClaim"]["claimName"] == "oss-pvc-rw"
+        assert shared_volume["persistentVolumeClaim"]["readOnly"] is False
+
+        mounts = pod_spec["containers"][0]["volumeMounts"]
+        assert len(mounts) == 2
+        assert all(mount["name"] == "skills" for mount in mounts)
+        assert all(mount["readOnly"] is False for mount in mounts)
+
+    def test_apply_volumes_to_pod_spec_same_pvc_mixed_read_only_raises(self, mock_k8s_client):
+        """Shared PVC mounts with mixed read_only values should fail fast."""
+        from opensandbox_server.api.schema import Volume, PVC
+
+        pod_spec = {
+            "containers": [{"name": "main", "volumeMounts": []}],
+            "volumes": [],
+        }
+        volumes = [
+            Volume(
+                name="skills",
+                pvc=PVC(claim_name="oss-pvc-mixed"),
+                mount_path="/path/to/skills",
+                read_only=False,
+            ),
+            Volume(
+                name="draft",
+                pvc=PVC(claim_name="oss-pvc-mixed"),
+                mount_path="/path/to/draft",
+                read_only=True,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="mixed read_only values"):
+            apply_volumes_to_pod_spec(pod_spec, volumes)

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -140,9 +140,14 @@ class TestBatchSandboxProvider:
             expires_at=expires_at,
             execd_image="execd:latest",
         )
-        
-        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
+        assert result == {
+            "name": "test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
@@ -869,8 +874,13 @@ spec:
             execd_image="execd:latest",
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-    
+        assert result == {
+            "name": "test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+
     # ===== Workload List Tests =====
 
     def test_list_workloads_returns_items(self, mock_k8s_client, mock_batchsandbox_list_response):
@@ -1324,8 +1334,13 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+        assert result == {
+            "name": "sandbox-test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1356,8 +1371,13 @@ spec:
         )
 
         # Should succeed and return workload info
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+        assert result == {
+            "name": "sandbox-test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1385,9 +1405,14 @@ spec:
             execd_image="execd:latest",
             extensions={"poolRef": "my-pool"},
         )
-        
-        assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
+        assert result == {
+            "name": "sandbox-test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
+
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1620,7 +1645,9 @@ spec:
         task_template = body["spec"]["taskTemplate"]
         assert task_template["spec"]["process"]["env"] == [{"name": "VERSION", "value": "11"}]
 
-    def test_create_workload_poolref_none_entrypoint_no_env_omits_task_template(self, mock_k8s_client):
+    def test_create_workload_poolref_none_entrypoint_no_env_omits_task_template(
+        self, mock_k8s_client
+    ):
         """When entrypoint is None and env is empty, taskTemplate is omitted.
 
         SDK pool mode callers omit entrypoint entirely (None), expecting the pool's
@@ -2637,7 +2664,12 @@ spec:
             volumes=volumes,
         )
 
-        assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
+        assert result == {
+            "name": "test-id",
+            "uid": "test-uid",
+            "apiVersion": "sandbox.opensandbox.io/v1alpha1",
+            "kind": "BatchSandbox",
+        }
 
     def test_create_workload_poolref_rejects_platform(self, mock_k8s_client):
         provider = BatchSandboxProvider(mock_k8s_client)
@@ -2698,8 +2730,11 @@ spec:
         main_container = pod_spec["containers"][0]
         mounts = main_container.get("volumeMounts", [])
         models_mount = next((m for m in mounts if m["name"] == "models-volume"), None)
+        models_volume = next((v for v in pod_spec["volumes"] if v["name"] == "models-volume"), None)
         assert models_mount is not None
         assert models_mount["readOnly"] is True
+        assert models_volume is not None
+        assert models_volume["persistentVolumeClaim"]["readOnly"] is True
 
     def test_create_workload_with_pvc_volume_subpath(self, mock_k8s_client):
         """
@@ -2961,7 +2996,10 @@ spec:
         # One volume definition for the shared PVC (first Volume name used)
         assert len(pod_spec["volumes"]) == 1
         assert pod_spec["volumes"][0]["name"] == "skills"
-        assert pod_spec["volumes"][0]["persistentVolumeClaim"]["claimName"] == "oss-pvc-r"
+        shared_volume = next((v for v in pod_spec["volumes"] if v["name"] == "skills"), None)
+        assert shared_volume is not None
+        assert shared_volume["persistentVolumeClaim"]["claimName"] == "oss-pvc-r"
+        assert shared_volume["persistentVolumeClaim"]["readOnly"] is True
 
         # Two volumeMounts, both referencing the same volume name
         mounts = pod_spec["containers"][0]["volumeMounts"]

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -140,9 +140,9 @@ class TestBatchSandboxProvider:
             expires_at=expires_at,
             execd_image="execd:latest",
         )
-
+        
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-
+        
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
@@ -870,7 +870,7 @@ spec:
         )
 
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-
+    
     # ===== Workload List Tests =====
 
     def test_list_workloads_returns_items(self, mock_k8s_client, mock_batchsandbox_list_response):
@@ -1325,7 +1325,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-
+        
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1357,7 +1357,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-
+        
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1385,9 +1385,9 @@ spec:
             execd_image="execd:latest",
             extensions={"poolRef": "my-pool"},
         )
-
+        
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-
+        
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -1542,6 +1542,56 @@ class TestCreateSandboxPvcFailureCleanup:
         k8s_service.workload_provider.create_workload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_shared_pvc_mixed_read_only_rejected_before_pvc_creation(
+        self, k8s_service
+    ):
+        from opensandbox_server.api.schema import (
+            CreateSandboxRequest,
+            ImageSpec,
+            PVC,
+            ResourceLimits,
+            Volume,
+        )
+
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash", "-c", "sleep 3600"],
+            timeout=3600,
+            resourceLimits=ResourceLimits(root={"cpu": "1", "memory": "1Gi"}),
+            volumes=[
+                Volume(
+                    name="shared-rw",
+                    mountPath="/data/rw",
+                    readOnly=False,
+                    pvc=PVC(
+                        claimName="auto-data",
+                        createIfNotExists=True,
+                        deleteOnSandboxTermination=True,
+                    ),
+                ),
+                Volume(
+                    name="shared-ro",
+                    mountPath="/data/ro",
+                    readOnly=True,
+                    pvc=PVC(
+                        claimName="auto-data",
+                        createIfNotExists=True,
+                        deleteOnSandboxTermination=True,
+                    ),
+                ),
+            ],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await k8s_service.create_sandbox(request)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == SandboxErrorCodes.INVALID_PARAMETER
+        assert "mixed read_only values" in exc_info.value.detail["message"]
+        k8s_service.k8s_client.create_pvc.assert_not_called()
+        k8s_service.workload_provider.create_workload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_pvc_cleanup_runs_when_wait_for_ready_rollback_reports_not_found(
         self, k8s_service, mock_workload
     ):


### PR DESCRIPTION
## Summary
- propagate `readOnly` to the PVC volume source in the Kubernetes pod spec, not only to the volume mount
- keep the existing read-only mount behavior and align the underlying `persistentVolumeClaim.readOnly` flag with it
- add focused k8s regression coverage for read-only PVC mounts and shared PVC mounts

Closes #545.

## Testing
- `cd server && uv run pytest tests/k8s/test_batchsandbox_provider.py -k 'pvc_volume_readonly or same_pvc_multiple_mounts' -q`
- `cd server && uv run ruff format opensandbox_server/services/k8s/volume_helper.py tests/k8s/test_batchsandbox_provider.py`
- `cd server && uv run ruff check opensandbox_server/services/k8s/volume_helper.py tests/k8s/test_batchsandbox_provider.py`
