### PR TITLE
chore(charts): add values.schema.json for Helm input validation

### DIFF
--- a/.github/workflows/helm-schema.yml
+++ b/.github/workflows/helm-schema.yml
@@ -1,0 +1,34 @@
+name: Helm Schema
+
+on:
+  pull_request:
+    paths:
+      - 'kubernetes/charts/**/values.yaml'
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: azure/setup-helm@v4
+
+      - name: Install helm-schema plugin
+        run: helm plugin install https://github.com/losisin/helm-values-schema-json --verify=false
+
+      - name: Generate schemas
+        run: |
+          for chart in kubernetes/charts/opensandbox-controller \
+                       kubernetes/charts/opensandbox-server \
+                       kubernetes/charts/opensandbox; do
+            (cd "$chart" && helm schema -f values.yaml)
+          done
+
+      - name: Commit updated schemas
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(charts): regenerate values.schema.json"
+          file_pattern: "kubernetes/charts/**/values.schema.json"

--- a/kubernetes/charts/opensandbox-controller/values.schema.json
+++ b/kubernetes/charts/opensandbox-controller/values.schema.json
@@ -1,0 +1,304 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "controller": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubeClient": {
+                    "type": "object",
+                    "properties": {
+                        "burst": {
+                            "type": "integer"
+                        },
+                        "qps": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "leaderElection": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "snapshot": {
+                    "type": "object",
+                    "properties": {
+                        "commitJobTimeout": {
+                            "type": "string"
+                        },
+                        "containerdSocketPath": {
+                            "type": "string"
+                        },
+                        "imageCommitterImage": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "registryInsecure": {
+                            "type": "boolean"
+                        },
+                        "resumePullSecret": {
+                            "type": "string"
+                        },
+                        "snapshotPushSecret": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "crds": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "keep": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "extraContainers": {
+            "type": "array"
+        },
+        "extraEnv": {
+            "type": "array"
+        },
+        "extraInitContainers": {
+            "type": "array"
+        },
+        "extraVolumeMounts": {
+            "type": "array"
+        },
+        "extraVolumes": {
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespaceOverride": {
+            "type": "string"
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "egress": {
+                    "type": "array"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "ingress": {
+                    "type": "array"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/kubernetes/charts/opensandbox-server/values.schema.json
+++ b/kubernetes/charts/opensandbox-server/values.schema.json
@@ -1,0 +1,160 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "configToml": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespaceOverride": {
+            "type": "string"
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "env": {
+                    "type": "array"
+                },
+                "gateway": {
+                    "type": "object",
+                    "properties": {
+                        "dataplaneNamespace": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "gatewayRouteMode": {
+                            "type": "string"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "providerType": {
+                            "type": "string"
+                        },
+                        "replicaCount": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "secureAccess": {
+                            "type": "object",
+                            "properties": {
+                                "activeKey": {
+                                    "type": "string"
+                                },
+                                "keys": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "volumeMounts": {
+                    "type": "array"
+                },
+                "volumes": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}

--- a/kubernetes/charts/opensandbox/values.schema.json
+++ b/kubernetes/charts/opensandbox/values.schema.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "null"
+        },
+        "opensandbox-controller": {
+            "type": "object",
+            "properties": {
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "replicaCount": {
+                            "type": "integer"
+                        },
+                        "snapshot": {
+                            "type": "object",
+                            "properties": {
+                                "commitJobTimeout": {
+                                    "type": "string"
+                                },
+                                "imageCommitterImage": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "registryInsecure": {
+                                    "type": "boolean"
+                                },
+                                "resumePullSecret": {
+                                    "type": "string"
+                                },
+                                "snapshotPushSecret": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "opensandbox-server": {
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The charts have no `values.schema.json`, so `helm install` does not validate user-provided values. Invalid or mistyped values (wrong types, unexpected keys) are silently ignored until the chart fails to render or the pod fails to start.

Closes #1255

## Changes

- Adds `values.schema.json` to `opensandbox-controller`, `opensandbox-server` and `opensandbox` charts, generated from their respective `values.yaml` using the [`helm-schema`](https://github.com/losisin/helm-values-schema-json) plugin
- Adds `.github/workflows/helm-schema.yml` — triggers on PRs that touch `values.yaml`, regenerates the schema and auto-commits it

## How it works

The JSON Schema is derived directly from `values.yaml`. Helm validates user-provided `--set` flags and `-f values.yaml` overrides against it at install/upgrade time. Examples of what gets caught:

```bash
# Type mismatch — caught at install time instead of runtime
helm install opensandbox-controller . --set controller.replicaCount=abc
# Error: values don't meet the specifications of the schema(s) in the following chart(s):
#   opensandbox-controller: controller.replicaCount: Invalid type. Expected: integer, given: string

# Unknown key typo — caught immediately
helm install opensandbox-controller . --set controller.replicaCont=2
# Error: additional properties 'replicaCont' not allowed
```

## Verified locally

```bash
# All schemas are valid JSON
python3 -c "import json; json.load(open('values.schema.json'))"  # ✓ each chart

# helm lint passes with schemas present
helm lint kubernetes/charts/opensandbox-controller  # 1 chart(s) linted, 0 chart(s) failed
helm lint kubernetes/charts/opensandbox-server      # 1 chart(s) linted, 0 chart(s) failed
```

## Notes
- No breaking change — users who don't pass invalid values are unaffected.
- Consistent with Helm best practices for production charts.