### PR TITLE
feat(execd): add bwrap bind mount support

### DIFF
--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -35,10 +35,11 @@ import (
 //  5. --dev /dev
 //  6. --proc /proc
 //  7. Workspace segment
-//  8. extra_writable segment
-//  9. Env segment
-//  10. --seccomp <fd>
-//  11. -- setpriv ... <user cmd>
+//  8. bind_mounts segment
+//  9. extra_writable segment
+//  10. Env segment
+//  11. --seccomp <fd>
+//  12. -- setpriv ... <user cmd>
 func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 	if err := validateWrapOptions(opts); err != nil {
 		return nil, err
@@ -83,22 +84,27 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 		argv = append(argv, "--tmpfs", upperRoot)
 	}
 
-	// 8. Extra writable paths.
+	// 8. Session-scoped bind mounts.
+	for _, mount := range opts.BindMounts {
+		argv = append(argv, bwrapBindMountSegment(mount)...)
+	}
+
+	// 9. Extra writable paths.
 	for _, p := range opts.ExtraWritable {
 		argv = append(argv, "--bind", p, p)
 	}
 
-	// 9. Environment segment.
+	// 10. Environment segment.
 	argv = append(argv, bwrapEnvSegment(opts.EnvPassthrough)...)
 
-	// 10. Seccomp (optional). bwrap --seccomp takes a decimal fd number.
+	// 11. Seccomp (optional). bwrap --seccomp takes a decimal fd number.
 	// The caller opens the BPF file, adds it to ExtraFiles, and passes the
 	// child-side fd number here.
 	if seccompFd != "" {
 		argv = append(argv, "--seccomp", seccompFd)
 	}
 
-	// 11. setpriv + user command.
+	// 12. setpriv + user command.
 	// The user command is appended by the caller via cmd.Args after Wrap.
 	argv = append(argv, "--")
 
@@ -138,6 +144,41 @@ func validateWrapOptions(opts WrapOptions) error {
 	}
 	if !opts.EnvPassthrough.Mode.Valid() && opts.EnvPassthrough.Mode != "" {
 		return fmt.Errorf("isolation: unknown env mode %q", opts.EnvPassthrough.Mode)
+	}
+	if err := validateBindMounts(opts.BindMounts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateBindMounts(mounts []BindMount) error {
+	targets := make(map[string]struct{}, len(mounts))
+	for i, mount := range mounts {
+		if mount.Source == "" {
+			return fmt.Errorf("isolation: bind_mounts[%d].source is required", i)
+		}
+		if !filepath.IsAbs(mount.Source) {
+			return fmt.Errorf("isolation: bind_mounts[%d].source must be an absolute path", i)
+		}
+		source := filepath.Clean(mount.Source)
+		if source == string(filepath.Separator) {
+			return fmt.Errorf("isolation: bind_mounts[%d].source must not be /", i)
+		}
+
+		if mount.Target == "" {
+			return fmt.Errorf("isolation: bind_mounts[%d].target is required", i)
+		}
+		if !filepath.IsAbs(mount.Target) {
+			return fmt.Errorf("isolation: bind_mounts[%d].target must be an absolute path", i)
+		}
+		target := filepath.Clean(mount.Target)
+		if target == string(filepath.Separator) {
+			return fmt.Errorf("isolation: bind_mounts[%d].target must not be /", i)
+		}
+		if _, ok := targets[target]; ok {
+			return fmt.Errorf("isolation: bind_mounts[%d].target duplicates %q", i, target)
+		}
+		targets[target] = struct{}{}
 	}
 	return nil
 }
@@ -179,6 +220,14 @@ func bwrapWorkspaceSegment(opts WrapOptions) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("isolation: unknown workspace mode %q", ws.Mode)
 	}
+}
+
+func bwrapBindMountSegment(mount BindMount) []string {
+	flag := "--bind"
+	if mount.ReadOnly {
+		flag = "--ro-bind"
+	}
+	return []string{flag, filepath.Clean(mount.Source), filepath.Clean(mount.Target)}
 }
 
 // unsetBlacklistedEnv returns --unsetenv args for all env vars matching strictEnvBlacklist.

--- a/components/execd/pkg/isolation/bwrap_test.go
+++ b/components/execd/pkg/isolation/bwrap_test.go
@@ -215,6 +215,20 @@ func TestBuildArgv_ExtraWritable(t *testing.T) {
 	}
 }
 
+func TestBuildArgv_BindMounts(t *testing.T) {
+	opts := basicWrapOpts()
+	opts.BindMounts = []BindMount{
+		{Source: "/var/lib/execd/mounts/session-1/data/.", Target: "/mnt/data/."},
+		{Source: "/var/lib/execd/mounts/session-1/models", Target: "/mnt/models", ReadOnly: true},
+	}
+
+	argv, err := buildArgv(opts, "")
+	require.NoError(t, err)
+
+	assertArgvSequence(t, argv, []string{"--bind", "/var/lib/execd/mounts/session-1/data", "/mnt/data"})
+	assertArgvSequence(t, argv, []string{"--ro-bind", "/var/lib/execd/mounts/session-1/models", "/mnt/models"})
+}
+
 func TestBuildArgv_Setpriv(t *testing.T) {
 	t.Run("default_uid_gid", func(t *testing.T) {
 		opts := basicWrapOpts()
@@ -263,6 +277,7 @@ func TestBuildArgv_SegmentOrder(t *testing.T) {
 	opts.Profile = ProfileStrict
 	opts.Workspace.Mode = WorkspaceOverlay
 	opts.UpperDir = "/tmp/upper"
+	opts.BindMounts = []BindMount{{Source: "/var/lib/execd/mounts/session-1/data", Target: "/mnt/data", ReadOnly: true}}
 	opts.ExtraWritable = []string{"/data"}
 	opts.EnvPassthrough = EnvSpec{Mode: EnvModeDeny, Keys: []string{"TOKEN"}}
 
@@ -275,25 +290,26 @@ func TestBuildArgv_SegmentOrder(t *testing.T) {
 	// and comparing the index of the first segment element.
 	type seg struct {
 		label string
-		match string // single argv element
+		match []string
 	}
 	order := []seg{
-		{"1.ns", "--unshare-pid"},
-		{"2.rootfs", "--ro-bind"},
-		{"3.tmp", "/tmp"},
-		{"4.run", "/run"},
-		{"5.dev", "--dev"},
-		{"6.proc", "--proc"},
-		{"7.workspace", "--overlay-src"},
-		{"8.extra_writable", "--bind"},
-		{"9.env", "--unsetenv"},
-		{"10.seccomp", "--seccomp"},
-		{"11.setpriv", "setpriv"},
+		{"1.ns", []string{"--unshare-pid"}},
+		{"2.rootfs", []string{"--ro-bind", "/", "/"}},
+		{"3.tmp", []string{"--tmpfs", "/tmp"}},
+		{"4.run", []string{"--tmpfs", "/run"}},
+		{"5.dev", []string{"--dev", "/dev"}},
+		{"6.proc", []string{"--proc", "/proc"}},
+		{"7.workspace", []string{"--overlay-src", "/workspace"}},
+		{"8.bind_mounts", []string{"--ro-bind", "/var/lib/execd/mounts/session-1/data", "/mnt/data"}},
+		{"9.extra_writable", []string{"--bind", "/data", "/data"}},
+		{"10.env", []string{"--unsetenv", "TOKEN"}},
+		{"11.seccomp", []string{"--seccomp", "3"}},
+		{"12.setpriv", []string{"setpriv"}},
 	}
 
 	lastIdx := -1
 	for _, s := range order {
-		idx := indexOf(argv, s.match)
+		idx := indexOfSequence(argv, s.match)
 		if idx < 0 {
 			t.Errorf("segment %s (%q) not found in argv:\n  %v", s.label, s.match, argv)
 			continue
@@ -306,6 +322,12 @@ func TestBuildArgv_SegmentOrder(t *testing.T) {
 }
 
 func TestBuildArgv_Validation(t *testing.T) {
+	withBindMounts := func(mounts []BindMount) WrapOptions {
+		opts := basicWrapOpts()
+		opts.BindMounts = mounts
+		return opts
+	}
+
 	tests := []struct {
 		name string
 		opts WrapOptions
@@ -314,6 +336,44 @@ func TestBuildArgv_Validation(t *testing.T) {
 		{"empty_workspace", WrapOptions{}, "workspace.path is required"},
 		{"bad_profile", WrapOptions{Workspace: WorkspaceSpec{Path: "/ws", Mode: WorkspaceRW}, Profile: "bogus"}, "unknown profile"},
 		{"bad_mode", WrapOptions{Profile: ProfileBalanced, Workspace: WorkspaceSpec{Path: "/ws", Mode: "bogus"}}, "unknown workspace mode"},
+		{
+			"bind_mount_empty_source",
+			withBindMounts([]BindMount{{Target: "/mnt/data"}}),
+			"bind_mounts[0].source is required",
+		},
+		{
+			"bind_mount_relative_source",
+			withBindMounts([]BindMount{{Source: "data", Target: "/mnt/data"}}),
+			"bind_mounts[0].source must be an absolute path",
+		},
+		{
+			"bind_mount_root_source",
+			withBindMounts([]BindMount{{Source: "/", Target: "/mnt/data"}}),
+			"bind_mounts[0].source must not be /",
+		},
+		{
+			"bind_mount_empty_target",
+			withBindMounts([]BindMount{{Source: "/var/lib/execd/mounts/session-1/data"}}),
+			"bind_mounts[0].target is required",
+		},
+		{
+			"bind_mount_relative_target",
+			withBindMounts([]BindMount{{Source: "/var/lib/execd/mounts/session-1/data", Target: "data"}}),
+			"bind_mounts[0].target must be an absolute path",
+		},
+		{
+			"bind_mount_root_target",
+			withBindMounts([]BindMount{{Source: "/var/lib/execd/mounts/session-1/data", Target: "/"}}),
+			"bind_mounts[0].target must not be /",
+		},
+		{
+			"bind_mount_duplicate_target",
+			withBindMounts([]BindMount{
+				{Source: "/var/lib/execd/mounts/session-1/data", Target: "/mnt/data"},
+				{Source: "/var/lib/execd/mounts/session-1/data-copy", Target: "/mnt/data/"},
+			}),
+			"bind_mounts[1].target duplicates",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -446,6 +506,32 @@ func indexOf(items []string, s string) int {
 		}
 	}
 	return -1
+}
+
+func indexOfSequence(items []string, seq []string) int {
+	if len(seq) == 0 || len(seq) > len(items) {
+		return -1
+	}
+	for i := 0; i <= len(items)-len(seq); i++ {
+		matched := true
+		for j := range seq {
+			if items[i+j] != seq[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return i
+		}
+	}
+	return -1
+}
+
+func assertArgvSequence(t *testing.T, argv []string, seq []string) {
+	t.Helper()
+	if indexOfSequence(argv, seq) < 0 {
+		t.Fatalf("argv sequence %q not found in:\n  %v", seq, argv)
+	}
 }
 
 // Ensure unused import vars don't break compilation on non-test.

--- a/components/execd/pkg/isolation/isolator.go
+++ b/components/execd/pkg/isolation/isolator.go
@@ -67,6 +67,13 @@ type WorkspaceSpec struct {
 	Mode WorkspaceMode
 }
 
+// BindMount describes a host path mounted into the isolated namespace.
+type BindMount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+}
+
 // EnvSpec controls environment variable passthrough into the namespace.
 type EnvSpec struct {
 	Mode EnvMode
@@ -95,6 +102,7 @@ type Capabilities struct {
 type WrapOptions struct {
 	Profile        Profile
 	Workspace      WorkspaceSpec
+	BindMounts     []BindMount
 	ExtraWritable  []string
 	ShareNet       bool
 	EnvPassthrough EnvSpec


### PR DESCRIPTION
# Summary
- Add a typed `BindMount` primitive to execd isolation options for session-scoped local path mounts.
- Teach the bwrap argv builder to emit read-write `--bind` and read-only `--ro-bind` mappings with independent source and target paths.
- Validate bind mounts before argv generation: source/target must be absolute, non-root paths, and targets must be unique after cleaning.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
  - `go test ./pkg/runtime`
  - `GOOS=linux GOARCH=amd64 go test -c ./pkg/isolation -o /tmp/opensandbox-execd-isolation-linux.test`
  - `GOOS=linux GOARCH=amd64 go test -c ./pkg/runtime -o /tmp/opensandbox-execd-runtime-linux.test`
  - `git diff --check`
  - Note: `go test ./pkg/isolation` does not complete on this macOS workstation because existing `MergedView` tests reject the `/var` symlink used by the local temp dir. The new bwrap tests are Linux-only and were compile-checked with `GOOS=linux`.
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
