### PR TITLE
feat(isolation): add list isolated sessions API

### DIFF
--- a/components/execd/pkg/runtime/isolated_session_ctrl.go
+++ b/components/execd/pkg/runtime/isolated_session_ctrl.go
@@ -227,6 +227,49 @@ type IsolatedSessionState struct {
 	IdleRemainingSeconds *int
 }
 
+// IsolatedSessionSummary describes a single session in a list response.
+type IsolatedSessionSummary struct {
+	SessionID string
+	IsolatedSessionState
+}
+
+// ListIsolatedSessions returns a summary of all active isolated sessions.
+func (r *IsolatedRunner) ListIsolatedSessions() []IsolatedSessionSummary {
+	summaries := make([]IsolatedSessionSummary, 0)
+	r.ctrl.isolatedSessionMap.Range(func(key, value any) bool {
+		s, ok := value.(*isolatedSession)
+		if !ok {
+			return true
+		}
+
+		s.mu.RLock()
+		status := SessionStatusActive
+		if s.dead() {
+			status = SessionStatusDead
+		}
+		summary := IsolatedSessionSummary{
+			SessionID: s.id,
+			IsolatedSessionState: IsolatedSessionState{
+				Status:    status,
+				CreatedAt: s.createdAt,
+				LastRunAt: s.lastRunAt,
+			},
+		}
+		if s.opts.IdleTimeoutSeconds > 0 {
+			remaining := s.opts.IdleTimeoutSeconds - int(time.Since(s.lastRunAt).Seconds())
+			if remaining < 0 {
+				remaining = 0
+			}
+			summary.IdleRemainingSeconds = &remaining
+		}
+		s.mu.RUnlock()
+
+		summaries = append(summaries, summary)
+		return true
+	})
+	return summaries
+}
+
 // StdoutCallback is called for each line of stdout output during Run.
 type StdoutCallback func(line string)
 

--- a/components/execd/pkg/runtime/isolated_session_stub.go
+++ b/components/execd/pkg/runtime/isolated_session_stub.go
@@ -67,6 +67,11 @@ func (r *IsolatedRunner) GetIsolatedSession(_ string) (*IsolatedSessionState, er
 	return nil, ErrContextNotFound
 }
 
+// ListIsolatedSessions returns an empty list on Windows.
+func (r *IsolatedRunner) ListIsolatedSessions() []IsolatedSessionSummary {
+	return []IsolatedSessionSummary{}
+}
+
 // RunInIsolatedSession returns an error on Windows.
 func (r *IsolatedRunner) RunInIsolatedSession(_ context.Context, _ string, _ string, _ map[string]string, _ StdoutCallback) error {
 	return ErrContextNotFound
@@ -103,4 +108,10 @@ type IsolatedSessionState struct {
 	CreatedAt            time.Time
 	LastRunAt            time.Time
 	IdleRemainingSeconds *int
+}
+
+// IsolatedSessionSummary describes a session in a list response (Windows stub).
+type IsolatedSessionSummary struct {
+	SessionID string
+	IsolatedSessionState
 }

--- a/components/execd/pkg/web/controller/isolated_session.go
+++ b/components/execd/pkg/web/controller/isolated_session.go
@@ -137,6 +137,28 @@ func (c *IsolatedSessionController) Get() {
 	})
 }
 
+// List handles GET /v1/isolated/sessions.
+func (c *IsolatedSessionController) List() {
+	if !c.probed() {
+		c.RespondError(http.StatusServiceUnavailable, model.ErrorCodeServiceUnavailable, "isolation unavailable")
+		return
+	}
+
+	sessions := isolatedRunner.ListIsolatedSessions()
+	items := make([]model.IsolatedSessionSummary, 0, len(sessions))
+	for _, s := range sessions {
+		items = append(items, model.IsolatedSessionSummary{
+			SessionID:            s.SessionID,
+			Status:               s.Status,
+			CreatedAt:            s.CreatedAt,
+			LastRunAt:            s.LastRunAt,
+			IdleRemainingSeconds: s.IdleRemainingSeconds,
+		})
+	}
+
+	c.RespondSuccess(model.ListIsolatedSessionsResponse{Sessions: items})
+}
+
 // Run handles POST /v1/isolated/session/:sessionId/run (SSE streaming).
 func (c *IsolatedSessionController) Run() {
 	if !c.probed() {

--- a/components/execd/pkg/web/model/isolated_session.go
+++ b/components/execd/pkg/web/model/isolated_session.go
@@ -119,6 +119,20 @@ type SessionState struct {
 	IdleRemainingSeconds *int      `json:"idle_remaining_seconds,omitempty"`
 }
 
+// IsolatedSessionSummary describes a single session in a list response.
+type IsolatedSessionSummary struct {
+	SessionID            string    `json:"session_id"`
+	Status               string    `json:"status"` // "active" | "dead"
+	CreatedAt            time.Time `json:"created_at"`
+	LastRunAt            time.Time `json:"last_run_at"`
+	IdleRemainingSeconds *int      `json:"idle_remaining_seconds,omitempty"`
+}
+
+// ListIsolatedSessionsResponse is returned by GET /v1/isolated/sessions.
+type ListIsolatedSessionsResponse struct {
+	Sessions []IsolatedSessionSummary `json:"sessions"`
+}
+
 // Capabilities
 
 // CapabilitiesResponse is returned by GET /v1/isolated/capabilities.

--- a/components/execd/pkg/web/router.go
+++ b/components/execd/pkg/web/router.go
@@ -95,6 +95,7 @@ func NewRouter(accessToken string) *gin.Engine {
 	isolated := r.Group("/v1/isolated")
 	{
 		isolated.POST("/session", withIsolated(func(c *controller.IsolatedSessionController) { c.Create() }))
+		isolated.GET("/sessions", withIsolated(func(c *controller.IsolatedSessionController) { c.List() }))
 		isolated.GET("/session/:sessionId", withIsolated(func(c *controller.IsolatedSessionController) { c.Get() }))
 		isolated.POST("/session/:sessionId/run", withIsolated(func(c *controller.IsolatedSessionController) { c.Run() }))
 		isolated.DELETE("/session/:sessionId", withIsolated(func(c *controller.IsolatedSessionController) { c.Delete() }))

--- a/sdks/sandbox/csharp/src/OpenSandbox/Adapters/IsolatedSessionsAdapter.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Adapters/IsolatedSessionsAdapter.cs
@@ -170,6 +170,20 @@ internal sealed class IsolatedSessionsAdapter : IIsolatedSessions
         return JsonSerializer.Deserialize<IsolatedCapabilities>(body, JsonOptions)!;
     }
 
+    public async Task<IReadOnlyList<IsolatedSessionSummary>> ListAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var url = $"{_baseUrl}/v1/isolated/sessions";
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
+        ApplyHeaders(httpRequest);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+        await EnsureSuccessAsync(response, "list isolated sessions");
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var result = JsonSerializer.Deserialize<ListIsolatedSessionsResponse>(body, JsonOptions)!;
+        return result.Sessions ?? new List<IsolatedSessionSummary>();
+    }
+
     internal ISandboxFiles CreateFilesForSession(string sessionId)
     {
         var sessionBaseUrl = $"{_baseUrl}/v1/isolated/session/{Uri.EscapeDataString(sessionId)}";

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
@@ -49,6 +49,18 @@ public record IsolatedSessionState(
     [property: JsonPropertyName("idle_remaining_seconds")] int? IdleRemainingSeconds = null
 );
 
+public record IsolatedSessionSummary(
+    [property: JsonPropertyName("session_id")] string SessionId,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("created_at")] DateTimeOffset? CreatedAt = null,
+    [property: JsonPropertyName("last_run_at")] DateTimeOffset? LastRunAt = null,
+    [property: JsonPropertyName("idle_remaining_seconds")] int? IdleRemainingSeconds = null
+);
+
+public record ListIsolatedSessionsResponse(
+    [property: JsonPropertyName("sessions")] List<IsolatedSessionSummary>? Sessions = null
+);
+
 public record IsolatedRunOpts(
     [property: JsonPropertyName("envs")] Dictionary<string, string>? Envs = null,
     [property: JsonPropertyName("timeout_seconds")] int? TimeoutSeconds = null

--- a/sdks/sandbox/csharp/src/OpenSandbox/Services/IIsolatedSessions.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Services/IIsolatedSessions.cs
@@ -43,4 +43,7 @@ public interface IIsolatedSessions
 
     Task<IsolatedCapabilities> CapabilitiesAsync(
         CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<IsolatedSessionSummary>> ListAsync(
+        CancellationToken cancellationToken = default);
 }

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/IsolatedSessionsAdapterListTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/IsolatedSessionsAdapterListTests.cs
@@ -1,0 +1,137 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenSandbox.Adapters;
+using Xunit;
+
+namespace OpenSandbox.Tests;
+
+public class IsolatedSessionsAdapterListTests
+{
+    [Fact]
+    public async Task ListAsync_ShouldParsePopulatedSessions()
+    {
+        var handler = new CaptureHandler(_ => """
+        {
+          "sessions": [
+            {
+              "session_id": "sess-1",
+              "status": "running",
+              "created_at": "2026-01-01T00:00:00Z",
+              "last_run_at": "2026-01-01T00:05:00Z",
+              "idle_remaining_seconds": 120
+            },
+            {
+              "session_id": "sess-2",
+              "status": "idle",
+              "created_at": "2026-01-01T00:01:00Z",
+              "last_run_at": null,
+              "idle_remaining_seconds": null
+            }
+          ]
+        }
+        """);
+        var adapter = CreateAdapter(handler, new Dictionary<string, string>
+        {
+            ["X-Global"] = "global"
+        });
+
+        var sessions = await adapter.ListAsync();
+
+        handler.Requests.Should().ContainSingle();
+        var request = handler.Requests[0];
+        request.Method.Should().Be(HttpMethod.Get);
+        request.PathAndQuery.Should().Be("/v1/isolated/sessions");
+        request.Headers.Should().Contain("X-Global", "global");
+
+        sessions.Should().HaveCount(2);
+        sessions[0].SessionId.Should().Be("sess-1");
+        sessions[0].Status.Should().Be("running");
+        sessions[0].CreatedAt.Should().Be(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        sessions[0].LastRunAt.Should().Be(DateTimeOffset.Parse("2026-01-01T00:05:00Z"));
+        sessions[0].IdleRemainingSeconds.Should().Be(120);
+        sessions[1].SessionId.Should().Be("sess-2");
+        sessions[1].LastRunAt.Should().BeNull();
+        sessions[1].IdleRemainingSeconds.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListAsync_ShouldReturnEmptyForEmptyArray()
+    {
+        var handler = new CaptureHandler(_ => """{ "sessions": [] }""");
+        var adapter = CreateAdapter(handler);
+
+        var sessions = await adapter.ListAsync();
+
+        sessions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAsync_ShouldReturnEmptyForMissingArray()
+    {
+        var handler = new CaptureHandler(_ => "{}");
+        var adapter = CreateAdapter(handler);
+
+        var sessions = await adapter.ListAsync();
+
+        sessions.Should().BeEmpty();
+    }
+
+    private static IsolatedSessionsAdapter CreateAdapter(
+        HttpMessageHandler handler,
+        IReadOnlyDictionary<string, string>? headers = null)
+    {
+        var client = new HttpClient(handler);
+        var sseClient = new HttpClient(handler);
+        return new IsolatedSessionsAdapter(
+            client,
+            sseClient,
+            "http://execd.local",
+            headers ?? new Dictionary<string, string>(),
+            NullLoggerFactory.Instance.CreateLogger("IsolatedSessionsAdapterListTests"));
+    }
+
+    private sealed class CaptureHandler(Func<HttpRequestMessage, string> payloadSelector) : HttpMessageHandler
+    {
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content == null
+                ? null
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            Requests.Add(new CapturedRequest(
+                request.Method,
+                request.RequestUri?.PathAndQuery,
+                request.Headers.ToDictionary(header => header.Key, header => string.Join(",", header.Value)),
+                body));
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payloadSelector(request), Encoding.UTF8, "application/json")
+            };
+            return response;
+        }
+    }
+
+    private sealed record CapturedRequest(
+        HttpMethod Method,
+        string? PathAndQuery,
+        IReadOnlyDictionary<string, string> Headers,
+        string? Body);
+}

--- a/sdks/sandbox/go/isolated.go
+++ b/sdks/sandbox/go/isolated.go
@@ -59,6 +59,20 @@ type IsolatedSessionState struct {
 	IdleRemainingSeconds *int      `json:"idle_remaining_seconds,omitempty"`
 }
 
+// IsolatedSessionSummary describes a single isolated session in a list response.
+type IsolatedSessionSummary struct {
+	SessionID            string    `json:"session_id"`
+	Status               string    `json:"status"`
+	CreatedAt            time.Time `json:"created_at"`
+	LastRunAt            time.Time `json:"last_run_at"`
+	IdleRemainingSeconds *int      `json:"idle_remaining_seconds,omitempty"`
+}
+
+// listIsolatedSessionsResponse is the wire response for listing isolated sessions.
+type listIsolatedSessionsResponse struct {
+	Sessions []IsolatedSessionSummary `json:"sessions"`
+}
+
 // IsolatedRunRequest is the request body for running code in an isolated session.
 type IsolatedRunRequest struct {
 	Code           string            `json:"code"`
@@ -95,6 +109,16 @@ func (e *ExecdClient) IsolatedGet(ctx context.Context, sessionID string) (*Isola
 		return nil, err
 	}
 	return &result, nil
+}
+
+// IsolatedList lists all active isolated sessions.
+func (e *ExecdClient) IsolatedList(ctx context.Context) ([]IsolatedSessionSummary, error) {
+	var result listIsolatedSessionsResponse
+	err := e.client.doRequest(ctx, http.MethodGet, "/v1/isolated/sessions", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Sessions, nil
 }
 
 // IsolatedRun runs code in an isolated session, streaming output via SSE.

--- a/sdks/sandbox/go/sandbox_isolated.go
+++ b/sdks/sandbox/go/sandbox_isolated.go
@@ -91,6 +91,14 @@ func (s *Sandbox) IsolationCapabilities(ctx context.Context) (*IsolatedCapabilit
 	return s.execd.IsolatedCapabilities(ctx)
 }
 
+// IsolationListSessions lists all active isolated sessions.
+func (s *Sandbox) IsolationListSessions(ctx context.Context) ([]IsolatedSessionSummary, error) {
+	if s.execd == nil {
+		return nil, fmt.Errorf("opensandbox: execd client not initialized")
+	}
+	return s.execd.IsolatedList(ctx)
+}
+
 // Deprecated: Use IsolationCreate instead.
 func (s *Sandbox) IsolatedCreate(ctx context.Context, req CreateIsolatedSessionRequest) (*IsolatedSessionInfo, error) {
 	if s.execd == nil {

--- a/sdks/sandbox/go/sandbox_isolated_test.go
+++ b/sdks/sandbox/go/sandbox_isolated_test.go
@@ -74,6 +74,68 @@ func TestIsolationRunOnce_CreatesRunsDeletes(t *testing.T) {
 	}
 }
 
+func TestIsolationListSessions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/isolated/sessions":
+			jsonResponse(w, http.StatusOK, map[string]any{
+				"sessions": []map[string]any{
+					{
+						"session_id":             "sess-1",
+						"status":                 "active",
+						"created_at":             "2026-01-01T00:00:00Z",
+						"last_run_at":            "2026-01-01T00:01:00Z",
+						"idle_remaining_seconds": 30,
+					},
+					{
+						"session_id":  "sess-2",
+						"status":      "dead",
+						"created_at":  "2026-01-01T00:00:00Z",
+						"last_run_at": "2026-01-01T00:00:00Z",
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	execd := NewExecdClient(srv.URL, "test-key")
+	sb := &Sandbox{id: "sbx-test", execd: execd}
+
+	sessions, err := sb.IsolationListSessions(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	require.Equal(t, "sess-1", sessions[0].SessionID)
+	require.Equal(t, "active", sessions[0].Status)
+	require.NotNil(t, sessions[0].IdleRemainingSeconds)
+	require.Equal(t, 30, *sessions[0].IdleRemainingSeconds)
+
+	require.Equal(t, "sess-2", sessions[1].SessionID)
+	require.Equal(t, "dead", sessions[1].Status)
+	require.True(t, sessions[1].IdleRemainingSeconds == nil)
+}
+
+func TestIsolationListSessions_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/isolated/sessions" {
+			jsonResponse(w, http.StatusOK, map[string]any{"sessions": []any{}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	execd := NewExecdClient(srv.URL, "test-key")
+	sb := &Sandbox{id: "sbx-test", execd: execd}
+
+	sessions, err := sb.IsolationListSessions(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sessions, 0)
+}
+
 func TestIsolationRunOnce_DeletesOnRunError(t *testing.T) {
 	var deleteCalled int32
 

--- a/sdks/sandbox/javascript/src/adapters/isolatedSessionsAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/isolatedSessionsAdapter.ts
@@ -30,6 +30,8 @@ import type {
   IsolatedRunOpts,
   IsolatedSessionInfo,
   IsolatedSessionState,
+  IsolatedSessionSummary,
+  ListIsolatedSessionsResponse,
 } from "../models/isolated.js";
 
 function joinUrl(baseUrl: string, pathname: string): string {
@@ -211,6 +213,14 @@ export class IsolatedSessionsAdapter implements IsolationService {
       "GET",
       "/v1/isolated/capabilities",
     );
+  }
+
+  async list(): Promise<IsolatedSessionSummary[]> {
+    const resp = await this.jsonRequest<ListIsolatedSessionsResponse>(
+      "GET",
+      "/v1/isolated/sessions",
+    );
+    return resp.sessions ?? [];
   }
 
   async runOnce(

--- a/sdks/sandbox/javascript/src/api/execd.ts
+++ b/sdks/sandbox/javascript/src/api/execd.ts
@@ -598,6 +598,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/isolated/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List isolated sessions */
+        get: operations["listIsolatedSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/isolated/capabilities": {
         parameters: {
             query?: never;
@@ -1256,6 +1273,11 @@ export interface components {
             uid?: number;
             /** Format: uint32 */
             gid?: number;
+            /**
+             * @description Controls how user identity is established inside the namespace. "setpriv" (default) uses real setuid via setpriv(1). "userns" creates a user namespace via --unshare-user --disable-userns.
+             * @enum {string}
+             */
+            uid_mode?: "setpriv" | "userns";
             idle_timeout_seconds?: number;
         };
         IsolatedWorkspaceSpec: {
@@ -1289,6 +1311,20 @@ export interface components {
             /** Format: date-time */
             last_run_at?: string;
             idle_remaining_seconds?: number | null;
+        };
+        IsolatedSessionSummary: {
+            /** Format: uuid */
+            session_id: string;
+            /** @enum {string} */
+            status: "active" | "dead" | "destroyed";
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            last_run_at: string;
+            idle_remaining_seconds?: number | null;
+        };
+        ListIsolatedSessionsResponse: {
+            sessions: components["schemas"]["IsolatedSessionSummary"][];
         };
         CapabilitiesResponse: {
             available?: boolean;
@@ -2296,6 +2332,27 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    listIsolatedSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of active isolated sessions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListIsolatedSessionsResponse"];
+                };
+            };
             503: components["responses"]["ServiceUnavailable"];
         };
     };

--- a/sdks/sandbox/javascript/src/index.ts
+++ b/sdks/sandbox/javascript/src/index.ts
@@ -156,4 +156,6 @@ export type {
   IsolatedSessionState,
   IsolatedRunOpts,
   IsolatedCapabilities,
+  IsolatedSessionSummary,
+  ListIsolatedSessionsResponse,
 } from "./models/isolated.js";

--- a/sdks/sandbox/javascript/src/models/isolated.ts
+++ b/sdks/sandbox/javascript/src/models/isolated.ts
@@ -58,3 +58,15 @@ export interface IsolatedCapabilities {
   commit_supported: boolean;
   diff_supported: boolean;
 }
+
+export interface IsolatedSessionSummary {
+  session_id: string;
+  status: string;
+  created_at?: string;
+  last_run_at?: string;
+  idle_remaining_seconds?: number;
+}
+
+export interface ListIsolatedSessionsResponse {
+  sessions?: IsolatedSessionSummary[];
+}

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -33,7 +33,7 @@ import type { ExecdHealth } from "./services/execdHealth.js";
 import type { ExecdMetrics } from "./services/execdMetrics.js";
 import type { IsolationService, IsolationSession } from "./services/isolatedSessions.js";
 import type { CommandExecution } from "./models/execd.js";
-import type { IsolatedCapabilities } from "./models/isolated.js";
+import type { IsolatedCapabilities, IsolatedSessionSummary } from "./models/isolated.js";
 import type {
   CreateSandboxRequest,
   CredentialProxyConfig,
@@ -57,6 +57,9 @@ const unavailableIsolation: IsolationService = {
   },
   capabilities(): Promise<IsolatedCapabilities> {
     return Promise.resolve({ available: false, commit_supported: false, diff_supported: false });
+  },
+  list(): Promise<IsolatedSessionSummary[]> {
+    throw new Error("Isolation is not available: the adapter factory did not provide an IsolationService");
   },
   runOnce(): Promise<CommandExecution> {
     throw new Error("Isolation is not available: the adapter factory did not provide an IsolationService");

--- a/sdks/sandbox/javascript/src/services/isolatedSessions.ts
+++ b/sdks/sandbox/javascript/src/services/isolatedSessions.ts
@@ -21,6 +21,7 @@ import type {
   IsolatedRunOpts,
   IsolatedSessionInfo,
   IsolatedSessionState,
+  IsolatedSessionSummary,
 } from "../models/isolated.js";
 
 export interface IsolationSession {
@@ -49,6 +50,7 @@ export interface RunOnceOpts {
 export interface IsolationService {
   create(request: CreateIsolatedSessionRequest): Promise<IsolationSession>;
   capabilities(): Promise<IsolatedCapabilities>;
+  list(): Promise<IsolatedSessionSummary[]>;
   /**
    * Create a session, run `code`, and delete the session (auto-cleanup).
    * Cleanup is best-effort and never masks the original error.

--- a/sdks/sandbox/javascript/tests/isolationRunOnce.test.mjs
+++ b/sdks/sandbox/javascript/tests/isolationRunOnce.test.mjs
@@ -82,6 +82,56 @@ describe("runOnce", () => {
   });
 });
 
+describe("list", () => {
+  it("returns the sessions array from the response", async () => {
+    const calls = [];
+    const mockFn = async (url, init) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      const method = init?.method ?? "GET";
+      if (method === "GET" && urlStr.includes("/v1/isolated/sessions")) {
+        calls.push("list");
+        return new Response(
+          JSON.stringify({
+            sessions: [
+              {
+                session_id: "sess-a",
+                status: "active",
+                created_at: "2026-01-01T00:00:00Z",
+                last_run_at: "2026-01-01T00:01:00Z",
+                idle_remaining_seconds: 42,
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    };
+    const adapter = createAdapter(mockFn);
+
+    const sessions = await adapter.list();
+
+    assert.deepStrictEqual(calls, ["list"]);
+    assert.strictEqual(sessions.length, 1);
+    assert.strictEqual(sessions[0].session_id, "sess-a");
+    assert.strictEqual(sessions[0].status, "active");
+    assert.strictEqual(sessions[0].idle_remaining_seconds, 42);
+  });
+
+  it("returns an empty array when sessions is absent", async () => {
+    const mockFn = async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    const adapter = createAdapter(mockFn);
+
+    const sessions = await adapter.list();
+
+    assert.deepStrictEqual(sessions, []);
+  });
+});
+
 describe("withSession", () => {
   it("calls create, runs callback, then deletes", async () => {
     const { mockFn, calls } = mockFetchForSession("sess-ws");

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
@@ -51,6 +51,14 @@ data class IsolatedSessionState(
     val idleRemainingSeconds: Int? = null,
 )
 
+data class IsolatedSessionSummary(
+    val sessionId: String,
+    val status: String,
+    val createdAt: OffsetDateTime? = null,
+    val lastRunAt: OffsetDateTime? = null,
+    val idleRemainingSeconds: Int? = null,
+)
+
 data class IsolatedRunRequest(
     val code: String,
     val envs: Map<String, String>? = null,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/IsolatedSessions.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/services/IsolatedSessions.kt
@@ -22,6 +22,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedCapa
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedRunRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionInfo
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionState
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionSummary
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedWorkspaceSpec
 import org.slf4j.LoggerFactory
 
@@ -45,6 +46,8 @@ interface IsolationService {
     fun create(request: CreateIsolatedSessionRequest): IsolationSession
 
     fun capabilities(): IsolatedCapabilities
+
+    fun list(): List<IsolatedSessionSummary>
 
     fun runOnce(
         code: String,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
@@ -27,6 +27,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedCapa
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedRunRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionInfo
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionState
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionSummary
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
 import com.alibaba.opensandbox.sandbox.domain.services.Filesystem
 import com.alibaba.opensandbox.sandbox.domain.services.IsolationService
@@ -83,6 +84,20 @@ private data class IsolatedSessionStateResponse(
     val created_at: String? = null,
     val last_run_at: String? = null,
     val idle_remaining_seconds: Int? = null,
+)
+
+@Serializable
+private data class IsolatedSessionSummaryResponse(
+    val session_id: String,
+    val status: String,
+    val created_at: String? = null,
+    val last_run_at: String? = null,
+    val idle_remaining_seconds: Int? = null,
+)
+
+@Serializable
+private data class ListIsolatedSessionsResponse(
+    val sessions: List<IsolatedSessionSummaryResponse> = emptyList(),
 )
 
 @Serializable
@@ -287,6 +302,37 @@ internal class IsolatedSessionsAdapter(
                     commitSupported = resp.commit_supported,
                     diffSupported = resp.diff_supported,
                 )
+            }
+        } catch (e: Exception) {
+            throw e.toSandboxException()
+        }
+    }
+
+    override fun list(): List<IsolatedSessionSummary> {
+        try {
+            val httpRequest =
+                Request.Builder()
+                    .url("$execdBaseUrl/v1/isolated/sessions")
+                    .get()
+                    .headers(execdEndpoint.headers.toHeaders())
+                    .build()
+
+            httpClientProvider.httpClient.newCall(httpRequest).execute().use { response ->
+                ensureSuccess(response, "list isolated sessions")
+                val resp =
+                    json.decodeFromString(
+                        ListIsolatedSessionsResponse.serializer(),
+                        response.body!!.string(),
+                    )
+                return resp.sessions.map { summary ->
+                    IsolatedSessionSummary(
+                        sessionId = summary.session_id,
+                        status = summary.status,
+                        createdAt = summary.created_at?.let { parseDateTime(it) },
+                        lastRunAt = summary.last_run_at?.let { parseDateTime(it) },
+                        idleRemainingSeconds = summary.idle_remaining_seconds,
+                    )
+                }
             }
         } catch (e: Exception) {
             throw e.toSandboxException()

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/IsolationRunOnceTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/IsolationRunOnceTest.kt
@@ -21,6 +21,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.CreateIsolat
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedCapabilities
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedRunRequest
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionInfo
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedSessionSummary
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedWorkspaceSpec
 import com.alibaba.opensandbox.sandbox.domain.services.IsolationService
 import com.alibaba.opensandbox.sandbox.domain.services.IsolationSession
@@ -52,6 +53,8 @@ class IsolationRunOnceTest {
             override fun create(request: CreateIsolatedSessionRequest): IsolationSession = session
 
             override fun capabilities(): IsolatedCapabilities = IsolatedCapabilities()
+
+            override fun list(): List<IsolatedSessionSummary> = emptyList()
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapterTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
+
+import com.alibaba.opensandbox.sandbox.HttpClientProvider
+import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IsolatedSessionsAdapterTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var adapter: IsolatedSessionsAdapter
+    private lateinit var httpClientProvider: HttpClientProvider
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val host = mockWebServer.hostName
+        val port = mockWebServer.port
+        val endpoint =
+            SandboxEndpoint(
+                endpoint = "$host:$port",
+                headers = mapOf("X-Execd-Token" to "route-token"),
+            )
+
+        val config =
+            ConnectionConfig.builder()
+                .domain("$host:$port")
+                .protocol("http")
+                .build()
+
+        httpClientProvider = HttpClientProvider(config)
+        adapter = IsolatedSessionsAdapter(httpClientProvider, endpoint)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+        httpClientProvider.close()
+    }
+
+    @Test
+    fun `list maps isolated session summaries`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(
+                    """
+                    {
+                      "sessions": [
+                        {
+                          "session_id": "sess-1",
+                          "status": "idle",
+                          "created_at": "2026-01-02T03:04:05Z",
+                          "last_run_at": "2026-01-02T03:05:06Z",
+                          "idle_remaining_seconds": 42
+                        },
+                        {
+                          "session_id": "sess-2",
+                          "status": "running",
+                          "created_at": "2026-01-02T03:06:07Z",
+                          "last_run_at": null,
+                          "idle_remaining_seconds": null
+                        }
+                      ]
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        val sessions = adapter.list()
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/v1/isolated/sessions", request.path)
+        assertEquals("route-token", request.getHeader("X-Execd-Token"))
+
+        assertEquals(2, sessions.size)
+
+        val first = sessions[0]
+        assertEquals("sess-1", first.sessionId)
+        assertEquals("idle", first.status)
+        assertEquals(2026, first.createdAt?.year)
+        assertEquals(5, first.lastRunAt?.minute)
+        assertEquals(42, first.idleRemainingSeconds)
+
+        val second = sessions[1]
+        assertEquals("sess-2", second.sessionId)
+        assertEquals("running", second.status)
+        assertNull(second.lastRunAt)
+        assertNull(second.idleRemainingSeconds)
+    }
+
+    @Test
+    fun `list returns empty when no sessions`() {
+        mockWebServer.enqueue(MockResponse().setBody("""{"sessions": []}"""))
+
+        val sessions = adapter.list()
+
+        assertEquals(0, sessions.size)
+        assertEquals("/v1/isolated/sessions", mockWebServer.takeRequest().path)
+    }
+}

--- a/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
@@ -40,6 +40,7 @@ from opensandbox.models.isolated import (
     IsolatedRunOpts,
     IsolatedSessionInfo,
     IsolatedSessionState,
+    IsolatedSessionSummary,
 )
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.services.filesystem import Filesystem
@@ -132,6 +133,7 @@ class IsolatedSessionsAdapter(IsolationServiceMixin, IsolationService):
     CREATE_PATH = "/v1/isolated/session"
     SESSION_PATH = "/v1/isolated/session/{session_id}"
     RUN_PATH = "/v1/isolated/session/{session_id}/run"
+    SESSIONS_PATH = "/v1/isolated/sessions"
     CAPABILITIES_PATH = "/v1/isolated/capabilities"
 
     def __init__(
@@ -275,6 +277,23 @@ class IsolatedSessionsAdapter(IsolationServiceMixin, IsolationService):
                     status_code=response.status_code,
                     request_id=extract_request_id(response.headers),
                 )
+        except Exception as e:
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    async def list(self) -> list[IsolatedSessionSummary]:
+        try:
+            url = self._get_url(self.SESSIONS_PATH)
+            response = await self._httpx_client.get(url)
+            if response.status_code != 200:
+                raise SandboxApiException(
+                    message=f"list isolated sessions failed. Status: {response.status_code}",
+                    status_code=response.status_code,
+                    request_id=extract_request_id(response.headers),
+                )
+            data = response.json()
+            return [
+                IsolatedSessionSummary(**item) for item in data.get("sessions", [])
+            ]
         except Exception as e:
             raise ExceptionConverter.to_sandbox_exception(e) from e
 

--- a/sdks/sandbox/python/src/opensandbox/api/execd/api/isolated_execution/list_isolated_sessions.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/api/isolated_execution/list_isolated_sessions.py
@@ -1,0 +1,149 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.list_isolated_sessions_response import ListIsolatedSessionsResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/isolated/sessions",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | ListIsolatedSessionsResponse | None:
+    if response.status_code == 200:
+        response_200 = ListIsolatedSessionsResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 503:
+        response_503 = ErrorResponse.from_dict(response.json())
+
+        return response_503
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | ListIsolatedSessionsResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ErrorResponse | ListIsolatedSessionsResponse]:
+    """List isolated sessions
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ListIsolatedSessionsResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> ErrorResponse | ListIsolatedSessionsResponse | None:
+    """List isolated sessions
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ListIsolatedSessionsResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ErrorResponse | ListIsolatedSessionsResponse]:
+    """List isolated sessions
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ListIsolatedSessionsResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> ErrorResponse | ListIsolatedSessionsResponse | None:
+    """List isolated sessions
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ListIsolatedSessionsResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/__init__.py
@@ -23,6 +23,7 @@ from .code_context_request import CodeContextRequest
 from .command_status_response import CommandStatusResponse
 from .create_isolated_session_request import CreateIsolatedSessionRequest
 from .create_isolated_session_request_profile import CreateIsolatedSessionRequestProfile
+from .create_isolated_session_request_uid_mode import CreateIsolatedSessionRequestUidMode
 from .create_session_request import CreateSessionRequest
 from .create_session_response import CreateSessionResponse
 from .env_passthrough_spec import EnvPassthroughSpec
@@ -40,9 +41,12 @@ from .isolated_replace_content_body import IsolatedReplaceContentBody
 from .isolated_replace_content_response_200 import IsolatedReplaceContentResponse200
 from .isolated_run_request import IsolatedRunRequest
 from .isolated_run_request_envs import IsolatedRunRequestEnvs
+from .isolated_session_summary import IsolatedSessionSummary
+from .isolated_session_summary_status import IsolatedSessionSummaryStatus
 from .isolated_upload_file_body import IsolatedUploadFileBody
 from .isolated_workspace_spec import IsolatedWorkspaceSpec
 from .isolated_workspace_spec_mode import IsolatedWorkspaceSpecMode
+from .list_isolated_sessions_response import ListIsolatedSessionsResponse
 from .make_dirs_body import MakeDirsBody
 from .metrics import Metrics
 from .permission import Permission
@@ -71,6 +75,7 @@ __all__ = (
     "CommandStatusResponse",
     "CreateIsolatedSessionRequest",
     "CreateIsolatedSessionRequestProfile",
+    "CreateIsolatedSessionRequestUidMode",
     "CreateSessionRequest",
     "CreateSessionResponse",
     "EnvPassthroughSpec",
@@ -88,9 +93,12 @@ __all__ = (
     "IsolatedReplaceContentResponse200",
     "IsolatedRunRequest",
     "IsolatedRunRequestEnvs",
+    "IsolatedSessionSummary",
+    "IsolatedSessionSummaryStatus",
     "IsolatedUploadFileBody",
     "IsolatedWorkspaceSpec",
     "IsolatedWorkspaceSpecMode",
+    "ListIsolatedSessionsResponse",
     "MakeDirsBody",
     "Metrics",
     "Permission",

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request.py
@@ -23,6 +23,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.create_isolated_session_request_profile import CreateIsolatedSessionRequestProfile
+from ..models.create_isolated_session_request_uid_mode import CreateIsolatedSessionRequestUidMode
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -44,6 +45,9 @@ class CreateIsolatedSessionRequest:
         env_passthrough (EnvPassthroughSpec | Unset):
         uid (int | Unset):
         gid (int | Unset):
+        uid_mode (CreateIsolatedSessionRequestUidMode | Unset): Controls how user identity is established inside the
+            namespace. "setpriv" (default) uses real setuid via setpriv(1). "userns" creates a user namespace via --unshare-
+            user --disable-userns.
         idle_timeout_seconds (int | Unset):
     """
 
@@ -54,6 +58,7 @@ class CreateIsolatedSessionRequest:
     env_passthrough: EnvPassthroughSpec | Unset = UNSET
     uid: int | Unset = UNSET
     gid: int | Unset = UNSET
+    uid_mode: CreateIsolatedSessionRequestUidMode | Unset = UNSET
     idle_timeout_seconds: int | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -78,6 +83,10 @@ class CreateIsolatedSessionRequest:
 
         gid = self.gid
 
+        uid_mode: str | Unset = UNSET
+        if not isinstance(self.uid_mode, Unset):
+            uid_mode = self.uid_mode.value
+
         idle_timeout_seconds = self.idle_timeout_seconds
 
         field_dict: dict[str, Any] = {}
@@ -99,6 +108,8 @@ class CreateIsolatedSessionRequest:
             field_dict["uid"] = uid
         if gid is not UNSET:
             field_dict["gid"] = gid
+        if uid_mode is not UNSET:
+            field_dict["uid_mode"] = uid_mode
         if idle_timeout_seconds is not UNSET:
             field_dict["idle_timeout_seconds"] = idle_timeout_seconds
 
@@ -134,6 +145,13 @@ class CreateIsolatedSessionRequest:
 
         gid = d.pop("gid", UNSET)
 
+        _uid_mode = d.pop("uid_mode", UNSET)
+        uid_mode: CreateIsolatedSessionRequestUidMode | Unset
+        if isinstance(_uid_mode, Unset):
+            uid_mode = UNSET
+        else:
+            uid_mode = CreateIsolatedSessionRequestUidMode(_uid_mode)
+
         idle_timeout_seconds = d.pop("idle_timeout_seconds", UNSET)
 
         create_isolated_session_request = cls(
@@ -144,6 +162,7 @@ class CreateIsolatedSessionRequest:
             env_passthrough=env_passthrough,
             uid=uid,
             gid=gid,
+            uid_mode=uid_mode,
             idle_timeout_seconds=idle_timeout_seconds,
         )
 

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request_uid_mode.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/create_isolated_session_request_uid_mode.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class CreateIsolatedSessionRequestUidMode(str, Enum):
+    SETPRIV = "setpriv"
+    USERNS = "userns"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/isolated_session_summary.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/isolated_session_summary.py
@@ -1,0 +1,127 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.isolated_session_summary_status import IsolatedSessionSummaryStatus
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="IsolatedSessionSummary")
+
+
+@_attrs_define
+class IsolatedSessionSummary:
+    """
+    Attributes:
+        session_id (UUID):
+        status (IsolatedSessionSummaryStatus):
+        created_at (datetime.datetime):
+        last_run_at (datetime.datetime):
+        idle_remaining_seconds (int | None | Unset):
+    """
+
+    session_id: UUID
+    status: IsolatedSessionSummaryStatus
+    created_at: datetime.datetime
+    last_run_at: datetime.datetime
+    idle_remaining_seconds: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        session_id = str(self.session_id)
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        last_run_at = self.last_run_at.isoformat()
+
+        idle_remaining_seconds: int | None | Unset
+        if isinstance(self.idle_remaining_seconds, Unset):
+            idle_remaining_seconds = UNSET
+        else:
+            idle_remaining_seconds = self.idle_remaining_seconds
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "session_id": session_id,
+                "status": status,
+                "created_at": created_at,
+                "last_run_at": last_run_at,
+            }
+        )
+        if idle_remaining_seconds is not UNSET:
+            field_dict["idle_remaining_seconds"] = idle_remaining_seconds
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_id = UUID(d.pop("session_id"))
+
+        status = IsolatedSessionSummaryStatus(d.pop("status"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        last_run_at = isoparse(d.pop("last_run_at"))
+
+        def _parse_idle_remaining_seconds(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        idle_remaining_seconds = _parse_idle_remaining_seconds(d.pop("idle_remaining_seconds", UNSET))
+
+        isolated_session_summary = cls(
+            session_id=session_id,
+            status=status,
+            created_at=created_at,
+            last_run_at=last_run_at,
+            idle_remaining_seconds=idle_remaining_seconds,
+        )
+
+        isolated_session_summary.additional_properties = d
+        return isolated_session_summary
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/isolated_session_summary_status.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/isolated_session_summary_status.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class IsolatedSessionSummaryStatus(str, Enum):
+    ACTIVE = "active"
+    DEAD = "dead"
+    DESTROYED = "destroyed"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/execd/models/list_isolated_sessions_response.py
+++ b/sdks/sandbox/python/src/opensandbox/api/execd/models/list_isolated_sessions_response.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.isolated_session_summary import IsolatedSessionSummary
+
+
+T = TypeVar("T", bound="ListIsolatedSessionsResponse")
+
+
+@_attrs_define
+class ListIsolatedSessionsResponse:
+    """
+    Attributes:
+        sessions (list[IsolatedSessionSummary]):
+    """
+
+    sessions: list[IsolatedSessionSummary]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        sessions = []
+        for sessions_item_data in self.sessions:
+            sessions_item = sessions_item_data.to_dict()
+            sessions.append(sessions_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "sessions": sessions,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.isolated_session_summary import IsolatedSessionSummary
+
+        d = dict(src_dict)
+        sessions = []
+        _sessions = d.pop("sessions")
+        for sessions_item_data in _sessions:
+            sessions_item = IsolatedSessionSummary.from_dict(sessions_item_data)
+
+            sessions.append(sessions_item)
+
+        list_isolated_sessions_response = cls(
+            sessions=sessions,
+        )
+
+        list_isolated_sessions_response.additional_properties = d
+        return list_isolated_sessions_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/models/__init__.py
@@ -48,6 +48,7 @@ from opensandbox.models.isolated import (
     IsolatedRunOpts,
     IsolatedSessionInfo,
     IsolatedSessionState,
+    IsolatedSessionSummary,
     IsolatedWorkspaceSpec,
 )
 from opensandbox.models.sandboxes import (
@@ -105,6 +106,7 @@ __all__ = [
     "IsolatedRunOpts",
     "IsolatedSessionInfo",
     "IsolatedSessionState",
+    "IsolatedSessionSummary",
     "IsolatedWorkspaceSpec",
     # Filesystem models
     "EntryInfo",

--- a/sdks/sandbox/python/src/opensandbox/models/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/models/isolated.py
@@ -115,6 +115,22 @@ class IsolatedSessionState(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class IsolatedSessionSummary(BaseModel):
+    """Summary of an isolated session as returned by list."""
+
+    session_id: str = Field(description="Unique session identifier")
+    status: str = Field(
+        description="Session status: 'active', 'dead', or 'destroyed'"
+    )
+    created_at: datetime = Field(description="Session creation timestamp")
+    last_run_at: datetime = Field(description="Timestamp of last code execution")
+    idle_remaining_seconds: int | None = Field(
+        default=None, description="Seconds until idle auto-destroy (null if no timeout)"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class IsolatedRunOpts(BaseModel):
     """Options for running code in an isolated session."""
 

--- a/sdks/sandbox/python/src/opensandbox/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/services/isolated.py
@@ -31,6 +31,7 @@ from opensandbox.models.isolated import (
     IsolatedRunOpts,
     IsolatedSessionInfo,
     IsolatedSessionState,
+    IsolatedSessionSummary,
     IsolatedWorkspaceSpec,
 )
 from opensandbox.services.filesystem import Filesystem
@@ -71,6 +72,8 @@ class IsolationService(Protocol):
     ) -> IsolationSession: ...
 
     async def capabilities(self) -> IsolatedCapabilities: ...
+
+    async def list(self) -> list[IsolatedSessionSummary]: ...
 
     async def run_once(
         self,

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
@@ -35,6 +35,7 @@ from opensandbox.models.isolated import (
     IsolatedRunOpts,
     IsolatedSessionInfo,
     IsolatedSessionState,
+    IsolatedSessionSummary,
 )
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.converter.execution_event_dispatcher import (
@@ -136,6 +137,7 @@ class IsolatedSessionsAdapterSync(IsolationServiceSyncMixin, IsolationServiceSyn
     CREATE_PATH = "/v1/isolated/session"
     SESSION_PATH = "/v1/isolated/session/{session_id}"
     RUN_PATH = "/v1/isolated/session/{session_id}/run"
+    SESSIONS_PATH = "/v1/isolated/sessions"
     CAPABILITIES_PATH = "/v1/isolated/capabilities"
 
     def __init__(
@@ -276,6 +278,23 @@ class IsolatedSessionsAdapterSync(IsolationServiceSyncMixin, IsolationServiceSyn
                     status_code=response.status_code,
                     request_id=extract_request_id(response.headers),
                 )
+        except Exception as e:
+            raise ExceptionConverter.to_sandbox_exception(e) from e
+
+    def list(self) -> list[IsolatedSessionSummary]:
+        try:
+            url = self._get_url(self.SESSIONS_PATH)
+            response = self._httpx_client.get(url)
+            if response.status_code != 200:
+                raise SandboxApiException(
+                    message=f"list isolated sessions failed. Status: {response.status_code}",
+                    status_code=response.status_code,
+                    request_id=extract_request_id(response.headers),
+                )
+            data = response.json()
+            return [
+                IsolatedSessionSummary(**item) for item in data.get("sessions", [])
+            ]
         except Exception as e:
             raise ExceptionConverter.to_sandbox_exception(e) from e
 

--- a/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
@@ -30,6 +30,7 @@ from opensandbox.models.isolated import (
     IsolatedRunOpts,
     IsolatedSessionInfo,
     IsolatedSessionState,
+    IsolatedSessionSummary,
     IsolatedWorkspaceSpec,
 )
 
@@ -69,6 +70,8 @@ class IsolationServiceSync(Protocol):
     ) -> IsolationSessionSync: ...
 
     def capabilities(self) -> IsolatedCapabilities: ...
+
+    def list(self) -> list[IsolatedSessionSummary]: ...
 
     def run_once(
         self,

--- a/sdks/sandbox/python/tests/test_isolation_list.py
+++ b/sdks/sandbox/python/tests/test_isolation_list.py
@@ -1,0 +1,145 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for IsolationService.list (async and sync)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from opensandbox.adapters.isolated_adapter import IsolatedSessionsAdapter
+from opensandbox.exceptions import SandboxApiException
+from opensandbox.models.isolated import IsolatedSessionSummary
+from opensandbox.sync.adapters.isolated_adapter import IsolatedSessionsAdapterSync
+
+_SESSIONS_PAYLOAD = {
+    "sessions": [
+        {
+            "session_id": "sess-1",
+            "status": "active",
+            "created_at": "2026-01-01T00:00:00Z",
+            "last_run_at": "2026-01-01T00:05:00Z",
+            "idle_remaining_seconds": 120,
+        },
+        {
+            "session_id": "sess-2",
+            "status": "dead",
+            "created_at": "2026-01-02T00:00:00Z",
+            "last_run_at": "2026-01-02T00:05:00Z",
+            "idle_remaining_seconds": None,
+        },
+    ]
+}
+
+
+def _mock_response(status_code=200, json_data=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {}
+    response.json = MagicMock(return_value=json_data)
+    return response
+
+
+@pytest.fixture
+def async_adapter():
+    from opensandbox.config import ConnectionConfig
+    from opensandbox.models.sandboxes import SandboxEndpoint
+
+    config = ConnectionConfig(api_key="test-key", domain="localhost")
+    endpoint = SandboxEndpoint(endpoint="localhost:8080", headers={})
+    return IsolatedSessionsAdapter(config, endpoint)
+
+
+@pytest.fixture
+def sync_adapter():
+    from opensandbox.config.connection_sync import ConnectionConfigSync
+    from opensandbox.models.sandboxes import SandboxEndpoint
+
+    config = ConnectionConfigSync(api_key="test-key", domain="localhost")
+    endpoint = SandboxEndpoint(endpoint="localhost:8080", headers={})
+    return IsolatedSessionsAdapterSync(config, endpoint)
+
+
+@pytest.mark.asyncio
+async def test_async_list_returns_summaries(async_adapter):
+    response = _mock_response(200, _SESSIONS_PAYLOAD)
+    async_adapter._httpx_client.get = AsyncMock(return_value=response)
+
+    result = await async_adapter.list()
+
+    async_adapter._httpx_client.get.assert_called_once()
+    assert len(result) == 2
+    assert all(isinstance(s, IsolatedSessionSummary) for s in result)
+    assert result[0].session_id == "sess-1"
+    assert result[0].status == "active"
+    assert isinstance(result[0].created_at, datetime)
+    assert isinstance(result[0].last_run_at, datetime)
+    assert result[0].idle_remaining_seconds == 120
+    assert result[1].session_id == "sess-2"
+    assert result[1].idle_remaining_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_async_list_empty(async_adapter):
+    response = _mock_response(200, {"sessions": []})
+    async_adapter._httpx_client.get = AsyncMock(return_value=response)
+
+    result = await async_adapter.list()
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_async_list_raises_on_error_status(async_adapter):
+    response = _mock_response(500, None)
+    async_adapter._httpx_client.get = AsyncMock(return_value=response)
+
+    with pytest.raises(SandboxApiException):
+        await async_adapter.list()
+
+
+def test_sync_list_returns_summaries(sync_adapter):
+    response = _mock_response(200, _SESSIONS_PAYLOAD)
+    sync_adapter._httpx_client.get = MagicMock(return_value=response)
+
+    result = sync_adapter.list()
+
+    sync_adapter._httpx_client.get.assert_called_once()
+    assert len(result) == 2
+    assert all(isinstance(s, IsolatedSessionSummary) for s in result)
+    assert result[0].session_id == "sess-1"
+    assert result[0].status == "active"
+    assert result[0].idle_remaining_seconds == 120
+    assert result[1].idle_remaining_seconds is None
+
+
+def test_sync_list_empty(sync_adapter):
+    response = _mock_response(200, {"sessions": []})
+    sync_adapter._httpx_client.get = MagicMock(return_value=response)
+
+    result = sync_adapter.list()
+
+    assert result == []
+
+
+def test_sync_list_raises_on_error_status(sync_adapter):
+    response = _mock_response(500, None)
+    sync_adapter._httpx_client.get = MagicMock(return_value=response)
+
+    with pytest.raises(SandboxApiException):
+        sync_adapter.list()

--- a/specs/execd-api.yaml
+++ b/specs/execd-api.yaml
@@ -1136,6 +1136,22 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /v1/isolated/sessions:
+    get:
+      summary: List isolated sessions
+      operationId: listIsolatedSessions
+      tags:
+        - IsolatedExecution
+      responses:
+        "200":
+          description: List of active isolated sessions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListIsolatedSessionsResponse"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   /v1/isolated/capabilities:
     get:
       summary: Get isolator capabilities
@@ -2156,6 +2172,40 @@ components:
         idle_remaining_seconds:
           type: integer
           nullable: true
+
+    IsolatedSessionSummary:
+      type: object
+      required:
+        - session_id
+        - status
+        - created_at
+        - last_run_at
+      properties:
+        session_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: ["active", "dead", "destroyed"]
+        created_at:
+          type: string
+          format: date-time
+        last_run_at:
+          type: string
+          format: date-time
+        idle_remaining_seconds:
+          type: integer
+          nullable: true
+
+    ListIsolatedSessionsResponse:
+      type: object
+      required:
+        - sessions
+      properties:
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/IsolatedSessionSummary"
 
     CapabilitiesResponse:
       type: object

--- a/tests/go/isolated_session_e2e_test.go
+++ b/tests/go/isolated_session_e2e_test.go
@@ -77,6 +77,48 @@ func TestIsolationSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIsolationListSessions(t *testing.T) {
+	ctx, sb := createIsolatedTestSandbox(t)
+
+	// Create two sessions and confirm both appear in the list.
+	sessionA, err := sb.IsolationCreate(ctx, opensandbox.CreateIsolatedSessionRequest{
+		Workspace: opensandbox.IsolatedWorkspaceSpec{Path: "/tmp", Mode: "rw"},
+	})
+	require.NoError(t, err)
+	defer sessionA.Delete(ctx)
+
+	sessionB, err := sb.IsolationCreate(ctx, opensandbox.CreateIsolatedSessionRequest{
+		Workspace: opensandbox.IsolatedWorkspaceSpec{Path: "/tmp", Mode: "rw"},
+	})
+	require.NoError(t, err)
+	defer sessionB.Delete(ctx)
+
+	sessions, err := sb.IsolationListSessions(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(sessions), 2)
+
+	ids := make(map[string]opensandbox.IsolatedSessionSummary, len(sessions))
+	for _, s := range sessions {
+		ids[s.SessionID] = s
+	}
+
+	sumA, okA := ids[sessionA.SessionID()]
+	require.True(t, okA, "sessionA should appear in list")
+	assert.Equal(t, "active", sumA.Status)
+	assert.False(t, sumA.CreatedAt.IsZero(), "created_at should be populated")
+
+	_, okB := ids[sessionB.SessionID()]
+	require.True(t, okB, "sessionB should appear in list")
+
+	// After deleting a session it should no longer be listed.
+	require.NoError(t, sessionB.Delete(ctx))
+	sessions, err = sb.IsolationListSessions(ctx)
+	require.NoError(t, err)
+	for _, s := range sessions {
+		assert.NotEqual(t, sessionB.SessionID(), s.SessionID, "deleted session should not be listed")
+	}
+}
+
 func TestIsolationRunEcho(t *testing.T) {
 	ctx, sb := createIsolatedTestSandbox(t)
 

--- a/tests/javascript/tests/test_isolated_session_e2e.test.ts
+++ b/tests/javascript/tests/test_isolated_session_e2e.test.ts
@@ -60,6 +60,37 @@ describe("IsolatedSession E2E", () => {
     await session.delete();
   });
 
+  it("test_list_sessions", async () => {
+    const sessionA = await sandbox.isolation.create({
+      workspace: { path: "/tmp", mode: "rw" },
+    });
+    let sessionBDeleted = false;
+    const sessionB = await sandbox.isolation.create({
+      workspace: { path: "/tmp", mode: "rw" },
+    });
+    try {
+      const sessions = await sandbox.isolation.list();
+      const byId = new Map(sessions.map(s => [s.session_id, s]));
+
+      expect(byId.has(sessionA.sessionId)).toBe(true);
+      expect(byId.has(sessionB.sessionId)).toBe(true);
+      expect(byId.get(sessionA.sessionId)?.status).toBe("active");
+      expect(byId.get(sessionA.sessionId)?.created_at).toBeTruthy();
+
+      // After deleting a session it should no longer be listed.
+      await sessionB.delete();
+      sessionBDeleted = true;
+      const remaining = await sandbox.isolation.list();
+      const remainingIds = remaining.map(s => s.session_id);
+      expect(remainingIds).not.toContain(sessionB.sessionId);
+    } finally {
+      await sessionA.delete();
+      if (!sessionBDeleted) {
+        await sessionB.delete();
+      }
+    }
+  });
+
   it("test_run_echo", async () => {
     const session = await sandbox.isolation.create({
       workspace: { path: "/tmp", mode: "rw" },

--- a/tests/python/tests/test_isolated_session_e2e.py
+++ b/tests/python/tests/test_isolated_session_e2e.py
@@ -112,6 +112,30 @@ class TestIsolatedSessionE2E:
 
         await session.delete()
 
+    async def test_list_sessions(self):
+        session_a = await self._create_session()
+        session_b = await self._create_session()
+        session_b_deleted = False
+        try:
+            sessions = await self.sandbox.isolation.list()
+            by_id = {s.session_id: s for s in sessions}
+
+            assert session_a.session_id in by_id, "session_a should appear in list"
+            assert session_b.session_id in by_id, "session_b should appear in list"
+            assert by_id[session_a.session_id].status == "active"
+            assert by_id[session_a.session_id].created_at is not None
+
+            # After deleting a session it should no longer be listed.
+            await session_b.delete()
+            session_b_deleted = True
+            remaining = await self.sandbox.isolation.list()
+            remaining_ids = {s.session_id for s in remaining}
+            assert session_b.session_id not in remaining_ids
+        finally:
+            await session_a.delete()
+            if not session_b_deleted:
+                await session_b.delete()
+
     async def test_run_echo(self):
         session = await self._create_session()
         try:


### PR DESCRIPTION
## Summary

Adds a `GET /v1/isolated/sessions` endpoint to list all active isolated sessions in execd, and wires it through the OpenAPI spec and every sandbox SDK.

Previously the isolation API supported create / get(single) / delete but had no way to list existing sessions. This adds the missing collection endpoint.

## Changes

- **execd**
  - `ListIsolatedSessions` runtime method (iterates the session map) + Windows stub
  - controller `List()` handler and route `GET /v1/isolated/sessions`
  - `IsolatedSessionSummary` / `ListIsolatedSessionsResponse` models
- **specs** (`execd-api.yaml`)
  - `listIsolatedSessions` operation
  - `IsolatedSessionSummary` and `ListIsolatedSessionsResponse` schemas
- **SDKs** — public `list` method added to handwritten layers, mirroring the existing `get`/`capabilities` patterns:
  - Go: `Sandbox.IsolationListSessions`
  - Python: `sandbox.isolation.list()` (async + sync)
  - JavaScript: `sandbox.isolation.list()` (+ unavailable-isolation stub)
  - Kotlin: `sandbox.isolation().list()`
  - C#: `sandbox.Isolation.ListAsync()`
  - Regenerated Python/JS/Kotlin generated clients from the spec
- **tests**
  - Per-SDK unit tests for the new list method
  - Cross-language e2e tests (`tests/go`, `tests/python`, `tests/javascript`): create two sessions, assert both are listed with correct status/created_at, delete one and assert it is no longer listed

## Verification

- execd: `go build` / `go vet` pass
- Go SDK: `go test ./...` pass
- Python SDK: `ruff` / `pyright` / `pytest -k isolat` pass
- JavaScript SDK: `lint` / `typecheck` / `build` / `test` pass
- Kotlin SDK: `spotlessApply` + `:sandbox:test` pass (203 tests)
- C#: code written to match existing patterns, but `dotnet build/test` **not run** (no .NET SDK in the environment) — needs verification in a .NET environment
- e2e: statically validated (go build/vet, tsc --noEmit, py_compile); require a live sandbox runtime to execute