### PR TITLE
chore(code-interpreter/kotlin): bump project.version to 1.0.16

### DIFF
--- a/sdks/code-interpreter/kotlin/gradle.properties
+++ b/sdks/code-interpreter/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.15
+project.version=1.0.16
 project.description=A Kotlin SDK for Code Interpreter

--- a/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
+++ b/sdks/code-interpreter/kotlin/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 jackson = "2.18.2"
-sandbox = "1.0.15"
+sandbox = "1.0.16"
 junit-platform = "1.13.4"
 
 [libraries]


### PR DESCRIPTION
## Summary

Align `sdks/code-interpreter/kotlin/gradle.properties` `project.version` with the release tag `java/code-interpreter/v1.0.16`.

## Context

The release build failed with:

```
Ref/tag version mismatch: expected version '1.0.15' from gradle.properties, but got '1.0.16' from tag 'java/code-interpreter/v...'. Please align the tag and project.version.
```

The tag/version consistency check in `sdks/code-interpreter/kotlin/build.gradle.kts` (L59) requires `project.version` in `gradle.properties` to match the ref tag when the build is triggered from a tag.

## Change

- `sdks/code-interpreter/kotlin/gradle.properties`: `project.version` `1.0.15` -> `1.0.16`

## Follow-up

After this PR is merged, the release tag `java/code-interpreter/v1.0.16` should be re-pointed to the merge commit:

```bash
git tag -d java/code-interpreter/v1.0.16
git push origin :refs/tags/java/code-interpreter/v1.0.16
git tag java/code-interpreter/v1.0.16 <merge-commit-sha>
git push origin java/code-interpreter/v1.0.16
```
