### PR TITLE
Fix/go sdk stale conn

### DIFF
--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -32,6 +32,13 @@ import (
 // instead to control individual call timeouts.
 const defaultTimeout = 0
 
+// streamResponseHeaderTimeout bounds how long an SSE request waits for the
+// server to send response headers after the connection is established. It does
+// NOT bound reading the (potentially long-lived) event stream body. Without it,
+// a server that accepts the connection but never sends headers would hang the
+// stream forever for callers using context.Background().
+const streamResponseHeaderTimeout = 30 * time.Second
+
 // Client is the base HTTP client shared by LifecycleClient and EgressClient.
 type Client struct {
 	baseURL    string
@@ -60,14 +67,24 @@ type Client struct {
 //     dropped by a load balancer while idle would stall the stream until it
 //     times out. Each stream therefore uses a fresh, non-pooled connection.
 //
-// Connection setup is still bounded by the transport's DialTimeout and
-// TLSHandshakeTimeout; only the (unbounded) body read is uncapped.
+// Connection setup is still bounded by the transport's DialTimeout,
+// TLSHandshakeTimeout, and ResponseHeaderTimeout (the wait for response
+// headers); only the (unbounded) body read is uncapped.
 func (c *Client) streamHTTPClient() *http.Client {
 	c.streamOnce.Do(func() {
 		sc := &http.Client{} // Timeout: 0 -> no overall request timeout
 		if tr, ok := c.httpClient.Transport.(*http.Transport); ok && tr != nil {
 			clone := tr.Clone()
 			clone.DisableKeepAlives = true // do not pool/reuse stream connections
+			// Bound only the "connected -> first response header" phase.
+			// DialTimeout/TLSHandshakeTimeout do not cover waiting for response
+			// headers, so without this a server that accepts the connection but
+			// never sends headers would hang forever for context.Background()
+			// callers. The SSE body read stays uncapped (Client.Timeout == 0).
+			// Only set it when unset, to preserve an explicit caller value.
+			if clone.ResponseHeaderTimeout == 0 {
+				clone.ResponseHeaderTimeout = streamResponseHeaderTimeout
+			}
 			sc.Transport = clone
 		} else {
 			// Custom RoundTripper: reuse it as-is (cannot toggle keep-alives).

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -40,6 +41,41 @@ type Client struct {
 	timeout    *time.Duration // stored separately, applied after all options
 	headers    map[string]string
 	retry      *RetryConfig
+
+	// streamClient is a dedicated HTTP client for SSE streaming, created lazily.
+	// It disables connection pooling/keep-alive and has no overall request
+	// timeout (see streamHTTPClient).
+	streamClient *http.Client
+	streamOnce   sync.Once
+}
+
+// streamHTTPClient returns a dedicated HTTP client for SSE streaming.
+//
+// Streaming differs from normal requests in two ways that make the shared
+// httpClient unsuitable:
+//   - It must not be bounded by an overall request timeout (http.Client.Timeout),
+//     because that timeout also covers reading the response body and would kill
+//     a long-running command's event stream mid-flight.
+//   - It must not reuse pooled keep-alive connections: a connection silently
+//     dropped by a load balancer while idle would stall the stream until it
+//     times out. Each stream therefore uses a fresh, non-pooled connection.
+//
+// Connection setup is still bounded by the transport's DialTimeout and
+// TLSHandshakeTimeout; only the (unbounded) body read is uncapped.
+func (c *Client) streamHTTPClient() *http.Client {
+	c.streamOnce.Do(func() {
+		sc := &http.Client{} // Timeout: 0 -> no overall request timeout
+		if tr, ok := c.httpClient.Transport.(*http.Transport); ok && tr != nil {
+			clone := tr.Clone()
+			clone.DisableKeepAlives = true // do not pool/reuse stream connections
+			sc.Transport = clone
+		} else {
+			// Custom RoundTripper: reuse it as-is (cannot toggle keep-alives).
+			sc.Transport = c.httpClient.Transport
+		}
+		c.streamClient = sc
+	})
+	return c.streamClient
 }
 
 // Option configures a Client.
@@ -260,7 +296,10 @@ func (c *Client) doStreamRequest(ctx context.Context, method, path string, body 
 		}
 		req.Header.Set("Accept", "text/event-stream")
 
-		r, err := c.httpClient.Do(req)
+		// SSE uses a dedicated non-pooled, timeout-free client so long streams
+		// are not killed by the overall request timeout and are never carried
+		// over a stale pooled connection.
+		r, err := c.streamHTTPClient().Do(req)
 		if err != nil {
 			return fmt.Errorf("opensandbox: do request: %w", err)
 		}

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"sync"
 	"time"
 )
@@ -70,9 +71,14 @@ type Client struct {
 // Connection setup is still bounded by the transport's DialTimeout,
 // TLSHandshakeTimeout, and ResponseHeaderTimeout (the wait for response
 // headers); only the (unbounded) body read is uncapped.
+//
+// The dedicated client is a shallow copy of the configured httpClient, so any
+// caller-provided CookieJar / CheckRedirect policy still applies to streams;
+// only Timeout (cleared) and Transport (replaced) differ.
 func (c *Client) streamHTTPClient() *http.Client {
 	c.streamOnce.Do(func() {
-		sc := &http.Client{} // Timeout: 0 -> no overall request timeout
+		sc := *c.httpClient // shallow copy: keep Jar, CheckRedirect, etc.
+		sc.Timeout = 0      // no overall request timeout for long-lived streams
 		if tr, ok := c.httpClient.Transport.(*http.Transport); ok && tr != nil {
 			clone := tr.Clone()
 			clone.DisableKeepAlives = true // do not pool/reuse stream connections
@@ -86,11 +92,10 @@ func (c *Client) streamHTTPClient() *http.Client {
 				clone.ResponseHeaderTimeout = streamResponseHeaderTimeout
 			}
 			sc.Transport = clone
-		} else {
-			// Custom RoundTripper: reuse it as-is (cannot toggle keep-alives).
-			sc.Transport = c.httpClient.Transport
 		}
-		c.streamClient = sc
+		// else: custom RoundTripper is kept as-is via the shallow copy
+		// (cannot toggle keep-alives on an unknown transport).
+		c.streamClient = &sc
 	})
 	return c.streamClient
 }
@@ -180,17 +185,21 @@ func NewClient(baseURL, apiKey, authHeader string, opts ...Option) *Client {
 // For idempotent requests (GET/HEAD) it also transparently recovers from a
 // stale pooled connection: some load balancers silently drop idle keep-alive
 // connections without sending a FIN, so a reused connection can hang until the
-// request timeout. On such a connection-level failure the client purges idle
-// connections and retries once on a fresh connection. This is always on and
+// request timeout. When such a failure happens on a REUSED pooled connection
+// the client purges idle connections and retries once on a fresh connection.
+// The retry is gated on the failed attempt having reused a pooled connection
+// (observed via httptrace), so a slow server hit over a brand-new connection is
+// not retried and cannot double the effective timeout. This is always on and
 // independent of the opt-in RetryConfig.
 func (c *Client) doRequest(ctx context.Context, method, path string, body any, result any) error {
 	return c.withRetry(ctx, func() error {
-		err := c.doRequestOnce(ctx, method, path, body, result)
-		if err != nil && c.shouldRetryOnFreshConn(ctx, method, err) {
-			// The pooled connection may have been silently dropped by an
+		var reused bool
+		err := c.doRequestOnce(ctx, method, path, body, result, &reused)
+		if err != nil && reused && c.shouldRetryOnFreshConn(ctx, method, err) {
+			// The reused pooled connection was likely silently dropped by an
 			// intermediary. Drop idle connections so the retry dials a new one.
 			c.httpClient.CloseIdleConnections()
-			err = c.doRequestOnce(ctx, method, path, body, result)
+			err = c.doRequestOnce(ctx, method, path, body, result, nil)
 		}
 		return err
 	})
@@ -201,7 +210,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any, r
 // for response headers, connection resets/EOF) that typically mean a reused
 // pooled connection was already dead. It is restricted to idempotent methods
 // and never fires when the caller's context is done (respecting cancellation)
-// or when the server actually responded with an error status.
+// or when the server actually responded with an error status. The caller
+// additionally gates this on the failed attempt having reused a pooled
+// connection.
 func (c *Client) shouldRetryOnFreshConn(ctx context.Context, method string, err error) bool {
 	if err == nil {
 		return false
@@ -228,8 +239,10 @@ func (c *Client) shouldRetryOnFreshConn(ctx context.Context, method string, err 
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
-// doRequestOnce is the single-attempt implementation of doRequest.
-func (c *Client) doRequestOnce(ctx context.Context, method, path string, body any, result any) error {
+// doRequestOnce is the single-attempt implementation of doRequest. If reused is
+// non-nil it is set to whether this attempt was carried over a reused pooled
+// connection (observed via httptrace GotConn).
+func (c *Client) doRequestOnce(ctx context.Context, method, path string, body any, result any, reused *bool) error {
 	var bodyReader io.Reader
 	if body != nil {
 		buf, err := json.Marshal(body)
@@ -237,6 +250,14 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body an
 			return fmt.Errorf("opensandbox: marshal request: %w", err)
 		}
 		bodyReader = bytes.NewReader(buf)
+	}
+
+	if reused != nil {
+		ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+			GotConn: func(info httptrace.GotConnInfo) {
+				*reused = info.Reused
+			},
+		})
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 )
@@ -121,10 +123,56 @@ func NewClient(baseURL, apiKey, authHeader string, opts ...Option) *Client {
 // retrying on transient errors if a RetryConfig is set.
 // If body is nil, no request body is sent. If result is non-nil, the
 // response body is decoded into it.
+//
+// For idempotent requests (GET/HEAD) it also transparently recovers from a
+// stale pooled connection: some load balancers silently drop idle keep-alive
+// connections without sending a FIN, so a reused connection can hang until the
+// request timeout. On such a connection-level failure the client purges idle
+// connections and retries once on a fresh connection. This is always on and
+// independent of the opt-in RetryConfig.
 func (c *Client) doRequest(ctx context.Context, method, path string, body any, result any) error {
 	return c.withRetry(ctx, func() error {
-		return c.doRequestOnce(ctx, method, path, body, result)
+		err := c.doRequestOnce(ctx, method, path, body, result)
+		if err != nil && c.shouldRetryOnFreshConn(ctx, method, err) {
+			// The pooled connection may have been silently dropped by an
+			// intermediary. Drop idle connections so the retry dials a new one.
+			c.httpClient.CloseIdleConnections()
+			err = c.doRequestOnce(ctx, method, path, body, result)
+		}
+		return err
 	})
+}
+
+// shouldRetryOnFreshConn reports whether a failed request should be retried once
+// on a fresh connection. It targets connection-level failures (timeouts waiting
+// for response headers, connection resets/EOF) that typically mean a reused
+// pooled connection was already dead. It is restricted to idempotent methods
+// and never fires when the caller's context is done (respecting cancellation)
+// or when the server actually responded with an error status.
+func (c *Client) shouldRetryOnFreshConn(ctx context.Context, method string, err error) bool {
+	if err == nil {
+		return false
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	// Respect caller cancellation / deadline: the caller gave up, don't retry.
+	if ctx.Err() != nil {
+		return false
+	}
+	// The server responded (4xx/5xx): not a connection problem.
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return false
+	}
+	// Network-level timeout (incl. http.Client.Timeout awaiting headers) or a
+	// connection error (reset, closed) surfaced as a net.Error.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	// Idle connection closed by the peer between pooling and reuse.
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 // doRequestOnce is the single-attempt implementation of doRequest.

--- a/sdks/sandbox/go/poolredis/go.mod
+++ b/sdks/sandbox/go/poolredis/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	golang.org/x/sync v0.7.0 // indirect
 )
 
 replace github.com/alibaba/OpenSandbox/sdks/sandbox/go => ../

--- a/sdks/sandbox/go/poolredis/go.sum
+++ b/sdks/sandbox/go/poolredis/go.sum
@@ -6,3 +6,5 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/sdks/sandbox/go/retry_test.go
+++ b/sdks/sandbox/go/retry_test.go
@@ -351,8 +351,8 @@ func TestDefaultTransport(t *testing.T) {
 	if tr.MaxIdleConnsPerHost != 10 {
 		assert.Fail(t, fmt.Sprintf("MaxIdleConnsPerHost = %d, want 10", tr.MaxIdleConnsPerHost))
 	}
-	if tr.IdleConnTimeout != 90*time.Second {
-		assert.Fail(t, fmt.Sprintf("IdleConnTimeout = %v, want 90s", tr.IdleConnTimeout))
+	if tr.IdleConnTimeout != 30*time.Second {
+		assert.Fail(t, fmt.Sprintf("IdleConnTimeout = %v, want 30s", tr.IdleConnTimeout))
 	}
 	if tr.TLSHandshakeTimeout != 10*time.Second {
 		assert.Fail(t, fmt.Sprintf("TLSHandshakeTimeout = %v, want 10s", tr.TLSHandshakeTimeout))

--- a/sdks/sandbox/go/staleconn_diag_test.go
+++ b/sdks/sandbox/go/staleconn_diag_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains DIAGNOSTIC tests for the "stale keep-alive connection"
+// hypothesis behind intermittent GetEndpoint timeouts
+// ("context deadline exceeded (Client.Timeout exceeded while awaiting headers)").
+//
+// They do not change any SDK behavior. They:
+//  1. Prove the SDK's default transport reuses idle pooled connections.
+//  2. Reproduce the exact "Client.Timeout ... while awaiting headers" error on a
+//     connection that goes black-hole (dead but no FIN) after being idle.
+//  3. Show that forcing a fresh connection (DisableKeepAlives, or an
+//     IdleConnTimeout shorter than the idle gap) avoids the hang.
+//  4. Provide an env-gated probe to run against the REAL lifecycle server.
+
+package opensandbox
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"sync"
+	"testing"
+	"time"
+)
+
+// traceTransport wraps a RoundTripper and logs per-request connection-reuse and
+// timing info via httptrace, so we can see Reused / WasIdle / IdleTime and where
+// a request stalls.
+type traceTransport struct {
+	base http.RoundTripper
+	t    *testing.T
+	mu   sync.Mutex
+	n    int
+
+	// lastReused records whether the most recent request reused a pooled
+	// connection (from httptrace GotConn), so tests can assert reuse behavior.
+	lastReused bool
+}
+
+func (tt *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tt.mu.Lock()
+	tt.n++
+	id := tt.n
+	tt.mu.Unlock()
+
+	start := time.Now()
+	trace := &httptrace.ClientTrace{
+		ConnectStart: func(network, addr string) {
+			tt.t.Logf("[req %d] +%-8v ConnectStart NEW dial %s %s", id, time.Since(start).Round(time.Millisecond), network, addr)
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			tt.mu.Lock()
+			tt.lastReused = info.Reused
+			tt.mu.Unlock()
+			tt.t.Logf("[req %d] +%-8v GotConn reused=%v wasIdle=%v idleTime=%v",
+				id, time.Since(start).Round(time.Millisecond), info.Reused, info.WasIdle, info.IdleTime.Round(time.Millisecond))
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			tt.t.Logf("[req %d] +%-8v WroteRequest err=%v", id, time.Since(start).Round(time.Millisecond), info.Err)
+		},
+		GotFirstResponseByte: func() {
+			tt.t.Logf("[req %d] +%-8v GotFirstResponseByte", id, time.Since(start).Round(time.Millisecond))
+		},
+		TLSHandshakeDone: func(cs tls.ConnectionState, err error) {
+			proto := cs.NegotiatedProtocol
+			if proto == "" {
+				proto = "(none/http1)"
+			}
+			tt.t.Logf("[req %d] +%-8v TLSHandshakeDone alpn=%q err=%v", id, time.Since(start).Round(time.Millisecond), proto, err)
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	resp, err := tt.base.RoundTrip(req)
+	tt.t.Logf("[req %d] +%-8v DONE err=%v", id, time.Since(start).Round(time.Millisecond), err)
+	return resp, err
+}
+
+// TestDiag_ConnReuseAfterIdle confirms the necessary precondition for the bug:
+// the SDK's default transport keeps an idle connection in the pool and REUSES it
+// on the next request (Reused=true, WasIdle=true) rather than dialing fresh.
+func TestDiag_ConnReuseAfterIdle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	tt := &traceTransport{base: DefaultTransport(), t: t}
+	c := NewClient(srv.URL, "k", "OPEN-SANDBOX-API-KEY",
+		WithHTTPClient(&http.Client{Transport: tt}))
+
+	for i := 0; i < 3; i++ {
+		if err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil); err != nil {
+			t.Fatalf("request %d failed: %v", i+1, err)
+		}
+		if i == 0 {
+			require.True(t, !tt.lastReused, "request 1 should dial a fresh connection")
+		} else {
+			// After an idle gap well under IdleConnTimeout, the pooled connection
+			// must be reused rather than re-dialed.
+			require.True(t, tt.lastReused, "request %d should REUSE the pooled idle connection", i+1)
+		}
+		time.Sleep(200 * time.Millisecond) // idle gap; well under IdleConnTimeout (30s)
+	}
+}
+
+// blackHoleAfterReuseServer models a load balancer that silently drops a
+// connection after it goes idle: the FIRST request on any TCP connection is
+// served normally (keep-alive), but a SECOND request on the SAME connection is
+// black-holed (request read, no response, no FIN) — while a brand-new
+// connection is always served fine.
+//
+// Returns the listener address and a cleanup func.
+func blackHoleAfterReuseServer(t *testing.T) (addr string, cleanup func()) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			wg.Add(1)
+			go func(c net.Conn) {
+				defer wg.Done()
+				defer c.Close()
+				br := bufio.NewReader(c)
+				reqOnConn := 0
+				for {
+					_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+					if _, err := http.ReadRequest(br); err != nil {
+						return
+					}
+					reqOnConn++
+					if reqOnConn == 1 {
+						// First request on this connection: serve OK, keep alive.
+						_, _ = c.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\n{}"))
+						continue
+					}
+					// Reused connection: black-hole. Read the request but never
+					// respond and never send FIN — the client cannot tell the
+					// connection is dead and will hang until Client.Timeout.
+					select {
+					case <-done:
+					case <-time.After(30 * time.Second):
+					}
+					return
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		close(done)
+		_ = ln.Close()
+		wg.Wait()
+	}
+}
+
+// TestDiag_ReusedConnBlackHoleReproducesClientTimeout reproduces the screenshot
+// error: with the SDK's default (keep-alive) transport, the second request
+// reuses the idle connection, which the "LB" has black-holed, so it hangs until
+// http.Client.Timeout and fails with the exact
+// "Client.Timeout exceeded while awaiting headers" text.
+func TestDiag_ReusedConnBlackHoleReproducesClientTimeout(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+	baseURL := "http://" + addr
+
+	tt := &traceTransport{base: DefaultTransport(), t: t}
+	c := NewClient(baseURL, "k", "OPEN-SANDBOX-API-KEY",
+		WithHTTPClient(&http.Client{Transport: tt, Timeout: 800 * time.Millisecond}))
+
+	// Request 1: fresh dial, served OK. Connection goes back to the pool.
+	if err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil); err != nil {
+		t.Fatalf("request 1 should succeed, got: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond) // connection now idle in the pool
+
+	// Request 2: reuses the idle (now black-holed) connection -> hangs -> timeout.
+	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	require.Error(t, err)
+	t.Logf("req2 error: %v", err)
+	assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+	t.Log("=> Reproduced: reused idle connection + black-hole => Client.Timeout while awaiting headers.")
+}
+
+// TestDiag_FixDisableKeepAlives shows that using a fresh connection per request
+// (DisableKeepAlives) avoids the hang: every request is the FIRST on its
+// connection, so the black-hole server always serves it.
+func TestDiag_FixDisableKeepAlives(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+	baseURL := "http://" + addr
+
+	tr := DefaultTransport()
+	tr.DisableKeepAlives = true
+	tt := &traceTransport{base: tr, t: t}
+	c := NewClient(baseURL, "k", "OPEN-SANDBOX-API-KEY",
+		WithHTTPClient(&http.Client{Transport: tt, Timeout: 800 * time.Millisecond}))
+
+	for i := 0; i < 3; i++ {
+		if err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil); err != nil {
+			t.Fatalf("request %d should succeed with DisableKeepAlives, got: %v", i+1, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Log("=> DisableKeepAlives: every request dials fresh (no reuse) => no hang.")
+}
+
+// TestDiag_FixShortIdleConnTimeout shows that an IdleConnTimeout shorter than
+// the idle gap makes the SDK evict the pooled connection before it is reused, so
+// the next request dials fresh and the black-hole is avoided.
+func TestDiag_FixShortIdleConnTimeout(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+	baseURL := "http://" + addr
+
+	tr := DefaultTransport()
+	tr.IdleConnTimeout = 50 * time.Millisecond // << idle gap below
+	tt := &traceTransport{base: tr, t: t}
+	c := NewClient(baseURL, "k", "OPEN-SANDBOX-API-KEY",
+		WithHTTPClient(&http.Client{Transport: tt, Timeout: 800 * time.Millisecond}))
+
+	if err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil); err != nil {
+		t.Fatalf("request 1 should succeed, got: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond) // idle > IdleConnTimeout => connection evicted
+
+	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	require.NoError(t, err)
+	t.Log("=> Short IdleConnTimeout: idle connection evicted before reuse => req2 dials fresh => OK.")
+}
+
+// TestDiag_SDKTransportUsesHTTP1 proves that the SDK's default transport shape
+// (custom DialContext + TLSClientConfig, no ForceAttemptHTTP2) negotiates
+// HTTP/1.1 even against an HTTP/2-capable TLS server, and that HTTP/2 is only
+// used when ForceAttemptHTTP2 is explicitly enabled.
+func TestDiag_SDKTransportUsesHTTP1(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(r.Proto))
+	}))
+	srv.EnableHTTP2 = true // make the test server actually offer HTTP/2 via ALPN
+	srv.StartTLS()
+	defer srv.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+
+	// SDK-shaped transport: exactly what DefaultTransport() builds. We only add
+	// RootCAs so TLS verifies, and clear VerifyConnection to isolate the protocol
+	// question from the NIST cert policy. Crucially: ForceAttemptHTTP2 is NOT set.
+	tr := DefaultTransport()
+	tr.TLSClientConfig.RootCAs = pool
+	tr.TLSClientConfig.VerifyConnection = nil
+
+	resp, err := (&http.Client{Transport: tr}).Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	t.Logf("SDK-shaped transport negotiated: %s", resp.Proto)
+	require.Equal(t, "HTTP/1.1", resp.Proto)
+
+	// Contrast: the SAME server negotiates HTTP/2 once we opt in.
+	tr2 := DefaultTransport()
+	tr2.TLSClientConfig.RootCAs = pool
+	tr2.TLSClientConfig.VerifyConnection = nil
+	tr2.ForceAttemptHTTP2 = true
+
+	resp2, err := (&http.Client{Transport: tr2}).Get(srv.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	t.Logf("with ForceAttemptHTTP2=true negotiated: %s", resp2.Proto)
+	require.Equal(t, "HTTP/2.0", resp2.Proto)
+
+	t.Log("=> SDK currently speaks HTTP/1.1 (no ForceAttemptHTTP2); HTTP/2 requires opting in.")
+}

--- a/sdks/sandbox/go/staleconn_diag_test.go
+++ b/sdks/sandbox/go/staleconn_diag_test.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -136,6 +137,12 @@ func blackHoleAfterReuseServer(t *testing.T) (addr string, cleanup func()) {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 
+	// Track live connections so cleanup can force-close them; otherwise a
+	// goroutine blocked in ReadRequest (waiting for a request that never comes)
+	// would delay cleanup's wg.Wait until its read deadline expired.
+	var connMu sync.Mutex
+	var conns []net.Conn
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -144,6 +151,9 @@ func blackHoleAfterReuseServer(t *testing.T) (addr string, cleanup func()) {
 			if err != nil {
 				return
 			}
+			connMu.Lock()
+			conns = append(conns, conn)
+			connMu.Unlock()
 			wg.Add(1)
 			go func(c net.Conn) {
 				defer wg.Done()
@@ -151,12 +161,17 @@ func blackHoleAfterReuseServer(t *testing.T) (addr string, cleanup func()) {
 				br := bufio.NewReader(c)
 				reqOnConn := 0
 				for {
-					_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
-					if _, err := http.ReadRequest(br); err != nil {
+					_ = c.SetReadDeadline(time.Now().Add(30 * time.Second))
+					req, err := http.ReadRequest(br)
+					if err != nil {
 						return
 					}
 					reqOnConn++
 					if reqOnConn == 1 {
+						// Drain the request body so the connection can be cleanly
+						// reused for the next request (matters for POST/PUT bodies).
+						_, _ = io.Copy(io.Discard, req.Body)
+						_ = req.Body.Close()
 						// First request on this connection: serve OK, keep alive.
 						_, _ = c.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\n{}"))
 						continue
@@ -177,36 +192,48 @@ func blackHoleAfterReuseServer(t *testing.T) (addr string, cleanup func()) {
 	return ln.Addr().String(), func() {
 		close(done)
 		_ = ln.Close()
+		connMu.Lock()
+		for _, c := range conns {
+			_ = c.Close() // unblock any goroutine parked in ReadRequest
+		}
+		connMu.Unlock()
 		wg.Wait()
 	}
 }
 
-// TestDiag_ReusedConnBlackHoleReproducesClientTimeout reproduces the screenshot
-// error: with the SDK's default (keep-alive) transport, the second request
-// reuses the idle connection, which the "LB" has black-holed, so it hangs until
-// http.Client.Timeout and fails with the exact
+// TestDiag_ReusedConnBlackHoleReproducesClientTimeout demonstrates the raw
+// transport-level root cause behind the screenshot error: issuing requests
+// directly on the SDK's default (keep-alive) transport, the second request
+// reuses the idle connection that the "LB" has black-holed, hangs until
+// http.Client.Timeout, and fails with the exact
 // "Client.Timeout exceeded while awaiting headers" text.
+//
+// This uses the raw *http.Client (NOT Client.doRequest) so it keeps documenting
+// the underlying transport behavior even after the SDK's doRequest recovery is
+// in place; the SDK-level recovery is covered by staleconn_fix_test.go.
 func TestDiag_ReusedConnBlackHoleReproducesClientTimeout(t *testing.T) {
 	addr, cleanup := blackHoleAfterReuseServer(t)
 	defer cleanup()
 	baseURL := "http://" + addr
 
 	tt := &traceTransport{base: DefaultTransport(), t: t}
-	c := NewClient(baseURL, "k", "OPEN-SANDBOX-API-KEY",
-		WithHTTPClient(&http.Client{Transport: tt, Timeout: 800 * time.Millisecond}))
+	httpClient := &http.Client{Transport: tt, Timeout: 800 * time.Millisecond}
 
 	// Request 1: fresh dial, served OK. Connection goes back to the pool.
-	if err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil); err != nil {
+	resp1, err := httpClient.Get(baseURL + "/")
+	if err != nil {
 		t.Fatalf("request 1 should succeed, got: %v", err)
 	}
+	_, _ = io.Copy(io.Discard, resp1.Body)
+	_ = resp1.Body.Close()
 	time.Sleep(100 * time.Millisecond) // connection now idle in the pool
 
 	// Request 2: reuses the idle (now black-holed) connection -> hangs -> timeout.
-	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	_, err = httpClient.Get(baseURL + "/")
 	require.Error(t, err)
 	t.Logf("req2 error: %v", err)
 	assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
-	t.Log("=> Reproduced: reused idle connection + black-hole => Client.Timeout while awaiting headers.")
+	t.Log("=> Raw transport: reused idle connection + black-hole => Client.Timeout while awaiting headers.")
 }
 
 // TestDiag_FixDisableKeepAlives shows that using a fresh connection per request

--- a/sdks/sandbox/go/staleconn_fix_test.go
+++ b/sdks/sandbox/go/staleconn_fix_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for the intermittent GetEndpoint failure caused by reusing a
+// keep-alive connection that a load balancer silently black-holes after it goes
+// idle ("context deadline exceeded (Client.Timeout exceeded while awaiting
+// headers)").
+//
+// These tests drive the SDK's real GetEndpoint path (via ConnectionConfig with
+// the endpoint cache disabled so every call hits the network) against the
+// connection-level black-hole server from staleconn_diag_test.go. They MUST fail
+// before the fix and pass after it.
+
+package opensandbox
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestStaleConn_GetEndpointRecoversFromBlackHoledConn is the deterministic,
+// millisecond-scale regression test.
+//
+// Setup: the black-hole server serves the FIRST request on any connection and
+// silently hangs on a SECOND request over the SAME connection (modeling an LB
+// that dropped the idle connection without sending FIN). The idle gap between
+// the two calls (50ms) is far below IdleConnTimeout, so the SDK keeps and
+// REUSES the (now black-holed) connection for the second call.
+//
+//   - Before the fix: the second GetEndpoint reuses the dead connection, stalls,
+//     and fails at RequestTimeout with "Client.Timeout exceeded while awaiting
+//     headers".
+//   - After the fix (B): doRequest detects the connection-level stall, purges
+//     idle connections, and retries once on a fresh connection -> success.
+func TestStaleConn_GetEndpointRecoversFromBlackHoledConn(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+
+	cfg := ConnectionConfig{
+		Domain:                "http://" + addr,
+		RequestTimeout:        300 * time.Millisecond, // detect a stalled reused conn quickly
+		EndpointCacheDisabled: true,                   // force a network call every time
+	}
+	lc := cfg.lifecycleClient()
+	useProxy := false
+
+	// Call 1: fresh connection, served OK; connection returns to the idle pool.
+	if _, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy); err != nil {
+		t.Fatalf("first GetEndpoint should succeed, got: %v", err)
+	}
+
+	// Idle gap well under IdleConnTimeout so the connection is reused (not evicted).
+	time.Sleep(50 * time.Millisecond)
+
+	// Call 2: reuses the black-holed connection. Must recover via a fresh-connection retry.
+	_, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy)
+	require.NoError(t, err, "GetEndpoint must recover from a black-holed reused connection")
+}
+
+// TestStaleConn_GetEndpointRecovers_RealTimescale exercises the same recovery at
+// realistic (second-scale) timings. Skipped under `go test -short`.
+func TestStaleConn_GetEndpointRecovers_RealTimescale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping second-scale stale-connection test in -short mode")
+	}
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+
+	cfg := ConnectionConfig{
+		Domain:                "http://" + addr,
+		RequestTimeout:        3 * time.Second,
+		EndpointCacheDisabled: true,
+	}
+	lc := cfg.lifecycleClient()
+	useProxy := false
+
+	if _, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy); err != nil {
+		t.Fatalf("first GetEndpoint should succeed, got: %v", err)
+	}
+
+	// Real idle gap: the connection stays pooled and is reused for call 2.
+	time.Sleep(2 * time.Second)
+
+	_, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy)
+	require.NoError(t, err, "GetEndpoint must recover from a black-holed reused connection at second scale")
+}
+
+// TestStaleConn_IdleConnEvictedBeforeLBDrops verifies the "A" lever: when a
+// connection stays idle longer than IdleConnTimeout, the SDK evicts it, so the
+// next request dials a FRESH connection instead of reusing a possibly-dead one.
+// Uses a short IdleConnTimeout via a custom transport so the test is fast and
+// deterministic.
+func TestStaleConn_IdleConnEvictedBeforeLBDrops(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+
+	trCfg := DefaultTransportConfig()
+	trCfg.IdleConnTimeout = 40 * time.Millisecond // evict quickly
+	cfg := ConnectionConfig{
+		Domain:                "http://" + addr,
+		RequestTimeout:        300 * time.Millisecond,
+		EndpointCacheDisabled: true,
+		Transport:             &trCfg,
+	}
+	lc := cfg.lifecycleClient()
+	useProxy := false
+
+	if _, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy); err != nil {
+		t.Fatalf("first GetEndpoint should succeed, got: %v", err)
+	}
+
+	// Idle longer than IdleConnTimeout: the pooled connection is evicted, so the
+	// second call dials fresh (first-request-on-connection => served OK) and
+	// never touches the black-holed connection.
+	time.Sleep(150 * time.Millisecond)
+
+	_, err := lc.GetEndpoint(context.Background(), "sbx", DefaultExecdPort, &useProxy)
+	require.NoError(t, err, "GetEndpoint should dial a fresh connection after IdleConnTimeout eviction")
+}
+
+// TestStaleConn_NonIdempotentNotRetried verifies the fresh-connection retry is
+// restricted to idempotent methods: a POST that hits a black-holed reused
+// connection is NOT retried (to avoid the risk of double execution) and fails.
+func TestStaleConn_NonIdempotentNotRetried(t *testing.T) {
+	addr, cleanup := blackHoleAfterReuseServer(t)
+	defer cleanup()
+
+	c := NewClient("http://"+addr, "k", "OPEN-SANDBOX-API-KEY",
+		WithTimeout(300*time.Millisecond))
+
+	// Call 1 (POST): fresh connection, served OK; connection pooled.
+	if err := c.doRequest(context.Background(), "POST", "/", map[string]string{"a": "b"}, nil); err != nil {
+		t.Fatalf("first POST should succeed, got: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Call 2 (POST): reuses black-holed connection. POST must NOT be retried.
+	err := c.doRequest(context.Background(), "POST", "/", map[string]string{"a": "b"}, nil)
+	require.Error(t, err, "POST must not be transparently retried on a fresh connection")
+	assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+}

--- a/sdks/sandbox/go/staleconn_fix_test.go
+++ b/sdks/sandbox/go/staleconn_fix_test.go
@@ -26,6 +26,11 @@ package opensandbox
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -150,4 +155,31 @@ func TestStaleConn_NonIdempotentNotRetried(t *testing.T) {
 	err := c.doRequest(context.Background(), "POST", "/", map[string]string{"a": "b"}, nil)
 	require.Error(t, err, "POST must not be transparently retried on a fresh connection")
 	assert.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+}
+
+// TestStaleConn_FreshConnTimeoutNotRetried verifies the fresh-connection retry
+// is gated on connection REUSE: a GET whose FIRST (brand-new) connection simply
+// times out against a slow server must NOT be retried, otherwise a slow server
+// would be hit twice and the effective timeout would roughly double. This is
+// the guard requested in PR review: only reused pooled connections are retried.
+func TestStaleConn_FreshConnTimeoutNotRetried(t *testing.T) {
+	var hits int32
+	// Every request blocks past the client timeout (never sends headers), so a
+	// first attempt on a fresh connection always times out.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "k", "OPEN-SANDBOX-API-KEY", WithTimeout(200*time.Millisecond))
+
+	// GET on a fresh connection: times out as a net.Error, but was NOT reused,
+	// so it must fail after exactly one attempt.
+	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	require.Error(t, err, "slow fresh-connection GET must fail (timeout)")
+	var netErr net.Error
+	require.True(t, errors.As(err, &netErr), "error should be a net timeout")
+	require.Equal(t, int32(1), atomic.LoadInt32(&hits),
+		"a fresh-connection timeout must NOT be retried (would double the timeout)")
 }

--- a/sdks/sandbox/go/streaming_timeout_test.go
+++ b/sdks/sandbox/go/streaming_timeout_test.go
@@ -75,7 +75,42 @@ func TestStreaming_UsesNonPooledClient(t *testing.T) {
 	tr, ok := sc.Transport.(*http.Transport)
 	require.True(t, ok, "streaming transport should be *http.Transport")
 	require.True(t, tr.DisableKeepAlives, "streaming client must disable keep-alive (no connection pooling)")
+	require.Equal(t, streamResponseHeaderTimeout, tr.ResponseHeaderTimeout,
+		"streaming client must bound the wait for response headers")
 
 	// The normal (non-streaming) client keeps its overall timeout and pooling.
 	require.Equal(t, 30*time.Second, client.client.httpClient.Timeout, "non-streaming client keeps its request timeout")
+}
+
+// TestStreaming_HeaderTimeoutBounded verifies that when the server accepts the
+// connection but never sends response headers, the stream fails within a bounded
+// time instead of hanging forever — even for a context.Background() caller that
+// provides no deadline of its own. It also confirms an explicitly-configured
+// ResponseHeaderTimeout is preserved (not overwritten by the default).
+func TestStreaming_HeaderTimeoutBounded(t *testing.T) {
+	// Server accepts the request but blocks without ever writing headers.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	// Inject a client whose transport has a short ResponseHeaderTimeout; the
+	// streaming client clones it and must keep this explicit value.
+	tr := DefaultTransport()
+	tr.ResponseHeaderTimeout = 200 * time.Millisecond
+	client := NewExecdClient(srv.URL, "tok", WithHTTPClient(&http.Client{Transport: tr}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.WatchMetrics(context.Background(), func(e StreamEvent) error { return nil })
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "stream must fail when the server never sends response headers")
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream hung waiting for response headers; ResponseHeaderTimeout not enforced")
+	}
 }

--- a/sdks/sandbox/go/streaming_timeout_test.go
+++ b/sdks/sandbox/go/streaming_timeout_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for streaming (SSE) connection handling:
+//  1. A long-running stream must NOT be killed by the client's overall request
+//     timeout (which would kill long commands mid-stream).
+//  2. SSE must use a fresh, non-pooled connection (keep-alive disabled), so a
+//     silently-dropped idle connection can never stall a stream.
+
+package opensandbox
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestStreaming_NotKilledByRequestTimeout: an SSE stream whose events span
+// longer than the client's overall RequestTimeout still completes, because
+// streaming uses the dedicated timeout-free client. Pre-fix (SSE shared the
+// httpClient whose Timeout == RequestTimeout) this failed with
+// "Client.Timeout ... while reading body".
+func TestStreaming_NotKilledByRequestTimeout(t *testing.T) {
+	// Stream 5 events, ~120ms apart => ~600ms total, well beyond the 200ms timeout.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		for i := 0; i < 5; i++ {
+			_, _ = w.Write([]byte(`{"type":"metrics","cpu_count":1,"timestamp":` + time.Now().Format("05") + "}\n\n"))
+			if fl != nil {
+				fl.Flush()
+			}
+			time.Sleep(120 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	// RequestTimeout is short (200ms). Non-streaming would be capped at 200ms,
+	// but streaming must not be.
+	client := NewExecdClient(srv.URL, "tok", WithTimeout(200*time.Millisecond))
+
+	start := time.Now()
+	var events []StreamEvent
+	err := client.WatchMetrics(context.Background(), func(e StreamEvent) error {
+		events = append(events, e)
+		return nil
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err, "long SSE stream must not be killed by the 200ms overall timeout")
+	require.True(t, elapsed > 200*time.Millisecond, "stream should have run longer than the overall timeout")
+	require.True(t, len(events) >= 3, "should have received the streamed events")
+}
+
+// TestStreaming_UsesNonPooledClient verifies the streaming client disables
+// keep-alive (no connection pooling) and has no overall timeout, so streams are
+// never carried over a stale pooled connection nor capped by RequestTimeout.
+func TestStreaming_UsesNonPooledClient(t *testing.T) {
+	client := NewExecdClient("https://example.com", "tok", WithTimeout(30*time.Second))
+	sc := client.client.streamHTTPClient()
+	require.Equal(t, time.Duration(0), sc.Timeout, "streaming client must have no overall timeout")
+	tr, ok := sc.Transport.(*http.Transport)
+	require.True(t, ok, "streaming transport should be *http.Transport")
+	require.True(t, tr.DisableKeepAlives, "streaming client must disable keep-alive (no connection pooling)")
+
+	// The normal (non-streaming) client keeps its overall timeout and pooling.
+	require.Equal(t, 30*time.Second, client.client.httpClient.Timeout, "non-streaming client keeps its request timeout")
+}

--- a/sdks/sandbox/go/streaming_timeout_test.go
+++ b/sdks/sandbox/go/streaming_timeout_test.go
@@ -23,6 +23,7 @@ package opensandbox
 import (
 	"context"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -113,4 +114,30 @@ func TestStreaming_HeaderTimeoutBounded(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("stream hung waiting for response headers; ResponseHeaderTimeout not enforced")
 	}
+}
+
+// TestStreaming_PreservesCustomClientState verifies the dedicated SSE client is
+// a shallow copy of the caller-provided http.Client, so a CookieJar (and other
+// client-level policy such as CheckRedirect) still applies to streams. Before
+// the fix the SSE client started from an empty http.Client and only copied the
+// transport, silently dropping such settings for /command and /metrics/watch.
+func TestStreaming_PreservesCustomClientState(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	redirect := func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+
+	custom := &http.Client{Jar: jar, CheckRedirect: redirect, Transport: DefaultTransport()}
+	client := NewExecdClient("https://example.com", "tok", WithHTTPClient(custom))
+
+	sc := client.client.streamHTTPClient()
+	require.Equal(t, jar, sc.Jar, "streaming client must preserve the caller's CookieJar")
+	require.True(t, sc.CheckRedirect != nil, "streaming client must preserve CheckRedirect")
+	require.Equal(t, time.Duration(0), sc.Timeout, "streaming client must clear the overall timeout")
+
+	// Transport is still the non-pooled, header-bounded clone (not the original).
+	tr, ok := sc.Transport.(*http.Transport)
+	require.True(t, ok, "streaming transport should be *http.Transport")
+	require.True(t, tr.DisableKeepAlives, "streaming transport must disable keep-alive")
+	require.Equal(t, streamResponseHeaderTimeout, tr.ResponseHeaderTimeout,
+		"streaming transport must bound the response-header wait")
 }

--- a/sdks/sandbox/go/transport.go
+++ b/sdks/sandbox/go/transport.go
@@ -51,11 +51,19 @@ type TransportConfig struct {
 
 // DefaultTransportConfig returns connection pool settings tuned for SDK
 // workloads: moderate concurrency across multiple sandbox endpoints.
+//
+// IdleConnTimeout is deliberately kept below the idle timeout of common load
+// balancers/proxies (often 60s). Many LBs drop an idle keep-alive connection
+// without sending a FIN; if the SDK later reuses such a connection the request
+// hangs until it times out. Evicting idle connections after 30s ensures the SDK
+// closes them before a typical LB does, so they are never reused while dead.
+// (doRequest additionally retries idempotent requests on a fresh connection as
+// a backstop for shorter or unknown LB timeouts.)
 func DefaultTransportConfig() TransportConfig {
 	return TransportConfig{
 		MaxIdleConns:                  100,
 		MaxIdleConnsPerHost:           10,
-		IdleConnTimeout:               90 * time.Second,
+		IdleConnTimeout:               30 * time.Second,
 		TLSHandshakeTimeout:           10 * time.Second,
 		DialTimeout:                   30 * time.Second,
 		KeepAlive:                     30 * time.Second,

--- a/tests/go/streaming_timeout_e2e_test.go
+++ b/tests/go/streaming_timeout_e2e_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreaming_NotKilledByRequestTimeout verifies that a command whose SSE
+// output stream lasts longer than the connection's RequestTimeout still runs to
+// completion. Streaming uses a dedicated client with no overall request timeout,
+// so RequestTimeout (which bounds normal request/response) must not kill a
+// long-running command mid-stream.
+//
+// Before the fix, the SSE read shared the request timeout and failed with
+// "sse read: context deadline exceeded (Client.Timeout ... while reading body)".
+func TestStreaming_NotKilledByRequestTimeout(t *testing.T) {
+	// Provision the sandbox with a generous streaming config (reliable startup).
+	ctx, sb := createTestSandbox(t)
+
+	// Reconnect with a SHORT RequestTimeout to prove streaming ignores it.
+	// Connection setup (GetEndpoint/ping) is fast and stays within this bound.
+	shortCfg := getConnectionConfig(t)
+	shortCfg.RequestTimeout = 5 * time.Second
+
+	sbShort, err := opensandbox.ConnectSandbox(ctx, shortCfg, sb.ID())
+	require.NoError(t, err, "reconnect with short RequestTimeout should succeed")
+
+	// Command runs ~8s > the 5s RequestTimeout.
+	start := time.Now()
+	exec, err := sbShort.RunCommand(ctx, "echo start-long; sleep 8; echo done-long", nil)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "streaming command longer than RequestTimeout must not be killed")
+	require.Greater(t, elapsed, 5*time.Second, "command should have run past the RequestTimeout")
+	require.NotNil(t, exec.ExitCode)
+	require.Equal(t, 0, *exec.ExitCode)
+	require.Contains(t, exec.Text(), "done-long")
+	t.Logf("long streaming command completed in %v (RequestTimeout was 5s)", elapsed.Round(time.Second))
+}


### PR DESCRIPTION
# Summary

Fix intermittent timeouts hitting Go SDK users doing direct sandbox exec. Two customer-facing symptoms:

1. `sse read: context deadline exceeded (Client.Timeout exceeded while
   reading body)` — any streamed command whose SSE output lasts longer than
   `RequestTimeout` (default 30s) was killed mid-stream.
2. `resolve execd: ... Get ".../endpoints/xxxxx?use_server_proxy=false":
   context deadline exceeded (Client.Timeout exceeded while awaiting headers)`
   — `GetEndpoint` occasionally stalled on a dead pooled keep-alive
   connection.

**Root cause:** the SDK applied `http.Client.Timeout` (= `RequestTimeout`) to
*all* requests, including long-lived SSE streams, and reused pooled keep-alive
connections that could go stale behind NAT/LB idle-timeouts.

**Changes (Go SDK only):**
- `http.go`: SSE now uses a dedicated, lazily-created client
  (`Timeout: 0`, cloned transport with `DisableKeepAlives=true`) so streaming
  is never bounded by a total-request deadline and never reuses a pooled
  connection. Non-streaming requests are unchanged.
- `http.go`: idempotent `GET`/`HEAD` requests retry once on a fresh
  connection (`CloseIdleConnections`) when they fail with a network
  timeout/reset/EOF, the context is not done, and the error is not an
  `APIError`.
- `transport.go`: `DefaultTransportConfig.IdleConnTimeout` 90s → 30s, matching
  the Python/JS/Kotlin SDKs and reducing the stale-connection window.

**Cross-SDK alignment:** `IdleConnTimeout=30s` and "no total timeout on SSE"
now match the Python (`read=None`), JS, and Kotlin SDKs. The
"non-pooled SSE" and "fresh-connection GET retry" hardening is Go-first;
tracked as a follow-up to port to the other SDKs.

# Testing

- [x] Unit tests — `go test -race -count=1 ./...` passes (incl. new
  `staleconn_diag_test.go`, `staleconn_fix_test.go`,
  `streaming_timeout_test.go`); `gofmt`/`go vet` clean.
- [x] e2e / manual verification — `tests/go/streaming_timeout_e2e_test.go`
  passes (11s stream completes under a 5s `RequestTimeout`). Full local Go
  e2e suite: relevant lifecycle/command/filesystem/pool/pause-resume/network
  tests pass.

# Breaking Changes

- [x] None — no public API changes; non-streaming request behavior unchanged.

# Checklist

- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed) — N/A (internal transport behavior)
- [x] Added/updated tests (if needed)
- [x] Security impact considered — no auth/secret handling changed
- [x] Backward compatibility considered