### PR TITLE
execd(isolation): always strip execd's own config env in bwrap

### DIFF
--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -226,6 +226,7 @@ var execdConfigEnvBlacklist = []string{
 	"JUPYTER_HOST",
 	"JUPYTER_TOKEN",
 	"EXECD_ISOLATION_CONFIG",
+	"EXECD_ENVS",
 }
 
 func unsetExecdConfigEnv() []string {

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -219,6 +219,23 @@ func bwrapWorkspaceSegment(opts WrapOptions) ([]string, error) {
 	}
 }
 
+// execdConfigEnvBlacklist enumerates execd's own configuration env vars.
+// They are always stripped so execd's credentials never leak into the sandbox.
+var execdConfigEnvBlacklist = []string{
+	"EXECD_ACCESS_TOKEN",
+	"JUPYTER_HOST",
+	"JUPYTER_TOKEN",
+	"EXECD_ISOLATION_CONFIG",
+}
+
+func unsetExecdConfigEnv() []string {
+	argv := make([]string, 0, 2*len(execdConfigEnvBlacklist))
+	for _, key := range execdConfigEnvBlacklist {
+		argv = append(argv, "--unsetenv", key)
+	}
+	return argv
+}
+
 // unsetBlacklistedEnv returns --unsetenv args for all env vars matching strictEnvBlacklist.
 func unsetBlacklistedEnv() []string {
 	var argv []string
@@ -233,15 +250,17 @@ func unsetBlacklistedEnv() []string {
 	return argv
 }
 
-// bwrapEnvSegment returns environment passthrough args.
+// bwrapEnvSegment returns environment passthrough args. execd's own config
+// env (execdConfigEnvBlacklist) is always stripped, regardless of mode.
 func bwrapEnvSegment(spec EnvSpec) []string {
 	if spec.Mode == "" {
-		return unsetBlacklistedEnv()
+		argv := unsetExecdConfigEnv()
+		return append(argv, unsetBlacklistedEnv()...)
 	}
 
 	switch spec.Mode {
 	case EnvModeDeny:
-		var argv []string
+		argv := unsetExecdConfigEnv()
 		for _, key := range spec.Keys {
 			argv = append(argv, "--unsetenv", key)
 		}
@@ -251,9 +270,17 @@ func bwrapEnvSegment(spec EnvSpec) []string {
 		return argv
 
 	case EnvModeAllow:
-		// Clear environment, inject only allow-listed keys.
+		// --clearenv wipes everything; refuse to re-inject execd config env
+		// even if the caller allow-lists it.
 		argv := []string{"--clearenv"}
+		blacklist := make(map[string]struct{}, len(execdConfigEnvBlacklist))
+		for _, k := range execdConfigEnvBlacklist {
+			blacklist[k] = struct{}{}
+		}
 		for _, key := range spec.Keys {
+			if _, blocked := blacklist[key]; blocked {
+				continue
+			}
 			if val, ok := os.LookupEnv(key); ok {
 				argv = append(argv, "--setenv", key, val)
 			}

--- a/components/execd/pkg/isolation/bwrap_test.go
+++ b/components/execd/pkg/isolation/bwrap_test.go
@@ -184,7 +184,7 @@ func TestBuildArgv_EnvPassthrough(t *testing.T) {
 		}
 	})
 
-	t.Run("empty_mode_no_env_args", func(t *testing.T) {
+	t.Run("empty_mode_strips_execd_config_env", func(t *testing.T) {
 		opts := basicWrapOpts()
 		opts.EnvPassthrough = EnvSpec{} // empty mode
 		argv, err := buildArgv(opts, "")
@@ -192,9 +192,61 @@ func TestBuildArgv_EnvPassthrough(t *testing.T) {
 			t.Fatal(err)
 		}
 		s := strings.Join(argv, " ")
-		if strings.Contains(s, "--clearenv") || strings.Contains(s, "--unsetenv") {
-			t.Error("should not have env args for empty mode")
+		// Default mode must always strip execd's own configuration env,
+		// but must not emit --clearenv (user business env is untouched).
+		if strings.Contains(s, "--clearenv") {
+			t.Error("empty mode must not use --clearenv")
 		}
+		for _, k := range execdConfigEnvBlacklist {
+			if !strings.Contains(s, "--unsetenv "+k) {
+				t.Errorf("empty mode must --unsetenv %s, argv:\n  %s", k, s)
+			}
+		}
+	})
+}
+
+func TestBuildArgv_ExecdConfigEnvAlwaysStripped(t *testing.T) {
+	tests := []struct {
+		name string
+		spec EnvSpec
+	}{
+		{"empty_mode", EnvSpec{}},
+		{"deny_empty_keys", EnvSpec{Mode: EnvModeDeny}},
+		{"deny_with_keys", EnvSpec{Mode: EnvModeDeny, Keys: []string{"FOO"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := basicWrapOpts()
+			opts.EnvPassthrough = tt.spec
+			argv, err := buildArgv(opts, "")
+			require.NoError(t, err)
+			s := strings.Join(argv, " ")
+			for _, k := range execdConfigEnvBlacklist {
+				assert.Contains(t, s, "--unsetenv "+k,
+					"%s: execd config env %s must be unset", tt.name, k)
+			}
+		})
+	}
+
+	t.Run("allow_mode_uses_clearenv_and_refuses_reinjection", func(t *testing.T) {
+		// Even if the caller explicitly allow-lists an execd config env,
+		// we must not re-inject it via --setenv.
+		t.Setenv("EXECD_ACCESS_TOKEN", "supersecret")
+		t.Setenv("JUPYTER_TOKEN", "jt")
+
+		opts := basicWrapOpts()
+		opts.EnvPassthrough = EnvSpec{
+			Mode: EnvModeAllow,
+			Keys: []string{"EXECD_ACCESS_TOKEN", "JUPYTER_TOKEN", "PATH"},
+		}
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.Contains(t, s, "--clearenv")
+		assert.NotContains(t, s, "supersecret",
+			"allow mode must not re-inject execd config env value")
+		assert.NotContains(t, s, "--setenv EXECD_ACCESS_TOKEN")
+		assert.NotContains(t, s, "--setenv JUPYTER_TOKEN")
 	})
 }
 


### PR DESCRIPTION
## Summary

Previously bwrap inherited execd's process env by default. In particular, the default `EnvPassthrough` mode (deny with empty keys) only stripped a generic secret-name blacklist (`*_TOKEN`, `AWS_*`, etc.), so credentials configured on execd itself leaked into sandbox processes.

This change unconditionally strips execd's own configuration env vars in every `EnvPassthrough` mode:

- \`EXECD_ACCESS_TOKEN\`
- \`JUPYTER_HOST\`
- \`JUPYTER_TOKEN\`
- \`EXECD_ISOLATION_CONFIG\`

In \`EnvModeAllow\`, even if the caller explicitly allow-lists one of these keys, we refuse to re-inject its value via \`--setenv\`.

## Behavior change

- Sandbox processes can no longer read the four env vars above.
- User business env (\`PATH\`, \`HOME\`, \`LANG\`, custom app env, etc.) is untouched.
- Existing \`envPassthroughMode\` semantics (\`deny\` with explicit keys, \`allow\` with allow-list) are preserved; the four blacklisted keys are simply unset in addition.

## Tests

- Updated \`empty_mode_no_env_args\` → \`empty_mode_strips_execd_config_env\`: default mode must emit \`--unsetenv\` for all four keys and must not emit \`--clearenv\`.
- Added \`TestBuildArgv_ExecdConfigEnvAlwaysStripped\`: covers empty / deny(empty keys) / deny(with keys) modes, and verifies allow mode does not re-inject blacklisted values.
- \`go build ./...\`, \`go vet ./pkg/isolation/...\`, \`GOOS=linux go test -c ./pkg/isolation/\` all pass.

## Note

If new \`EXECD_*\` / \`JUPYTER_*\` configuration env vars are added to execd, remember to add them to \`execdConfigEnvBlacklist\` in \`components/execd/pkg/isolation/bwrap.go\`.