### PR TITLE
fix(sdk/python): defer annotations in isolated service Protocols

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/services/isolated.py
@@ -19,6 +19,8 @@ Isolated session service interface.
 Protocol for namespace-isolated execution operations (OSEP-0013).
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager

--- a/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
@@ -17,6 +17,8 @@
 Synchronous isolated session service interface.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager

--- a/sdks/sandbox/python/tests/test_isolated_service_import.py
+++ b/sdks/sandbox/python/tests/test_isolated_service_import.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Regression tests for isolated service Protocol module import.
+
+The ``IsolationService`` Protocol declares both a ``list`` method and a
+``binds: list[BindMount] | None`` parameter annotation.  Without deferred
+annotation evaluation (``from __future__ import annotations``), the class-scoped
+``list`` method shadows the builtin ``list`` while the class body is evaluated,
+raising ``TypeError: 'function' object is not subscriptable`` at import time.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_async_isolated_service_module_imports() -> None:
+    module = importlib.import_module("opensandbox.services.isolated")
+    assert hasattr(module, "IsolationService")
+    assert hasattr(module, "IsolationSession")
+
+
+def test_sync_isolated_service_module_imports() -> None:
+    module = importlib.import_module("opensandbox.sync.services.isolated")
+    assert hasattr(module, "IsolationServiceSync")
+    assert hasattr(module, "IsolationSessionSync")


### PR DESCRIPTION
## Problem

The main branch CI (SDK Tests) is red. Run [29004692407](https://github.com/opensandbox-group/OpenSandbox/actions/runs/29004692407) has 4 failing jobs, all with the same root cause:

- Python SDK Tests (sandbox)
- Python SDK Tests (code-interpreter)
- CLI Tests
- Python SDK Quality (sandbox) — pyright

All fail at import time with:

```
src/opensandbox/services/isolated.py:89: in IsolationService
    binds: list[BindMount] | None = None,
E   TypeError: 'function' object is not subscriptable
```

## Root cause

Introduced by f31696b4 (#1264). The `IsolationService` / `IsolationServiceSync` Protocols declare both:

- an `async def list(...)` method, and
- a `binds: list[BindMount] | None = None` parameter annotation on `run_once`.

Because these modules lack `from __future__ import annotations`, the annotation is evaluated at class-definition time. In the class body scope, the name `list` resolves to the class-scoped `list` method instead of the builtin, so `list[BindMount]` raises `TypeError: 'function' object is not subscriptable`. pyright reports the equivalent `Expected class but received ... -> list[...]`.

## Fix

Add `from __future__ import annotations` to both modules so annotations are evaluated lazily (PEP 563), restoring `list` to the builtin.

- `sdks/sandbox/python/src/opensandbox/services/isolated.py`
- `sdks/sandbox/python/src/opensandbox/sync/services/isolated.py`

Also adds a regression test that imports both service modules.

## Verification (local)

- `uv run pytest tests/` — all pass (Python sandbox SDK)
- `uv run pyright` — 0 errors
- `uv run ruff check` — passed
- CLI `uv run pytest tests/` — all pass