### PR TITLE
fix(server): use tenant namespace for diagnostics

### DIFF
--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -57,7 +57,7 @@ class K8sDiagnosticsMixin:
         label_selector = f"{SANDBOX_ID_LABEL}={sandbox_id}"
         try:
             pods = self.k8s_client.list_pods(
-                namespace=self.namespace,
+                namespace=self._resolve_namespace(),
                 label_selector=label_selector,
             )
         except Exception as exc:
@@ -94,7 +94,7 @@ class K8sDiagnosticsMixin:
 
         kwargs: dict = {
             "name": pod_name,
-            "namespace": self.namespace,
+            "namespace": pod.metadata.namespace,
             "container": target_container,
             "tail_lines": tail,
             "timestamps": True,
@@ -241,7 +241,7 @@ class K8sDiagnosticsMixin:
         core_v1 = self.k8s_client.get_core_v1_api()
 
         events_resp = core_v1.list_namespaced_event(
-            namespace=self.namespace,
+            namespace=pod.metadata.namespace,
             field_selector=f"involvedObject.name={pod_name}",
             limit=limit,
         )

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -27,12 +27,16 @@ from opensandbox_server.services.k8s.k8s_diagnostics import (
 
 
 class _DiagnosticsService(K8sDiagnosticsMixin):
-    def __init__(self, pods):
+    def __init__(self, pods, resolved_namespace: str | None = None):
         self.namespace = "sandbox-system"
+        self.resolved_namespace = resolved_namespace or self.namespace
         self.k8s_client = MagicMock()
         self.k8s_client.list_pods.return_value = pods
         self.core_v1 = MagicMock()
         self.k8s_client.get_core_v1_api.return_value = self.core_v1
+
+    def _resolve_namespace(self) -> str:
+        return self.resolved_namespace
 
 
 def _status(
@@ -56,11 +60,16 @@ def _status(
     )
 
 
-def _pod(container_statuses=None, init_container_statuses=None, conditions=None):
+def _pod(
+    container_statuses=None,
+    init_container_statuses=None,
+    conditions=None,
+    namespace="sandbox-system",
+):
     return SimpleNamespace(
         metadata=SimpleNamespace(
             name="pod-1",
-            namespace="sandbox-system",
+            namespace=namespace,
             labels={SANDBOX_ID_LABEL: "sbx-1", "app": "opensandbox"},
         ),
         spec=SimpleNamespace(
@@ -116,6 +125,17 @@ def test_find_pod_uses_label_selector_and_maps_errors() -> None:
     assert api_error.value.status_code == 500
 
 
+def test_find_pod_uses_resolved_tenant_namespace() -> None:
+    service = _DiagnosticsService([_pod(namespace="tenant-a")], resolved_namespace="tenant-a")
+
+    service._find_pod_for_sandbox("sbx-1")
+
+    service.k8s_client.list_pods.assert_called_once_with(
+        namespace="tenant-a",
+        label_selector=f"{SANDBOX_ID_LABEL}=sbx-1",
+    )
+
+
 def test_get_sandbox_logs_passes_tail_and_since() -> None:
     service = _DiagnosticsService([_pod()])
     service.core_v1.read_namespaced_pod_log.return_value = "log line"
@@ -130,6 +150,21 @@ def test_get_sandbox_logs_passes_tail_and_since() -> None:
         tail_lines=10,
         timestamps=True,
         since_seconds=3600,
+    )
+
+
+def test_get_sandbox_logs_uses_found_pod_namespace() -> None:
+    service = _DiagnosticsService([_pod(namespace="tenant-a")], resolved_namespace="tenant-a")
+    service.core_v1.read_namespaced_pod_log.return_value = "tenant log"
+
+    assert service.get_sandbox_logs("sbx-1") == "tenant log"
+
+    service.core_v1.read_namespaced_pod_log.assert_called_once_with(
+        name="pod-1",
+        namespace="tenant-a",
+        container="main",
+        tail_lines=100,
+        timestamps=True,
     )
 
 
@@ -317,3 +352,16 @@ def test_get_sandbox_events_formats_events_and_empty_result() -> None:
 
     service.core_v1.list_namespaced_event.return_value = SimpleNamespace(items=[])
     assert service.get_sandbox_events("sbx-1") == "(no events)"
+
+
+def test_get_sandbox_events_uses_found_pod_namespace() -> None:
+    service = _DiagnosticsService([_pod(namespace="tenant-a")], resolved_namespace="tenant-a")
+    service.core_v1.list_namespaced_event.return_value = SimpleNamespace(items=[])
+
+    assert service.get_sandbox_events("sbx-1") == "(no events)"
+
+    service.core_v1.list_namespaced_event.assert_called_once_with(
+        namespace="tenant-a",
+        field_selector="involvedObject.name=pod-1",
+        limit=50,
+    )


### PR DESCRIPTION
# Summary
- Resolve Kubernetes diagnostics pod lookups in the request-scoped tenant namespace.
- Read pod logs and events from the namespace of the pod that was found.
- Keep the existing default namespace behavior for non-tenant requests.

Closes #1304

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

Commands:

```bash
cd server
uv run pytest tests/k8s/test_k8s_diagnostics.py tests/test_devops.py tests/k8s/test_kubernetes_service.py -q
uv run pytest -q
uv run ruff check opensandbox_server/services/k8s/k8s_diagnostics.py tests/k8s/test_k8s_diagnostics.py
```

The focused tenant-namespace regressions failed before the fix and pass afterward. The complete server suite passes 1272 tests.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

No public API, configuration, schema, or persistence behavior changes. Diagnostics remain scoped to the namespace resolved from the authenticated tenant context.
