### PR TITLE
feat(controller): add --image-committer-pull-secret for authenticated registry proxies (e.g. Artifactory virtual repos mirroring Docker Hub)

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -375,6 +375,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	$(KUSTOMIZE) build config/default | \
 		sed 's|--snapshot-registry=docker-registry.default.svc.cluster.local:5000|--snapshot-registry=$(SNAPSHOT_REGISTRY)|' | \
 		sed 's|--image-committer-image=image-committer:dev|--image-committer-image=$(IMAGE_COMMITTER_IMG)|' | \
+		sed 's|--image-committer-pull-secret=|--image-committer-pull-secret=$(IMAGE_COMMITTER_PULL_SECRET)|' | \
 		$(KUBECTL) apply -f -
 
 .PHONY: undeploy

--- a/kubernetes/charts/opensandbox-controller/README.md
+++ b/kubernetes/charts/opensandbox-controller/README.md
@@ -80,6 +80,7 @@ kubectl delete crd sandboxsnapshots.sandbox.opensandbox.io
 | `controller.snapshot.registry` | OCI registry prefix used for snapshot images | `""` |
 | `controller.snapshot.registryInsecure` | Use insecure registry mode for snapshot pushes | `false` |
 | `controller.snapshot.snapshotPushSecret` | Secret name used by commit Jobs to push snapshots | `""` |
+| `controller.snapshot.imageCommitterPullSecret` | Secret name for pulling the image-committer image in commit Jobs (needed when it's in a private registry) | `""` |
 | `controller.snapshot.resumePullSecret` | Secret name injected into resumed sandboxes for image pulls | `""` |
 | `controller.leaderElection.enabled` | Enable leader election | `true` |
 | `controller.nodeSelector` | Node labels for pod assignment | `{}` |
@@ -169,6 +170,7 @@ controller:
     registry: my-registry/snapshots
     registryInsecure: false
     snapshotPushSecret: registry-snapshot-push-secret
+    imageCommitterPullSecret: registry-image-committer-pull-secret
     resumePullSecret: registry-pull-secret
 ```
 
@@ -179,6 +181,7 @@ These values render directly to the controller flags:
 - `--snapshot-registry`
 - `--snapshot-registry-insecure`
 - `--snapshot-push-secret`
+- `--image-committer-pull-secret`
 - `--resume-pull-secret`
 
 ### Node Affinity

--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
         {{- if .Values.controller.snapshot.snapshotPushSecret }}
         - --snapshot-push-secret={{ .Values.controller.snapshot.snapshotPushSecret }}
         {{- end }}
+        {{- if .Values.controller.snapshot.imageCommitterPullSecret }}
+        - --image-committer-pull-secret={{ .Values.controller.snapshot.imageCommitterPullSecret }}
+        {{- end }}
         {{- if .Values.controller.snapshot.resumePullSecret }}
         - --resume-pull-secret={{ .Values.controller.snapshot.resumePullSecret }}
         {{- end }}

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -59,6 +59,9 @@ controller:
     registryInsecure: false
     # -- Secret name used by commit Jobs to push snapshot images.
     snapshotPushSecret: ""
+    # -- Secret name for pulling the image-committer image in commit Jobs.
+    # Required when imageCommitterImage is stored in a private registry.
+    imageCommitterPullSecret: ""
     # -- Secret name injected into resumed sandboxes for pulling snapshot images.
     resumePullSecret: ""
 

--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -220,6 +220,9 @@ func main() {
 	var snapshotPushSecret string
 	flag.StringVar(&snapshotPushSecret, "snapshot-push-secret", "", "K8s Secret name for pushing snapshots to registry.")
 
+	var imageCommitterPullSecret string
+	flag.StringVar(&imageCommitterPullSecret, "image-committer-pull-secret", "", "K8s Secret name for pulling the image-committer image in commit Jobs. Required when imageCommitterImage is in a private registry.")
+
 	var resumePullSecret string
 	flag.StringVar(&resumePullSecret, "resume-pull-secret", "", "K8s Secret name for pulling snapshot images during resume.")
 
@@ -461,6 +464,7 @@ func main() {
 		SnapshotRegistry:         snapshotRegistry,
 		SnapshotRegistryInsecure: snapshotRegistryInsecure,
 		SnapshotPushSecret:       snapshotPushSecret,
+		ImageCommitterPullSecret: imageCommitterPullSecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SandboxSnapshot")
 		os.Exit(1)

--- a/kubernetes/config/manager/manager.yaml
+++ b/kubernetes/config/manager/manager.yaml
@@ -69,6 +69,7 @@ spec:
           - --resume-pull-secret=registry-pull-secret
           - --image-committer-image=image-committer:dev
           - --commit-job-timeout=2m
+          - --image-committer-pull-secret=
         image: controller:dev
         name: manager
         ports: []

--- a/kubernetes/docs/HELM-DEPLOYMENT.md
+++ b/kubernetes/docs/HELM-DEPLOYMENT.md
@@ -127,6 +127,7 @@ controller:
   snapshot:
     registry: myregistry.example.com/opensandbox/snapshots
     snapshotPushSecret: registry-snapshot-push-secret
+    imageCommitterPullSecret: registry-image-committer-pull-secret
     resumePullSecret: registry-pull-secret
 
 imagePullSecrets:
@@ -184,6 +185,7 @@ helm install opensandbox-controller ./charts/opensandbox-controller \
 helm install opensandbox-controller ./charts/opensandbox-controller \
   --set controller.snapshot.registry=myregistry.example.com/opensandbox/snapshots \
   --set controller.snapshot.snapshotPushSecret=registry-snapshot-push-secret \
+  --set controller.snapshot.imageCommitterPullSecret=registry-image-committer-pull-secret \
   --set controller.snapshot.resumePullSecret=registry-pull-secret \
   --namespace opensandbox-system
 ```

--- a/kubernetes/internal/controller/sandboxsnapshot_controller.go
+++ b/kubernetes/internal/controller/sandboxsnapshot_controller.go
@@ -79,6 +79,10 @@ type SandboxSnapshotReconciler struct {
 	// SnapshotPushSecret is the K8s Secret name for pushing to registry (from Controller Manager startup params)
 	SnapshotPushSecret string
 
+	// ImageCommitterPullSecret is the K8s Secret name used to pull the image-committer image in commit Jobs.
+	// Required when imageCommitterImage lives in a private registry.
+	ImageCommitterPullSecret string
+
 	// SnapshotRegistryInsecure controls whether image-committer uses insecure registry mode.
 	SnapshotRegistryInsecure bool
 }

--- a/kubernetes/internal/controller/sandboxsnapshot_lifecycle.go
+++ b/kubernetes/internal/controller/sandboxsnapshot_lifecycle.go
@@ -312,6 +312,13 @@ func (r *SandboxSnapshotReconciler) containerdSocketPath() string {
 	return ContainerdSocketPath
 }
 
+func (r *SandboxSnapshotReconciler) imageCommitterPullSecrets() []corev1.LocalObjectReference {
+	if r.ImageCommitterPullSecret == "" {
+		return nil
+	}
+	return []corev1.LocalObjectReference{{Name: r.ImageCommitterPullSecret}}
+}
+
 func commitJobSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsUser:                ptrToInt64(0),
@@ -380,7 +387,8 @@ func (r *SandboxSnapshotReconciler) buildCommitJob(snapshot *sandboxv1alpha1.San
 			ActiveDeadlineSeconds:   ptrToInt64(int64(r.getCommitJobTimeout().Seconds())),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:    corev1.RestartPolicyNever,
+					ImagePullSecrets: r.imageCommitterPullSecrets(),
 					Containers: []corev1.Container{
 						{
 							Name:            CommitJobContainerName,
@@ -448,7 +456,8 @@ func (r *SandboxSnapshotReconciler) buildUnpauseJob(snapshot *sandboxv1alpha1.Sa
 			ActiveDeadlineSeconds:   ptrToInt64(int64(r.getCommitJobTimeout().Seconds())),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:    corev1.RestartPolicyNever,
+					ImagePullSecrets: r.imageCommitterPullSecrets(),
 					Containers: []corev1.Container{
 						{
 							Name:            CommitJobContainerName,


### PR DESCRIPTION
Fixes #1299.

## Problem

In corporate environments, direct access to Docker Hub is blocked and all images are pulled through a **private virtual repository** (e.g. JFrog Artifactory, Nexus) that proxies Docker Hub and requires authentication. Even though `image-committer` is a public image, pulling it through such a proxy fails because the commit Job has no `ImagePullSecrets`:

```
Failed to pull image "artifactory.corp.example.com/docker/opensandbox/image-committer:v0.1.1":
failed to authorize: unexpected status 401
```

```
Kubernetes node
  └─► pull "artifactory.corp.example.com/docker/image-committer:v0.1.1"
            │
            ▼
    Artifactory virtual repo   ← requires auth — no ImagePullSecret → 401
            │
            ▼ proxy / mirror
      Docker Hub (public image, but unreachable directly)
```

The controller already has `--snapshot-push-secret` and `--resume-pull-secret` for the same credential-injection pattern. This PR adds the missing equivalent for the image-committer pull.

## Changes

- **`sandboxsnapshot_controller.go`** — add `ImageCommitterPullSecret string` to `SandboxSnapshotReconciler`
- **`sandboxsnapshot_lifecycle.go`** — new `imageCommitterPullSecrets()` helper; set `PodSpec.ImagePullSecrets` in both `buildCommitJob` and `ensureUnpauseJob`
- **`cmd/controller/main.go`** — parse `--image-committer-pull-secret` and wire it to the reconciler
- **`charts/opensandbox-controller/values.yaml`** — add `controller.snapshot.imageCommitterPullSecret: ""`
- **`charts/opensandbox-controller/templates/deployment.yaml`** — pass the new flag when set

## Backwards compatibility

When `imageCommitterPullSecret` is empty (default), `imageCommitterPullSecrets()` returns `nil` — the Job `PodSpec` is identical to before. No behaviour change for existing deployments.

## Test plan

- [x] `go build ./...` passes
- [x] Empty `imageCommitterPullSecret` → `nil` ImagePullSecrets (no regression)
- [ ] Deploy with `imageCommitterImage` behind a private Artifactory virtual repo and `imageCommitterPullSecret` pointing to a valid dockerconfigjson Secret → commit Job pulls the image and snapshot completes successfully

Co-authored-by: Atenea Agent <svc_atenea_gitlab@ofidona.net>