### PR TITLE
chore: add missing Apache 2.0 license headers

### DIFF
--- a/cli/src/opensandbox_cli/skill_registry.py
+++ b/cli/src/opensandbox_cli/skill_registry.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Built-in OpenSandbox skill metadata and rendering helpers."""
 
 from __future__ import annotations

--- a/cli/tests/__init__.py
+++ b/cli/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/components/egress/cleanup_script_test.go
+++ b/components/egress/cleanup_script_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/components/egress/pkg/iptables/redirect_test.go
+++ b/components/egress/pkg/iptables/redirect_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package iptables
 
 import (

--- a/components/execd/configs/isolation.example.toml
+++ b/components/execd/configs/isolation.example.toml
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Isolation configuration for execd.
 #
 # Usage:

--- a/components/execd/tests/smoke_bwrap.sh
+++ b/components/execd/tests/smoke_bwrap.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Smoke test: build execd image, extract execd+bwrap, verify bwrap works.
 #
 # Prerequisites: docker

--- a/components/ingress/pkg/proxy/errors.go
+++ b/components/ingress/pkg/proxy/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy
 
 import (

--- a/components/ingress/pkg/sandbox/endpoint.go
+++ b/components/ingress/pkg/sandbox/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sandbox
 
 // EndpointInfo is the single lookup result used by ingress routing.

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/environment/Dockerfile
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/environment/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu:24.04
 
 WORKDIR /app

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/solution/solve.sh
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/solution/solve.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 echo "Hello from OpenSandbox!" > /app/greeting.txt

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/task.toml
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/task.toml
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version = "1.0"
 
 [task]

--- a/examples/harbor-evaluation/tasks/hello-opensandbox/tests/test.sh
+++ b/examples/harbor-evaluation/tasks/hello-opensandbox/tests/test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Offline verifier: checks the result directly with coreutils, so it needs no
 # network access or extra packages. It writes the reward Harbor reads from
 # /logs/verifier/reward.txt (1.0 = pass, 0.0 = fail).

--- a/kubernetes/internal/controller/events.go
+++ b/kubernetes/internal/controller/events.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controller
 
 // Event reasons for BatchSandbox and Pool controllers.

--- a/sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh
+++ b/sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)

--- a/scripts/ci-docker-cleanup.sh
+++ b/scripts/ci-docker-cleanup.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 echo "Disk usage before Docker cleanup:"

--- a/sdks/sandbox/python/tests/test_async_redis_pool_store.py
+++ b/sdks/sandbox/python/tests/test_async_redis_pool_store.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import asyncio

--- a/sdks/sandbox/python/tests/test_pool_async.py
+++ b/sdks/sandbox/python/tests/test_pool_async.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import asyncio

--- a/sdks/sandbox/python/tests/test_pool_manager.py
+++ b/sdks/sandbox/python/tests/test_pool_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/sdks/sandbox/python/tests/test_pool_store.py
+++ b/sdks/sandbox/python/tests/test_pool_store.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime, timedelta, timezone
 from threading import Lock, Thread
 

--- a/sdks/sandbox/python/tests/test_pool_sync.py
+++ b/sdks/sandbox/python/tests/test_pool_sync.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import threading

--- a/sdks/sandbox/python/tests/test_redis_pool_store.py
+++ b/sdks/sandbox/python/tests/test_redis_pool_store.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import time


### PR DESCRIPTION
## Summary

Fix the `verify-license` workflow which is currently failing on `main`. `scripts/verify-license.sh` flagged 21 source files missing the Apache 2.0 license header. This PR adds the standard header (with year 2026) to all of them.

## Files updated (21)

**Python (8)**
- `cli/src/opensandbox_cli/skill_registry.py`
- `cli/tests/__init__.py`
- `sdks/sandbox/python/tests/test_async_redis_pool_store.py`
- `sdks/sandbox/python/tests/test_pool_async.py`
- `sdks/sandbox/python/tests/test_pool_manager.py`
- `sdks/sandbox/python/tests/test_pool_store.py`
- `sdks/sandbox/python/tests/test_pool_sync.py`
- `sdks/sandbox/python/tests/test_redis_pool_store.py`

**Go (5)**
- `components/egress/cleanup_script_test.go`
- `components/egress/pkg/iptables/redirect_test.go`
- `components/ingress/pkg/proxy/errors.go`
- `components/ingress/pkg/sandbox/endpoint.go`
- `kubernetes/internal/controller/events.go`

**Shell (5)**
- `components/execd/tests/smoke_bwrap.sh`
- `examples/harbor-evaluation/tasks/hello-opensandbox/solution/solve.sh`
- `examples/harbor-evaluation/tasks/hello-opensandbox/tests/test.sh`
- `sandboxes/code-interpreter/tests/test_code_interpreter_node_setup.sh`
- `scripts/ci-docker-cleanup.sh`

**TOML (2)**
- `components/execd/configs/isolation.example.toml`
- `examples/harbor-evaluation/tasks/hello-opensandbox/task.toml`

**Dockerfile (1)**
- `examples/harbor-evaluation/tasks/hello-opensandbox/environment/Dockerfile`

## Verification

```
$ ./scripts/verify-license.sh
License headers verified.
```

Shebangs preserved on shell scripts; `package` declarations kept below the header on Go files.