### PR TITLE
ci: make self-hosted E2E setup portable

### DIFF
--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -436,12 +436,15 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      GOCACHE: ${{ runner.temp }}/go-build
-      GOMODCACHE: ${{ runner.temp }}/go-mod-cache
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Configure Go cache
+        run: |
+          echo "GOCACHE=${RUNNER_TEMP}/go-build" >> "$GITHUB_ENV"
+          echo "GOMODCACHE=${RUNNER_TEMP}/go-mod-cache" >> "$GITHUB_ENV"
 
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -253,7 +253,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      NODE_VERSION: "20.19.0"
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
@@ -271,20 +270,9 @@ jobs:
           uv run python --version
 
       - name: Set up Node.js
-        run: |
-          NODE_DIR="/home/admin/.local/node-v${NODE_VERSION}-linux-x64"
-          if [ -x "${NODE_DIR}/bin/node" ]; then
-            echo "Node.js ${NODE_VERSION} already cached"
-          else
-            echo "Downloading Node.js ${NODE_VERSION}..."
-            mkdir -p /home/admin/.local
-            curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
-              | tar -xJ -C /home/admin/.local/
-          fi
-          echo "${NODE_DIR}/bin" >> "$GITHUB_PATH"
-          export PATH="${NODE_DIR}/bin:${PATH}"
-          node --version
-          npm --version
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20.19.0"
 
       - name: Clean up previous E2E resources
         run: |
@@ -375,8 +363,6 @@ jobs:
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v5
-        env:
-          DOTNET_INSTALL_DIR: /home/admin/.local/dotnet
         with:
           dotnet-version: "10.0.x"
 
@@ -450,9 +436,8 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      HOME: /home/admin/actions-runner
-      GOCACHE: /home/admin/actions-runner/_temp/go-build
-      GOMODCACHE: /home/admin/actions-runner/_temp/go-mod-cache
+      GOCACHE: ${{ runner.temp }}/go-build
+      GOMODCACHE: ${{ runner.temp }}/go-mod-cache
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -361,6 +361,9 @@ jobs:
           uv --version
           uv run python --version
 
+      - name: Configure .NET install directory
+        run: echo "DOTNET_INSTALL_DIR=${RUNNER_TEMP}/dotnet" >> "$GITHUB_ENV"
+
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -33,7 +33,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      UV_BIN: /home/admin/.local/bin
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
@@ -42,10 +41,11 @@ jobs:
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh
 
-      - name: Set up uv PATH and verify
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv
         run: |
-          echo "${UV_BIN}" >> "$GITHUB_PATH"
-          export PATH="${UV_BIN}:${PATH}"
           uv --version
           uv run python --version
 
@@ -133,7 +133,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      UV_BIN: /home/admin/.local/bin
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
@@ -142,10 +141,11 @@ jobs:
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh
 
-      - name: Set up uv PATH and verify
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv
         run: |
-          echo "${UV_BIN}" >> "$GITHUB_PATH"
-          export PATH="${UV_BIN}:${PATH}"
           uv --version
           uv run python --version
 
@@ -253,7 +253,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      UV_BIN: /home/admin/.local/bin
       NODE_VERSION: "20.19.0"
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
@@ -263,10 +262,11 @@ jobs:
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh
 
-      - name: Set up uv PATH and verify
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv
         run: |
-          echo "${UV_BIN}" >> "$GITHUB_PATH"
-          export PATH="${UV_BIN}:${PATH}"
           uv --version
           uv run python --version
 
@@ -357,7 +357,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      UV_BIN: /home/admin/.local/bin
       RUN_CODE_INTERPRETER_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.run_code_interpreter_e2e == true && 'true' || 'false' }}
     steps:
       - name: Checkout code
@@ -366,10 +365,11 @@ jobs:
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh
 
-      - name: Set up uv PATH and verify
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv
         run: |
-          echo "${UV_BIN}" >> "$GITHUB_PATH"
-          export PATH="${UV_BIN}:${PATH}"
           uv --version
           uv run python --version
 
@@ -450,7 +450,6 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: self-hosted
     env:
-      UV_BIN: /home/admin/.local/bin
       HOME: /home/admin/actions-runner
       GOCACHE: /home/admin/actions-runner/_temp/go-build
       GOMODCACHE: /home/admin/actions-runner/_temp/go-mod-cache
@@ -462,10 +461,11 @@ jobs:
       - name: Clean Docker runner cache
         run: bash scripts/ci-docker-cleanup.sh
 
-      - name: Set up uv PATH and verify
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv
         run: |
-          echo "${UV_BIN}" >> "$GITHUB_PATH"
-          export PATH="${UV_BIN}:${PATH}"
           uv --version
           uv run python --version
 

--- a/scripts/ci-docker-cleanup.sh
+++ b/scripts/ci-docker-cleanup.sh
@@ -31,7 +31,8 @@ if [ -n "${containers}" ]; then
   echo "${containers}" | xargs -r docker rm -f || true
 fi
 
-timeout 30s rm -rf "${HOME:-/home/admin}/.docker/buildx/activity"/* || true
+: "${HOME:?HOME must be set for Docker cleanup}"
+timeout 30s rm -rf "${HOME}/.docker/buildx/activity"/* || true
 
 echo "Disk usage after Docker cleanup:"
 df -h /


### PR DESCRIPTION
## Summary

- install `uv` explicitly with `astral-sh/setup-uv@v7` in every self-hosted Real E2E job
- use standard setup actions and runner-local cache paths instead of paths tied to the former `admin` user
- remove the remaining `/home/admin` fallback from the shared Docker cleanup script and use the runner's actual `$HOME`
- keep explicit `uv` and Python availability checks before running tests

## Root cause

The Real E2E workflow assumed that self-hosted runners had `uv` and language runtimes preinstalled under `/home/admin`. Newly registered runners execute as `ecs-user`, so jobs failed before tests started.

## Impact

Self-hosted Real E2E jobs now provision `uv`, Node.js, and .NET consistently. Go caches and the .NET install directory use `RUNNER_TEMP`, while Docker's buildx state is cleaned under the current runner user's home directory.

## Validation

- `bash -n scripts/ci-docker-cleanup.sh`
- `bash scripts/verify-license.sh`
- `git diff --check`
- parsed `.github/workflows/real-e2e.yml` with Ruby YAML
- verified all five self-hosted Real E2E jobs use `astral-sh/setup-uv@v7`
- verified the repository no longer contains hard-coded `/home/admin` paths
- latest CI confirms `setup-uv`, Node.js, .NET, Go, and the shared cleanup step all succeed under `/home/ecs-user`

## Current runner prerequisite

The workflow now reaches the Docker image build, but the newly registered runner service user cannot access `/var/run/docker.sock`. The runner host must grant `ecs-user` Docker access and restart the GitHub Runner service so the service process inherits the updated group membership.
