### PR TITLE
ci: enforce repository and release safeguards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Rules are evaluated top-to-bottom; the last matching pattern wins.
 
 # Default owners (fallback for files not matched by specific rules)
-* @jwx0925 @hittyt @hellomypastor @Pangjiping @ninan-nn
+* @jwx0925 @hittyt @Pangjiping @ninan-nn
 
 # Control plane (server)
 /server/ @Pangjiping @hittyt @jwx0925 @Generalwin @ninan-nn
@@ -11,13 +11,13 @@
 /components/execd/ @Pangjiping @hittyt @ninan-nn
 /components/ingress/ @Pangjiping @hittyt @Generalwin @Spground
 /components/egress/ @Pangjiping @hittyt @jwx0925
-/sandboxes/ @Pangjiping @ninan-nn @jwx0925 @hittyt @hellomypastor
+/sandboxes/ @Pangjiping @ninan-nn @jwx0925 @hittyt
 
 # Kubernetes controller
 /kubernetes/ @Spground @Generalwin @fengcone @kevinlynx @ninan-nn @hittyt @Pangjiping
 
 # SDKs
-/sdks/ @ninan-nn @jwx0925 @hittyt @hellomypastor @Pangjiping
+/sdks/ @ninan-nn @jwx0925 @hittyt @Pangjiping
 
 # Specs and docs
 /specs/ @jwx0925 @hittyt @ninan-nn

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -45,33 +45,45 @@ jobs:
               [file.filename, file.previous_filename].filter(Boolean),
             );
 
+            const workflowChanged = (path, caller) =>
+              path === ".github/workflows/detect-changes.yml" ||
+              path === `.github/workflows/${caller}`;
+
             const matchers = {
-              server: (path) => path.startsWith("server/"),
+              server: (path) =>
+                workflowChanged(path, "server-test.yml") ||
+                path.startsWith("server/"),
               kubernetes: (path) =>
-                path.startsWith("kubernetes/") &&
-                !path.startsWith("kubernetes/docs/"),
+                workflowChanged(path, "kubernetes-test.yml") ||
+                (path.startsWith("kubernetes/") &&
+                  !path.startsWith("kubernetes/docs/")),
               "real-e2e": (path) =>
+                workflowChanged(path, "real-e2e.yml") ||
                 path.startsWith("server/opensandbox_server/") ||
                 path.startsWith("components/execd/") ||
                 path.startsWith("components/egress/") ||
                 path.startsWith("sdks/") ||
                 path.startsWith("tests/"),
               egress: (path) =>
+                workflowChanged(path, "egress-test.yaml.yml") ||
                 path.startsWith("components/egress/") ||
                 path.startsWith("components/internal/"),
               "kubernetes-mini-e2e": (path) =>
-                path === ".github/workflows/kubernetes-nightly-build.yml" ||
+                workflowChanged(path, "kubernetes-nightly-build.yml") ||
                 path === "scripts/python-k8s-e2e.sh" ||
                 path === "scripts/python-k8s-e2e-ingress.sh" ||
                 path === "scripts/common/kubernetes-e2e.sh" ||
                 path.startsWith("kubernetes/charts/"),
               ingress: (path) =>
+                workflowChanged(path, "ingress-test.yaml") ||
                 path.startsWith("components/ingress/") ||
                 path.startsWith("components/internal/"),
               execd: (path) =>
+                workflowChanged(path, "execd-test.yml") ||
                 path.startsWith("components/execd/") ||
                 path.startsWith("components/internal/"),
               sdk: (path) =>
+                workflowChanged(path, "sdk-tests.yml") ||
                 path.startsWith("cli/") ||
                 path.startsWith("sdks/") ||
                 path.startsWith("specs/"),

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,103 @@
+name: Detect Relevant Changes
+
+on:
+  workflow_call:
+    inputs:
+      area:
+        description: Test area whose existing path scope should be evaluated
+        required: true
+        type: string
+    outputs:
+      relevant:
+        description: Whether the caller's tests are relevant to this event
+        value: ${{ jobs.detect.outputs.relevant }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.changes.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: changes
+        uses: actions/github-script@v7
+        env:
+          AREA: ${{ inputs.area }}
+        with:
+          script: |
+            if (context.eventName !== "pull_request") {
+              core.info(`Running ${process.env.AREA} tests for ${context.eventName}.`);
+              core.setOutput("relevant", "true");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const paths = files.flatMap((file) =>
+              [file.filename, file.previous_filename].filter(Boolean),
+            );
+
+            const detector = ".github/workflows/detect-changes.yml";
+            const workflow = {
+              server: ".github/workflows/server-test.yml",
+              kubernetes: ".github/workflows/kubernetes-test.yml",
+              "real-e2e": ".github/workflows/real-e2e.yml",
+              egress: ".github/workflows/egress-test.yaml.yml",
+              "kubernetes-mini-e2e": ".github/workflows/kubernetes-nightly-build.yml",
+              ingress: ".github/workflows/ingress-test.yaml",
+              execd: ".github/workflows/execd-test.yml",
+              sdk: ".github/workflows/sdk-tests.yml",
+            };
+            const matchers = {
+              server: (path) => path.startsWith("server/"),
+              kubernetes: (path) =>
+                path.startsWith("kubernetes/") &&
+                !path.startsWith("kubernetes/docs/"),
+              "real-e2e": (path) =>
+                path.startsWith("server/opensandbox_server/") ||
+                path.startsWith("components/execd/") ||
+                path.startsWith("components/egress/") ||
+                path.startsWith("sdks/") ||
+                path.startsWith("tests/"),
+              egress: (path) =>
+                path.startsWith("components/egress/") ||
+                path.startsWith("components/internal/"),
+              "kubernetes-mini-e2e": (path) =>
+                path === "scripts/python-k8s-e2e.sh" ||
+                path === "scripts/python-k8s-e2e-ingress.sh" ||
+                path === "scripts/common/kubernetes-e2e.sh" ||
+                path.startsWith("kubernetes/charts/"),
+              ingress: (path) =>
+                path.startsWith("components/ingress/") ||
+                path.startsWith("components/internal/"),
+              execd: (path) =>
+                path.startsWith("components/execd/") ||
+                path.startsWith("components/internal/"),
+              sdk: (path) =>
+                path.startsWith("cli/") ||
+                path.startsWith("sdks/") ||
+                path.startsWith("specs/"),
+            };
+
+            const area = process.env.AREA;
+            if (!Object.hasOwn(matchers, area)) {
+              core.setFailed(`Unknown test area: ${area}`);
+              return;
+            }
+
+            const relevant = paths.some(
+              (path) =>
+                path === detector ||
+                path === workflow[area] ||
+                matchers[area](path),
+            );
+            core.info(`${area}: relevant=${relevant}; files=${files.length}`);
+            core.setOutput("relevant", String(relevant));

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -45,17 +45,6 @@ jobs:
               [file.filename, file.previous_filename].filter(Boolean),
             );
 
-            const detector = ".github/workflows/detect-changes.yml";
-            const workflow = {
-              server: ".github/workflows/server-test.yml",
-              kubernetes: ".github/workflows/kubernetes-test.yml",
-              "real-e2e": ".github/workflows/real-e2e.yml",
-              egress: ".github/workflows/egress-test.yaml.yml",
-              "kubernetes-mini-e2e": ".github/workflows/kubernetes-nightly-build.yml",
-              ingress: ".github/workflows/ingress-test.yaml",
-              execd: ".github/workflows/execd-test.yml",
-              sdk: ".github/workflows/sdk-tests.yml",
-            };
             const matchers = {
               server: (path) => path.startsWith("server/"),
               kubernetes: (path) =>
@@ -71,6 +60,7 @@ jobs:
                 path.startsWith("components/egress/") ||
                 path.startsWith("components/internal/"),
               "kubernetes-mini-e2e": (path) =>
+                path === ".github/workflows/kubernetes-nightly-build.yml" ||
                 path === "scripts/python-k8s-e2e.sh" ||
                 path === "scripts/python-k8s-e2e-ingress.sh" ||
                 path === "scripts/common/kubernetes-e2e.sh" ||
@@ -93,11 +83,6 @@ jobs:
               return;
             }
 
-            const relevant = paths.some(
-              (path) =>
-                path === detector ||
-                path === workflow[area] ||
-                matchers[area](path),
-            );
+            const relevant = paths.some(matchers[area]);
             core.info(`${area}: relevant=${relevant}; files=${files.length}`);
             core.setOutput("relevant", String(relevant));

--- a/.github/workflows/egress-test.yaml.yml
+++ b/.github/workflows/egress-test.yaml.yml
@@ -3,19 +3,24 @@ name: Egress Tests
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'components/egress/**'
-      - 'components/internal/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: egress
+
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,6 +52,8 @@ jobs:
           go test ./...
 
   smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     steps:
       - name: Checkout code
@@ -80,6 +87,8 @@ jobs:
           ./tests/smoke-dns-upstream-probe.sh
 
   bench:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -100,3 +109,27 @@ jobs:
           name: egress-log-for-bench
           path: /tmp/egress-logs/
           retention-days: 5
+
+  required:
+    name: Egress CI
+    if: always()
+    needs: [changes, test, smoke, bench]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+          BENCH_RESULT: ${{ needs.bench.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$TEST_RESULT" == "success" && "$SMOKE_RESULT" == "success" && "$BENCH_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$SMOKE_RESULT" == "skipped" && "$BENCH_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -3,19 +3,24 @@ name: Execd Tests
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'components/execd/**'
-      - 'components/internal/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: execd
+
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -69,6 +74,8 @@ jobs:
           echo "*Coverage targets: Core packages >80%, API layer >70%*" >> $GITHUB_STEP_SUMMARY
 
   smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +138,8 @@ jobs:
           cat components/execd/execd.log || true
 
   bwrap-smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -155,3 +164,27 @@ jobs:
       - name: Run bwrap integration tests
         working-directory: components/execd
         run: sudo -E env "PATH=$PATH" go test -tags="linux,bwrap" -v -count=1 -timeout=5m ./pkg/runtime/bwrap_test/
+
+  required:
+    name: Execd CI
+    if: always()
+    needs: [changes, test, smoke, bwrap-smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+          BWRAP_SMOKE_RESULT: ${{ needs.bwrap-smoke.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$TEST_RESULT" == "success" && "$SMOKE_RESULT" == "success" && "$BWRAP_SMOKE_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$SMOKE_RESULT" == "skipped" && "$BWRAP_SMOKE_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/ingress-test.yaml
+++ b/.github/workflows/ingress-test.yaml
@@ -3,16 +3,24 @@ name: Ingress Tests
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'components/ingress/**'
-      - 'components/internal/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: ingress
+
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -48,3 +56,25 @@ jobs:
         working-directory: components/ingress
         run: |
           make test
+
+  required:
+    name: Ingress CI
+    if: always()
+    needs: [changes, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$TEST_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/kubernetes-nightly-build.yml
+++ b/.github/workflows/kubernetes-nightly-build.yml
@@ -2,6 +2,7 @@ name: Kubernetes nightly build (Monorepo)
 
 permissions:
   contents: read
+  pull-requests: read
   packages: write
 
 on:
@@ -10,20 +11,21 @@ on:
     - cron: "0 20 * * *"
   pull_request:
     branches: [ main ]
-    paths:
-      - '.github/workflows/kubernetes-nightly-build.yml'
-      - 'scripts/python-k8s-e2e.sh'
-      - 'scripts/python-k8s-e2e-ingress.sh'
-      - 'scripts/common/kubernetes-e2e.sh'
-      - 'kubernetes/charts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: kubernetes-mini-e2e
+
   k8s-mini-e2e:
     name: Kubernetes mini E2E (${{ matrix.variant }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -173,3 +175,25 @@ jobs:
           fi
           chmod +x build.sh
           ./build.sh
+
+  required:
+    name: Kubernetes Mini E2E CI
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [changes, k8s-mini-e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          E2E_RESULT: ${{ needs.k8s-mini-e2e.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$E2E_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$E2E_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/kubernetes-test.yml
+++ b/.github/workflows/kubernetes-test.yml
@@ -3,12 +3,10 @@ name: Sandbox Kubernetes Tests
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'kubernetes/**'
-      - '!kubernetes/docs/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,8 +16,15 @@ env:
   GO_VERSION: '1.24'
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: kubernetes
+
   controller-e2e-core:
     name: Controller E2E Core (Kubernetes v${{ matrix.version }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +46,8 @@ jobs:
 
   controller-e2e-pause-resume:
     name: Controller E2E PauseResume (Kubernetes v${{ matrix.version }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +68,8 @@ jobs:
           make test-e2e-pause-resume KIND_K8S_VERSION=v${{ matrix.version }}
 
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -95,3 +104,27 @@ jobs:
         working-directory: kubernetes
         run: |
           make test
+
+  required:
+    name: Kubernetes CI
+    if: always()
+    needs: [changes, controller-e2e-core, controller-e2e-pause-resume, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CORE_RESULT: ${{ needs.controller-e2e-core.result }}
+          PAUSE_RESUME_RESULT: ${{ needs.controller-e2e-pause-resume.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$CORE_RESULT" == "success" && "$PAUSE_RESUME_RESULT" == "success" && "$TEST_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$CORE_RESULT" == "skipped" && "$PAUSE_RESUME_RESULT" == "skipped" && "$TEST_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -12,7 +12,11 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish-pypi:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/cli/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -40,7 +40,11 @@ on:
       - 'k8s/image-committer/**'
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: release-preflight
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-csharp-sdks.yml
+++ b/.github/workflows/publish-csharp-sdks.yml
@@ -13,7 +13,11 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: release-preflight
     name: Publish (${{ matrix.sdk.name }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -68,6 +68,30 @@ jobs:
             echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Verify release tag on origin
+        env:
+          RELEASE_TAG: helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          local_commit="$(git rev-parse 'HEAD^{commit}')"
+          remote_commit="$(git ls-remote origin "refs/tags/${RELEASE_TAG}^{}" | awk 'NR == 1 { print $1 }')"
+
+          if [[ -z "$remote_commit" ]]; then
+            remote_commit="$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | awk 'NR == 1 { print $1 }')"
+          fi
+
+          if [[ -z "$remote_commit" ]]; then
+            echo "::error::Release tag '${RELEASE_TAG}' does not exist on origin. Have an authorized release manager push the protected tag before publishing the Helm chart."
+            exit 1
+          fi
+
+          if [[ "$local_commit" != "$remote_commit" ]]; then
+            echo "::error::Current commit is ${local_commit}, but origin tag '${RELEASE_TAG}' resolves to ${remote_commit}. Refusing to publish the Helm chart."
+            exit 1
+          fi
+
+          echo "Verified release tag '${RELEASE_TAG}' at ${remote_commit}."
+
       - name: Set chart path
         id: chart_path
         run: |

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -21,7 +21,11 @@ on:
       - 'helm/**'  # Format: helm/<component>/<app_version>, e.g., helm/opensandbox-controller/0.1.0
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: release-preflight
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -63,14 +63,16 @@ jobs:
             
             echo "component=$COMPONENT" >> $GITHUB_OUTPUT
             echo "app_version=$VERSION" >> $GITHUB_OUTPUT
+            echo "release_tag=$TAG_PATH" >> $GITHUB_OUTPUT
           else
             echo "component=${{ inputs.component }}" >> $GITHUB_OUTPUT
             echo "app_version=${{ inputs.app_version }}" >> $GITHUB_OUTPUT
+            echo "release_tag=helm/${{ inputs.component }}/${{ inputs.app_version }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Verify release tag on origin
         env:
-          RELEASE_TAG: helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}
+          RELEASE_TAG: ${{ steps.parse_tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           local_commit="$(git rev-parse 'HEAD^{commit}')"
@@ -154,7 +156,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}
+          tag_name: ${{ steps.parse_tag.outputs.release_tag }}
           name: Helm Chart ${{ steps.parse_tag.outputs.component }} ${{ steps.chart_version.outputs.version }} (App v${{ steps.parse_tag.outputs.app_version }})
           body: |
             ## ${{ steps.parse_tag.outputs.component }} Helm Chart
@@ -168,7 +170,7 @@ jobs:
             
             ```bash
             helm install ${{ steps.parse_tag.outputs.component }} \
-              https://github.com/${{ github.repository }}/releases/download/helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}/${{ steps.parse_tag.outputs.component }}-${{ steps.chart_version.outputs.version }}.tgz \
+              https://github.com/${{ github.repository }}/releases/download/${{ steps.parse_tag.outputs.release_tag }}/${{ steps.parse_tag.outputs.component }}-${{ steps.chart_version.outputs.version }}.tgz \
               --namespace opensandbox-system \
               --create-namespace
             ```
@@ -177,7 +179,7 @@ jobs:
             
             ```bash
             # 下载
-            wget https://github.com/${{ github.repository }}/releases/download/helm/${{ steps.parse_tag.outputs.component }}/${{ steps.parse_tag.outputs.app_version }}/${{ steps.parse_tag.outputs.component }}-${{ steps.chart_version.outputs.version }}.tgz
+            wget https://github.com/${{ github.repository }}/releases/download/${{ steps.parse_tag.outputs.release_tag }}/${{ steps.parse_tag.outputs.component }}-${{ steps.chart_version.outputs.version }}.tgz
             
             # 安装
             helm install ${{ steps.parse_tag.outputs.component }} ./${{ steps.parse_tag.outputs.component }}-${{ steps.chart_version.outputs.version }}.tgz \

--- a/.github/workflows/publish-java-sdks.yml
+++ b/.github/workflows/publish-java-sdks.yml
@@ -10,7 +10,11 @@ permissions:
   contents: read
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: release-preflight
     name: Publish (${{ matrix.sdk.name }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish-js-sdks.yml
+++ b/.github/workflows/publish-js-sdks.yml
@@ -13,7 +13,11 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: release-preflight
     name: Publish (${{ matrix.sdk.name }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish-python-sdks.yml
+++ b/.github/workflows/publish-python-sdks.yml
@@ -14,7 +14,11 @@ on:
       - "python/mcp/sandbox/v*"
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish-sandbox:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/python/sandbox/v')
     runs-on: ubuntu-latest
     steps:
@@ -55,6 +59,7 @@ jobs:
           uv publish
 
   publish-code-interpreter:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/python/code-interpreter/v')
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +95,7 @@ jobs:
           uv publish
 
   publish-mcp-sandbox:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/python/mcp/sandbox/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -13,7 +13,11 @@ permissions:
   packages: write
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish-pypi:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/server/v')
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +53,7 @@ jobs:
           uv publish
 
   publish-image:
+    needs: release-preflight
     if: startsWith(github.ref, 'refs/tags/server/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -2,6 +2,7 @@ name: Real E2E Tests
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   workflow_dispatch:
@@ -13,12 +14,6 @@ on:
         default: false
   pull_request:
     branches: [ main ]
-    paths:
-      - 'server/opensandbox_server/**'
-      - 'components/execd/**'
-      - 'components/egress/**'
-      - 'sdks/**'
-      - 'tests/**'
   push:
     branches: [ main ]
 
@@ -27,8 +22,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: real-e2e
+
   python-e2e:
     name: Python E2E (docker bridge)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
@@ -127,6 +129,8 @@ jobs:
 
   java-e2e:
     name: Java E2E (docker bridge)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
@@ -245,6 +249,8 @@ jobs:
 
   javascript-e2e:
     name: JavaScript E2E (docker bridge)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
@@ -347,6 +353,8 @@ jobs:
 
   csharp-e2e:
     name: C# E2E (docker bridge)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
@@ -438,6 +446,8 @@ jobs:
 
   go-e2e:
     name: Go E2E (docker bridge)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
       UV_BIN: /home/admin/.local/bin
@@ -528,3 +538,29 @@ jobs:
           docker rm -f opensandbox-e2e-credential-vault-target || true
           docker ps -aq --filter "label=opensandbox.e2e=credential-vault" | xargs -r docker rm -f || true
           docker run --rm -v /tmp:/host_tmp alpine rm -rf /host_tmp/opensandbox-e2e || true
+
+  required:
+    name: Real E2E CI
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [changes, python-e2e, java-e2e, javascript-e2e, csharp-e2e, go-e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          PYTHON_RESULT: ${{ needs.python-e2e.result }}
+          JAVA_RESULT: ${{ needs.java-e2e.result }}
+          JAVASCRIPT_RESULT: ${{ needs.javascript-e2e.result }}
+          CSHARP_RESULT: ${{ needs.csharp-e2e.result }}
+          GO_RESULT: ${{ needs.go-e2e.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$PYTHON_RESULT" == "success" && "$JAVA_RESULT" == "success" && "$JAVASCRIPT_RESULT" == "success" && "$CSHARP_RESULT" == "success" && "$GO_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$PYTHON_RESULT" == "skipped" && "$JAVA_RESULT" == "skipped" && "$JAVASCRIPT_RESULT" == "skipped" && "$CSHARP_RESULT" == "skipped" && "$GO_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -50,11 +50,6 @@ on:
         required: true
         default: false
         type: boolean
-      push_tag:
-        description: "Push new tag to origin"
-        required: true
-        default: false
-        type: boolean
       dry_run:
         description: "Preview only, no side effects"
         required: true
@@ -68,7 +63,13 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+    with:
+      require_approval: ${{ inputs.dry_run == false }}
+
   release:
+    needs: release-preflight
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -112,10 +113,6 @@ jobs:
             ARGS+=(--initial-release)
           fi
 
-          if [[ "${{ inputs.push_tag }}" == "true" ]]; then
-            ARGS+=(--push)
-          fi
-
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             ARGS+=(--dry-run)
           fi
@@ -136,7 +133,7 @@ jobs:
           fi
 
           if [[ -z "$remote_commit" ]]; then
-            echo "::error::Release tag '${RELEASE_TAG}' does not exist on origin. Re-run with push_tag=true or push the tag before publishing source artifacts."
+            echo "::error::Release tag '${RELEASE_TAG}' does not exist on origin. Have an authorized release manager push the tag before publishing source artifacts."
             exit 1
           fi
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,36 @@
+name: Release Preflight
+
+on:
+  workflow_call:
+    inputs:
+      require_approval:
+        description: Require approval through the release environment
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  verify-source:
+    name: Verify release source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify release commit is reachable from main
+        run: scripts/release/verify-release-ref.sh
+
+  approve-release:
+    name: Approve release
+    if: ${{ inputs.require_approval }}
+    needs: verify-source
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Record approval
+        run: echo "Release environment approval granted."

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -17,10 +17,6 @@ name: SDK Tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "cli/**"
-      - "sdks/**"
-      - "specs/**"
   push:
     branches: [main]
     paths:
@@ -30,14 +26,22 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: sdk
+
   cli-quality:
     name: CLI Quality
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -70,6 +74,8 @@ jobs:
 
   cli-tests:
     name: CLI Tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -106,6 +112,8 @@ jobs:
 
   python-sdk-quality:
     name: Python SDK Quality (${{ matrix.package_name }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -152,6 +160,8 @@ jobs:
 
   python-sdk-tests:
     name: Python SDK Tests (${{ matrix.package_name }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -208,6 +218,8 @@ jobs:
 
   javascript-sdk-quality:
     name: JavaScript SDK Quality And Tests (${{ matrix.package_name }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -270,6 +282,8 @@ jobs:
 
   kotlin-sdk-quality:
     name: Kotlin SDK Quality And Tests (${{ matrix.package_name }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -318,6 +332,8 @@ jobs:
 
   csharp-sdk-quality:
     name: C# SDK Quality And Tests (${{ matrix.package_name }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -365,6 +381,8 @@ jobs:
 
   go-sdk-quality:
     name: Go SDK Quality And Tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -403,3 +421,41 @@ jobs:
           name: go-sdk-reports
           path: |
             sdks/sandbox/go/reports/**
+
+  required:
+    name: SDK CI
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - changes
+      - cli-quality
+      - cli-tests
+      - python-sdk-quality
+      - python-sdk-tests
+      - javascript-sdk-quality
+      - kotlin-sdk-quality
+      - csharp-sdk-quality
+      - go-sdk-quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CLI_QUALITY_RESULT: ${{ needs.cli-quality.result }}
+          CLI_TESTS_RESULT: ${{ needs.cli-tests.result }}
+          PYTHON_QUALITY_RESULT: ${{ needs.python-sdk-quality.result }}
+          PYTHON_TESTS_RESULT: ${{ needs.python-sdk-tests.result }}
+          JAVASCRIPT_RESULT: ${{ needs.javascript-sdk-quality.result }}
+          KOTLIN_RESULT: ${{ needs.kotlin-sdk-quality.result }}
+          CSHARP_RESULT: ${{ needs.csharp-sdk-quality.result }}
+          GO_RESULT: ${{ needs.go-sdk-quality.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$CLI_QUALITY_RESULT" == "success" && "$CLI_TESTS_RESULT" == "success" && "$PYTHON_QUALITY_RESULT" == "success" && "$PYTHON_TESTS_RESULT" == "success" && "$JAVASCRIPT_RESULT" == "success" && "$KOTLIN_RESULT" == "success" && "$CSHARP_RESULT" == "success" && "$GO_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$CLI_QUALITY_RESULT" == "skipped" && "$CLI_TESTS_RESULT" == "skipped" && "$PYTHON_QUALITY_RESULT" == "skipped" && "$PYTHON_TESTS_RESULT" == "skipped" && "$JAVASCRIPT_RESULT" == "skipped" && "$KOTLIN_RESULT" == "skipped" && "$CSHARP_RESULT" == "skipped" && "$GO_RESULT" == "skipped" ]]
+          fi

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -3,18 +3,24 @@ name: Server Tests
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'server/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    with:
+      area: server
+
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +62,8 @@ jobs:
           path: server/reports/coverage.xml
 
   docker-smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       matrix:
         network: [host, bridge]
@@ -117,3 +125,26 @@ jobs:
         if: always()
         run: |
           cat server/app.log
+
+  required:
+    name: Server CI
+    if: always()
+    needs: [changes, test, docker-smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          DOCKER_SMOKE_RESULT: ${{ needs.docker-smoke.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed: $CHANGES_RESULT"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" ]]; then
+            [[ "$TEST_RESULT" == "success" && "$DOCKER_SMOKE_RESULT" == "success" ]]
+          else
+            [[ "$RELEVANT" == "false" && "$TEST_RESULT" == "skipped" && "$DOCKER_SMOKE_RESULT" == "skipped" ]]
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -632,7 +632,9 @@ Use GitHub Discussions for:
 
 - **Issues**: Technical problems or bugs
 - **Discussions**: Questions and community support
-- **Email**: For security issues, email conduct@opensandbox.io
+- **Security vulnerabilities**: Follow [SECURITY.md](SECURITY.md) and use
+  GitHub private vulnerability reporting. Do not open a public issue.
+- **Code of Conduct reports**: Email conduct@opensandbox.io
 
 ## Additional Resources
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,12 @@ The OpenSandbox team takes security seriously. If you discover a security vulner
 
 ### How to Report
 
-- **GitHub Security Advisories**: Open a private security advisory on GitHub
-- **Email**: Contact the maintainers directly with "[SECURITY]" in the subject
+- **GitHub Private Vulnerability Reporting**: Open a
+  [private security advisory](https://github.com/opensandbox-group/OpenSandbox/security/advisories/new)
+
+Do not report vulnerabilities in a public issue or to the Code of Conduct
+reporting address. The `conduct@opensandbox.io` address is only for community
+conduct reports.
 
 ### What to Include
 

--- a/docs/community/release-automation.md
+++ b/docs/community/release-automation.md
@@ -52,6 +52,27 @@ The script aligns with existing workflow triggers:
   - `<target>/<version>` for docker/k8s/helm targets
   - examples: `docker/execd/v0.3.0`, `helm/opensandbox/0.1.0`
 
+Release tag namespaces are protected by repository rulesets. Only authorized
+release managers may create matching tags, and an existing release tag cannot
+be updated or deleted.
+
+## Release Approval and Source Verification
+
+Hosted publish workflows run a shared release preflight before publishing:
+
+- the release commit must be reachable from `origin/main`
+- non-dry-run releases require approval through the `release` environment
+- the person who triggered the release cannot approve their own deployment
+
+This implements two-person control: one person initiates the release and a
+different Project Maintainer approves it. GitHub environments require one of
+the configured reviewers; they do not natively support requiring two reviewer
+approvals in addition to the initiator.
+
+The hosted Generic Release workflow does not create or push release tags. An
+authorized release manager must create the tag from a commit on `main` before
+running a non-dry-run Generic Release.
+
 ## Release Notes Format
 
 Generated notes follow this section structure:
@@ -213,13 +234,11 @@ Inputs exposed in the workflow dispatch form:
 - `version`
 - `from_tag` (optional)
 - `initial_release` (boolean)
-- `push_tag` (boolean)
 - `dry_run` (boolean, default `true`)
 
 Dry-run in GitHub Actions:
 
 - set `dry_run=true`
-- set `push_tag=false`
 - check logs for:
   - computed tag (`New tag`)
   - range (`Computed range`)
@@ -228,9 +247,10 @@ Dry-run in GitHub Actions:
 Recommended first run in UI:
 
 - set `dry_run=true`
-- keep `push_tag=false`
 - verify the generated release notes preview in logs
-- rerun with `dry_run=false` and `push_tag=true` when confirmed
+- have an authorized release manager create and push the release tag from
+  `main`
+- select that tag as the workflow ref and rerun with `dry_run=false`
 
 When `dry_run=false`, `.github/workflows/release-generic.yml` uploads an
 explicit `opensandbox-<tag>.tar.gz` source archive and `SHA256SUMS` file to the

--- a/scripts/release/create-release.sh
+++ b/scripts/release/create-release.sh
@@ -675,6 +675,11 @@ if [[ "$DRY_RUN" == true ]]; then
 fi
 
 if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+  existing_tag_commit="$(git rev-parse "${NEW_TAG}^{commit}")"
+  head_commit="$(git rev-parse 'HEAD^{commit}')"
+  if [[ "$existing_tag_commit" != "$head_commit" ]]; then
+    die "Existing tag '${NEW_TAG}' resolves to ${existing_tag_commit}, but HEAD resolves to ${head_commit}."
+  fi
   warn "Tag '${NEW_TAG}' already exists. Reusing existing tag."
 else
   if [[ "$SIGN_TAG" == true ]]; then

--- a/scripts/release/verify-release-ref.sh
+++ b/scripts/release/verify-release-ref.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+remote="${RELEASE_REMOTE:-origin}"
+default_branch="${RELEASE_DEFAULT_BRANCH:-main}"
+release_ref="${RELEASE_REF:-${GITHUB_SHA:-HEAD}}"
+remote_ref="refs/remotes/${remote}/${default_branch}"
+
+git fetch --force --no-tags "$remote" \
+  "+refs/heads/${default_branch}:${remote_ref}"
+
+release_commit="$(git rev-parse --verify "${release_ref}^{commit}")"
+default_branch_commit="$(git rev-parse --verify "${remote_ref}^{commit}")"
+
+if ! git merge-base --is-ancestor "$release_commit" "$default_branch_commit"; then
+  echo "::error::Release commit ${release_commit} is not reachable from ${remote}/${default_branch}."
+  exit 1
+fi
+
+echo "Verified release commit ${release_commit} is reachable from ${remote}/${default_branch}."
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Release source verified"
+    echo
+    echo "Commit \`${release_commit}\` is reachable from \`${remote}/${default_branch}\`."
+  } >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/sdks/sandbox/python/src/opensandbox/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/services/isolated.py
@@ -19,6 +19,8 @@ Isolated session service interface.
 Protocol for namespace-isolated execution operations (OSEP-0013).
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager

--- a/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/services/isolated.py
@@ -17,6 +17,8 @@
 Synchronous isolated session service interface.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager

--- a/sdks/sandbox/python/tests/test_isolated_service_import.py
+++ b/sdks/sandbox/python/tests/test_isolated_service_import.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Regression tests for isolated service Protocol module import.
+
+The ``IsolationService`` Protocol declares both a ``list`` method and a
+``binds: list[BindMount] | None`` parameter annotation.  Without deferred
+annotation evaluation (``from __future__ import annotations``), the class-scoped
+``list`` method shadows the builtin ``list`` while the class body is evaluated,
+raising ``TypeError: 'function' object is not subscriptable`` at import time.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_async_isolated_service_module_imports() -> None:
+    module = importlib.import_module("opensandbox.services.isolated")
+    assert hasattr(module, "IsolationService")
+    assert hasattr(module, "IsolationSession")
+
+
+def test_sync_isolated_service_module_imports() -> None:
+    module = importlib.import_module("opensandbox.sync.services.isolated")
+    assert hasattr(module, "IsolationServiceSync")
+    assert hasattr(module, "IsolationSessionSync")


### PR DESCRIPTION
# Summary
- remove the former maintainer `@hellomypastor` from every active CODEOWNERS rule and keep the current Project Maintainer list authoritative
- point vulnerability reports to GitHub private vulnerability reporting, while reserving `conduct@opensandbox.io` for Code of Conduct reports
- make eight path-scoped CI suites report stable required gates without running irrelevant heavy jobs
- require release commits to be reachable from `main`, gate hosted publishing through the protected `release` environment, and stop the generic workflow from pushing release tags
- reject reusing an existing release tag when it does not resolve to the current release commit

Repository settings applied with this change:
- active release-tag creation and immutability rulesets for all current release namespaces
- `release` environment restricted to `main` and release tags, with self-review prevented and the current four Project Maintainers as reviewers
- the active `main` ruleset now requires the existing `verify-license` context; after this PR merges, the eight new gate contexts can be activated without locking out existing PRs

# Testing
- [ ] Not run (explain why)
- [ ] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

Validated with:
- `actionlint v1.7.12` across all GitHub Actions workflows
- `./scripts/verify-license.sh`
- `bash -n scripts/release/create-release.sh scripts/release/verify-release-ref.sh`
- positive and negative `verify-release-ref.sh` ancestry checks
- `cd docs && pnpm@9.15.0 docs:build`
- `git diff --check`

The PR exercises the always-on gate behavior while retaining the previous path scopes for heavy suites.

Current CI dependency: Kubernetes Mini E2E reaches the Python test phase, then fails on the existing deferred-annotation bug in `isolated.py`. #1270 contains the focused fix and all of its checks are green; this PR should be updated and rerun after #1270 merges.

# Breaking Changes
- [ ] None
- [x] Yes (describe impact and migration path)

The hosted Generic Release workflow no longer exposes `push_tag`. An authorized Project Maintainer must create and push the protected tag from a commit on `main`, then a different maintainer approves the `release` environment deployment.

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
