### PR TITLE
fix(docker): persist renewed sandbox expiration

### DIFF
--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -318,6 +318,9 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             tracked = self._sandbox_expirations.get(sandbox_id)
         if tracked:
             return tracked
+        persisted = self._metadata_store.get_expiration(sandbox_id)
+        if persisted:
+            return parse_timestamp(persisted)
         label_value = labels.get(SANDBOX_EXPIRES_AT_LABEL)
         if label_value:
             return parse_timestamp(label_value)
@@ -338,6 +341,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                 self._cleanup_windows_oem_volume(sandbox_id, None)
                 if fallback_mount_keys:
                     self._release_ossfs_mounts(fallback_mount_keys)
+                self._metadata_store.delete(sandbox_id)
             else:
                 with self._expiration_lock:
                     current_expires = self._sandbox_expirations.get(sandbox_id)
@@ -363,9 +367,10 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     )
             return
 
-        with self._expiration_lock:
-            current_expires = self._sandbox_expirations.get(sandbox_id)
+        labels = container.attrs.get("Config", {}).get("Labels") or {}
+        current_expires = self._get_tracked_expiration(sandbox_id, labels)
         if current_expires and current_expires > datetime.now(timezone.utc):
+            self._schedule_expiration(sandbox_id, current_expires, update_expiration=False)
             logger.info(
                 "Sandbox %s was renewed (expires %s); aborting expiration.",
                 sandbox_id,
@@ -373,7 +378,6 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             )
             return
 
-        labels = container.attrs.get("Config", {}).get("Labels") or {}
         mount_keys_raw = labels.get(SANDBOX_OSSFS_MOUNTS_LABEL, "[]")
         try:
             parsed_mount_keys = json.loads(mount_keys_raw)
@@ -452,13 +456,11 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
 
             mount_keys = _parse_and_accumulate_mount_refs(labels)
 
-            expires_label = labels.get(SANDBOX_EXPIRES_AT_LABEL)
-            if expires_label:
-                expires_at = parse_timestamp(expires_label)
-            elif self._has_manual_cleanup(labels):
-                restored += 1
-                continue
-            else:
+            expires_at = self._get_tracked_expiration(sandbox_id, labels)
+            if expires_at is None:
+                if self._has_manual_cleanup(labels):
+                    restored += 1
+                    continue
                 logger.warning(
                     "Sandbox %s missing expires-at label; skipping expiration scheduling.",
                     sandbox_id,
@@ -1165,8 +1167,12 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                 },
             )
 
-        # Persist the new timeout in memory; it will also be respected on restart via _restore_existing_sandboxes
+        # Persist the new timeout in memory; the file-backed override also keeps renewals correct across restarts
         self._schedule_expiration(sandbox_id, new_expiration)
+        try:
+            self._metadata_store.set_expiration(sandbox_id, new_expiration)
+        except OSError as exc:
+            logger.warning("Failed to persist expiration override for sandbox %s: %s", sandbox_id, exc)
         labels[SANDBOX_EXPIRES_AT_LABEL] = new_expiration.isoformat()
         try:
             with self._docker_operation("update sandbox labels", sandbox_id):

--- a/server/opensandbox_server/services/docker/metadata.py
+++ b/server/opensandbox_server/services/docker/metadata.py
@@ -15,14 +15,16 @@
 """Per-sandbox file-backed metadata store for Docker.
 
 Docker cannot update labels on running containers, so user metadata patches
-are persisted to individual JSON files under ``~/.opensandbox/metadata/``.
-Atomic writes (tmp + rename) guard against truncation during crash.
+and expiration overrides are persisted to individual JSON files under
+``~/.opensandbox/metadata/``. Atomic writes (tmp + rename) guard against
+truncation during crash.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -47,7 +49,7 @@ def _extract_user_labels(labels: dict) -> dict:
 
 
 class DockerMetadataStore:
-    """Per-sandbox file-backed store for user metadata overrides."""
+    """Per-sandbox file-backed store for user metadata and expiration overrides."""
 
     def __init__(self, root: Path | None = None) -> None:
         self._root = root or DEFAULT_STORE_DIR
@@ -97,13 +99,30 @@ class DockerMetadataStore:
 
         self._write_file(path, current)
 
+    def get_expiration(self, sandbox_id: str) -> str | None:
+        """Return a persisted expiration override when one exists."""
+        payload = self._read_file(self._expiration_path(sandbox_id))
+        if not isinstance(payload, dict):
+            return None
+        expires_at = payload.get("expires_at")
+        if isinstance(expires_at, str) and expires_at.strip():
+            return expires_at
+        return None
+
+    def set_expiration(self, sandbox_id: str, expires_at: datetime) -> None:
+        """Persist the latest sandbox expiration override atomically."""
+        self._write_file(
+            self._expiration_path(sandbox_id),
+            {"expires_at": expires_at.isoformat()},
+        )
+
     def delete(self, sandbox_id: str) -> None:
         """Remove persisted overrides for a sandbox."""
-        path = self._sandbox_path(sandbox_id)
-        try:
-            path.unlink(missing_ok=True)
-        except OSError as exc:
-            logger.warning("Failed to delete metadata file %s: %s", path, exc)
+        for path in (self._sandbox_path(sandbox_id), self._expiration_path(sandbox_id)):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("Failed to delete metadata file %s: %s", path, exc)
 
     # ------------------------------------------------------------------
     # Internal
@@ -111,6 +130,9 @@ class DockerMetadataStore:
 
     def _sandbox_path(self, sandbox_id: str) -> Path:
         return self._root / f"{sandbox_id}.json"
+
+    def _expiration_path(self, sandbox_id: str) -> Path:
+        return self._root / "_expiration" / f"{sandbox_id}.json"
 
     @staticmethod
     def _read_file(path: Path) -> dict | None:

--- a/server/tests/test_docker_metadata_store.py
+++ b/server/tests/test_docker_metadata_store.py
@@ -14,6 +14,7 @@
 
 """Unit tests for DockerMetadataStore (per-sandbox file-backed)."""
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from opensandbox_server.services.docker.metadata import (
@@ -170,6 +171,27 @@ class TestDockerMetadataStore:
     def test_delete_nonexistent_silent(self, tmp_path: Path):
         store = self._make_store(tmp_path)
         store.delete("nonexistent")  # Should not raise
+
+    def test_set_get_expiration_override(self, tmp_path: Path):
+        store = self._make_store(tmp_path)
+        expires_at = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+        store.set_expiration("sbx-001", expires_at)
+
+        assert store.get_expiration("sbx-001") == expires_at.isoformat()
+
+    def test_delete_removes_expiration_override_file(self, tmp_path: Path):
+        store = self._make_store(tmp_path)
+        expires_at = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        store.set_expiration("sbx-001", expires_at)
+
+        expiration_file = tmp_path / "metadata" / "_expiration" / "sbx-001.json"
+        assert expiration_file.exists()
+
+        store.delete("sbx-001")
+
+        assert not expiration_file.exists()
+        assert store.get_expiration("sbx-001") is None
 
     # -- crash recovery ------------------------------------------------------
 

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -52,6 +52,7 @@ from opensandbox_server.services.constants import (
     SandboxErrorCodes,
 )
 from opensandbox_server.services.docker import DockerSandboxService
+from opensandbox_server.services.docker.metadata import DockerMetadataStore
 from opensandbox_server.services.helpers import (
     parse_gpu_request,
     parse_memory_limit,
@@ -69,6 +70,7 @@ from opensandbox_server.api.schema import (
     PlatformSpec,
     PVC,
     ResourceLimits,
+    RenewSandboxExpirationRequest,
     SandboxStatus,
     Volume,
 )
@@ -1348,6 +1350,25 @@ def test_expire_not_found_attempts_windows_oem_volume_cleanup():
     mock_remove.assert_called_once_with("sandbox-missing")
     mock_cleanup_oem.assert_called_once_with("sandbox-missing", None)
 
+
+def test_expire_not_found_deletes_persisted_expiration_override(tmp_path):
+    service = DockerSandboxService(config=_app_config())
+    service._metadata_store = DockerMetadataStore(root=tmp_path / "metadata")
+    service._metadata_store.set_expiration("sandbox-missing", datetime(2030, 1, 1, tzinfo=timezone.utc))
+
+    with (
+        patch.object(
+            service,
+            "_get_container_by_sandbox_id",
+            side_effect=HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail={}),
+        ),
+        patch.object(service, "_remove_expiration_tracking"),
+        patch.object(service, "_cleanup_windows_oem_volume"),
+    ):
+        service._expire_sandbox("sandbox-missing")
+
+    assert service._metadata_store.get_expiration("sandbox-missing") is None
+
 def test_prepare_creation_context_allows_manual_cleanup():
     service = DockerSandboxService(config=_app_config())
     request = CreateSandboxRequest(
@@ -2104,6 +2125,85 @@ def test_renew_expiration_rejects_manual_cleanup_sandbox():
 
     assert exc_info.value.status_code == status.HTTP_409_CONFLICT
     assert exc_info.value.detail["message"] == "Sandbox manual-id does not have automatic expiration enabled."
+
+
+def test_renew_expiration_persists_override_when_label_refresh_fails(tmp_path):
+    service = DockerSandboxService(config=_app_config())
+    service._metadata_store = DockerMetadataStore(root=tmp_path / "metadata")
+    container = MagicMock()
+    container.attrs = {
+        "Config": {
+            "Labels": {
+                SANDBOX_ID_LABEL: "sandbox-1",
+                SANDBOX_EXPIRES_AT_LABEL: datetime(2026, 7, 9, tzinfo=timezone.utc).isoformat(),
+            }
+        }
+    }
+    new_expiration = datetime.now(timezone.utc) + timedelta(hours=2)
+    request = RenewSandboxExpirationRequest(expiresAt=new_expiration)
+
+    with (
+        patch.object(service, "_get_container_by_sandbox_id", return_value=container),
+        patch.object(service, "_schedule_expiration") as mock_schedule,
+        patch.object(service, "_update_container_labels", side_effect=TypeError("labels unsupported")),
+    ):
+        response = service.renew_expiration("sandbox-1", request)
+
+    mock_schedule.assert_called_once_with("sandbox-1", new_expiration)
+    assert response.expires_at == new_expiration
+    assert service._metadata_store.get_expiration("sandbox-1") == new_expiration.isoformat()
+
+
+def test_get_tracked_expiration_prefers_persisted_override(tmp_path):
+    service = DockerSandboxService(config=_app_config())
+    service._metadata_store = DockerMetadataStore(root=tmp_path / "metadata")
+    persisted = datetime.now(timezone.utc) + timedelta(hours=3)
+    service._metadata_store.set_expiration("sandbox-1", persisted)
+    labels = {SANDBOX_EXPIRES_AT_LABEL: datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat()}
+
+    assert service._get_tracked_expiration("sandbox-1", labels) == persisted
+
+
+def test_restore_existing_sandboxes_prefers_persisted_expiration_override(tmp_path):
+    service = DockerSandboxService(config=_app_config())
+    service._metadata_store = DockerMetadataStore(root=tmp_path / "metadata")
+    persisted = datetime.now(timezone.utc) + timedelta(hours=1)
+    service._metadata_store.set_expiration("sandbox-1", persisted)
+    container = MagicMock()
+    container.attrs = {
+        "Config": {
+            "Labels": {
+                SANDBOX_ID_LABEL: "sandbox-1",
+                SANDBOX_EXPIRES_AT_LABEL: datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            }
+        }
+    }
+
+    with (
+        patch.object(service.docker_client.containers, "list", return_value=[container]),
+        patch.object(service, "_schedule_expiration") as mock_schedule,
+    ):
+        service._restore_existing_sandboxes()
+
+    mock_schedule.assert_called_once_with("sandbox-1", persisted)
+
+
+def test_expire_sandbox_renewed_reschedules_timer():
+    service = DockerSandboxService(config=_app_config())
+    current_expires = datetime.now(timezone.utc) + timedelta(minutes=10)
+    container = MagicMock()
+    container.attrs = {"Config": {"Labels": {SANDBOX_ID_LABEL: "sandbox-1"}}}
+    service._sandbox_expirations["sandbox-1"] = current_expires
+
+    with (
+        patch.object(service, "_get_container_by_sandbox_id", return_value=container),
+        patch.object(service, "_schedule_expiration") as mock_schedule,
+    ):
+        service._expire_sandbox("sandbox-1")
+
+    mock_schedule.assert_called_once_with("sandbox-1", current_expires, update_expiration=False)
+    container.kill.assert_not_called()
+    container.remove.assert_not_called()
 
 @pytest.mark.asyncio
 @patch("opensandbox_server.services.docker.docker_service.docker")


### PR DESCRIPTION
## Summary
- persist renewed Docker sandbox expirations in the file-backed metadata store so restart recovery no longer depends on immutable container labels
- prefer the persisted expiration override when rebuilding Docker timers and clean it up if the container is already gone
- re-arm the expiration timer when an old callback observes that the sandbox was renewed, preventing running-orphan sandboxes with past `expiresAt`

Closes #1200.

## Testing
- `cd server && uv run pytest tests/test_docker_metadata_store.py tests/test_docker_service.py -q -k 'renew_expiration or restore_existing_sandboxes or expire_not_found or tracked_expiration or DockerMetadataStore'`
- `cd server && uv run ruff check opensandbox_server/services/docker/metadata.py opensandbox_server/services/docker/docker_service.py tests/test_docker_metadata_store.py tests/test_docker_service.py`
- `git diff --check`
