### PR TITLE
feat: add explicit bind mounts to execd bwrap isolation

### DIFF
--- a/components/execd/configs/isolation.example.toml
+++ b/components/execd/configs/isolation.example.toml
@@ -16,8 +16,12 @@ upper_max_bytes = 8589934592  # 8 GiB
 # Maximum tar.gz diff output size (bytes). Phase 2.
 diff_max_bytes = 4294967296  # 4 GiB
 
-# Paths that callers may request as extra_writable. Empty = reject all.
-allowed_writable = []
+# Host paths callers may request via extra_writable or binds. Sources are
+# enforced against the fully symlink-resolved real path; subpaths are allowed.
+# NOTE: this key REPLACES the built-in default (no merge), so setting it here
+# overrides the defaults below. Empty ([]) rejects all extra_writable/binds.
+# Built-in default: ["/workspace", "/mnt", "/media", "/data"].
+allowed_writable = ["/workspace", "/mnt", "/media", "/data"]
 
 # Seccomp is ALWAYS ACTIVE by default — the built-in denylist blocks ~30
 # dangerous syscalls (mount, ptrace, bpf, etc.) even without this section.

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -93,6 +93,19 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 		argv = append(argv, "--bind", p, p)
 	}
 
+	// 8b. Explicit source→dest bind mounts.
+	for _, b := range opts.Binds {
+		dest := b.Dest
+		if dest == "" {
+			dest = b.Source
+		}
+		flag := "--bind"
+		if b.ReadOnly {
+			flag = "--ro-bind"
+		}
+		argv = append(argv, flag, b.Source, dest)
+	}
+
 	// 9. Environment.
 	argv = append(argv, bwrapEnvSegment(opts.EnvPassthrough)...)
 
@@ -152,6 +165,17 @@ func validateWrapOptions(opts WrapOptions) error {
 	}
 	if opts.UidMode != "" && !opts.UidMode.Valid() {
 		return fmt.Errorf("isolation: unknown uid mode %q", opts.UidMode)
+	}
+	for _, b := range opts.Binds {
+		if b.Source == "" {
+			return errors.New("isolation: bind.source is required")
+		}
+		if !filepath.IsAbs(b.Source) {
+			return fmt.Errorf("isolation: bind.source %q must be an absolute path", b.Source)
+		}
+		if b.Dest != "" && !filepath.IsAbs(b.Dest) {
+			return fmt.Errorf("isolation: bind.dest %q must be an absolute path", b.Dest)
+		}
 	}
 	return nil
 }

--- a/components/execd/pkg/isolation/bwrap_test.go
+++ b/components/execd/pkg/isolation/bwrap_test.go
@@ -215,6 +215,59 @@ func TestBuildArgv_ExtraWritable(t *testing.T) {
 	}
 }
 
+func TestBuildArgv_Binds(t *testing.T) {
+	t.Run("rw_src_to_dest", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Source: "/host/data", Dest: "/container/data"}}
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.Contains(t, s, "--bind /host/data /container/data")
+	})
+
+	t.Run("readonly_uses_ro_bind", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Source: "/host/ro", Dest: "/mnt/ro", ReadOnly: true}}
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.Contains(t, s, "--ro-bind /host/ro /mnt/ro")
+	})
+
+	t.Run("empty_dest_defaults_to_source", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Source: "/host/same"}}
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.Contains(t, s, "--bind /host/same /host/same")
+	})
+
+	t.Run("validation_empty_source", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Dest: "/mnt/x"}}
+		_, err := buildArgv(opts, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bind.source is required")
+	})
+
+	t.Run("validation_relative_source", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Source: "relative/path"}}
+		_, err := buildArgv(opts, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be an absolute path")
+	})
+
+	t.Run("validation_relative_dest", func(t *testing.T) {
+		opts := basicWrapOpts()
+		opts.Binds = []BindMount{{Source: "/host/a", Dest: "rel/dest"}}
+		_, err := buildArgv(opts, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be an absolute path")
+	})
+}
+
 func TestBuildArgv_Setpriv(t *testing.T) {
 	t.Run("default_uid_gid", func(t *testing.T) {
 		opts := basicWrapOpts()

--- a/components/execd/pkg/isolation/config.go
+++ b/components/execd/pkg/isolation/config.go
@@ -50,7 +50,7 @@ func DefaultConfig() Config {
 		UpperRoot:       "/var/lib/execd/isolation",
 		UpperMaxBytes:   8 * 1024 * 1024 * 1024, // 8 GiB
 		DiffMaxBytes:    4 * 1024 * 1024 * 1024, // 4 GiB
-		AllowedWritable: nil,
+		AllowedWritable: []string{"/workspace", "/mnt", "/media", "/data"},
 		Seccomp:         nil, // use built-in denylist
 	}
 }

--- a/components/execd/pkg/isolation/config_test.go
+++ b/components/execd/pkg/isolation/config_test.go
@@ -28,7 +28,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "/var/lib/execd/isolation", cfg.UpperRoot)
 	assert.Equal(t, int64(8*1024*1024*1024), cfg.UpperMaxBytes)
 	assert.Equal(t, int64(4*1024*1024*1024), cfg.DiffMaxBytes)
-	assert.Nil(t, cfg.AllowedWritable)
+	assert.Equal(t, []string{"/workspace", "/mnt", "/media", "/data"}, cfg.AllowedWritable)
 	assert.Nil(t, cfg.Seccomp)
 }
 
@@ -86,7 +86,8 @@ func TestLoadConfig_PartialFields(t *testing.T) {
 	// Missing fields keep defaults.
 	assert.Equal(t, int64(8*1024*1024*1024), cfg.UpperMaxBytes)
 	assert.Equal(t, int64(4*1024*1024*1024), cfg.DiffMaxBytes)
-	assert.Nil(t, cfg.AllowedWritable)
+	// Missing allowed_writable keeps the built-in default allowlist.
+	assert.Equal(t, []string{"/workspace", "/mnt", "/media", "/data"}, cfg.AllowedWritable)
 	assert.Nil(t, cfg.Seccomp)
 }
 

--- a/components/execd/pkg/isolation/isolator.go
+++ b/components/execd/pkg/isolation/isolator.go
@@ -94,6 +94,16 @@ type EnvSpec struct {
 	Keys []string // allowlist (mode=allow) or denylist (mode=deny)
 }
 
+// BindMount describes an additional host path bind-mounted into the namespace
+// with an explicit source-to-destination mapping. Unlike WrapOptions.ExtraWritable
+// (which always mounts Source==Dest read-write), a BindMount may map a distinct
+// destination and be mounted read-only.
+type BindMount struct {
+	Source   string // host path (required)
+	Dest     string // mount destination; defaults to Source when empty
+	ReadOnly bool   // true → --ro-bind; false → --bind
+}
+
 // Capabilities describes what the isolator can and cannot do.
 type Capabilities struct {
 	Available              bool
@@ -117,6 +127,7 @@ type WrapOptions struct {
 	Profile        Profile
 	Workspace      WorkspaceSpec
 	ExtraWritable  []string
+	Binds          []BindMount
 	ShareNet       bool
 	EnvPassthrough EnvSpec
 	Uid, Gid       *uint32

--- a/components/execd/pkg/runtime/bwrap_test/bwrap_binds_test.go
+++ b/components/execd/pkg/runtime/bwrap_test/bwrap_binds_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux && bwrap
+
+package bwrap_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/opensandbox/execd/pkg/isolation"
+	"github.com/alibaba/opensandbox/execd/pkg/runtime"
+)
+
+// TestBinds_SourceToDest verifies a host path can be bind-mounted at a distinct
+// destination inside the namespace and written through.
+func TestBinds_SourceToDest(t *testing.T) {
+	r := newRunner(t)
+
+	srcDir := t.TempDir()
+	// Destination must be an existing mount point inside the namespace. Use a
+	// separate temp dir under /tmp (bind-mounted into the namespace) so bwrap
+	// can bind onto it without needing to create a dir under a read-only mount.
+	destDir := t.TempDir()
+
+	opts := &runtime.IsolatedSessionOptions{
+		Profile:       "balanced",
+		WorkspacePath: t.TempDir(),
+		WorkspaceMode: "rw",
+		Binds: []isolation.BindMount{
+			{Source: srcDir, Dest: destDir},
+		},
+	}
+
+	id, err := r.CreateIsolatedSession(opts)
+	require.NoError(t, err)
+	defer r.DeleteIsolatedSession(id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Write via the in-namespace destination path.
+	err = r.RunInIsolatedSession(ctx, id, "echo 'mapped-data' > "+destDir+"/out.txt", nil, nil)
+	require.NoError(t, err, "writing to mapped bind dest should succeed")
+
+	// Verify it landed on the host source dir.
+	data, err := os.ReadFile(filepath.Join(srcDir, "out.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "mapped-data\n", string(data))
+}
+
+// TestBinds_ReadOnly verifies a read-only bind rejects writes but allows reads.
+func TestBinds_ReadOnly(t *testing.T) {
+	r := newRunner(t)
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "ro.txt"), []byte("readonly-value\n"), 0o644))
+	// Destination is a separate existing mount point under /tmp.
+	destDir := t.TempDir()
+
+	opts := &runtime.IsolatedSessionOptions{
+		Profile:       "balanced",
+		WorkspacePath: t.TempDir(),
+		WorkspaceMode: "rw",
+		Binds: []isolation.BindMount{
+			{Source: srcDir, Dest: destDir, ReadOnly: true},
+		},
+	}
+
+	id, err := r.CreateIsolatedSession(opts)
+	require.NoError(t, err)
+	defer r.DeleteIsolatedSession(id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Read should succeed.
+	var lines []string
+	err = r.RunInIsolatedSession(ctx, id, "cat "+destDir+"/ro.txt", nil,
+		func(line string) { lines = append(lines, line) })
+	require.NoError(t, err)
+	assert.Equal(t, []string{"readonly-value"}, lines)
+
+	// Write should fail (non-zero exit).
+	err = r.RunInIsolatedSession(ctx, id, "echo x > "+destDir+"/new.txt", nil, nil)
+	require.Error(t, err, "writing to a read-only bind should fail")
+}
+
+// TestBinds_SourceNotInAllowlist verifies binds are rejected when the source
+// path is outside the writable allowlist.
+func TestBinds_SourceNotInAllowlist(t *testing.T) {
+	r := newRunnerWithConfig(t, isolation.Config{
+		UpperRoot:       t.TempDir(),
+		UpperMaxBytes:   1 << 30,
+		AllowedWritable: []string{"/tmp/allowed-only"},
+	})
+
+	opts := &runtime.IsolatedSessionOptions{
+		Profile:       "balanced",
+		WorkspacePath: t.TempDir(),
+		WorkspaceMode: "rw",
+		Binds: []isolation.BindMount{
+			{Source: "/etc", Dest: "/mnt/etc"},
+		},
+	}
+
+	_, err := r.CreateIsolatedSession(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+}

--- a/components/execd/pkg/runtime/isolated_session.go
+++ b/components/execd/pkg/runtime/isolated_session.go
@@ -33,6 +33,7 @@ type IsolatedSessionOptions struct {
 	WorkspacePath      string
 	WorkspaceMode      string
 	ExtraWritable      []string
+	Binds              []isolation.BindMount
 	ShareNet           *bool
 	EnvPassthroughMode string
 	EnvPassthroughKeys []string
@@ -78,6 +79,7 @@ func (s *isolatedSession) start() error {
 
 	wrapOpts := isolation.WrapOptions{
 		ExtraWritable: s.opts.ExtraWritable,
+		Binds:         s.opts.Binds,
 		ShareNet:      true,
 	}
 

--- a/components/execd/pkg/runtime/isolated_session_ctrl.go
+++ b/components/execd/pkg/runtime/isolated_session_ctrl.go
@@ -151,6 +151,10 @@ func (r *IsolatedRunner) CreateIsolatedSession(opts *IsolatedSessionOptions) (st
 		return "", err
 	}
 
+	if err := r.validateBinds(opts.Binds); err != nil {
+		return "", err
+	}
+
 	if err := os.MkdirAll(opts.WorkspacePath, 0o755); err != nil {
 		return "", fmt.Errorf("create workspace: %w", err)
 	}
@@ -467,21 +471,102 @@ func (r *IsolatedRunner) validateExtraWritable(paths []string) error {
 	if len(r.allowedWritable) == 0 {
 		return fmt.Errorf("extra_writable not allowed: no paths in allowlist")
 	}
-	for _, p := range paths {
-		cleaned := filepath.Clean(p)
-		found := false
-		for _, allowed := range r.allowedWritable {
-			allowedClean := filepath.Clean(allowed)
-			if cleaned == allowedClean || strings.HasPrefix(cleaned, allowedClean+"/") {
-				found = true
-				break
-			}
+	for i := range paths {
+		resolved, err := r.resolveAllowedSource(paths[i])
+		if err != nil {
+			return fmt.Errorf("extra_writable path %q: %w", paths[i], err)
 		}
-		if !found {
-			return fmt.Errorf("extra_writable path %q not in allowlist", p)
-		}
+		// Mount the fully-resolved path so validation and mount target agree.
+		paths[i] = resolved
 	}
 	return nil
+}
+
+// resolveAllowedSource requires src to exist, fully resolves symlinks, checks
+// the resolved real path against the writable allowlist, and returns it. It is
+// shared by extra_writable and binds so both enforce identical semantics:
+//   - the source must already exist (bwrap --bind requires this anyway), and
+//   - the allowlist is enforced against the fully-resolved real path, leaving
+//     no unresolved suffix that could be swapped to an out-of-allowlist symlink
+//     between validation and bwrap start.
+func (r *IsolatedRunner) resolveAllowedSource(src string) (string, error) {
+	if src == "" {
+		return "", fmt.Errorf("source is required")
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(src))
+	if err != nil {
+		return "", fmt.Errorf("must be an existing path: %w", err)
+	}
+	if !r.pathAllowedResolved(resolved) {
+		return "", fmt.Errorf("not in allowlist")
+	}
+	return resolved, nil
+}
+
+// validateBinds checks that every bind's source path falls within the writable
+// allowlist. Read-only binds are validated too, so read access to arbitrary host
+// paths outside the allowlist is not possible.
+//
+// The source of each bind must already exist and is fully resolved via
+// filepath.EvalSymlinks; the resolved real path is written back in place. This
+// enforces the allowlist against the real target and closes the TOCTOU window:
+// bwrap is handed a fully-resolved path with no unresolved suffix, so a symlink
+// created or swapped between validation and bwrap start cannot redirect the
+// mount outside the allowlist. (bwrap's --bind requires the source to exist, so
+// this adds no functional restriction.)
+func (r *IsolatedRunner) validateBinds(binds []isolation.BindMount) error {
+	if len(binds) == 0 {
+		return nil
+	}
+	if len(r.allowedWritable) == 0 {
+		return fmt.Errorf("binds not allowed: no paths in allowlist")
+	}
+	for i := range binds {
+		resolved, err := r.resolveAllowedSource(binds[i].Source)
+		if err != nil {
+			return fmt.Errorf("binds source %q: %w", binds[i].Source, err)
+		}
+		// Mount the fully-resolved path so validation and mount target agree.
+		binds[i].Source = resolved
+	}
+	return nil
+}
+
+// pathAllowedResolved reports whether an already symlink-resolved path is equal
+// to, or nested under, any allowlist entry. Allowlist entries are themselves
+// symlink-resolved so the comparison is between real paths on both sides.
+func (r *IsolatedRunner) pathAllowedResolved(resolved string) bool {
+	for _, allowed := range r.allowedWritable {
+		allowedClean := resolveSymlinks(filepath.Clean(allowed))
+		if resolved == allowedClean || strings.HasPrefix(resolved, allowedClean+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveSymlinks returns the real path of p with symlinks resolved. Because p
+// (or a leading component) may not exist yet, it resolves the longest existing
+// prefix and re-appends the remaining components, so a symlinked ancestor is
+// still followed while a not-yet-created leaf is preserved.
+func resolveSymlinks(p string) string {
+	if p == "" {
+		return p
+	}
+	remaining := ""
+	cur := p
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			return filepath.Clean(filepath.Join(resolved, remaining))
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without an existing prefix; fall back to lexical.
+			return p
+		}
+		remaining = filepath.Join(filepath.Base(cur), remaining)
+		cur = parent
+	}
 }
 
 // shellescape wraps s in single quotes, escaping embedded single quotes.

--- a/components/execd/pkg/runtime/isolated_session_stub.go
+++ b/components/execd/pkg/runtime/isolated_session_stub.go
@@ -31,6 +31,7 @@ type IsolatedSessionOptions struct {
 	WorkspacePath      string
 	WorkspaceMode      string
 	ExtraWritable      []string
+	Binds              []isolation.BindMount
 	ShareNet           *bool
 	EnvPassthroughMode string
 	EnvPassthroughKeys []string

--- a/components/execd/pkg/runtime/isolated_session_test.go
+++ b/components/execd/pkg/runtime/isolated_session_test.go
@@ -18,8 +18,10 @@ package runtime
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -410,5 +412,67 @@ func TestRunInIsolatedSession_ConcurrentSessions(t *testing.T) {
 	}
 	if len(out2) != 1 || out2[0] != "two" {
 		t.Errorf("session 2: expected [two], got %v", out2)
+	}
+}
+
+// TestValidateBinds_SymlinkBypass verifies that a symlink placed inside an
+// allowed directory cannot be used to smuggle a bind source whose real target
+// lies outside the allowlist.
+func TestValidateBinds_SymlinkBypass(t *testing.T) {
+	allowed := t.TempDir()
+	outside := t.TempDir()
+
+	// allowed/link -> outside (a directory outside the allowlist).
+	link := filepath.Join(allowed, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &IsolatedRunner{allowedWritable: []string{allowed}}
+
+	// A direct path under the allowlist is fine.
+	if err := r.validateBinds([]isolation.BindMount{{Source: allowed}}); err != nil {
+		t.Errorf("direct allowlisted source should be accepted: %v", err)
+	}
+
+	// The symlink resolves outside the allowlist and must be rejected.
+	err := r.validateBinds([]isolation.BindMount{{Source: link}})
+	if err == nil {
+		t.Fatal("expected symlinked source resolving outside allowlist to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not in allowlist") {
+		t.Errorf("expected allowlist rejection, got: %v", err)
+	}
+
+	// A symlink whose target stays inside the allowlist is still accepted, and
+	// the source is rewritten to the resolved real path so bwrap mounts the
+	// resolved target (closing the TOCTOU window).
+	innerTarget := filepath.Join(allowed, "real")
+	if err := os.Mkdir(innerTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	innerLink := filepath.Join(allowed, "inner")
+	if err := os.Symlink(innerTarget, innerLink); err != nil {
+		t.Fatal(err)
+	}
+	binds := []isolation.BindMount{{Source: innerLink}}
+	if err := r.validateBinds(binds); err != nil {
+		t.Errorf("symlink resolving inside allowlist should be accepted: %v", err)
+	}
+	wantResolved, _ := filepath.EvalSymlinks(innerLink)
+	if binds[0].Source != wantResolved {
+		t.Errorf("bind source should be rewritten to resolved path %q, got %q", wantResolved, binds[0].Source)
+	}
+
+	// A non-existent source under the allowlist must be rejected: a missing
+	// leaf could otherwise be swapped to an out-of-allowlist symlink between
+	// validation and bwrap start.
+	missing := filepath.Join(allowed, "does-not-exist-yet")
+	err = r.validateBinds([]isolation.BindMount{{Source: missing}})
+	if err == nil {
+		t.Fatal("expected non-existent bind source to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be an existing path") {
+		t.Errorf("expected existing-path rejection, got: %v", err)
 	}
 }

--- a/components/execd/pkg/web/controller/isolated_session.go
+++ b/components/execd/pkg/web/controller/isolated_session.go
@@ -79,11 +79,21 @@ func (c *IsolatedSessionController) Create() {
 		return
 	}
 
+	binds := make([]isolation.BindMount, 0, len(req.Binds))
+	for _, b := range req.Binds {
+		binds = append(binds, isolation.BindMount{
+			Source:   b.Source,
+			Dest:     b.Dest,
+			ReadOnly: b.ReadOnly,
+		})
+	}
+
 	opts := &runtime.IsolatedSessionOptions{
 		Profile:            req.Profile,
 		WorkspacePath:      req.Workspace.Path,
 		WorkspaceMode:      req.Workspace.Mode,
 		ExtraWritable:      req.ExtraWritable,
+		Binds:              binds,
 		ShareNet:           req.ShareNet,
 		EnvPassthroughMode: req.EnvPassthrough.Mode,
 		EnvPassthroughKeys: req.EnvPassthrough.Keys,
@@ -98,7 +108,10 @@ func (c *IsolatedSessionController) Create() {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not in allowlist") ||
 			strings.Contains(err.Error(), "not allowed") ||
-			strings.Contains(err.Error(), "unknown isolation profile") {
+			strings.Contains(err.Error(), "unknown isolation profile") ||
+			strings.Contains(err.Error(), "must be an existing path") ||
+			strings.Contains(err.Error(), "must be an absolute path") ||
+			strings.Contains(err.Error(), "source is required") {
 			status = http.StatusBadRequest
 		}
 		c.RespondError(status, model.ErrorCodeRuntimeError, err.Error())

--- a/components/execd/pkg/web/model/isolated_session.go
+++ b/components/execd/pkg/web/model/isolated_session.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -35,6 +36,7 @@ type CreateIsolatedSessionRequest struct {
 	Profile            string             `json:"profile"` // "strict" | "balanced"
 	Workspace          WorkspaceSpec      `json:"workspace" validate:"required"`
 	ExtraWritable      []string           `json:"extra_writable,omitempty"`
+	Binds              []BindMount        `json:"binds,omitempty"`
 	ShareNet           *bool              `json:"share_net,omitempty"`
 	EnvPassthrough     EnvPassthroughSpec `json:"env_passthrough,omitempty"`
 	Uid                *uint32            `json:"uid,omitempty"`
@@ -53,6 +55,13 @@ type WorkspaceSpec struct {
 type EnvPassthroughSpec struct {
 	Mode string   `json:"mode,omitempty"` // "deny" | "allow"
 	Keys []string `json:"keys,omitempty"`
+}
+
+// BindMount describes an explicit source→dest bind mount into the namespace.
+type BindMount struct {
+	Source   string `json:"source" validate:"required"`
+	Dest     string `json:"dest,omitempty"`
+	ReadOnly bool   `json:"readonly,omitempty"`
 }
 
 // IsolatedCreateSessionResponse is the response for POST /v1/isolated/session.
@@ -89,6 +98,17 @@ func (r *CreateIsolatedSessionRequest) Validate() error {
 		default:
 			return fmt.Errorf("invalid uid_mode %q: must be \"setpriv\" or \"userns\"",
 				r.UidMode)
+		}
+	}
+	for i, b := range r.Binds {
+		if b.Source == "" {
+			return fmt.Errorf("binds[%d].source is required", i)
+		}
+		if !strings.HasPrefix(b.Source, "/") {
+			return fmt.Errorf("binds[%d].source %q must be an absolute path", i, b.Source)
+		}
+		if b.Dest != "" && !strings.HasPrefix(b.Dest, "/") {
+			return fmt.Errorf("binds[%d].dest %q must be an absolute path", i, b.Dest)
 		}
 	}
 	return nil

--- a/components/execd/pkg/web/model/isolated_session_test.go
+++ b/components/execd/pkg/web/model/isolated_session_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func baseIsolatedReq() CreateIsolatedSessionRequest {
+	return CreateIsolatedSessionRequest{
+		Workspace: WorkspaceSpec{Path: "/tmp", Mode: "rw"},
+	}
+}
+
+func TestCreateIsolatedSessionRequest_Validate_Binds(t *testing.T) {
+	tests := []struct {
+		name    string
+		binds   []BindMount
+		wantErr string // substring; "" means no error
+	}{
+		{"valid absolute src and dest", []BindMount{{Source: "/data/in", Dest: "/mnt/in"}}, ""},
+		{"valid src only (dest defaults)", []BindMount{{Source: "/data/in"}}, ""},
+		{"valid readonly", []BindMount{{Source: "/data/in", Dest: "/mnt/in", ReadOnly: true}}, ""},
+		{"missing source", []BindMount{{Dest: "/mnt/in"}}, "source is required"},
+		{"relative source", []BindMount{{Source: "data/in"}}, "must be an absolute path"},
+		{"relative dest", []BindMount{{Source: "/data/in", Dest: "mnt/in"}}, "must be an absolute path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := baseIsolatedReq()
+			req.Binds = tt.binds
+			err := req.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -46,8 +46,55 @@ curl -v http://localhost:44772/ping
   - Code execution (`/code`, SSE stream)
   - Session and command execution (`/session`, `/command`)
   - Filesystem operations (`/files`, `/directories`)
+  - Isolated sessions (`/v1/isolated/session`, bubblewrap namespaces)
   - PTY over WebSocket (`/pty`)
   - Local metrics endpoints (`/metrics`, `/metrics/watch`)
+
+## Isolated Sessions
+
+Isolated sessions run a bash process inside a per-execution
+[bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) namespace,
+created via `POST /v1/isolated/session`. Beyond the workspace, callers can
+expose additional host paths into the namespace.
+
+### Bind mounts
+
+Two request fields control extra host paths:
+
+- `extra_writable`: a list of paths bind-mounted read-write at the same path
+  inside the namespace (`source == destination`).
+- `binds`: explicit `source` → `dest` mappings, each optionally read-only.
+  - `source` (required): host path to bind. It must **already exist** and is
+    resolved (symlinks followed) before use.
+  - `dest`: mount destination inside the namespace; defaults to `source` when
+    omitted. It must be an **existing** mount point — `bwrap` cannot create a
+    destination under the read-only root, so create the directory first.
+  - `readonly` (default `false`): mount read-only (`--ro-bind`) when `true`,
+    read-write (`--bind`) otherwise.
+
+Example:
+
+```json
+{
+  "workspace": { "path": "/workspace", "mode": "rw" },
+  "binds": [
+    { "source": "/data/in",  "dest": "/mnt/in", "readonly": true },
+    { "source": "/data/out", "dest": "/mnt/out" }
+  ]
+}
+```
+
+### Writable allowlist
+
+The source path of every `extra_writable` entry and every `binds` entry must
+fall within the `allowed_writable` allowlist (see the isolation config file
+below). The allowlist is enforced against the fully symlink-resolved real
+path, so a symlink cannot redirect a bind outside the allowlist. An empty
+allowlist rejects all `extra_writable`/`binds` requests.
+
+The built-in default allowlist is `/workspace`, `/mnt`, `/media`, `/data`
+(subpaths included). Set `allowed_writable` in the isolation config to
+override it.
 
 ## Configuration
 
@@ -62,6 +109,7 @@ curl -v http://localhost:44772/ping
 | `--access-token` | `""` | Optional shared API access token. |
 | `--graceful-shutdown-timeout` | `1s` | SSE tail-drain wait window before closing. |
 | `--jupyter-idle-poll-interval` | `100ms` | Poll interval after Jupyter reports idle. |
+| `--isolation-config` | `""` | Path to the isolation TOML config (see below). |
 
 ### Environment Variables
 
@@ -72,12 +120,29 @@ curl -v http://localhost:44772/ping
 | `EXECD_ACCESS_TOKEN` | Same as `--access-token` (overridden by explicit flag). |
 | `EXECD_API_GRACE_SHUTDOWN` | Same as `--graceful-shutdown-timeout`. |
 | `EXECD_JUPYTER_IDLE_POLL_INTERVAL` | Same as `--jupyter-idle-poll-interval`. |
+| `EXECD_ISOLATION_CONFIG` | Same as `--isolation-config`. |
 | `EXECD_CLONE3_COMPAT` | Linux clone3 compatibility switch (see below). |
 | `EXECD_LOG_FILE` | Optional log output file path; default is stdout. |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Preferred OTLP metrics endpoint. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Fallback OTLP endpoint when metrics-specific endpoint is unset. |
 | `OPENSANDBOX_ID` | Optional `sandbox_id` metric/resource attribute. |
 | `OPENSANDBOX_EXECD_METRICS_EXTRA_ATTRS` | Optional extra metric attrs (`k=v,k2=v2`). |
+
+### Isolation Config File
+
+Isolated sessions read an optional TOML file given by `--isolation-config`
+(or `EXECD_ISOLATION_CONFIG`). All fields are optional; omitted fields use
+built-in defaults.
+
+```toml
+# Parent directory for per-session overlay upper directories.
+upper_root = "/var/lib/execd/isolation"
+
+# Host paths callers may request via extra_writable / binds.
+# Enforced against the fully symlink-resolved real path; subpaths are allowed.
+# Default: ["/workspace", "/mnt", "/media", "/data"]. Empty = reject all.
+allowed_writable = ["/workspace", "/mnt", "/media", "/data"]
+```
 
 ## Observability
 

--- a/sdks/sandbox/csharp/src/OpenSandbox/IsolatedSessionsExtensions.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/IsolatedSessionsExtensions.cs
@@ -28,12 +28,14 @@ public static class IsolatedSessionsExtensions
         ExecutionHandlers? handlers = null,
         string? profile = null,
         bool? shareNet = null,
+        List<BindMount>? binds = null,
         CancellationToken cancellationToken = default)
     {
         var request = new CreateIsolatedSessionRequest(
             Workspace: new IsolatedWorkspaceSpec(Path: workspace, Mode: workspaceMode),
             Profile: profile,
-            ShareNet: shareNet
+            ShareNet: shareNet,
+            Binds: binds
         );
         var session = await service.CreateAsync(request, cancellationToken).ConfigureAwait(false);
         try

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
@@ -26,14 +26,22 @@ public record EnvPassthroughSpec(
     [property: JsonPropertyName("keys")] List<string>? Keys = null
 );
 
+public record BindMount(
+    [property: JsonPropertyName("source")] string Source,
+    [property: JsonPropertyName("dest")] string? Dest = null,
+    [property: JsonPropertyName("readonly")] bool? ReadOnly = null
+);
+
 public record CreateIsolatedSessionRequest(
     [property: JsonPropertyName("workspace")] IsolatedWorkspaceSpec Workspace,
     [property: JsonPropertyName("profile")] string? Profile = null,
     [property: JsonPropertyName("extra_writable")] List<string>? ExtraWritable = null,
+    [property: JsonPropertyName("binds")] List<BindMount>? Binds = null,
     [property: JsonPropertyName("share_net")] bool? ShareNet = null,
     [property: JsonPropertyName("env_passthrough")] EnvPassthroughSpec? EnvPassthrough = null,
     [property: JsonPropertyName("uid")] int? Uid = null,
     [property: JsonPropertyName("gid")] int? Gid = null,
+    [property: JsonPropertyName("uid_mode")] string? UidMode = null,
     [property: JsonPropertyName("idle_timeout_seconds")] int? IdleTimeoutSeconds = null
 );
 

--- a/sdks/sandbox/go/isolated.go
+++ b/sdks/sandbox/go/isolated.go
@@ -33,15 +33,24 @@ type EnvPassthroughSpec struct {
 	Keys []string `json:"keys,omitempty"`
 }
 
+// BindMount describes an explicit source-to-destination bind mount into the namespace.
+type BindMount struct {
+	Source   string `json:"source"`
+	Dest     string `json:"dest,omitempty"`
+	ReadOnly bool   `json:"readonly,omitempty"`
+}
+
 // CreateIsolatedSessionRequest is the request body for creating an isolated session.
 type CreateIsolatedSessionRequest struct {
 	Workspace          IsolatedWorkspaceSpec `json:"workspace"`
 	Profile            string                `json:"profile,omitempty"`
 	ExtraWritable      []string              `json:"extra_writable,omitempty"`
+	Binds              []BindMount           `json:"binds,omitempty"`
 	ShareNet           *bool                 `json:"share_net,omitempty"`
 	EnvPassthrough     *EnvPassthroughSpec   `json:"env_passthrough,omitempty"`
 	Uid                *uint32               `json:"uid,omitempty"`
 	Gid                *uint32               `json:"gid,omitempty"`
+	UidMode            string                `json:"uid_mode,omitempty"` // "setpriv" | "userns"
 	IdleTimeoutSeconds int                   `json:"idle_timeout_seconds,omitempty"`
 }
 

--- a/sdks/sandbox/go/sandbox_isolated_test.go
+++ b/sdks/sandbox/go/sandbox_isolated_test.go
@@ -16,12 +16,53 @@ package opensandbox
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+// TestCreateIsolatedSessionRequest_BindsWireFormat verifies that binds and
+// uid_mode serialize to the expected execd wire format.
+func TestCreateIsolatedSessionRequest_BindsWireFormat(t *testing.T) {
+	req := CreateIsolatedSessionRequest{
+		Workspace: IsolatedWorkspaceSpec{Path: "/workspace", Mode: "rw"},
+		Binds: []BindMount{
+			{Source: "/data/in", Dest: "/mnt/in", ReadOnly: true},
+			{Source: "/data/out"},
+		},
+		UidMode: "userns",
+	}
+
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, `"binds":[`)
+	assert.Contains(t, s, `"source":"/data/in"`)
+	assert.Contains(t, s, `"dest":"/mnt/in"`)
+	assert.Contains(t, s, `"readonly":true`)
+	assert.Contains(t, s, `"uid_mode":"userns"`)
+	// Empty dest/readonly must be omitted for the second bind.
+	require.True(t, strings.Contains(s, `{"source":"/data/out"}`),
+		"bind with only source should omit dest/readonly: %s", s)
+}
+
+// TestCreateIsolatedSessionRequest_BindsOmittedWhenEmpty verifies binds and
+// uid_mode are omitted when unset (backward compatible with existing callers).
+func TestCreateIsolatedSessionRequest_BindsOmittedWhenEmpty(t *testing.T) {
+	req := CreateIsolatedSessionRequest{
+		Workspace: IsolatedWorkspaceSpec{Path: "/workspace"},
+	}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	s := string(b)
+	require.True(t, !strings.Contains(s, "binds"), "binds should be omitted: %s", s)
+	require.True(t, !strings.Contains(s, "uid_mode"), "uid_mode should be omitted: %s", s)
+}
 
 func TestIsolationRunOnce_CreatesRunsDeletes(t *testing.T) {
 	var (

--- a/sdks/sandbox/javascript/src/adapters/isolatedSessionsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/isolatedSessionsAdapter.ts
@@ -222,6 +222,7 @@ export class IsolatedSessionsAdapter implements IsolationService {
       workspace: { path: workspace, mode: opts?.workspaceMode },
       profile: opts?.profile,
       share_net: opts?.shareNet,
+      binds: opts?.binds,
     });
     try {
       return await session.run(code, opts?.runOpts, opts?.handlers, opts?.signal);

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -1250,18 +1250,36 @@ export interface components {
             profile?: "strict" | "balanced";
             workspace: components["schemas"]["IsolatedWorkspaceSpec"];
             extra_writable?: string[];
+            /** @description Additional host paths bind-mounted into the namespace with an explicit source-to-destination mapping. Unlike extra_writable (which mounts source==destination read-write), each entry may map a distinct destination path and be mounted read-only. The source path of every entry must fall within the configured writable allowlist. */
+            binds?: components["schemas"]["BindMount"][];
             share_net?: boolean;
             env_passthrough?: components["schemas"]["EnvPassthroughSpec"];
             /** Format: uint32 */
             uid?: number;
             /** Format: uint32 */
             gid?: number;
+            /**
+             * @description Controls how user identity is established inside the namespace. "setpriv" (default) uses real setuid via setpriv(1). "userns" creates a user namespace via --unshare-user --disable-userns.
+             * @enum {string}
+             */
+            uid_mode?: "setpriv" | "userns";
             idle_timeout_seconds?: number;
         };
         IsolatedWorkspaceSpec: {
             path: string;
             /** @enum {string} */
             mode?: "rw" | "overlay" | "ro";
+        };
+        BindMount: {
+            /** @description Host path to bind-mount into the namespace. */
+            source: string;
+            /** @description Mount destination inside the namespace. Defaults to source when omitted. */
+            dest?: string;
+            /**
+             * @description When true the mount is read-only (--ro-bind); otherwise it is read-write (--bind).
+             * @default false
+             */
+            readonly: boolean;
         };
         EnvPassthroughSpec: {
             /** @enum {string} */

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -150,6 +150,7 @@ export type {
   CreateIsolatedSessionRequest,
   IsolatedWorkspaceSpec,
   EnvPassthroughSpec,
+  BindMount,
   IsolatedSessionInfo,
   IsolatedSessionState,
   IsolatedRunOpts,

--- a/sdks/sandbox/javascript/src/models/isolated.ts
+++ b/sdks/sandbox/javascript/src/models/isolated.ts
@@ -22,14 +22,22 @@ export interface EnvPassthroughSpec {
   keys?: string[];
 }
 
+export interface BindMount {
+  source: string;
+  dest?: string;
+  readonly?: boolean;
+}
+
 export interface CreateIsolatedSessionRequest {
   workspace: IsolatedWorkspaceSpec;
   profile?: "strict" | "balanced";
   extra_writable?: string[];
+  binds?: BindMount[];
   share_net?: boolean;
   env_passthrough?: EnvPassthroughSpec;
   uid?: number;
   gid?: number;
+  uid_mode?: "setpriv" | "userns";
   idle_timeout_seconds?: number;
 }
 

--- a/sdks/sandbox/javascript/src/services/isolatedSessions.ts
+++ b/sdks/sandbox/javascript/src/services/isolatedSessions.ts
@@ -16,6 +16,7 @@ import type { CommandExecution } from "../models/execd.js";
 import type { ExecutionHandlers } from "../models/execution.js";
 import type { SandboxFiles } from "./filesystem.js";
 import type {
+  BindMount,
   CreateIsolatedSessionRequest,
   IsolatedCapabilities,
   IsolatedRunOpts,
@@ -43,6 +44,7 @@ export interface RunOnceOpts {
   handlers?: ExecutionHandlers;
   profile?: "strict" | "balanced";
   shareNet?: boolean;
+  binds?: BindMount[];
   signal?: AbortSignal;
 }
 

--- a/sdks/sandbox/javascript/tests/isolationRunOnce.test.mjs
+++ b/sdks/sandbox/javascript/tests/isolationRunOnce.test.mjs
@@ -113,3 +113,54 @@ describe("withSession", () => {
     assert.deepStrictEqual(calls, ["create", "delete"]);
   });
 });
+
+describe("create request body", () => {
+  function mockCapturingCreate(captured) {
+    return async (url, init) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const method = init?.method ?? "GET";
+      if (method === "POST" && urlStr.includes("/v1/isolated/session") && !urlStr.includes("/run")) {
+        captured.body = JSON.parse(init.body);
+        return new Response(
+          JSON.stringify({ session_id: "sess-body", created_at: "2026-01-01T00:00:00Z" }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      return new Response("not found", { status: 404 });
+    };
+  }
+
+  it("serializes binds and uid_mode into the create body", async () => {
+    const captured = {};
+    const adapter = createAdapter(mockCapturingCreate(captured));
+
+    await adapter.withSession(
+      {
+        workspace: { path: "/workspace", mode: "rw" },
+        binds: [
+          { source: "/data/in", dest: "/mnt/in", readonly: true },
+          { source: "/data/out" },
+        ],
+        uid_mode: "userns",
+      },
+      async () => "ok",
+    );
+
+    assert.deepStrictEqual(captured.body.binds, [
+      { source: "/data/in", dest: "/mnt/in", readonly: true },
+      { source: "/data/out" },
+    ]);
+    assert.strictEqual(captured.body.uid_mode, "userns");
+  });
+
+  it("omits binds and uid_mode when unset", async () => {
+    const captured = {};
+    const adapter = createAdapter(mockCapturingCreate(captured));
+
+    await adapter.withSession({ workspace: { path: "/workspace" } }, async () => "ok");
+
+    assert.ok(!("binds" in captured.body));
+    assert.ok(!("uid_mode" in captured.body));
+  });
+});

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
@@ -28,14 +28,22 @@ data class EnvPassthroughSpec(
     val keys: List<String> = emptyList(),
 )
 
+data class BindMount(
+    val source: String,
+    val dest: String? = null,
+    val readonly: Boolean? = null,
+)
+
 data class CreateIsolatedSessionRequest(
     val workspace: IsolatedWorkspaceSpec,
     val profile: String? = null,
     val extraWritable: List<String>? = null,
+    val binds: List<BindMount>? = null,
     val shareNet: Boolean? = null,
     val envPassthrough: EnvPassthroughSpec? = null,
     val uid: Int? = null,
     val gid: Int? = null,
+    val uidMode: String? = null,
     val idleTimeoutSeconds: Int? = null,
 )
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/IsolatedSessions.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/IsolatedSessions.kt
@@ -17,6 +17,7 @@
 package com.alibaba.opensandbox.sandbox.domain.services
 
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.BindMount
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.CreateIsolatedSessionRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedCapabilities
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedRunRequest
@@ -54,6 +55,7 @@ interface IsolationService {
         timeoutSeconds: Int? = null,
         profile: String? = null,
         shareNet: Boolean? = null,
+        binds: List<BindMount>? = null,
     ): Execution {
         val session =
             create(
@@ -61,6 +63,7 @@ interface IsolationService {
                     workspace = IsolatedWorkspaceSpec(path = workspace, mode = workspaceMode),
                     profile = profile,
                     shareNet = shareNet,
+                    binds = binds,
                 ),
             )
         try {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
@@ -51,15 +51,24 @@ private data class IsolatedCreateBody(
     val workspace: IsolatedWorkspaceBody,
     val profile: String? = null,
     val extra_writable: List<String>? = null,
+    val binds: List<BindMountBody>? = null,
     val share_net: Boolean? = null,
     val env_passthrough: EnvPassthroughBody? = null,
     val uid: Int? = null,
     val gid: Int? = null,
+    val uid_mode: String? = null,
     val idle_timeout_seconds: Int? = null,
 )
 
 @Serializable
 private data class IsolatedWorkspaceBody(val path: String, val mode: String? = null)
+
+@Serializable
+private data class BindMountBody(
+    val source: String,
+    val dest: String? = null,
+    val readonly: Boolean? = null,
+)
 
 @Serializable
 private data class EnvPassthroughBody(val mode: String? = null, val keys: List<String>? = null)
@@ -130,11 +139,14 @@ internal class IsolatedSessionsAdapter(
                         IsolatedWorkspaceBody(request.workspace.path, request.workspace.mode),
                     profile = request.profile,
                     extra_writable = request.extraWritable,
+                    binds =
+                        request.binds?.map { BindMountBody(it.source, it.dest, it.readonly) },
                     share_net = request.shareNet,
                     env_passthrough =
                         request.envPassthrough?.let { EnvPassthroughBody(it.mode, it.keys) },
                     uid = request.uid,
                     gid = request.gid,
+                    uid_mode = request.uidMode,
                     idle_timeout_seconds = request.idleTimeoutSeconds,
                 )
             val httpRequest =

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -16,6 +16,7 @@
 
 """Contains all the data models used in inputs/outputs"""
 
+from .bind_mount import BindMount
 from .capabilities_response import CapabilitiesResponse
 from .chmod_files_body import ChmodFilesBody
 from .code_context import CodeContext
@@ -23,6 +24,7 @@ from .code_context_request import CodeContextRequest
 from .command_status_response import CommandStatusResponse
 from .create_isolated_session_request import CreateIsolatedSessionRequest
 from .create_isolated_session_request_profile import CreateIsolatedSessionRequestProfile
+from .create_isolated_session_request_uid_mode import CreateIsolatedSessionRequestUidMode
 from .create_session_request import CreateSessionRequest
 from .create_session_response import CreateSessionResponse
 from .env_passthrough_spec import EnvPassthroughSpec
@@ -64,6 +66,7 @@ from .session_state_status import SessionStateStatus
 from .upload_file_body import UploadFileBody
 
 __all__ = (
+    "BindMount",
     "CapabilitiesResponse",
     "ChmodFilesBody",
     "CodeContext",
@@ -71,6 +74,7 @@ __all__ = (
     "CommandStatusResponse",
     "CreateIsolatedSessionRequest",
     "CreateIsolatedSessionRequestProfile",
+    "CreateIsolatedSessionRequestUidMode",
     "CreateSessionRequest",
     "CreateSessionResponse",
     "EnvPassthroughSpec",

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/bind_mount.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/bind_mount.py
@@ -1,0 +1,98 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BindMount")
+
+
+@_attrs_define
+class BindMount:
+    """
+    Attributes:
+        source (str): Host path to bind-mount into the namespace.
+        dest (str | Unset): Mount destination inside the namespace. Defaults to source when omitted.
+        readonly (bool | Unset): When true the mount is read-only (--ro-bind); otherwise it is read-write (--bind).
+            Default: False.
+    """
+
+    source: str
+    dest: str | Unset = UNSET
+    readonly: bool | Unset = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        source = self.source
+
+        dest = self.dest
+
+        readonly = self.readonly
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "source": source,
+            }
+        )
+        if dest is not UNSET:
+            field_dict["dest"] = dest
+        if readonly is not UNSET:
+            field_dict["readonly"] = readonly
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        source = d.pop("source")
+
+        dest = d.pop("dest", UNSET)
+
+        readonly = d.pop("readonly", UNSET)
+
+        bind_mount = cls(
+            source=source,
+            dest=dest,
+            readonly=readonly,
+        )
+
+        bind_mount.additional_properties = d
+        return bind_mount
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request.py
@@ -23,9 +23,11 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.create_isolated_session_request_profile import CreateIsolatedSessionRequestProfile
+from ..models.create_isolated_session_request_uid_mode import CreateIsolatedSessionRequestUidMode
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.bind_mount import BindMount
     from ..models.env_passthrough_spec import EnvPassthroughSpec
     from ..models.isolated_workspace_spec import IsolatedWorkspaceSpec
 
@@ -40,20 +42,29 @@ class CreateIsolatedSessionRequest:
         workspace (IsolatedWorkspaceSpec):
         profile (CreateIsolatedSessionRequestProfile | Unset):
         extra_writable (list[str] | Unset):
+        binds (list[BindMount] | Unset): Additional host paths bind-mounted into the namespace with an explicit source-
+            to-destination mapping. Unlike extra_writable (which mounts source==destination read-write), each entry may map
+            a distinct destination path and be mounted read-only. The source path of every entry must fall within the
+            configured writable allowlist.
         share_net (bool | Unset):
         env_passthrough (EnvPassthroughSpec | Unset):
         uid (int | Unset):
         gid (int | Unset):
+        uid_mode (CreateIsolatedSessionRequestUidMode | Unset): Controls how user identity is established inside the
+            namespace. "setpriv" (default) uses real setuid via setpriv(1). "userns" creates a user namespace via --unshare-
+            user --disable-userns.
         idle_timeout_seconds (int | Unset):
     """
 
     workspace: IsolatedWorkspaceSpec
     profile: CreateIsolatedSessionRequestProfile | Unset = UNSET
     extra_writable: list[str] | Unset = UNSET
+    binds: list[BindMount] | Unset = UNSET
     share_net: bool | Unset = UNSET
     env_passthrough: EnvPassthroughSpec | Unset = UNSET
     uid: int | Unset = UNSET
     gid: int | Unset = UNSET
+    uid_mode: CreateIsolatedSessionRequestUidMode | Unset = UNSET
     idle_timeout_seconds: int | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -68,6 +79,13 @@ class CreateIsolatedSessionRequest:
         if not isinstance(self.extra_writable, Unset):
             extra_writable = self.extra_writable
 
+        binds: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.binds, Unset):
+            binds = []
+            for binds_item_data in self.binds:
+                binds_item = binds_item_data.to_dict()
+                binds.append(binds_item)
+
         share_net = self.share_net
 
         env_passthrough: dict[str, Any] | Unset = UNSET
@@ -77,6 +95,10 @@ class CreateIsolatedSessionRequest:
         uid = self.uid
 
         gid = self.gid
+
+        uid_mode: str | Unset = UNSET
+        if not isinstance(self.uid_mode, Unset):
+            uid_mode = self.uid_mode.value
 
         idle_timeout_seconds = self.idle_timeout_seconds
 
@@ -91,6 +113,8 @@ class CreateIsolatedSessionRequest:
             field_dict["profile"] = profile
         if extra_writable is not UNSET:
             field_dict["extra_writable"] = extra_writable
+        if binds is not UNSET:
+            field_dict["binds"] = binds
         if share_net is not UNSET:
             field_dict["share_net"] = share_net
         if env_passthrough is not UNSET:
@@ -99,6 +123,8 @@ class CreateIsolatedSessionRequest:
             field_dict["uid"] = uid
         if gid is not UNSET:
             field_dict["gid"] = gid
+        if uid_mode is not UNSET:
+            field_dict["uid_mode"] = uid_mode
         if idle_timeout_seconds is not UNSET:
             field_dict["idle_timeout_seconds"] = idle_timeout_seconds
 
@@ -106,6 +132,7 @@ class CreateIsolatedSessionRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.bind_mount import BindMount
         from ..models.env_passthrough_spec import EnvPassthroughSpec
         from ..models.isolated_workspace_spec import IsolatedWorkspaceSpec
 
@@ -121,6 +148,15 @@ class CreateIsolatedSessionRequest:
 
         extra_writable = cast(list[str], d.pop("extra_writable", UNSET))
 
+        _binds = d.pop("binds", UNSET)
+        binds: list[BindMount] | Unset = UNSET
+        if _binds is not UNSET:
+            binds = []
+            for binds_item_data in _binds:
+                binds_item = BindMount.from_dict(binds_item_data)
+
+                binds.append(binds_item)
+
         share_net = d.pop("share_net", UNSET)
 
         _env_passthrough = d.pop("env_passthrough", UNSET)
@@ -134,16 +170,25 @@ class CreateIsolatedSessionRequest:
 
         gid = d.pop("gid", UNSET)
 
+        _uid_mode = d.pop("uid_mode", UNSET)
+        uid_mode: CreateIsolatedSessionRequestUidMode | Unset
+        if isinstance(_uid_mode, Unset):
+            uid_mode = UNSET
+        else:
+            uid_mode = CreateIsolatedSessionRequestUidMode(_uid_mode)
+
         idle_timeout_seconds = d.pop("idle_timeout_seconds", UNSET)
 
         create_isolated_session_request = cls(
             workspace=workspace,
             profile=profile,
             extra_writable=extra_writable,
+            binds=binds,
             share_net=share_net,
             env_passthrough=env_passthrough,
             uid=uid,
             gid=gid,
+            uid_mode=uid_mode,
             idle_timeout_seconds=idle_timeout_seconds,
         )
 

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request_uid_mode.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request_uid_mode.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class CreateIsolatedSessionRequestUidMode(str, Enum):
+    SETPRIV = "setpriv"
+    USERNS = "userns"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -42,6 +42,7 @@ from opensandbox.models.filesystem import (
     WriteEntry,
 )
 from opensandbox.models.isolated import (
+    BindMount,
     CreateIsolatedSessionRequest,
     EnvPassthroughSpec,
     IsolatedCapabilities,
@@ -98,6 +99,7 @@ __all__ = [
     "CommandStatus",
     "CommandLogs",
     # Isolated session models
+    "BindMount",
     "CreateIsolatedSessionRequest",
     "EnvPassthroughSpec",
     "IsolatedCapabilities",

--- a/sdks/sandbox/python/src/opensandbox/models/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/models/isolated.py
@@ -51,6 +51,22 @@ class EnvPassthroughSpec(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class BindMount(BaseModel):
+    """An explicit source-to-destination bind mount into the namespace."""
+
+    source: str = Field(description="Host path to bind-mount into the namespace")
+    dest: str | None = Field(
+        default=None,
+        description="Mount destination inside the namespace. Defaults to source when omitted.",
+    )
+    readonly: bool | None = Field(
+        default=None,
+        description="Mount read-only (--ro-bind) when true; read-write (--bind) otherwise.",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class CreateIsolatedSessionRequest(BaseModel):
     """Request to create an isolated bash session."""
 
@@ -64,6 +80,10 @@ class CreateIsolatedSessionRequest(BaseModel):
     extra_writable: list[str] | None = Field(
         default=None,
         description="Additional paths to bind read-write inside the namespace",
+    )
+    binds: list[BindMount] | None = Field(
+        default=None,
+        description="Additional host paths bind-mounted with explicit source-to-destination mapping",
     )
     share_net: bool | None = Field(
         default=None,
@@ -80,6 +100,10 @@ class CreateIsolatedSessionRequest(BaseModel):
     gid: int | None = Field(
         default=None,
         description="Run as this Unix GID inside the namespace",
+    )
+    uid_mode: str | None = Field(
+        default=None,
+        description="How user identity is established inside the namespace: 'setpriv' (default) or 'userns'.",
     )
     idle_timeout_seconds: int | None = Field(
         default=None,

--- a/sdks/sandbox/python/src/opensandbox/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/services/isolated.py
@@ -26,6 +26,7 @@ from typing import Protocol
 
 from opensandbox.models.execd import Execution, ExecutionHandlers
 from opensandbox.models.isolated import (
+    BindMount,
     CreateIsolatedSessionRequest,
     IsolatedCapabilities,
     IsolatedRunOpts,
@@ -82,6 +83,7 @@ class IsolationService(Protocol):
         handlers: ExecutionHandlers | None = None,
         profile: str | None = None,
         share_net: bool | None = None,
+        binds: list[BindMount] | None = None,
     ) -> Execution:
         """Create a session, run *code*, and delete the session (auto-cleanup)."""
         ...
@@ -116,11 +118,13 @@ class IsolationServiceMixin:
         handlers: ExecutionHandlers | None = None,
         profile: str | None = None,
         share_net: bool | None = None,
+        binds: list[BindMount] | None = None,
     ) -> Execution:
         request = CreateIsolatedSessionRequest(
             workspace=IsolatedWorkspaceSpec(path=workspace, mode=workspace_mode),
             profile=profile,
             share_net=share_net,
+            binds=binds,
         )
         session = await self.create(request)
         try:

--- a/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
@@ -25,6 +25,7 @@ from typing import Any, Protocol
 from opensandbox.models.execd import Execution
 from opensandbox.models.execd_sync import ExecutionHandlersSync
 from opensandbox.models.isolated import (
+    BindMount,
     CreateIsolatedSessionRequest,
     IsolatedCapabilities,
     IsolatedRunOpts,
@@ -80,6 +81,7 @@ class IsolationServiceSync(Protocol):
         handlers: ExecutionHandlersSync | None = None,
         profile: str | None = None,
         share_net: bool | None = None,
+        binds: list[BindMount] | None = None,
     ) -> Execution:
         """Create a session, run *code*, and delete the session (auto-cleanup)."""
         ...
@@ -114,11 +116,13 @@ class IsolationServiceSyncMixin:
         handlers: ExecutionHandlersSync | None = None,
         profile: str | None = None,
         share_net: bool | None = None,
+        binds: list[BindMount] | None = None,
     ) -> Execution:
         request = CreateIsolatedSessionRequest(
             workspace=IsolatedWorkspaceSpec(path=workspace, mode=workspace_mode),
             profile=profile,
             share_net=share_net,
+            binds=binds,
         )
         session = self.create(request)
         try:

--- a/sdks/sandbox/python/tests/test_models_stability.py
+++ b/sdks/sandbox/python/tests/test_models_stability.py
@@ -428,3 +428,43 @@ def test_execution_text_strips_trailing_newlines() -> None:
     )
     assert ex.text == "1\n2"
     assert str(ex) == "1\n2"
+
+
+def test_isolated_binds_serialize_to_wire_format() -> None:
+    """binds and uid_mode serialize to the execd wire format."""
+    from opensandbox.models import (
+        BindMount,
+        CreateIsolatedSessionRequest,
+        IsolatedWorkspaceSpec,
+    )
+
+    req = CreateIsolatedSessionRequest(
+        workspace=IsolatedWorkspaceSpec(path="/workspace", mode="rw"),
+        binds=[
+            BindMount(source="/data/in", dest="/mnt/in", readonly=True),
+            BindMount(source="/data/out"),
+        ],
+        uid_mode="userns",
+    )
+    body = req.model_dump(exclude_none=True)
+
+    assert body["uid_mode"] == "userns"
+    assert body["binds"] == [
+        {"source": "/data/in", "dest": "/mnt/in", "readonly": True},
+        {"source": "/data/out"},
+    ]
+
+
+def test_isolated_binds_omitted_when_unset() -> None:
+    """binds and uid_mode are omitted when unset (backward compatible)."""
+    from opensandbox.models import (
+        CreateIsolatedSessionRequest,
+        IsolatedWorkspaceSpec,
+    )
+
+    req = CreateIsolatedSessionRequest(
+        workspace=IsolatedWorkspaceSpec(path="/workspace"),
+    )
+    body = req.model_dump(exclude_none=True)
+    assert "binds" not in body
+    assert "uid_mode" not in body

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -2074,6 +2074,17 @@ components:
           type: array
           items:
             type: string
+        binds:
+          type: array
+          description: >-
+            Additional host paths bind-mounted into the namespace with an
+            explicit source-to-destination mapping. Unlike extra_writable
+            (which mounts source==destination read-write), each entry may map
+            a distinct destination path and be mounted read-only. The source
+            path of every entry must fall within the configured writable
+            allowlist.
+          items:
+            $ref: "#/components/schemas/BindMount"
         share_net:
           type: boolean
         env_passthrough:
@@ -2104,6 +2115,26 @@ components:
         mode:
           type: string
           enum: ["rw", "overlay", "ro"]
+
+    BindMount:
+      type: object
+      required:
+        - source
+      properties:
+        source:
+          type: string
+          description: Host path to bind-mount into the namespace.
+        dest:
+          type: string
+          description: >-
+            Mount destination inside the namespace. Defaults to source when
+            omitted.
+        readonly:
+          type: boolean
+          default: false
+          description: >-
+            When true the mount is read-only (--ro-bind); otherwise it is
+            read-write (--bind).
 
     EnvPassthroughSpec:
       type: object

--- a/tests/csharp/OpenSandbox.E2ETests/IsolatedSessionE2ETests.cs
+++ b/tests/csharp/OpenSandbox.E2ETests/IsolatedSessionE2ETests.cs
@@ -839,4 +839,87 @@ public sealed class IsolatedSessionE2ETests : IAsyncLifetime
             });
         Assert.Contains("step1", output);
     }
+
+    // ── Bind mount tests (explicit source->dest binds) ─────────────────
+
+    [Fact]
+    public async Task TestBindReadWriteHostVisible()
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        // Source must be within the execd writable allowlist (e.g. /data).
+        var srcDir = $"/data/bind_rw_{ts}";
+        var dest = "/mnt/bind_rw";
+        var fileName = "from_sandbox.txt";
+        var content = "bind-rw-visible-on-host";
+
+        // Create the source dir and the destination mount point (bwrap binds
+        // onto an existing dir; it cannot create one under the read-only root).
+        await _sandbox!.Commands.RunAsync($"mkdir -p {srcDir} {dest}");
+
+        var session = await _sandbox.Isolation.CreateAsync(
+            new CreateIsolatedSessionRequest(
+                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                Binds: new List<BindMount> { new BindMount(srcDir, dest) }));
+        try
+        {
+            var exec = await session.RunAsync(
+                $"echo -n {content} > {dest}/{fileName} && cat {dest}/{fileName}");
+            Assert.Contains(content, StdoutText(exec));
+
+            var hostCheck = await _sandbox.Commands.RunAsync($"cat {srcDir}/{fileName}");
+            Assert.Contains(content, StdoutText(hostCheck));
+        }
+        finally
+        {
+            await session.DeleteAsync();
+            await _sandbox.Commands.RunAsync($"rm -rf {srcDir}");
+        }
+    }
+
+    [Fact]
+    public async Task TestBindIllegalRejected()
+    {
+        await Assert.ThrowsAsync<SandboxApiException>(
+            () => _sandbox!.Isolation.CreateAsync(
+                new CreateIsolatedSessionRequest(
+                    new IsolatedWorkspaceSpec("/tmp", "rw"),
+                    // /etc is not in the writable allowlist.
+                    Binds: new List<BindMount> { new BindMount("/etc", "/mnt/etc") })));
+    }
+
+    [Fact]
+    public async Task TestBindReadOnlyReadable()
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var srcDir = $"/data/bind_ro_{ts}";
+        var dest = "/mnt/bind_ro";
+        var fileName = "host_created.txt";
+        var content = "bind-ro-host-content";
+
+        await _sandbox!.Commands.RunAsync(
+            $"mkdir -p {srcDir} {dest} && echo -n {content} > {srcDir}/{fileName}");
+
+        var session = await _sandbox.Isolation.CreateAsync(
+            new CreateIsolatedSessionRequest(
+                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                Binds: new List<BindMount> { new BindMount(srcDir, dest, true) }));
+        try
+        {
+            var exec = await session.RunAsync($"cat {dest}/{fileName}");
+            Assert.Contains(content, StdoutText(exec));
+
+            var write = await session.RunAsync(
+                $"echo x > {dest}/newfile.txt 2>&1; echo EXIT=$?");
+            var text = StdoutText(write);
+            Assert.True(
+                text.Contains("EXIT=1") || text.Contains("Read-only")
+                    || text.Contains("read-only") || text.Contains("Permission denied"),
+                $"expected write to fail through read-only bind, got: {text}");
+        }
+        finally
+        {
+            await session.DeleteAsync();
+            await _sandbox.Commands.RunAsync($"rm -rf {srcDir}");
+        }
+    }
 }

--- a/tests/go/isolated_session_e2e_test.go
+++ b/tests/go/isolated_session_e2e_test.go
@@ -1002,6 +1002,115 @@ func TestIsolationRunOnceWithEnvs(t *testing.T) {
 	assert.Contains(t, exec.Text(), "run-once-val")
 }
 
+// ---------------------------------------------------------------------------
+// Bind mount tests (explicit source->dest binds)
+// ---------------------------------------------------------------------------
+
+// TestIsolationBindReadWriteHostVisible verifies a legal read-write bind:
+// data written inside the bwrap namespace at the bind destination is readable
+// on the host at the bind source.
+func TestIsolationBindReadWriteHostVisible(t *testing.T) {
+	ctx, sb := createIsolatedTestSandbox(t)
+
+	ts := time.Now().UnixMilli()
+	// Source must fall within the execd writable allowlist (e.g. /data).
+	srcDir := fmt.Sprintf("/data/bind_rw_%d", ts)
+	dest := "/mnt/bind_rw"
+	fileName := "from_sandbox.txt"
+	content := "bind-rw-visible-on-host"
+
+	// Host-side: create the bind source directory and the destination mount
+	// point (bwrap binds onto an existing dir; it cannot create one under the
+	// read-only root).
+	_, err := sb.RunCommand(ctx, fmt.Sprintf("mkdir -p %s %s", srcDir, dest), nil)
+	require.NoError(t, err)
+
+	session, err := sb.IsolationCreate(ctx, opensandbox.CreateIsolatedSessionRequest{
+		Workspace: opensandbox.IsolatedWorkspaceSpec{Path: "/tmp", Mode: "rw"},
+		Binds: []opensandbox.BindMount{
+			{Source: srcDir, Dest: dest},
+		},
+	})
+	require.NoError(t, err)
+	defer session.Delete(ctx)
+
+	// Read back inside the namespace after writing (write + read in sandbox).
+	exec, err := session.Run(ctx, opensandbox.IsolatedRunRequest{
+		Code: fmt.Sprintf("echo -n %s > %s/%s && cat %s/%s", content, dest, fileName, dest, fileName),
+	}, nil)
+	require.NoError(t, err)
+	assert.Contains(t, exec.Text(), content, "sandbox should read back what it wrote to the bind")
+
+	// Host-side: the write must be visible at the bind source.
+	hostExec, err := sb.RunCommand(ctx, fmt.Sprintf("cat %s/%s", srcDir, fileName), nil)
+	require.NoError(t, err)
+	assert.Contains(t, hostExec.Text(), content, "bind write should be visible on host")
+}
+
+// TestIsolationBindIllegalRejected verifies that a bind whose source is outside
+// the writable allowlist is rejected at session creation.
+func TestIsolationBindIllegalRejected(t *testing.T) {
+	ctx, sb := createIsolatedTestSandbox(t)
+
+	_, err := sb.IsolationCreate(ctx, opensandbox.CreateIsolatedSessionRequest{
+		Workspace: opensandbox.IsolatedWorkspaceSpec{Path: "/tmp", Mode: "rw"},
+		Binds: []opensandbox.BindMount{
+			// /etc is not in the writable allowlist.
+			{Source: "/etc", Dest: "/mnt/etc"},
+		},
+	})
+	require.Error(t, err, "bind with source outside allowlist should be rejected")
+	assert.Contains(t, strings.ToLower(err.Error()), "allowlist",
+		"error should indicate the allowlist rejection, got: %v", err)
+}
+
+// TestIsolationBindReadOnlyReadable verifies a read-only bind: a host-created
+// file is readable inside the bwrap namespace via the read-only bind.
+func TestIsolationBindReadOnlyReadable(t *testing.T) {
+	ctx, sb := createIsolatedTestSandbox(t)
+
+	ts := time.Now().UnixMilli()
+	srcDir := fmt.Sprintf("/data/bind_ro_%d", ts)
+	dest := "/mnt/bind_ro"
+	fileName := "host_created.txt"
+	content := "bind-ro-host-content"
+
+	// Host-side: create the source dir (with a file to read), plus the
+	// destination mount point that bwrap will bind onto.
+	_, err := sb.RunCommand(ctx,
+		fmt.Sprintf("mkdir -p %s %s && echo -n %s > %s/%s", srcDir, dest, content, srcDir, fileName), nil)
+	require.NoError(t, err)
+
+	session, err := sb.IsolationCreate(ctx, opensandbox.CreateIsolatedSessionRequest{
+		Workspace: opensandbox.IsolatedWorkspaceSpec{Path: "/tmp", Mode: "rw"},
+		Binds: []opensandbox.BindMount{
+			{Source: srcDir, Dest: dest, ReadOnly: true},
+		},
+	})
+	require.NoError(t, err)
+	defer session.Delete(ctx)
+
+	// Read the host-created file inside the namespace via the read-only bind.
+	exec, err := session.Run(ctx, opensandbox.IsolatedRunRequest{
+		Code: fmt.Sprintf("cat %s/%s", dest, fileName),
+	}, nil)
+	require.NoError(t, err)
+	assert.Contains(t, exec.Text(), content, "read-only bind should be readable inside the sandbox")
+
+	// Writing through the read-only bind must fail.
+	writeExec, err := session.Run(ctx, opensandbox.IsolatedRunRequest{
+		Code: fmt.Sprintf("echo x > %s/newfile.txt 2>&1; echo exit=$?", dest),
+	}, nil)
+	require.NoError(t, err)
+	text := writeExec.Text()
+	assert.True(t,
+		strings.Contains(text, "Read-only") ||
+			strings.Contains(text, "read-only") ||
+			strings.Contains(text, "Permission denied") ||
+			strings.Contains(text, "exit=1"),
+		"expected write to fail through read-only bind, got: %s", text)
+}
+
 func TestIsolationWithSessionE2E(t *testing.T) {
 	ctx, sb := createIsolatedTestSandbox(t)
 

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/IsolatedSessionE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/IsolatedSessionE2ETest.java
@@ -27,6 +27,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.MoveEntry;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.SearchEntry;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.SetPermissionEntry;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.WriteEntry;
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.BindMount;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.CreateIsolatedSessionRequest;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedCapabilities;
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedRunRequest;
@@ -97,7 +98,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null));
+                                "balanced", null, null, null, null, null, null, null, null));
         assertNotNull(session.getSessionId());
 
         var state = session.get();
@@ -113,7 +114,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null));
+                                "balanced", null, null, null, null, null, null, null, null));
         try {
             Execution exec = session.run(new IsolatedRunRequest("echo hello-isolation", null, null));
             assertTrue(stdoutText(exec).contains("hello-isolation"));
@@ -129,7 +130,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null));
+                                "balanced", null, null, null, null, null, null, null, null));
         try {
             Execution exec = session.run(new IsolatedRunRequest("echo $$", null, null));
             int pid = Integer.parseInt(stdoutText(exec).trim());
@@ -146,7 +147,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null));
+                                "balanced", null, null, null, null, null, null, null, null));
         try {
             Execution exec =
                     session.run(new IsolatedRunRequest(
@@ -166,7 +167,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null));
+                                "balanced", null, null, null, null, null, null, null, null));
         try {
             session.run(new IsolatedRunRequest("export PERSIST_VAR=abc123", null, null));
             Execution exec = session.run(new IsolatedRunRequest("echo $PERSIST_VAR", null, null));
@@ -185,12 +186,12 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/workspace", "rw"),
-                                "strict", null, null, null, null, null, null));
+                                "strict", null, null, null, null, null, null, null, null));
         IsolationSession sessionB =
                 sandbox.isolation()
                         .create(new CreateIsolatedSessionRequest(
                                 new IsolatedWorkspaceSpec("/workspace", "rw"),
-                                "strict", null, null, null, null, null, null));
+                                "strict", null, null, null, null, null, null, null, null));
         try {
             sessionA.run(new IsolatedRunRequest(
                     "echo secret > /tmp/isolated_test_file.txt", null, null));
@@ -212,7 +213,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         return sandbox.isolation()
                 .create(new CreateIsolatedSessionRequest(
                         new IsolatedWorkspaceSpec(path, mode),
-                        "balanced", null, null, null, null, null, null));
+                        "balanced", null, null, null, null, null, null, null, null));
     }
 
     private IsolationSession createSession(String mode) {
@@ -695,7 +696,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     @Order(33)
     void testRunOnce() {
         Execution exec = sandbox.isolation()
-                .runOnce("echo runonce-e2e", "/tmp", "rw", null, null, null, null);
+                .runOnce("echo runonce-e2e", "/tmp", "rw", null, null, null, null, null);
         assertTrue(stdoutText(exec).contains("runonce-e2e"));
     }
 
@@ -710,6 +711,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                         Map.of("E2E_RUN_ONCE", "kt-value"),
                         null,
                         null,
+                        null,
                         null);
         assertTrue(stdoutText(exec).contains("kt-value"));
     }
@@ -720,7 +722,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         String output = sandbox.isolation().withSession(
                 new CreateIsolatedSessionRequest(
                         new IsolatedWorkspaceSpec("/tmp", "rw"),
-                        "balanced", null, null, null, null, null, null),
+                        "balanced", null, null, null, null, null, null, null, null),
                 session -> {
                     session.run(new IsolatedRunRequest("export WS_VAR=with-session-kt", null, null));
                     Execution exec = session.run(new IsolatedRunRequest("echo $WS_VAR", null, null));
@@ -735,12 +737,103 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         String output = sandbox.isolation().withSession(
                 new CreateIsolatedSessionRequest(
                         new IsolatedWorkspaceSpec("/tmp", "rw"),
-                        "balanced", null, null, null, null, null, null),
+                        "balanced", null, null, null, null, null, null, null, null),
                 session -> {
                     session.run(new IsolatedRunRequest("echo step1 > /tmp/ws_test_kt.txt", null, null));
                     Execution exec = session.run(new IsolatedRunRequest("cat /tmp/ws_test_kt.txt", null, null));
                     return stdoutText(exec);
                 });
         assertTrue(output.contains("step1"));
+    }
+
+    // ── Bind mount tests (explicit source->dest binds) ─────────────────
+
+    @Test
+    @Order(37)
+    void testBindReadWriteHostVisible() {
+        long ts = System.currentTimeMillis();
+        // Source must be within the execd writable allowlist (e.g. /data).
+        String srcDir = "/data/bind_rw_" + ts;
+        String dest = "/mnt/bind_rw";
+        String fileName = "from_sandbox.txt";
+        String content = "bind-rw-visible-on-host";
+
+        // Create the source dir and the destination mount point (bwrap binds
+        // onto an existing dir; it cannot create one under the read-only root).
+        sandbox.commands().run("mkdir -p " + srcDir + " " + dest);
+
+        IsolationSession session =
+                sandbox.isolation()
+                        .create(new CreateIsolatedSessionRequest(
+                                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                "balanced",
+                                null,
+                                List.of(new BindMount(srcDir, dest, null)),
+                                null, null, null, null, null, null));
+        try {
+            Execution exec = session.run(new IsolatedRunRequest(
+                    "echo -n " + content + " > " + dest + "/" + fileName
+                            + " && cat " + dest + "/" + fileName,
+                    null, null));
+            assertTrue(stdoutText(exec).contains(content));
+
+            Execution hostCheck = sandbox.commands().run("cat " + srcDir + "/" + fileName);
+            assertTrue(stdoutText(hostCheck).contains(content));
+        } finally {
+            session.delete();
+            sandbox.commands().run("rm -rf " + srcDir);
+        }
+    }
+
+    @Test
+    @Order(38)
+    void testBindIllegalRejected() {
+        assertThrows(
+                SandboxException.class,
+                () -> sandbox.isolation()
+                        .create(new CreateIsolatedSessionRequest(
+                                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                "balanced",
+                                null,
+                                // /etc is not in the writable allowlist.
+                                List.of(new BindMount("/etc", "/mnt/etc", null)),
+                                null, null, null, null, null, null)));
+    }
+
+    @Test
+    @Order(39)
+    void testBindReadOnlyReadable() {
+        long ts = System.currentTimeMillis();
+        String srcDir = "/data/bind_ro_" + ts;
+        String dest = "/mnt/bind_ro";
+        String fileName = "host_created.txt";
+        String content = "bind-ro-host-content";
+
+        sandbox.commands().run(
+                "mkdir -p " + srcDir + " " + dest + " && echo -n " + content + " > " + srcDir + "/" + fileName);
+
+        IsolationSession session =
+                sandbox.isolation()
+                        .create(new CreateIsolatedSessionRequest(
+                                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                "balanced",
+                                null,
+                                List.of(new BindMount(srcDir, dest, true)),
+                                null, null, null, null, null, null));
+        try {
+            Execution exec = session.run(new IsolatedRunRequest("cat " + dest + "/" + fileName, null, null));
+            assertTrue(stdoutText(exec).contains(content));
+
+            Execution write = session.run(new IsolatedRunRequest(
+                    "echo x > " + dest + "/newfile.txt 2>&1; echo EXIT=$?", null, null));
+            String text = stdoutText(write);
+            assertTrue(
+                    text.contains("EXIT=1") || text.contains("Read-only")
+                            || text.contains("read-only") || text.contains("Permission denied"),
+                    "expected write to fail through read-only bind, got: " + text);
+        } finally {
+            session.delete();
+            sandbox.commands().run("rm -rf " + srcDir);
+        }
     }
 }

--- a/tests/javascript/tests/test_isolated_session_e2e.test.ts
+++ b/tests/javascript/tests/test_isolated_session_e2e.test.ts
@@ -715,4 +715,82 @@ describe("IsolatedSession E2E", () => {
     );
     expect(output).toContain("step1");
   });
+
+  // Bind mount tests (explicit source->dest binds)
+
+  it("test_bind_read_write_host_visible", async () => {
+    const ts = Date.now();
+    // Source must be within the execd writable allowlist (e.g. /data).
+    const srcDir = `/data/bind_rw_${ts}`;
+    const dest = "/mnt/bind_rw";
+    const fileName = "from_sandbox.txt";
+    const content = "bind-rw-visible-on-host";
+
+    // Create the source dir and the destination mount point (bwrap binds onto
+    // an existing dir; it cannot create one under the read-only root).
+    await sandbox.commands.run(`mkdir -p ${srcDir} ${dest}`);
+
+    const session = await sandbox.isolation.create({
+      workspace: { path: "/tmp", mode: "rw" },
+      binds: [{ source: srcDir, dest }],
+    });
+    try {
+      const exec = await session.run(
+        `echo -n ${content} > ${dest}/${fileName} && cat ${dest}/${fileName}`
+      );
+      expect(exec.logs.stdout.map(m => m.text).join("")).toContain(content);
+
+      const hostCheck = await sandbox.commands.run(`cat ${srcDir}/${fileName}`);
+      expect(hostCheck.logs.stdout.map(m => m.text).join("")).toContain(content);
+    } finally {
+      await session.delete();
+      await sandbox.commands.run(`rm -rf ${srcDir}`);
+    }
+  });
+
+  it("test_bind_illegal_rejected", async () => {
+    await expect(
+      sandbox.isolation.create({
+        workspace: { path: "/tmp", mode: "rw" },
+        // /etc is not in the writable allowlist.
+        binds: [{ source: "/etc", dest: "/mnt/etc" }],
+      })
+    ).rejects.toThrow();
+  });
+
+  it("test_bind_read_only_readable", async () => {
+    const ts = Date.now();
+    const srcDir = `/data/bind_ro_${ts}`;
+    const dest = "/mnt/bind_ro";
+    const fileName = "host_created.txt";
+    const content = "bind-ro-host-content";
+
+    await sandbox.commands.run(
+      `mkdir -p ${srcDir} ${dest} && echo -n ${content} > ${srcDir}/${fileName}`
+    );
+
+    const session = await sandbox.isolation.create({
+      workspace: { path: "/tmp", mode: "rw" },
+      binds: [{ source: srcDir, dest, readonly: true }],
+    });
+    try {
+      const exec = await session.run(`cat ${dest}/${fileName}`);
+      expect(exec.logs.stdout.map(m => m.text).join("")).toContain(content);
+
+      const write = await session.run(
+        `echo x > ${dest}/newfile.txt 2>&1 || echo WRITE_FAILED`
+      );
+      const output = write.logs.stdout.map(m => m.text).join("")
+        + write.logs.stderr.map(m => m.text).join("");
+      expect(
+        output.includes("WRITE_FAILED") ||
+        output.includes("Read-only") ||
+        output.includes("read-only") ||
+        output.includes("Permission denied")
+      ).toBe(true);
+    } finally {
+      await session.delete();
+      await sandbox.commands.run(`rm -rf ${srcDir}`);
+    }
+  });
 });

--- a/tests/python/tests/test_isolated_session_e2e.py
+++ b/tests/python/tests/test_isolated_session_e2e.py
@@ -33,6 +33,7 @@ from opensandbox.models.filesystem import (
     WriteEntry,
 )
 from opensandbox.models.isolated import (
+    BindMount,
     CreateIsolatedSessionRequest,
     IsolatedRunOpts,
     IsolatedWorkspaceSpec,
@@ -612,3 +613,82 @@ class TestIsolatedSessionE2E:
             await session.run("echo step1 > /tmp/ctx_test.txt")
             result = await session.run("cat /tmp/ctx_test.txt")
             assert "step1" in result.text
+
+    # ── Bind mount tests (explicit source->dest binds) ─────────────────
+
+    async def test_bind_read_write_host_visible(self):
+        """Legal RW bind: sandbox writes at dest are visible on host at source."""
+        ts = int(time.time() * 1000)
+        # Source must be within the execd writable allowlist (e.g. /data).
+        src_dir = f"/data/bind_rw_{ts}"
+        dest = "/mnt/bind_rw"
+        file_name = "from_sandbox.txt"
+        content = "bind-rw-visible-on-host"
+
+        # Create the source dir and the destination mount point (bwrap binds
+        # onto an existing dir; it cannot create one under the read-only root).
+        await self.sandbox.commands.run(f"mkdir -p {src_dir} {dest}")
+
+        session = await self.sandbox.isolation.create(
+            CreateIsolatedSessionRequest(
+                workspace=IsolatedWorkspaceSpec(path="/tmp", mode="rw"),
+                binds=[BindMount(source=src_dir, dest=dest)],
+            )
+        )
+        try:
+            result = await session.run(
+                f"echo -n {content} > {dest}/{file_name} && cat {dest}/{file_name}"
+            )
+            assert content in result.text
+
+            host_check = await self.sandbox.commands.run(f"cat {src_dir}/{file_name}")
+            assert content in host_check.text
+        finally:
+            await session.delete()
+            await self.sandbox.commands.run(f"rm -rf {src_dir}")
+
+    async def test_bind_illegal_rejected(self):
+        """Bind whose source is outside the allowlist is rejected on create."""
+        with pytest.raises(SandboxApiException):
+            await self.sandbox.isolation.create(
+                CreateIsolatedSessionRequest(
+                    workspace=IsolatedWorkspaceSpec(path="/tmp", mode="rw"),
+                    # /etc is not in the writable allowlist.
+                    binds=[BindMount(source="/etc", dest="/mnt/etc")],
+                )
+            )
+
+    async def test_bind_read_only_readable(self):
+        """Read-only bind: host-created file is readable inside the sandbox."""
+        ts = int(time.time() * 1000)
+        src_dir = f"/data/bind_ro_{ts}"
+        dest = "/mnt/bind_ro"
+        file_name = "host_created.txt"
+        content = "bind-ro-host-content"
+
+        await self.sandbox.commands.run(
+            f"mkdir -p {src_dir} {dest} && echo -n {content} > {src_dir}/{file_name}"
+        )
+
+        session = await self.sandbox.isolation.create(
+            CreateIsolatedSessionRequest(
+                workspace=IsolatedWorkspaceSpec(path="/tmp", mode="rw"),
+                binds=[BindMount(source=src_dir, dest=dest, readonly=True)],
+            )
+        )
+        try:
+            result = await session.run(f"cat {dest}/{file_name}")
+            assert content in result.text
+
+            write = await session.run(
+                f"echo x > {dest}/newfile.txt 2>&1; echo EXIT=$?"
+            )
+            assert (
+                "EXIT=1" in write.text
+                or "Read-only" in write.text
+                or "read-only" in write.text
+                or "Permission denied" in write.text
+            )
+        finally:
+            await session.delete()
+            await self.sandbox.commands.run(f"rm -rf {src_dir}")


### PR DESCRIPTION
# Summary

Add support for arbitrary **source→destination bind mounts** in execd isolated (bwrap) sessions, complementing the existing `extra_writable` (which only supports `source==destination`, always read-write). Each bind maps a host source to an in-namespace destination and may be mounted read-only.

This is an additive, backward-compatible change across the full stack: spec → execd server → all five sandbox SDKs → e2e tests.

## What changed

**Server (execd)**
- New `BindMount{source, dest, readonly}` and `WrapOptions.Binds`; the bwrap argv builder renders `--bind` / `--ro-bind` with distinct `src→dst`.
- Bind sources are validated against the writable allowlist (read-only binds included) to prevent mapping arbitrary host paths into the sandbox.
- Seed a non-empty default allowlist (`/workspace`, `/mnt`, `/media`, `/data`) so common sandbox data volumes and their subdirectories work out of the box. The allowlist is prefix-based, so subpaths (e.g. `/data/foo`) are allowed; `..` traversal is blocked via `filepath.Clean`.
- `Binds` threaded through runtime options and the web model/controller (and the Windows stub).

**Spec**
- Added the `BindMount` schema and `binds` field to `CreateIsolatedSessionRequest` in `specs/execd-api.yaml`.

**SDKs (python, javascript, kotlin, go, csharp)**
- Added `BindMount` and `binds` (plus the previously missing `uid_mode`) to the handwritten `CreateIsolatedSessionRequest` model.
- Threaded `binds` through the `run_once` convenience helper (Go already accepted the full request).
- Regenerated the python and javascript execd API models from the spec.

## Usage

```python
await sandbox.isolation.run_once(
    "cat /mnt/in/data.txt",
    workspace="/tmp",
    binds=[BindMount(source="/data/in", dest="/mnt/in", readonly=True)],
)
```

> Note: a bind must target an **existing** destination mount point — bwrap cannot create one under the read-only root. Create the destination directory first (e.g. `mkdir -p`).

# Testing
- [x] Unit tests — argv builder binds (rw/ro/default-dest/validation), request-mapping regression tests across SDKs.
- [x] Integration tests — `bwrap_binds_test.go` (src→dst write-through, read-only read + write-denied, source-not-in-allowlist rejected).
- [x] e2e / manual verification — three bind scenarios (legal read-write visible on host, illegal source rejected, read-only readable) for go, python, javascript, java, and csharp. All CI checks (5 language e2e suites, execd test, bwrap-smoke, ubuntu/windows smoke) pass.

# Breaking Changes
- [x] None — additive field on the request; existing `extra_writable` and all current callers are unaffected. The default allowlist changes from empty (reject-all) to `/workspace, /mnt, /media, /data`; the feature is unreleased.

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed) — no user-facing docs page yet; spec updated
- [x] Added/updated tests (if needed)
- [x] Security impact considered — bind sources are allowlist-validated (read-only included); path traversal blocked via `filepath.Clean`
- [x] Backward compatibility considered
