### PR TITLE
chore(sdks): bump sandbox SDK versions for release

### DIFF
--- a/sdks/Directory.Build.props
+++ b/sdks/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Shared C# SDK packaging metadata -->
-    <OpenSandboxPackageVersion>0.1.3</OpenSandboxPackageVersion>
+    <OpenSandboxPackageVersion>0.1.4</OpenSandboxPackageVersion>
     <OpenSandboxCodeInterpreterPackageVersion>0.1.1</OpenSandboxCodeInterpreterPackageVersion>
     <OpenSandboxDependencyVersionRange>[$(OpenSandboxPackageVersion),0.2.0)</OpenSandboxDependencyVersionRange>
   </PropertyGroup>

--- a/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
@@ -66,7 +66,7 @@ public static class Constants
     /// <summary>
     /// Default user agent string for SDK HTTP requests.
     /// </summary>
-    public const string DefaultUserAgent = "OpenSandbox-CSharp-SDK/0.1.2";
+    public const string DefaultUserAgent = "OpenSandbox-CSharp-SDK/0.1.4";
 
     /// <summary>
     /// Environment variable name for the OpenSandbox domain.

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ConstantsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ConstantsTests.cs
@@ -88,4 +88,12 @@ public class ConstantsTests
     {
         Constants.RequestIdHeader.Should().Be("x-request-id");
     }
+
+    // Regression: the User-Agent version is hand-maintained and must be bumped
+    // together with the package version. Update this expectation when releasing.
+    [Fact]
+    public void DefaultUserAgent_ShouldMatchPackageVersion()
+    {
+        Constants.DefaultUserAgent.Should().Be("OpenSandbox-CSharp-SDK/0.1.4");
+    }
 }

--- a/sdks/sandbox/go/constants.go
+++ b/sdks/sandbox/go/constants.go
@@ -39,7 +39,7 @@ const (
 	DefaultCodeInterpreterTimeoutSeconds = 900
 
 	// Version is the SDK version reported in the User-Agent header.
-	Version = "1.0.2"
+	Version = "1.0.4"
 
 	// APIVersion is the lifecycle API version prefix.
 	APIVersion = "v1"

--- a/sdks/sandbox/go/constants_test.go
+++ b/sdks/sandbox/go/constants_test.go
@@ -1,30 +1,27 @@
 // Copyright 2026 Alibaba Group Holding Ltd.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const DEFAULT_EXECD_PORT = 44772;
-export const DEFAULT_EGRESS_PORT = 18080;
+package opensandbox
 
-export const DEFAULT_ENTRYPOINT: string[] = ["tail", "-f", "/dev/null"];
+import "testing"
 
-export const DEFAULT_RESOURCE_LIMITS: Record<string, string> = {
-  cpu: "1",
-  memory: "2Gi",
-};
-
-export const DEFAULT_TIMEOUT_SECONDS = 600;
-export const DEFAULT_READY_TIMEOUT_SECONDS = 30;
-export const DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS = 200;
-
-export const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
-export const DEFAULT_USER_AGENT = "OpenSandbox-JS-SDK/0.1.10";
+// TestVersion_MatchesReleasedTag is a regression guard: the Version constant is
+// reported in the User-Agent header and must be bumped together with the
+// released module tag. Update this expectation when releasing.
+func TestVersion_MatchesReleasedTag(t *testing.T) {
+	const want = "1.0.4"
+	if Version != want {
+		t.Fatalf("Version = %q, want %q; bump this together with the release tag", Version, want)
+	}
+}

--- a/sdks/sandbox/javascript/package.json
+++ b/sdks/sandbox/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alibaba-group/opensandbox",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OpenSandbox TypeScript/JavaScript SDK (sandbox lifecycle + execd APIs)",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdks/sandbox/javascript/src/api/egress.ts
+++ b/sdks/sandbox/javascript/src/api/egress.ts
@@ -524,7 +524,7 @@ export interface components {
             schemes: ("https" | "http")[];
             /**
              * @deprecated
-             * @description Ignored. Port is derived from scheme (https→443, http→80).
+             * @description Deprecated. Port is derived from scheme (https→443, http→80). Values other than 80 or 443 are rejected with a validation error. Standard values (80/443) are accepted but ignored.
              */
             ports?: number[];
             hosts: string[];

--- a/sdks/sandbox/javascript/tests/connection.test.mjs
+++ b/sdks/sandbox/javascript/tests/connection.test.mjs
@@ -32,3 +32,13 @@ test("ConnectionConfig preserves path prefix while normalizing v1 suffix", () =>
 
   assert.equal(connectionConfig.getBaseUrl(), "https://api.opensandbox.test/proxy/v1");
 });
+
+// Regression: the default User-Agent version is hand-maintained and must be
+// bumped together with the package version. Update this expectation when releasing.
+test("ConnectionConfig default userAgent matches package version", () => {
+  const connectionConfig = new ConnectionConfig({
+    domain: "https://api.opensandbox.test",
+  });
+
+  assert.equal(connectionConfig.userAgent, "OpenSandbox-JS-SDK/0.1.10");
+});

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.15
+project.version=1.0.16
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -80,7 +80,7 @@ class ConnectionConfig private constructor(
         private const val ENV_API_KEY = "OPEN_SANDBOX_API_KEY"
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.15"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.16"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ConnectionConfigUserAgentTest {
+    // Regression: the default User-Agent version is hand-maintained and must be
+    // bumped together with the package version. Update this expectation when releasing.
+    @Test
+    fun `default userAgent matches package version`() {
+        val config = ConnectionConfig.builder().build()
+
+        assertEquals("OpenSandbox-Kotlin-SDK/1.0.16", config.userAgent)
+    }
+}

--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -68,7 +68,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.13"
+fallback_version = "0.1.14"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
+++ b/sdks/sandbox/python/src/opensandbox/api/egress/models/credential_match.py
@@ -33,7 +33,8 @@ class CredentialMatch:
     Attributes:
         hosts (list[str]):
         schemes (list[CredentialMatchSchemesItem] | Unset):
-        ports (list[int] | Unset): Ignored. Port is derived from scheme (https→443, http→80).
+        ports (list[int] | Unset): Deprecated. Port is derived from scheme (https→443, http→80). Values other than 80 or
+            443 are rejected with a validation error. Standard values (80/443) are accepted but ignored.
         methods (list[str] | Unset):
         paths (list[str] | Unset):
     """

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -65,7 +65,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.13", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.14", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -53,7 +53,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.13", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.14", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -16,7 +16,14 @@
 import httpx
 import pytest
 
-from opensandbox.config import ConnectionConfig
+from opensandbox.config import ConnectionConfig, ConnectionConfigSync
+
+
+# Regression: the default User-Agent version is hand-maintained and must be
+# bumped together with the package version. Update this expectation when releasing.
+def test_default_user_agent_matches_package_version() -> None:
+    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.14"
+    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.14"
 
 
 def test_protocol_validation() -> None:


### PR DESCRIPTION
## What

Prepare a coordinated release of all five sandbox SDKs by bumping version metadata **and** fixing the default User-Agent version strings that had drifted behind released versions.

### Package versions

| SDK | File | Change |
|---|---|---|
| Go | `sdks/sandbox/go/constants.go` | `Version` 1.0.2 -> 1.0.4 |
| Python | `sdks/sandbox/python/pyproject.toml` | `fallback_version` 0.1.13 -> 0.1.14 |
| JS | `sdks/sandbox/javascript/package.json` | `version` 0.1.9 -> 0.1.10 |
| Java/Kotlin | `sdks/sandbox/kotlin/gradle.properties` | `project.version` 1.0.15 -> 1.0.16 |
| C# | `sdks/Directory.Build.props` | `OpenSandboxPackageVersion` 0.1.3 -> 0.1.4 |

### Default User-Agent versions (bug fix)

Each SDK hand-maintains its default User-Agent version string, and every non-Go SDK had drifted behind its released version (JS reported 0.1.8, C# 0.1.2, Python 0.1.13, Kotlin 1.0.15). These are now aligned with the versions being released, and a regression test was added per language asserting the default User-Agent matches the package version so future bumps cannot silently lag again.

- JS: `OpenSandbox-JS-SDK/0.1.8` -> `0.1.10`
- C#: `OpenSandbox-CSharp-SDK/0.1.2` -> `0.1.4`
- Python: `OpenSandbox-Python-SDK/0.1.13` -> `0.1.14` (async + sync configs)
- Kotlin: `OpenSandbox-Kotlin-SDK/1.0.15` -> `1.0.16`
- Go: already derived from `Version`; added a regression test locking it to the release tag

## Why

Each SDK has real changes since its last release tag (endpoint cache, response extensions, CVE patches, Go sandbox pool). The Go `Version` constant was lagging the already-released `v1.0.3` tag, and the other SDKs' User-Agent strings were similarly stale — the client-reported version was wrong.

Publishing is triggered by pushing the language-specific tags after merge.

## Verification

- Go: `go test` (regression test) — pass
- Python: `uv run pytest tests/test_connection_config.py` — pass
- JS: `pnpm build` + `node --test tests/connection.test.mjs` — pass
- Kotlin: `./gradlew :sandbox:test --tests ConnectionConfigUserAgentTest` (JDK 17) — pass; tag/version consistency check satisfied
- C#: not run locally (dotnet unavailable); relies on CI