### PR TITLE
fix(sdks/sandbox/go): survive silently-dropped LB connections and long SSE streams

### DIFF
--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -23,7 +23,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -159,32 +161,58 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body an
 		encodedBody = buf
 	}
 
-	err := c.sendJSONRequest(ctx, method, path, encodedBody, result)
+	var reusedIdle atomic.Bool
+	err := c.sendJSONRequest(ctx, method, path, encodedBody, result, &reusedIdle)
 	if err == nil {
 		return nil
 	}
-	if !shouldRetryStaleConnection(method, err) {
+	if !shouldRetryStaleConnection(method, err, reusedIdle.Load()) {
 		return err
 	}
-	// The failure looks like a reused-but-silently-dropped keep-alive
-	// connection: request written locally but no response headers arrived
-	// before http.Client.Timeout fired. Evict idle connections in the pool
-	// and retry exactly once on a freshly dialed connection. Only safe for
-	// idempotent methods; see shouldRetryStaleConnection.
+	// The failure signature matches a reused-but-silently-dropped keep-alive
+	// connection: we observed the http client picking up an idle pooled
+	// connection, wrote the request locally, and then no response headers
+	// arrived before the header-phase timeout fired. Evict idle connections
+	// in the pool and retry exactly once on a freshly dialed connection.
+	// Only safe for idempotent methods; see shouldRetryStaleConnection.
+	//
+	// The retry uses the same caller ctx and http.Client.Timeout as the
+	// first attempt. That matches the "one bounded retry within the
+	// caller's budget" semantics: the total wait a caller can observe is
+	// bounded by roughly two http.Client.Timeout windows, but the retry
+	// only fires when we can prove (via httptrace) that the first attempt
+	// reused an idle pooled connection — which never happens on a genuinely
+	// slow-but-alive server that just accepted a fresh connection.
 	if tr, ok := c.httpClient.Transport.(*http.Transport); ok {
 		tr.CloseIdleConnections()
 	}
-	return c.sendJSONRequest(ctx, method, path, encodedBody, result)
+	return c.sendJSONRequest(ctx, method, path, encodedBody, result, nil)
 }
 
 // sendJSONRequest builds and executes a single HTTP request. encodedBody is
 // the pre-marshaled JSON payload (or nil for GET/DELETE-style requests). The
 // caller is responsible for retry policy; this function performs exactly one
 // round-trip.
-func (c *Client) sendJSONRequest(ctx context.Context, method, path string, encodedBody []byte, result any) error {
+//
+// If reusedIdle is non-nil, it is set to true when the underlying http
+// transport handed the request an already-idle pooled connection. This is
+// the signal used to distinguish "server is genuinely slow" (fresh dial,
+// reusedIdle=false) from "we reused a black-holed pooled connection"
+// (reusedIdle=true); see doRequestOnce for how it is used.
+func (c *Client) sendJSONRequest(ctx context.Context, method, path string, encodedBody []byte, result any, reusedIdle *atomic.Bool) error {
 	var bodyReader io.Reader
 	if encodedBody != nil {
 		bodyReader = bytes.NewReader(encodedBody)
+	}
+
+	if reusedIdle != nil {
+		ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+			GotConn: func(info httptrace.GotConnInfo) {
+				if info.Reused && info.WasIdle {
+					reusedIdle.Store(true)
+				}
+			},
+		})
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
@@ -233,21 +261,37 @@ func (c *Client) sendJSONRequest(ctx context.Context, method, path string, encod
 // silently dropped by an intermediate load balancer: the write succeeds
 // locally but the response headers never arrive.
 //
-// The check is deliberately conservative:
+// The check is deliberately conservative and requires ALL of:
 //
-//   - Only idempotent methods are eligible (GET, HEAD, OPTIONS). Retrying a
-//     POST that may have already been applied server-side is unsafe.
-//   - The caller's context must not be the source of the failure. If the
-//     caller cancelled or its deadline elapsed, retrying would be
-//     pointless and misleading.
-//   - The error must not be an APIError (i.e. we did receive response
-//     headers). Response-body-side failures are out of scope; a retry
-//     there could mask real server errors.
-//   - The error must be either the Go net/http "awaiting headers" timeout
-//     signature or a net.Error reporting Timeout()==true. Both indicate we
-//     never got past the response-header phase.
-func shouldRetryStaleConnection(method string, err error) bool {
+//   - reusedIdlePooledConn is true. The httptrace GotConn hook observed the
+//     transport handing this request an already-idle pooled connection. If
+//     the transport instead dialed a fresh connection and that fresh
+//     connection is slow, this is not a stale-reuse case — the server or
+//     network is genuinely slow, and retrying would just double the caller's
+//     timeout budget for no benefit. This gates out the "slow server"
+//     scenario raised in PR review.
+//   - Method is idempotent (GET/HEAD/OPTIONS). Retrying a POST that may
+//     have already been applied server-side is unsafe.
+//   - The error is not an APIError (that would mean we received response
+//     headers; response-body-side failures are out of scope).
+//   - The error signature matches the header-phase timeout: either the Go
+//     net/http "Client.Timeout exceeded while awaiting headers" suffix, or
+//     an http.Transport.ResponseHeaderTimeout firing, or a net.Error whose
+//     Timeout() is true. All indicate we never got past the response-header
+//     phase.
+//   - The error is not a plain caller-driven context.Canceled /
+//     context.DeadlineExceeded. Checked after the more specific timeout
+//     signatures, because http.Client.Timeout wraps DeadlineExceeded and
+//     would otherwise be misclassified as caller-driven.
+func shouldRetryStaleConnection(method string, err error, reusedIdlePooledConn bool) bool {
 	if err == nil {
+		return false
+	}
+	// Without an observed idle-pool reuse, this cannot be a stale-connection
+	// case: a freshly dialed connection that times out simply means the
+	// remote is slow or unreachable, and retrying wastes the caller's
+	// timeout budget. See the doc comment above.
+	if !reusedIdlePooledConn {
 		return false
 	}
 	switch method {
@@ -261,15 +305,20 @@ func shouldRetryStaleConnection(method string, err error) bool {
 		return false
 	}
 	// The Go net/http package appends this exact suffix when
-	// http.Client.Timeout fires while waiting for response headers. This is
-	// the definitive signature of a black-holed reused connection. Check
-	// this BEFORE the generic context.DeadlineExceeded check below, since
-	// the wrapped error also satisfies errors.Is(context.DeadlineExceeded)
-	// but is emphatically not caller-driven.
+	// http.Client.Timeout fires while waiting for response headers.
 	if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
 		return true
 	}
+	// http.Transport.ResponseHeaderTimeout fires this specific error text
+	// when the transport gives up waiting for response headers on a
+	// specific connection. This is the SDK's primary header-phase guard
+	// for streaming requests but also protects non-streaming requests.
+	if strings.Contains(err.Error(), "timeout awaiting response headers") {
+		return true
+	}
 	// Caller-driven cancellation/deadline: don't paper over it with a retry.
+	// Checked AFTER the specific timeout signatures above, since
+	// http.Client.Timeout wraps context.DeadlineExceeded.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -18,9 +18,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -35,9 +38,14 @@ type Client struct {
 	apiKey     string
 	authHeader string
 	httpClient *http.Client
-	timeout    *time.Duration // stored separately, applied after all options
-	headers    map[string]string
-	retry      *RetryConfig
+	// streamClient shares the same Transport as httpClient but always has
+	// Timeout=0. It is used by doStreamRequest so that a caller-configured
+	// per-request timeout on httpClient does not kill long-lived SSE
+	// connections. See the comment on defaultTimeout above.
+	streamClient *http.Client
+	timeout      *time.Duration // stored separately, applied after all options
+	headers      map[string]string
+	retry        *RetryConfig
 }
 
 // Option configures a Client.
@@ -114,6 +122,15 @@ func NewClient(baseURL, apiKey, authHeader string, opts ...Option) *Client {
 	if c.timeout != nil {
 		c.httpClient.Timeout = *c.timeout
 	}
+	// Build a stream client that shares the same Transport (and therefore
+	// the same connection pool) as httpClient but never sets an overall
+	// http.Client.Timeout. A non-zero Timeout on an SSE request kills the
+	// connection at the deadline mid-stream, regardless of activity;
+	// long-running commands and metric watches must control their total
+	// duration via the caller's context instead.
+	streamClient := *c.httpClient
+	streamClient.Timeout = 0
+	c.streamClient = &streamClient
 	return c
 }
 
@@ -127,15 +144,47 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any, r
 	})
 }
 
-// doRequestOnce is the single-attempt implementation of doRequest.
+// doRequestOnce is the single-attempt implementation of doRequest from the
+// perspective of the higher-level retry policy (withRetry). Internally, it
+// may transparently retry once against a fresh TCP connection when a stale
+// pooled connection appears to have been silently dropped by an intermediate
+// load balancer; see shouldRetryStaleConnection for the trigger conditions.
 func (c *Client) doRequestOnce(ctx context.Context, method, path string, body any, result any) error {
-	var bodyReader io.Reader
+	var encodedBody []byte
 	if body != nil {
 		buf, err := json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("opensandbox: marshal request: %w", err)
 		}
-		bodyReader = bytes.NewReader(buf)
+		encodedBody = buf
+	}
+
+	err := c.sendJSONRequest(ctx, method, path, encodedBody, result)
+	if err == nil {
+		return nil
+	}
+	if !shouldRetryStaleConnection(method, err) {
+		return err
+	}
+	// The failure looks like a reused-but-silently-dropped keep-alive
+	// connection: request written locally but no response headers arrived
+	// before http.Client.Timeout fired. Evict idle connections in the pool
+	// and retry exactly once on a freshly dialed connection. Only safe for
+	// idempotent methods; see shouldRetryStaleConnection.
+	if tr, ok := c.httpClient.Transport.(*http.Transport); ok {
+		tr.CloseIdleConnections()
+	}
+	return c.sendJSONRequest(ctx, method, path, encodedBody, result)
+}
+
+// sendJSONRequest builds and executes a single HTTP request. encodedBody is
+// the pre-marshaled JSON payload (or nil for GET/DELETE-style requests). The
+// caller is responsible for retry policy; this function performs exactly one
+// round-trip.
+func (c *Client) sendJSONRequest(ctx context.Context, method, path string, encodedBody []byte, result any) error {
+	var bodyReader io.Reader
+	if encodedBody != nil {
+		bodyReader = bytes.NewReader(encodedBody)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
@@ -150,7 +199,7 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body an
 	if c.apiKey != "" {
 		req.Header.Set(c.authHeader, c.apiKey)
 	}
-	if body != nil {
+	if encodedBody != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
@@ -176,6 +225,60 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body an
 	}
 	io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+// shouldRetryStaleConnection reports whether err looks like a stale pooled
+// connection failure that should be retried on a fresh connection. This
+// targets the common case where an idle keep-alive connection has been
+// silently dropped by an intermediate load balancer: the write succeeds
+// locally but the response headers never arrive.
+//
+// The check is deliberately conservative:
+//
+//   - Only idempotent methods are eligible (GET, HEAD, OPTIONS). Retrying a
+//     POST that may have already been applied server-side is unsafe.
+//   - The caller's context must not be the source of the failure. If the
+//     caller cancelled or its deadline elapsed, retrying would be
+//     pointless and misleading.
+//   - The error must not be an APIError (i.e. we did receive response
+//     headers). Response-body-side failures are out of scope; a retry
+//     there could mask real server errors.
+//   - The error must be either the Go net/http "awaiting headers" timeout
+//     signature or a net.Error reporting Timeout()==true. Both indicate we
+//     never got past the response-header phase.
+func shouldRetryStaleConnection(method string, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+	default:
+		return false
+	}
+	// APIError means we received response headers; not a stale-connection case.
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return false
+	}
+	// The Go net/http package appends this exact suffix when
+	// http.Client.Timeout fires while waiting for response headers. This is
+	// the definitive signature of a black-holed reused connection. Check
+	// this BEFORE the generic context.DeadlineExceeded check below, since
+	// the wrapped error also satisfies errors.Is(context.DeadlineExceeded)
+	// but is emphatically not caller-driven.
+	if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
+		return true
+	}
+	// Caller-driven cancellation/deadline: don't paper over it with a retry.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// Fall back to a generic timeout classification for other transports.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
 }
 
 // doStreamRequest builds an HTTP request, executes it, and streams SSE events
@@ -212,7 +315,7 @@ func (c *Client) doStreamRequest(ctx context.Context, method, path string, body 
 		}
 		req.Header.Set("Accept", "text/event-stream")
 
-		r, err := c.httpClient.Do(req)
+		r, err := c.streamClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("opensandbox: do request: %w", err)
 		}

--- a/sdks/sandbox/go/http_retry_test.go
+++ b/sdks/sandbox/go/http_retry_test.go
@@ -101,6 +101,49 @@ func TestStreamClient_TimeoutOverrideStillYieldsZeroOnStreamClient(t *testing.T)
 	}
 }
 
+// TestStreamRequest_ResponseHeaderTimeoutBoundsPreStreamHang verifies the
+// PR-review fix for "keep a setup timeout for SSE handshakes": even though
+// the stream client has Timeout=0 to allow arbitrarily long response bodies,
+// the underlying Transport's ResponseHeaderTimeout must bound the wait for
+// the initial SSE response headers. Without this, a streaming endpoint or
+// load balancer that accepts the connection but never sends headers would
+// make RunCommand / ExecuteCode / WatchMetrics hang indefinitely.
+func TestStreamRequest_ResponseHeaderTimeoutBoundsPreStreamHang(t *testing.T) {
+	blackHole := newHijackBlackHoleHandler()
+	defer blackHole.release()
+
+	srv := httptest.NewServer(http.HandlerFunc(blackHole.ServeHTTP))
+	defer srv.Close()
+
+	// Custom transport with a tight ResponseHeaderTimeout so the test
+	// completes fast. All other defaults preserved.
+	tc := DefaultTransportConfig()
+	tc.ResponseHeaderTimeout = 300 * time.Millisecond
+	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY",
+		WithHTTPClient(&http.Client{Transport: tc.NewTransport()}),
+	)
+
+	handler := func(event StreamEvent) error { return nil }
+	// Use a caller context deadline far larger than the transport timeout.
+	// If the transport-level guard is missing, this test hangs until the
+	// caller ctx fires; if the guard works, we get a header-phase timeout
+	// error well before the ctx deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := client.doStreamRequest(ctx, http.MethodGet, "/", nil, handler)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "timeout awaiting response headers") {
+		assert.Fail(t, fmt.Sprintf("expected response-header timeout, got: %v", err))
+	}
+	if elapsed > 3*time.Second {
+		assert.Fail(t, fmt.Sprintf("expected header-phase guard to fire quickly (<3s), took %v", elapsed))
+	}
+}
+
 // hijackBlackHoleHandler simulates an intermediate load balancer that has
 // silently dropped a keep-alive connection: it hijacks the TCP connection,
 // discards the request, and never writes any response. The connection is
@@ -136,16 +179,18 @@ func (h *hijackBlackHoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 func (h *hijackBlackHoleHandler) release() { close(h.closed) }
 
-// TestStaleConnectionRetry_GETRetriesOnFreshConnection verifies that a GET
-// that hangs waiting for response headers (because a pooled connection was
-// silently dropped by an LB) is transparently retried once on a fresh TCP
-// connection. This is the core mitigation for the intermittent
+// TestStaleConnectionRetry_GETRetriesOnReusedPooledConn verifies that a GET
+// that hangs waiting for response headers on a REUSED pooled connection
+// (because an LB silently dropped it) is transparently retried once on a
+// fresh TCP connection. This is the core mitigation for the intermittent
 // "Client.Timeout exceeded while awaiting headers" failures observed
 // against enterprise load balancers.
-func TestStaleConnectionRetry_GETRetriesOnFreshConnection(t *testing.T) {
-	// Mux: first request black-holes (hijack, never respond); subsequent
-	// requests reply 200 with a JSON body. We use a request counter to
-	// switch behavior.
+//
+// The test primes the connection pool with a successful request first, so
+// the second (black-holed) request actually reuses an idle pooled
+// connection. This matches production reality and exercises the
+// httptrace-driven "reused idle" gate.
+func TestStaleConnectionRetry_GETRetriesOnReusedPooledConn(t *testing.T) {
 	var reqCount atomic.Int32
 	blackHole := newHijackBlackHoleHandler()
 	defer blackHole.release()
@@ -153,7 +198,10 @@ func TestStaleConnectionRetry_GETRetriesOnFreshConnection(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
 		n := reqCount.Add(1)
-		if n == 1 {
+		// First call: prime the pool with a successful response.
+		// Second call: black-hole (simulates LB-dropped keep-alive conn).
+		// Third call (retry): reply normally.
+		if n == 2 {
 			blackHole.ServeHTTP(w, r)
 			return
 		}
@@ -164,10 +212,16 @@ func TestStaleConnectionRetry_GETRetriesOnFreshConnection(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Tight http.Client.Timeout so the black-holed first request surfaces
-	// the stall quickly.
 	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(300*time.Millisecond))
 
+	// Prime the pool: this request completes and returns the conn to the
+	// idle pool so the next request can reuse it.
+	var priming map[string]bool
+	require.NoError(t, client.doRequest(context.Background(), http.MethodGet, "/probe", nil, &priming))
+
+	// Now the real test: request #2 will reuse the idle pooled conn and
+	// hit the black-hole; the SDK must retry on a fresh connection and
+	// succeed on request #3.
 	var result map[string]bool
 	start := time.Now()
 	err := client.doRequest(context.Background(), http.MethodGet, "/probe", nil, &result)
@@ -175,21 +229,20 @@ func TestStaleConnectionRetry_GETRetriesOnFreshConnection(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, true, result["ok"])
-	if reqCount.Load() < 2 {
-		assert.Fail(t, fmt.Sprintf("expected at least 2 server hits (first black-holed, retry succeeds), got %d", reqCount.Load()))
+	if reqCount.Load() != 3 {
+		assert.Fail(t, fmt.Sprintf("expected 3 total server hits (prime, black-hole, retry), got %d", reqCount.Load()))
 	}
-	// Sanity: total time should be roughly one timeout window plus the
-	// retry. Give generous headroom for CI slowness.
 	if elapsed > 5*time.Second {
 		assert.Fail(t, fmt.Sprintf("retry took too long: %v", elapsed))
 	}
 }
 
-// TestStaleConnectionRetry_POSTNotRetried verifies that non-idempotent
-// methods are NEVER retried by the stale-connection fallback, even when the
-// error signature matches, because retrying a POST that may have been
-// applied server-side is unsafe.
-func TestStaleConnectionRetry_POSTNotRetried(t *testing.T) {
+// TestStaleConnectionRetry_FreshConnDoesNotRetry verifies the critical
+// guard from PR review: a slow server that never returns response headers
+// on a FRESHLY DIALED connection must NOT be retried. Retrying would
+// double the caller's timeout budget for no benefit and would issue the
+// same GET twice against a server that is simply overloaded.
+func TestStaleConnectionRetry_FreshConnDoesNotRetry(t *testing.T) {
 	var reqCount atomic.Int32
 	blackHole := newHijackBlackHoleHandler()
 	defer blackHole.release()
@@ -202,13 +255,63 @@ func TestStaleConnectionRetry_POSTNotRetried(t *testing.T) {
 
 	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(300*time.Millisecond))
 
-	err := client.doRequest(context.Background(), http.MethodPost, "/anything", map[string]string{"a": "b"}, nil)
+	// A brand-new client with an empty pool: the request must dial fresh.
+	// Server never returns headers -> Client.Timeout fires. Because this
+	// is NOT a reused-idle-conn scenario, the SDK must respect the
+	// caller's timeout budget and not retry.
+	start := time.Now()
+	err := client.doRequest(context.Background(), http.MethodGet, "/anything", nil, nil)
+	elapsed := time.Since(start)
+
 	require.Error(t, err)
 	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
 		assert.Fail(t, fmt.Sprintf("expected client-timeout error, got: %v", err))
 	}
 	if reqCount.Load() != 1 {
-		assert.Fail(t, fmt.Sprintf("POST must not be retried on stale-connection failure; got %d hits", reqCount.Load()))
+		assert.Fail(t, fmt.Sprintf("fresh-dial slow-server must not be retried; got %d hits", reqCount.Load()))
+	}
+	// The elapsed time should be roughly one timeout window, not two.
+	if elapsed > 2*time.Second {
+		assert.Fail(t, fmt.Sprintf("elapsed=%v suggests the SDK retried and burned two timeout budgets", elapsed))
+	}
+}
+
+// TestStaleConnectionRetry_POSTNotRetried verifies that non-idempotent
+// methods are NEVER retried by the stale-connection fallback, even when the
+// error signature matches, because retrying a POST that may have been
+// applied server-side is unsafe.
+func TestStaleConnectionRetry_POSTNotRetried(t *testing.T) {
+	var reqCount atomic.Int32
+	blackHole := newHijackBlackHoleHandler()
+	defer blackHole.release()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/anything", func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		blackHole.ServeHTTP(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(300*time.Millisecond))
+
+	// Prime the pool with a successful GET so the follow-up POST reuses
+	// an idle pooled connection. This confirms POST is refused even when
+	// the reused-idle guard would otherwise allow a retry.
+	require.NoError(t, client.doRequest(context.Background(), http.MethodGet, "/ok", nil, nil))
+	priming := reqCount.Load()
+
+	err := client.doRequest(context.Background(), http.MethodPost, "/anything", map[string]string{"a": "b"}, nil)
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
+		assert.Fail(t, fmt.Sprintf("expected client-timeout error, got: %v", err))
+	}
+	if got := reqCount.Load() - priming; got != 1 {
+		assert.Fail(t, fmt.Sprintf("POST must not be retried on stale-connection failure; got %d POST hits", got))
 	}
 }
 
@@ -217,32 +320,47 @@ func TestStaleConnectionRetry_POSTNotRetried(t *testing.T) {
 // error mapping do not accidentally broaden or narrow the policy.
 func TestShouldRetryStaleConnection_TableDriven(t *testing.T) {
 	awaitHeadersErr := errors.New(`Get "http://x": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`)
+	respHeaderTimeoutErr := errors.New(`Get "http://x": net/http: timeout awaiting response headers`)
 	plainCtxDeadline := context.DeadlineExceeded
 	plainCtxCanceled := context.Canceled
 	apiErr := &APIError{StatusCode: 502}
 	randomErr := errors.New("boom")
 
 	cases := []struct {
-		name   string
-		method string
-		err    error
-		want   bool
+		name       string
+		method     string
+		err        error
+		reusedIdle bool
+		want       bool
 	}{
-		{"GET awaiting-headers timeout retries", http.MethodGet, awaitHeadersErr, true},
-		{"HEAD awaiting-headers timeout retries", http.MethodHead, awaitHeadersErr, true},
-		{"OPTIONS awaiting-headers timeout retries", http.MethodOptions, awaitHeadersErr, true},
-		{"POST awaiting-headers timeout does not retry", http.MethodPost, awaitHeadersErr, false},
-		{"PUT awaiting-headers timeout does not retry", http.MethodPut, awaitHeadersErr, false},
-		{"PATCH awaiting-headers timeout does not retry", http.MethodPatch, awaitHeadersErr, false},
-		{"DELETE awaiting-headers timeout does not retry", http.MethodDelete, awaitHeadersErr, false},
-		{"caller ctx deadline does not retry", http.MethodGet, plainCtxDeadline, false},
-		{"caller ctx canceled does not retry", http.MethodGet, plainCtxCanceled, false},
-		{"APIError does not retry (headers already received)", http.MethodGet, apiErr, false},
-		{"generic non-timeout error does not retry", http.MethodGet, randomErr, false},
-		{"nil error does not retry", http.MethodGet, nil, false},
+		// Positive: idempotent method + observed idle-conn reuse + header-phase timeout.
+		{"GET awaiting-headers on reused idle conn retries", http.MethodGet, awaitHeadersErr, true, true},
+		{"HEAD awaiting-headers on reused idle conn retries", http.MethodHead, awaitHeadersErr, true, true},
+		{"OPTIONS awaiting-headers on reused idle conn retries", http.MethodOptions, awaitHeadersErr, true, true},
+		{"GET response-header timeout on reused idle conn retries", http.MethodGet, respHeaderTimeoutErr, true, true},
+
+		// The critical guard: fresh-conn slow server MUST NOT be retried.
+		// This protects the caller's timeout budget for the "genuinely slow
+		// server" scenario raised in PR review.
+		{"GET awaiting-headers on FRESH conn does not retry", http.MethodGet, awaitHeadersErr, false, false},
+		{"HEAD awaiting-headers on FRESH conn does not retry", http.MethodHead, awaitHeadersErr, false, false},
+		{"GET response-header timeout on FRESH conn does not retry", http.MethodGet, respHeaderTimeoutErr, false, false},
+
+		// Non-idempotent methods are never retried even on reused idle conn.
+		{"POST awaiting-headers on reused idle conn does not retry", http.MethodPost, awaitHeadersErr, true, false},
+		{"PUT awaiting-headers on reused idle conn does not retry", http.MethodPut, awaitHeadersErr, true, false},
+		{"PATCH awaiting-headers on reused idle conn does not retry", http.MethodPatch, awaitHeadersErr, true, false},
+		{"DELETE awaiting-headers on reused idle conn does not retry", http.MethodDelete, awaitHeadersErr, true, false},
+
+		// Caller-driven and non-timeout errors are never retried.
+		{"caller ctx deadline does not retry", http.MethodGet, plainCtxDeadline, true, false},
+		{"caller ctx canceled does not retry", http.MethodGet, plainCtxCanceled, true, false},
+		{"APIError does not retry (headers already received)", http.MethodGet, apiErr, true, false},
+		{"generic non-timeout error does not retry", http.MethodGet, randomErr, true, false},
+		{"nil error does not retry", http.MethodGet, nil, true, false},
 	}
 	for _, tc := range cases {
-		if got := shouldRetryStaleConnection(tc.method, tc.err); got != tc.want {
+		if got := shouldRetryStaleConnection(tc.method, tc.err, tc.reusedIdle); got != tc.want {
 			assert.Fail(t, fmt.Sprintf("%s: shouldRetryStaleConnection = %v, want %v", tc.name, got, tc.want))
 		}
 	}

--- a/sdks/sandbox/go/http_retry_test.go
+++ b/sdks/sandbox/go/http_retry_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStreamClient_NoOverallTimeoutOnLongStream verifies that the streaming
+// path is not killed by http.Client.Timeout. Historically, the SDK applied
+// the same 30s (or user-configured) http.Client.Timeout to both the
+// non-streaming lifecycle client and the streaming execd client, cutting off
+// any SSE stream that ran longer than the timeout mid-flight. The fix routes
+// SSE requests through a stream client that shares the same Transport but
+// keeps Timeout=0; per-call duration is controlled by the caller's context.
+func TestStreamClient_NoOverallTimeoutOnLongStream(t *testing.T) {
+	// SSE server that emits three events over ~600ms, well beyond the tiny
+	// http.Client.Timeout we install below.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("test server: response writer does not support flushing")
+			return
+		}
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(200 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	// Deliberately absurd 100ms timeout on the non-streaming client. If the
+	// stream client inherited this, the SSE connection would be killed
+	// almost immediately after the first event and the test would fail.
+	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(100*time.Millisecond))
+
+	var received []string
+	handler := func(event StreamEvent) error {
+		received = append(received, event.Data)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.doStreamRequest(ctx, http.MethodGet, "/", nil, handler)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(received))
+	require.Equal(t, "event-0", received[0])
+	require.Equal(t, "event-2", received[2])
+}
+
+// TestStreamClient_SharesTransportWithHTTPClient documents the invariant
+// that the stream client and the regular http client must share the same
+// Transport, so that connection pool state is not split into two disjoint
+// pools (which would defeat keep-alive and waste connections).
+func TestStreamClient_SharesTransportWithHTTPClient(t *testing.T) {
+	client := NewClient("https://example.com", "", "OPEN-SANDBOX-API-KEY")
+	require.NotNil(t, client.httpClient)
+	require.NotNil(t, client.streamClient)
+	if client.httpClient.Transport != client.streamClient.Transport {
+		assert.Fail(t, "streamClient must share Transport with httpClient")
+	}
+	// Regardless of what Timeout is set on httpClient, the stream client
+	// must always have Timeout=0 so it never kills long-lived SSE streams.
+	if client.streamClient.Timeout != 0 {
+		assert.Fail(t, fmt.Sprintf("streamClient.Timeout = %v, want 0", client.streamClient.Timeout))
+	}
+}
+
+// TestStreamClient_TimeoutOverrideStillYieldsZeroOnStreamClient verifies the
+// stream client is unaffected even when the user configures a non-zero
+// timeout via WithTimeout.
+func TestStreamClient_TimeoutOverrideStillYieldsZeroOnStreamClient(t *testing.T) {
+	client := NewClient("https://example.com", "", "OPEN-SANDBOX-API-KEY", WithTimeout(15*time.Second))
+	require.Equal(t, 15*time.Second, client.httpClient.Timeout)
+	if client.streamClient.Timeout != 0 {
+		assert.Fail(t, fmt.Sprintf("streamClient.Timeout = %v, want 0", client.streamClient.Timeout))
+	}
+}
+
+// hijackBlackHoleHandler simulates an intermediate load balancer that has
+// silently dropped a keep-alive connection: it hijacks the TCP connection,
+// discards the request, and never writes any response. The connection is
+// held open until the test ends, mimicking a black-holed reused connection.
+// A callback is invoked once so the test can observe how many times this
+// path fires.
+type hijackBlackHoleHandler struct {
+	hits   atomic.Int32
+	closed chan struct{}
+}
+
+func newHijackBlackHoleHandler() *hijackBlackHoleHandler {
+	return &hijackBlackHoleHandler{closed: make(chan struct{})}
+}
+
+func (h *hijackBlackHoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.hits.Add(1)
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijack unsupported", http.StatusInternalServerError)
+		return
+	}
+	conn, _, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+	// Hold the connection open with no reply until the test tears down.
+	go func() {
+		<-h.closed
+		_ = conn.Close()
+	}()
+}
+
+func (h *hijackBlackHoleHandler) release() { close(h.closed) }
+
+// TestStaleConnectionRetry_GETRetriesOnFreshConnection verifies that a GET
+// that hangs waiting for response headers (because a pooled connection was
+// silently dropped by an LB) is transparently retried once on a fresh TCP
+// connection. This is the core mitigation for the intermittent
+// "Client.Timeout exceeded while awaiting headers" failures observed
+// against enterprise load balancers.
+func TestStaleConnectionRetry_GETRetriesOnFreshConnection(t *testing.T) {
+	// Mux: first request black-holes (hijack, never respond); subsequent
+	// requests reply 200 with a JSON body. We use a request counter to
+	// switch behavior.
+	var reqCount atomic.Int32
+	blackHole := newHijackBlackHoleHandler()
+	defer blackHole.release()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
+		n := reqCount.Add(1)
+		if n == 1 {
+			blackHole.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Tight http.Client.Timeout so the black-holed first request surfaces
+	// the stall quickly.
+	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(300*time.Millisecond))
+
+	var result map[string]bool
+	start := time.Now()
+	err := client.doRequest(context.Background(), http.MethodGet, "/probe", nil, &result)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, true, result["ok"])
+	if reqCount.Load() < 2 {
+		assert.Fail(t, fmt.Sprintf("expected at least 2 server hits (first black-holed, retry succeeds), got %d", reqCount.Load()))
+	}
+	// Sanity: total time should be roughly one timeout window plus the
+	// retry. Give generous headroom for CI slowness.
+	if elapsed > 5*time.Second {
+		assert.Fail(t, fmt.Sprintf("retry took too long: %v", elapsed))
+	}
+}
+
+// TestStaleConnectionRetry_POSTNotRetried verifies that non-idempotent
+// methods are NEVER retried by the stale-connection fallback, even when the
+// error signature matches, because retrying a POST that may have been
+// applied server-side is unsafe.
+func TestStaleConnectionRetry_POSTNotRetried(t *testing.T) {
+	var reqCount atomic.Int32
+	blackHole := newHijackBlackHoleHandler()
+	defer blackHole.release()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		blackHole.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "", "OPEN-SANDBOX-API-KEY", WithTimeout(300*time.Millisecond))
+
+	err := client.doRequest(context.Background(), http.MethodPost, "/anything", map[string]string{"a": "b"}, nil)
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
+		assert.Fail(t, fmt.Sprintf("expected client-timeout error, got: %v", err))
+	}
+	if reqCount.Load() != 1 {
+		assert.Fail(t, fmt.Sprintf("POST must not be retried on stale-connection failure; got %d hits", reqCount.Load()))
+	}
+}
+
+// TestShouldRetryStaleConnection_TableDriven documents the precise trigger
+// conditions of the stale-connection retry decision, so future changes to
+// error mapping do not accidentally broaden or narrow the policy.
+func TestShouldRetryStaleConnection_TableDriven(t *testing.T) {
+	awaitHeadersErr := errors.New(`Get "http://x": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`)
+	plainCtxDeadline := context.DeadlineExceeded
+	plainCtxCanceled := context.Canceled
+	apiErr := &APIError{StatusCode: 502}
+	randomErr := errors.New("boom")
+
+	cases := []struct {
+		name   string
+		method string
+		err    error
+		want   bool
+	}{
+		{"GET awaiting-headers timeout retries", http.MethodGet, awaitHeadersErr, true},
+		{"HEAD awaiting-headers timeout retries", http.MethodHead, awaitHeadersErr, true},
+		{"OPTIONS awaiting-headers timeout retries", http.MethodOptions, awaitHeadersErr, true},
+		{"POST awaiting-headers timeout does not retry", http.MethodPost, awaitHeadersErr, false},
+		{"PUT awaiting-headers timeout does not retry", http.MethodPut, awaitHeadersErr, false},
+		{"PATCH awaiting-headers timeout does not retry", http.MethodPatch, awaitHeadersErr, false},
+		{"DELETE awaiting-headers timeout does not retry", http.MethodDelete, awaitHeadersErr, false},
+		{"caller ctx deadline does not retry", http.MethodGet, plainCtxDeadline, false},
+		{"caller ctx canceled does not retry", http.MethodGet, plainCtxCanceled, false},
+		{"APIError does not retry (headers already received)", http.MethodGet, apiErr, false},
+		{"generic non-timeout error does not retry", http.MethodGet, randomErr, false},
+		{"nil error does not retry", http.MethodGet, nil, false},
+	}
+	for _, tc := range cases {
+		if got := shouldRetryStaleConnection(tc.method, tc.err); got != tc.want {
+			assert.Fail(t, fmt.Sprintf("%s: shouldRetryStaleConnection = %v, want %v", tc.name, got, tc.want))
+		}
+	}
+}

--- a/sdks/sandbox/go/retry_test.go
+++ b/sdks/sandbox/go/retry_test.go
@@ -351,8 +351,11 @@ func TestDefaultTransport(t *testing.T) {
 	if tr.MaxIdleConnsPerHost != 10 {
 		assert.Fail(t, fmt.Sprintf("MaxIdleConnsPerHost = %d, want 10", tr.MaxIdleConnsPerHost))
 	}
-	if tr.IdleConnTimeout != 90*time.Second {
-		assert.Fail(t, fmt.Sprintf("IdleConnTimeout = %v, want 90s", tr.IdleConnTimeout))
+	// IdleConnTimeout is intentionally set below the typical enterprise LB
+	// idle timeout (~60s) to evict potentially black-holed connections
+	// before they are reused. See DefaultTransportConfig for rationale.
+	if tr.IdleConnTimeout != 25*time.Second {
+		assert.Fail(t, fmt.Sprintf("IdleConnTimeout = %v, want 25s", tr.IdleConnTimeout))
 	}
 	if tr.TLSHandshakeTimeout != 10*time.Second {
 		assert.Fail(t, fmt.Sprintf("TLSHandshakeTimeout = %v, want 10s", tr.TLSHandshakeTimeout))

--- a/sdks/sandbox/go/retry_test.go
+++ b/sdks/sandbox/go/retry_test.go
@@ -357,6 +357,15 @@ func TestDefaultTransport(t *testing.T) {
 	if tr.IdleConnTimeout != 25*time.Second {
 		assert.Fail(t, fmt.Sprintf("IdleConnTimeout = %v, want 25s", tr.IdleConnTimeout))
 	}
+	// ResponseHeaderTimeout bounds the pre-response-header wait for BOTH
+	// non-streaming and streaming requests. Streaming requests set
+	// http.Client.Timeout=0 to allow long-lived bodies, so this transport-
+	// level guard is what prevents SSE endpoints from hanging indefinitely
+	// when a server or LB accepts the TCP connection but never emits
+	// response headers.
+	if tr.ResponseHeaderTimeout != 30*time.Second {
+		assert.Fail(t, fmt.Sprintf("ResponseHeaderTimeout = %v, want 30s", tr.ResponseHeaderTimeout))
+	}
 	if tr.TLSHandshakeTimeout != 10*time.Second {
 		assert.Fail(t, fmt.Sprintf("TLSHandshakeTimeout = %v, want 10s", tr.TLSHandshakeTimeout))
 	}

--- a/sdks/sandbox/go/transport.go
+++ b/sdks/sandbox/go/transport.go
@@ -38,6 +38,13 @@ type TransportConfig struct {
 	// TLSHandshakeTimeout limits the TLS handshake duration.
 	TLSHandshakeTimeout time.Duration
 
+	// ResponseHeaderTimeout caps the time spent waiting for a server's
+	// response headers after fully writing the request. Unlike
+	// http.Client.Timeout, it does NOT cover reading the response body,
+	// so it is safe to apply to long-lived SSE streams while still
+	// bounding the pre-stream handshake. Zero disables the bound.
+	ResponseHeaderTimeout time.Duration
+
 	// DialTimeout limits TCP connection establishment.
 	DialTimeout time.Duration
 
@@ -64,10 +71,16 @@ type TransportConfig struct {
 // connections alive longer can override via TransportConfig.
 func DefaultTransportConfig() TransportConfig {
 	return TransportConfig{
-		MaxIdleConns:                  100,
-		MaxIdleConnsPerHost:           10,
-		IdleConnTimeout:               25 * time.Second,
-		TLSHandshakeTimeout:           10 * time.Second,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     25 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		// Bounds the response-header phase for every request, including
+		// SSE streams that intentionally leave http.Client.Timeout at 0.
+		// Without this, a server or LB that accepts the TCP connection
+		// but never emits response headers would make streaming calls
+		// (ExecuteCode / RunCommand / WatchMetrics) hang indefinitely.
+		ResponseHeaderTimeout:         30 * time.Second,
 		DialTimeout:                   30 * time.Second,
 		KeepAlive:                     30 * time.Second,
 		AllowWeakServerCertKeyLengths: false,
@@ -87,11 +100,12 @@ func (tc TransportConfig) NewTransport() *http.Transport {
 			Timeout:   tc.DialTimeout,
 			KeepAlive: tc.KeepAlive,
 		}).DialContext,
-		MaxIdleConns:        tc.MaxIdleConns,
-		MaxIdleConnsPerHost: tc.MaxIdleConnsPerHost,
-		IdleConnTimeout:     tc.IdleConnTimeout,
-		TLSHandshakeTimeout: tc.TLSHandshakeTimeout,
-		TLSClientConfig:     tlsClientConfig,
+		MaxIdleConns:          tc.MaxIdleConns,
+		MaxIdleConnsPerHost:   tc.MaxIdleConnsPerHost,
+		IdleConnTimeout:       tc.IdleConnTimeout,
+		TLSHandshakeTimeout:   tc.TLSHandshakeTimeout,
+		ResponseHeaderTimeout: tc.ResponseHeaderTimeout,
+		TLSClientConfig:       tlsClientConfig,
 	}
 }
 

--- a/sdks/sandbox/go/transport.go
+++ b/sdks/sandbox/go/transport.go
@@ -51,11 +51,22 @@ type TransportConfig struct {
 
 // DefaultTransportConfig returns connection pool settings tuned for SDK
 // workloads: moderate concurrency across multiple sandbox endpoints.
+//
+// IdleConnTimeout is intentionally lower than Go's stdlib default of 90s.
+// Many enterprise load balancers silently drop idle TCP connections after
+// 60s without sending FIN/RST. If the SDK holds a connection idle past
+// that point, the next request reuses a black-holed connection: the
+// request writes succeed locally but no response headers ever arrive,
+// causing the client to hang until http.Client.Timeout fires with
+// "Client.Timeout exceeded while awaiting headers". Evicting idle
+// connections well before the typical LB idle timeout avoids this class
+// of intermittent failure. Callers that know their infrastructure keeps
+// connections alive longer can override via TransportConfig.
 func DefaultTransportConfig() TransportConfig {
 	return TransportConfig{
 		MaxIdleConns:                  100,
 		MaxIdleConnsPerHost:           10,
-		IdleConnTimeout:               90 * time.Second,
+		IdleConnTimeout:               25 * time.Second,
 		TLSHandshakeTimeout:           10 * time.Second,
 		DialTimeout:                   30 * time.Second,
 		KeepAlive:                     30 * time.Second,


### PR DESCRIPTION
## Summary

Three related transport-layer fixes to the Go sandbox SDK, motivated by the intermittent `Client.Timeout exceeded while awaiting headers` and `context canceled` failures observed when a long-running CLI (aenv) calls `GetEndpoint` through an enterprise load balancer.

Root cause (confirmed by local isolation experiments with `httptrace`):

- SDK transport keeps idle connections in the pool for **90s** (`IdleConnTimeout` default).
- Enterprise LBs commonly drop idle TCP connections after ~**60s** without FIN/RST.
- When the idle interval falls in the LB-already-dropped-but-SDK-still-cached window, the next request reuses a black-holed connection. `WroteRequest` succeeds locally, but `GotFirstResponseByte` never fires, and the request hangs until `http.Client.Timeout` fires — producing the Go net/http-specific `Client.Timeout exceeded while awaiting headers` signature.
- The SDK's custom `DialContext` and `TLSClientConfig` also disable Go's automatic HTTP/2, so requests are HTTP/1.1 only with no PING-level liveness probing that could evict a black-holed connection.

Separately discovered while investigating: `http.Client.Timeout` is applied uniformly to all clients (lifecycle **and** execd streaming). Because that timeout is an overall wall-clock deadline that includes body reads, **any SSE stream running past `RequestTimeout` (default 30s) is cut off mid-flight**. This diverges from the Python SDK, which uses `httpx.Timeout(read=None, connect=…, write=…)` for streaming endpoints. Independent bug, fixed here in the same commit.

## Changes

### 1. Route SSE requests through a stream client with `Timeout=0`

`http.go`: `Client` now holds a `streamClient` that shares the same `Transport` as `httpClient` (so the connection pool is not split) but always has `Timeout=0`. `doStreamRequest` uses it. Callers control total SSE duration via their `context.Context`, matching the Python SDK.

### 2. Lower `DefaultTransportConfig.IdleConnTimeout` from 90s to 25s

`transport.go`: 25s comfortably beats the typical 60s LB idle timeout, so the SDK evicts potentially stale connections before the LB drops them silently. Users on reliable internal links can override via `TransportConfig`.

### 3. Retry stale-connection failures once on a fresh connection

`http.go`: `doRequestOnce` now transparently `CloseIdleConnections()` and retries once when:

- Method is `GET`/`HEAD`/`OPTIONS` (idempotent only — `POST`/`PUT`/`PATCH`/`DELETE` never retried, they may already have been applied server-side).
- Error is not an `APIError` (i.e. we never got response headers).
- Error signature matches `Client.Timeout exceeded while awaiting headers` **or** a generic `net.Error` with `Timeout()==true`.
- Error is not a plain caller-driven `context.Canceled` / `context.DeadlineExceeded` (checked **after** the awaiting-headers suffix, because `http.Client.Timeout` wraps `DeadlineExceeded` and would otherwise be misclassified as caller-driven).

This is deliberately kept separate from the existing status-code-based `withRetry`, to keep policy semantics unambiguous.

## Tests

New file `http_retry_test.go` with 6 tests, all passing (`go test ./...` green):

- `TestStreamClient_NoOverallTimeoutOnLongStream` — SSE stream running longer than the client's `WithTimeout(100ms)` still receives all 3 events over 600ms.
- `TestStreamClient_SharesTransportWithHTTPClient` — invariant: stream client shares Transport, `Timeout=0`.
- `TestStreamClient_TimeoutOverrideStillYieldsZeroOnStreamClient` — user-set `WithTimeout(15s)` does not leak onto the stream client.
- `TestStaleConnectionRetry_GETRetriesOnFreshConnection` — `httptest` server hijacks and black-holes the first connection; GET transparently succeeds on retry.
- `TestStaleConnectionRetry_POSTNotRetried` — same black-hole scenario, POST returns the timeout error, server sees exactly 1 hit.
- `TestShouldRetryStaleConnection_TableDriven` — full policy matrix (method × error type → retry?).

Pre-existing `TestDefaultTransport` assertion updated from 90s to 25s.

## Compatibility

Two user-visible default behavior changes:

1. **`DefaultTransportConfig().IdleConnTimeout`: 90s → 25s.** Safe (only affects idle eviction). Users depending on longer idle reuse can override via `TransportConfig`.
2. **`GET`/`HEAD`/`OPTIONS` may retry once on `Client.Timeout exceeded while awaiting headers`.** Safe (only idempotent methods). Callers that assert a single request per call in mocks may see one extra hit in the specific timeout-before-headers scenario.

Cross-language stance: this bug pattern is Go-specific (HTTP/1.1-only pool with 90s idle window and no liveness probe). Other language SDKs (Python `httpx`, JS `fetch`, Kotlin OkHttp, C#) have different pooling defaults and are not affected. Not synchronizing default values across languages.

## Verification still recommended

Consumer (`aenv`) should confirm on real infrastructure with `httptrace`:

- Failing request: `GotConn reused=true wasIdle=true`, `idleTime` near LB idle timeout, `WroteRequest err=<nil>`, no `GotFirstResponseByte`.
- Immediate retry succeeds.

If those hold, this PR is a full mitigation. If not, we regroup on the root cause.

## Related

- Independent finding fixed here: SSE streams being cut by `http.Client.Timeout` (matches Python SDK behavior).
