### PR TITLE
fix(sdk): widen isolated uid/gid to long for uint32 range

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Isolated.cs
@@ -39,8 +39,8 @@ public record CreateIsolatedSessionRequest(
     [property: JsonPropertyName("binds")] List<BindMount>? Binds = null,
     [property: JsonPropertyName("share_net")] bool? ShareNet = null,
     [property: JsonPropertyName("env_passthrough")] EnvPassthroughSpec? EnvPassthrough = null,
-    [property: JsonPropertyName("uid")] int? Uid = null,
-    [property: JsonPropertyName("gid")] int? Gid = null,
+    [property: JsonPropertyName("uid")] long? Uid = null,
+    [property: JsonPropertyName("gid")] long? Gid = null,
     [property: JsonPropertyName("uid_mode")] string? UidMode = null,
     [property: JsonPropertyName("idle_timeout_seconds")] int? IdleTimeoutSeconds = null
 );

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
@@ -370,6 +370,29 @@ public class ModelsTests
     }
 
     [Fact]
+    public void CreateIsolatedSessionRequest_ShouldRoundTripUidAboveInt32Max()
+    {
+        // Spec declares uid/gid as uint32; values above Int32.MaxValue must not fail.
+        const long uidAboveInt32 = 3_000_000_000L;
+        const long gidAboveInt32 = 4_000_000_000L;
+        var request = new CreateIsolatedSessionRequest(
+            Workspace: new IsolatedWorkspaceSpec("/workspace"),
+            Uid: uidAboveInt32,
+            Gid: gidAboveInt32
+        );
+
+        var json = JsonSerializer.Serialize(request);
+        var restored = JsonSerializer.Deserialize<CreateIsolatedSessionRequest>(json);
+
+        restored.Should().NotBeNull();
+        restored!.Uid.Should().Be(uidAboveInt32);
+        restored.Gid.Should().Be(gidAboveInt32);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("uid").GetInt64().Should().Be(uidAboveInt32);
+        doc.RootElement.GetProperty("gid").GetInt64().Should().Be(gidAboveInt32);
+    }
+
+    [Fact]
     public void CreateSessionOptions_ShouldStoreWorkingDirectory()
     {
         var options = new CreateSessionOptions

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/execd/isolated/IsolatedModels.kt
@@ -41,8 +41,8 @@ data class CreateIsolatedSessionRequest(
     val binds: List<BindMount>? = null,
     val shareNet: Boolean? = null,
     val envPassthrough: EnvPassthroughSpec? = null,
-    val uid: Int? = null,
-    val gid: Int? = null,
+    val uid: Long? = null,
+    val gid: Long? = null,
     val uidMode: String? = null,
     val idleTimeoutSeconds: Int? = null,
 )

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
@@ -55,8 +55,8 @@ private data class IsolatedCreateBody(
     val binds: List<BindMountBody>? = null,
     val share_net: Boolean? = null,
     val env_passthrough: EnvPassthroughBody? = null,
-    val uid: Int? = null,
-    val gid: Int? = null,
+    val uid: Long? = null,
+    val gid: Long? = null,
     val uid_mode: String? = null,
     val idle_timeout_seconds: Int? = null,
 )

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapterTest.kt
@@ -18,7 +18,13 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.CreateIsolatedSessionRequest
+import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.IsolatedWorkspaceSpec
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -120,5 +126,38 @@ class IsolatedSessionsAdapterTest {
 
         assertEquals(0, sessions.size)
         assertEquals("/v1/isolated/sessions", mockWebServer.takeRequest().path)
+    }
+
+    @Test
+    fun `create serializes uid and gid above Int MaxValue`() {
+        // Spec declares uid/gid as uint32; values above Int.MAX_VALUE must not fail.
+        val uidAboveInt = 3_000_000_000L
+        val gidAboveInt = 4_000_000_000L
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(
+                    """
+                    {
+                      "session_id": "00000000-0000-0000-0000-000000000001",
+                      "created_at": "2026-01-02T03:04:05Z"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+
+        adapter.create(
+            CreateIsolatedSessionRequest(
+                workspace = IsolatedWorkspaceSpec(path = "/workspace"),
+                uid = uidAboveInt,
+                gid = gidAboveInt,
+            ),
+        )
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/v1/isolated/session", request.path)
+        val body = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals(uidAboveInt, body["uid"]!!.jsonPrimitive.long)
+        assertEquals(gidAboveInt, body["gid"]!!.jsonPrimitive.long)
     }
 }


### PR DESCRIPTION


# Summary
- What is changing and why?
C#/Kotlin int could not hold values above Int32.MaxValue; align with execd-api uint32 and add deserialization/serialization regression tests.
cloes https://github.com/opensandbox-group/OpenSandbox/issues/1296
# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
