### PR TITLE
chore(charts): add chart-testing (ct) CI for lint validation

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -1,0 +1,106 @@
+name: Chart Testing
+
+on:
+  pull_request:
+    paths:
+      - 'kubernetes/charts/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # helm lint + yamllint on every chart, for the default values AND each
+  # ci/*-values.yaml value set. ct renders one lint pass per value set, so the
+  # conditional branches (gateway, non-empty volumes, disabled components...)
+  # are exercised, not just the defaults.
+  lint:
+    name: ct lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@v4
+
+      - uses: helm/chart-testing-action@v2
+
+      - name: Lint charts
+        run: |
+          ct lint \
+            --chart-dirs kubernetes/charts \
+            --all \
+            --validate-maintainers=false \
+            --check-version-increment=false
+
+  # Render every chart (default + each ci/ value set) and validate the produced
+  # manifests against explicit, pinned Kubernetes schema versions with
+  # kubeconform. Pinning the versions avoids the false confidence of validating
+  # against a single bundled/stale schema set, and the ci/ value sets make sure
+  # the conditional template branches are the ones being validated.
+  validate-manifests:
+    name: kubeconform (K8s ${{ matrix.k8s }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor from the charts' kubeVersion (">=1.21.1-0") plus a mid and a
+        # recent release, mirroring kubernetes-test.yml.
+        k8s: ["1.21.1", "1.28.6", "1.34.2"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+
+      - name: Install kubeconform
+        env:
+          KUBECONFORM_VERSION: v0.7.0
+        run: |
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: helm template + kubeconform
+        run: |
+          set -euo pipefail
+          fail=0
+          for chart in kubernetes/charts/*/; do
+            chart_name="$(basename "$chart")"
+            # Vendor file:// sub-charts for the umbrella chart before templating.
+            if grep -q '^dependencies:' "${chart}Chart.yaml"; then
+              helm dependency build "$chart" >/dev/null
+            fi
+            # Default values, then every ci/ value set.
+            value_files=("")
+            if [ -d "${chart}ci" ]; then
+              for vf in "${chart}"ci/*-values.yaml; do
+                value_files+=("$vf")
+              done
+            fi
+            for vf in "${value_files[@]}"; do
+              label="default"; render=(helm template ci-release "$chart")
+              if [ -n "$vf" ]; then
+                label="$(basename "$vf")"
+                render=(helm template ci-release "$chart" -f "$vf")
+              fi
+              echo "::group::${chart_name} [${label}] — K8s ${{ matrix.k8s }}"
+              # CustomResourceDefinition is skipped: the CRDs shipped by the
+              # controller chart are static definitions and kubeconform's default
+              # schema set does not carry the CRD meta-schema. The validation
+              # target is the rendered workload manifests, which stay strict.
+              if ! "${render[@]}" | kubeconform \
+                    -strict \
+                    -summary \
+                    -skip CustomResourceDefinition \
+                    -kubernetes-version "${{ matrix.k8s }}" \
+                    -schema-location default; then
+                fail=1
+              fi
+              echo "::endgroup::"
+            done
+          done
+          exit "$fail"

--- a/kubernetes/charts/opensandbox-controller/ci/full-features-values.yaml
+++ b/kubernetes/charts/opensandbox-controller/ci/full-features-values.yaml
@@ -1,0 +1,52 @@
+# CI values (chart-testing + kubeconform).
+# Turns on every optional controller branch that a default render skips:
+# non-empty extraVolumes/extraVolumeMounts, sidecar and init containers,
+# extra env, image pull secrets, scheduling, and the snapshot push/pull
+# secret args. The empty case is already covered by the default values.
+imagePullSecrets:
+  - name: my-registry-secret
+
+controller:
+  priorityClassName: system-cluster-critical
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: controller
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values: ["linux"]
+  snapshot:
+    registry: "registry.example.com/snapshots"
+    registryInsecure: true
+    snapshotPushSecret: "snapshot-push"
+    resumePullSecret: "snapshot-pull"
+
+extraEnv:
+  - name: CUSTOM_VAR
+    value: "custom-value"
+
+extraVolumes:
+  - name: custom-volume
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: custom-volume
+    mountPath: /custom-path
+
+extraInitContainers:
+  - name: init-perms
+    image: busybox:1.36
+    command: ["sh", "-c", "echo init"]
+
+extraContainers:
+  - name: sidecar
+    image: busybox:1.36
+    command: ["sh", "-c", "sleep infinity"]

--- a/kubernetes/charts/opensandbox-controller/ci/minimal-values.yaml
+++ b/kubernetes/charts/opensandbox-controller/ci/minimal-values.yaml
@@ -1,0 +1,18 @@
+# CI values (chart-testing + kubeconform).
+# Exercises the "disabled/off" branches that the default values (all enabled)
+# never render: no ServiceAccount creation, no RBAC, no CRD install, no leader
+# election and no probes.
+serviceAccount:
+  create: false
+rbac:
+  create: false
+crds:
+  install: false
+
+controller:
+  leaderElection:
+    enabled: false
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    enabled: false

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -21,10 +21,10 @@ controller:
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""
-  
+
   # -- Number of controller replicas
   replicaCount: 1
-  
+
   # -- Resource requests and limits for the controller
   resources:
     limits:
@@ -33,7 +33,7 @@ controller:
     requests:
       cpu: 10m
       memory: 64Mi
-  
+
   # -- Log level for zap logger (debug, info, error)
   logLevel: info
 
@@ -65,7 +65,7 @@ controller:
   # -- Enable leader election for controller manager
   leaderElection:
     enabled: true
-  
+
   # -- Liveness probe configuration
   livenessProbe:
     enabled: true
@@ -77,7 +77,7 @@ controller:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
-  
+
   # -- Readiness probe configuration
   readinessProbe:
     enabled: true
@@ -89,22 +89,22 @@ controller:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
-  
+
   # -- Node labels for controller pod assignment
   nodeSelector: {}
-  
+
   # -- Tolerations for controller pod assignment
   tolerations: []
-  
+
   # -- Affinity for controller pod assignment
   affinity: {}
-  
+
   # -- Pod security context
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
-  
+
   # -- Container security context
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -112,13 +112,13 @@ controller:
       drop:
         - "ALL"
     readOnlyRootFilesystem: false
-  
+
   # -- Additional labels for controller pods
   podLabels: {}
-  
+
   # -- Additional annotations for controller pods
   podAnnotations: {}
-  
+
   # -- Priority class name for controller pods
   priorityClassName: ""
 

--- a/kubernetes/charts/opensandbox-server/ci/gateway-enabled-values.yaml
+++ b/kubernetes/charts/opensandbox-server/ci/gateway-enabled-values.yaml
@@ -1,0 +1,18 @@
+# CI values (chart-testing + kubeconform).
+# Enables the ingress gateway so the whole ingress-gateway.yaml block
+# (ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service) and
+# the secure-access-keys signing branch are rendered and schema-validated.
+# This is exactly the class of regressions from #1233, #1235 and #1236, which
+# a gateway-disabled default render never exercises.
+imagePullSecrets:
+  - name: my-registry-secret
+
+server:
+  gateway:
+    enabled: true
+    host: sandbox.example.com
+    secureAccess:
+      activeKey: "a"
+      keys:
+        - key_id: "a"
+          key: "c2VjcmV0LWtleS1tYXRlcmlhbA=="

--- a/kubernetes/charts/opensandbox-server/ci/volumes-and-env-values.yaml
+++ b/kubernetes/charts/opensandbox-server/ci/volumes-and-env-values.yaml
@@ -1,0 +1,32 @@
+# CI values (chart-testing + kubeconform).
+# Non-empty server volumes/volumeMounts, env, image pull secrets and
+# scheduling — the branches a default (empty) render skips. Guards against the
+# `volumeMounts: null` / `volumes: null` class of bugs (#1240) in the
+# non-empty direction.
+imagePullSecrets:
+  - name: my-registry-secret
+
+server:
+  env:
+    - name: OPENSANDBOX_LOG_FORMAT
+      value: json
+  volumes:
+    - name: cache
+      emptyDir: {}
+  volumeMounts:
+    - name: cache
+      mountPath: /var/cache/opensandbox
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: server
+      effect: NoSchedule
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: opensandbox-server

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -96,7 +96,7 @@ configToml: |
   snapshot_create_timeout_seconds = 900
   workload_provider = "batchsandbox"
   batchsandbox_template_file = "/etc/opensandbox/example.batchsandbox-template.yaml"
-  
+
   [egress]
   image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.1.3"
   mode = "dns+nft"

--- a/kubernetes/charts/opensandbox/ci/full-values.yaml
+++ b/kubernetes/charts/opensandbox/ci/full-values.yaml
@@ -1,0 +1,21 @@
+# CI values (chart-testing + kubeconform) for the all-in-one umbrella chart.
+# Exercises both sub-charts together with their optional branches enabled:
+# controller extra volumes/mounts and the server ingress gateway. Values are
+# nested under each dependency name.
+opensandbox-controller:
+  extraVolumes:
+    - name: custom-volume
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: custom-volume
+      mountPath: /custom-path
+
+opensandbox-server:
+  server:
+    gateway:
+      enabled: true
+      secureAccess:
+        activeKey: "a"
+        keys:
+          - key_id: "a"
+            key: "c2VjcmV0LWtleS1tYXRlcmlhbA=="


### PR DESCRIPTION
## Summary

Adds automated linting **and** template/schema validation for the Helm charts on every PR that touches a chart, closing the gap that let issues like #1233, #1235, #1236 and #1240 through.

Closes #1254

## What it does

`.github/workflows/chart-testing.yml` with two jobs:

1. **`ct lint`** — `helm lint` + `yamllint` over all three charts, run for the default values **and** each `ci/*-values.yaml` value set.
2. **`kubeconform`** — renders every chart (default + each `ci/` value set) and validates the produced manifests against **explicit, pinned Kubernetes schema versions** (`1.21.1`, `1.28.6`, `1.34.2`) — the charts' `kubeVersion` floor plus a mid and a recent release, mirroring `kubernetes-test.yml`.

## Values matrix (the important part)

A single default-values render misses the conditional branches — which is exactly where the referenced regressions lived. Each chart ships a `ci/` value set so those branches are the ones being linted and validated:

| Chart | Value set | Exercises |
|---|---|---|
| opensandbox-server | `ci/gateway-enabled-values.yaml` | Full ingress-gateway block (SA, ClusterRole/Binding, Deployment, Service) + secure-access signing (#1233/#1235/#1236) |
| opensandbox-server | `ci/volumes-and-env-values.yaml` | Non-empty `server.volumes`/`volumeMounts`/`env` (#1240, non-empty side) |
| opensandbox-controller | `ci/full-features-values.yaml` | Non-empty extra volumes/mounts, sidecars, init containers, env, pull secrets, scheduling, snapshot secrets |
| opensandbox-controller | `ci/minimal-values.yaml` | Disabled SA/RBAC/CRDs/probes/leader-election |
| opensandbox | `ci/full-values.yaml` | Both sub-charts' optional branches together |

## Notes

- `CustomResourceDefinition` is skipped in kubeconform (the CRDs are static definitions and the default schema set carries no CRD meta-schema); the workload manifests stay `-strict`.
- `--validate-maintainers=false` / `--check-version-increment=false` on `ct lint` (team email, no per-PR version bump).
- Strips trailing whitespace from `opensandbox-controller` / `opensandbox-server` `values.yaml`, which `yamllint` (run by `ct`) flags.

## Verified locally

- `ct lint` — all charts green, incl. every `ci/` value set.
- `kubeconform` — green across all three Kubernetes versions × all charts × every value set.
