### PR TITLE
feat(sdks/kotlin): shade kotlinx-serialization to isolate downstream classpath

### DIFF
--- a/sdks/sandbox/kotlin/build.gradle.kts
+++ b/sdks/sandbox/kotlin/build.gradle.kts
@@ -48,6 +48,7 @@ plugins {
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.shadow) apply false
 }
 
 val manualProjectVersion = project.findProperty("project.version") as String

--- a/sdks/sandbox/kotlin/code-interpreter/build.gradle.kts
+++ b/sdks/sandbox/kotlin/code-interpreter/build.gradle.kts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.shadow)
+}
+
+// See sandbox/build.gradle.kts for rationale. code-interpreter transitively depends on the
+// shaded `jsonParser` from :sandbox at runtime, but at compile time still needs the original
+// kotlinx-serialization types on the classpath. Keep it in compileOnly + shaded configuration
+// so the published jar bundles the relocated copy and the pom omits the runtime dependency.
+val shadedDependencies: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     api(project(":sandbox"))
     implementation(project(":sandbox-api"))
@@ -23,9 +36,11 @@ dependencies {
 
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
-    implementation(libs.bundles.serialization)
+    compileOnly(libs.bundles.serialization)
+    shadedDependencies(libs.bundles.serialization)
 
     testImplementation(libs.bundles.testing)
+    testImplementation(libs.bundles.serialization)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 
@@ -64,4 +79,44 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
             moduleName.set("CodeInterpreter")
         }
     }
+}
+
+// See sandbox-api/build.gradle.kts for the rationale.
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    configurations = listOf(shadedDependencies)
+    relocate("kotlinx.serialization", "com.alibaba.opensandbox.shaded.kotlinx.serialization")
+    mergeServiceFiles()
+    exclude("META-INF/versions/9/module-info.class")
+    exclude("META-INF/maven/**")
+}
+
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("plain")
+}
+
+tasks.named("assemble") { dependsOn(tasks.named("shadowJar")) }
+
+afterEvaluate {
+    extensions.configure<PublishingExtension> {
+        publications.withType<MavenPublication>().configureEach {
+            val shadowTask = tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar")
+            setArtifacts(
+                artifacts.filter {
+                    val c = it.classifier
+                    !c.isNullOrEmpty() && c != "plain"
+                },
+            )
+            artifact(shadowTask.map { it.archiveFile }) {
+                classifier = ""
+                extension = "jar"
+                builtBy(shadowTask)
+            }
+        }
+    }
+}
+
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
 }

--- a/sdks/sandbox/kotlin/gradle/libs.versions.toml
+++ b/sdks/sandbox/kotlin/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ spotless = "6.23.3"
 maven-publish = "0.35.0"
 dokka = "1.9.10"
 openapi-generator = "7.17.0"
+shadow = "9.5.1"
 jackson = "2.18.2"
 junit-platform = "1.13.4"
 
@@ -65,6 +66,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 
 [bundles]
 serialization = ["kotlinx-serialization-json"]

--- a/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
+++ b/sdks/sandbox/kotlin/sandbox-api/build.gradle.kts
@@ -18,15 +18,82 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
     alias(libs.plugins.openapi.generator)
+    alias(libs.plugins.shadow)
 }
 
 repositories {
     mavenCentral()
 }
 
+// See sandbox/build.gradle.kts for rationale: kotlinx-serialization is used only for wire
+// encoding, and the generated `$$serializer` classes reference kotlinx internals. Shade the
+// runtime into com.alibaba.opensandbox.shaded.kotlinx.serialization so downstream consumers
+// stay isolated from whatever kotlinx-serialization their classpath resolves to.
+val shadedDependencies: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     implementation(libs.okhttp)
-    implementation(libs.bundles.serialization)
+    compileOnly(libs.bundles.serialization)
+    shadedDependencies(libs.bundles.serialization)
+}
+
+// shadowJar produces the module's primary artifact: this module's own classes plus a
+// relocated copy of kotlinx-serialization. Both Maven and Gradle consumers pull the same
+// shaded jar via the standard `com.alibaba.opensandbox:sandbox-api:<version>` coordinate.
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    // Empty classifier so this jar takes over the default `<module>-<version>.jar` name.
+    archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    configurations = listOf(shadedDependencies)
+    relocate("kotlinx.serialization", "com.alibaba.opensandbox.shaded.kotlinx.serialization")
+    mergeServiceFiles()
+    exclude("META-INF/versions/9/module-info.class")
+    exclude("META-INF/maven/**")
+}
+
+// The plain `jar` task still runs (it's referenced by intra-project compilation and by
+// the `apiElements`/`runtimeElements` variant metadata), but we redirect its output path
+// via a classifier so it never collides with shadowJar's output on disk. The classifier
+// output is *not* attached to the maven publication (see afterEvaluate below).
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("plain")
+}
+
+tasks.named("assemble") { dependsOn(tasks.named("shadowJar")) }
+
+// Swap in shadowJar as the maven publication's main artifact so downstream Maven consumers
+// receive the shaded jar. The plain `jar` output (classifier=plain) is used for intra-project
+// compile/test only and is stripped from the publication here.
+afterEvaluate {
+    extensions.configure<PublishingExtension> {
+        publications.withType<MavenPublication>().configureEach {
+            val shadowTask = tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar")
+            // Drop both the auto-added main jar (classifier=null-turned-plain) and the plain
+            // classifier artifact; keep sources / javadoc classifiers.
+            setArtifacts(
+                artifacts.filter {
+                    val c = it.classifier
+                    !c.isNullOrEmpty() && c != "plain"
+                },
+            )
+            artifact(shadowTask.map { it.archiveFile }) {
+                classifier = ""
+                extension = "jar"
+                builtBy(shadowTask)
+            }
+        }
+    }
+}
+
+// Gradle-native (`.module`) consumers would resolve the plain jar via variant metadata,
+// bypassing the swap above. Disable GMM so Gradle consumers fall back to the maven pom
+// (which points at shadowJar). This is fine because our audience is Maven-based; the SDK
+// is not published to consumers who need Gradle-specific variant selection.
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
 }
 
 fun GenerateTask.configureCommonOptions() {

--- a/sdks/sandbox/kotlin/sandbox-bom/build.gradle.kts
+++ b/sdks/sandbox/kotlin/sandbox-bom/build.gradle.kts
@@ -28,7 +28,10 @@ dependencies {
         api(libs.kotlin.stdlib)
         api(libs.okhttp)
         api(libs.okhttp.logging)
-        api(libs.kotlinx.serialization.json)
         api(libs.slf4j.api)
+        // kotlinx-serialization is not constrained here on purpose: it is shaded into the SDK
+        // jars (com.alibaba.opensandbox.shaded.kotlinx.serialization.*) and no longer appears
+        // in the SDK's runtime classpath. Downstream users who want to use kotlinx-serialization
+        // directly should pick a version themselves; the SDK does not care.
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/build.gradle.kts
+++ b/sdks/sandbox/kotlin/sandbox/build.gradle.kts
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.shadow)
+}
+
+// Isolated configuration that carries only the kotlinx-serialization artifacts we want to
+// relocate and bundle into the published jar. Kept separate from `implementation` so the
+// generated pom does not declare kotlinx-serialization as a runtime dependency; downstream
+// consumers whose classpath resolves an older kotlinx-serialization no longer clash with the
+// shaded copy we ship inside the jar.
+val shadedDependencies: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     implementation(project(":sandbox-api"))
     api(libs.kotlin.stdlib)
@@ -21,10 +35,58 @@ dependencies {
 
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
-    implementation(libs.bundles.serialization)
+
+    // kotlinx-serialization is used only for internal wire encoding/decoding; hide it from
+    // downstream classpath by shading + relocating into com.alibaba.opensandbox.shaded.
+    compileOnly(libs.bundles.serialization)
+    shadedDependencies(libs.bundles.serialization)
 
     testImplementation(libs.bundles.testing)
+    testImplementation(libs.bundles.serialization)
     testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+// Relocate kotlinx.serialization -> com.alibaba.opensandbox.shaded.kotlinx.serialization.
+// The generated `$$serializer` classes reference internal kotlinx types; Shadow rewrites those
+// references in the module's own bytecode as it repackages the shaded classes into the jar.
+// See sandbox-api/build.gradle.kts for the rationale.
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    configurations = listOf(shadedDependencies)
+    relocate("kotlinx.serialization", "com.alibaba.opensandbox.shaded.kotlinx.serialization")
+    mergeServiceFiles()
+    exclude("META-INF/versions/9/module-info.class")
+    exclude("META-INF/maven/**")
+}
+
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("plain")
+}
+
+tasks.named("assemble") { dependsOn(tasks.named("shadowJar")) }
+
+afterEvaluate {
+    extensions.configure<PublishingExtension> {
+        publications.withType<MavenPublication>().configureEach {
+            val shadowTask = tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar")
+            setArtifacts(
+                artifacts.filter {
+                    val c = it.classifier
+                    !c.isNullOrEmpty() && c != "plain"
+                },
+            )
+            artifact(shadowTask.map { it.archiveFile }) {
+                classifier = ""
+                extension = "jar"
+                builtBy(shadowTask)
+            }
+        }
+    }
+}
+
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
 }
 
 // Configure test tasks to use JDK 17


### PR DESCRIPTION
## Summary

Downstream consumers of the Kotlin SDK have been hitting `AbstractMethodError` inside kotlinx.serialization when their runtime classpath resolves `kotlinx-serialization-core` to a version older than 1.4. The SDK is compiled against kotlinx-serialization 1.9.0 and its generated `$$serializer` classes rely on the default implementation of `GeneratedSerializer.typeParametersSerializers()` introduced in 1.4. Against a pre-1.4 runtime that method is still abstract, so any call site (e.g. name-based JSON decoding) explodes with:

```
AbstractMethodError: Receiver class …$$serializer does not define or inherit an implementation
of the resolved method typeParametersSerializers() of interface
kotlinx.serialization.internal.GeneratedSerializer
```

Downstream applications often cannot pin kotlinx-serialization to 1.4+ themselves because their classpath is dictated by higher-priority BOMs (Spring Boot dependency management, internal component BOMs, etc.). Fix by **shading the kotlinx-serialization runtime into the SDK jars and relocating it** to `com.alibaba.opensandbox.shaded.kotlinx.serialization` so downstream classpath versions no longer matter.

## Changes

- Add the Gradle Shadow plugin (`com.gradleup.shadow` 9.5.1) to each module that references kotlinx-serialization (`sandbox`, `sandbox-api`, `code-interpreter`), wired via an isolated `shadedDependencies` configuration so the plugin's Maven publication does not declare kotlinx-serialization as a runtime dependency.
- Move kotlinx-serialization to `compileOnly` in those modules so the SDK still compiles against the vanilla API but the dependency is not leaked into the published pom. Test classpaths keep it via `testImplementation`.
- Relocate `kotlinx.serialization` → `com.alibaba.opensandbox.shaded.kotlinx.serialization` in the shadowJar output. Verified: `CreateSandboxResponse$$serializer.class` in the published `sandbox-api` jar `implements com.alibaba.opensandbox.shaded.kotlinx.serialization.internal.GeneratedSerializer`.
- Publish `shadowJar` as the primary Maven artifact (classifier=null). The plain `jar` output keeps a `plain` classifier and is used only by intra-project compile classpaths so `:sandbox` / `:code-interpreter` still see un-relocated kotlinx types at compile time (which matches the kotlinx types on their own `compileOnly` classpath).
- Disable Gradle module metadata (`.module`) for the shaded modules. Maven pom is the source of truth; pointing `runtimeElements` at the shaded jar while `apiElements` stays on the plain jar would otherwise leave GMM inconsistent with the pom. Our published audience is Maven-based.
- Drop the `kotlinx-serialization-json` constraint from `sandbox-bom`, since the SDK no longer exposes kotlinx-serialization to consumers. The bom still manages the sandbox artifacts + `kotlin-stdlib` + `okhttp` + `slf4j-api`.

No source code or public API changes; the shade is entirely a build/packaging concern.

## Verification

- `./gradlew clean :sandbox:test :code-interpreter:test` — all green.
- `./gradlew publishToMavenLocal` — published `sandbox`, `sandbox-api`, `code-interpreter`, `sandbox-pool-redis`, `sandbox-bom` locally.
- Published `sandbox-<v>.pom` no longer declares any `kotlinx-serialization*` dependency.
- `CreateSandboxResponse$$serializer.class` in the published `sandbox-api` jar was inspected via `javap -v`: all references to `kotlinx.serialization.**` are rewritten to the shaded package.
- Downstream `agent-sandbox` project upgraded to this SDK version locally: full build + test suite green, `mvn dependency:tree` shows only `com.alibaba.opensandbox:sandbox` / `sandbox-api` with no `kotlinx-serialization*` transitive dependency.

## Not included

- Version bump. Kept at `1.0.16` intentionally; release manager to bump when cutting the next release.
- Consumers of the SDK need to upgrade to a version containing this change to benefit; no source-side workaround is possible for the older releases.
