### PR TITLE
fix(execd): bound idle-post wait and fail streams on WS teardown (#1206)

### DIFF
--- a/components/execd/pkg/flag/flags.go
+++ b/components/execd/pkg/flag/flags.go
@@ -39,6 +39,12 @@ var (
 	// late execute_result/error messages after receiving idle status.
 	JupyterIdlePollInterval time.Duration
 
+	// JupyterIdleGracePeriod bounds the wait for a late execute_reply/error
+	// after kernel idle. On timeout ExecuteCodeStream synthesizes an error
+	// and closes the stream, preventing codes.run() from hanging when the
+	// shell-channel reply is lost. See issue #1206.
+	JupyterIdleGracePeriod time.Duration
+
 	// IsolationConfigPath points to the TOML isolation config file.
 	// Empty means use built-in defaults.
 	IsolationConfigPath string

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -30,6 +30,7 @@ const (
 	accessTokenEnv             = "EXECD_ACCESS_TOKEN"
 	gracefulShutdownTimeoutEnv = "EXECD_API_GRACE_SHUTDOWN"
 	jupyterIdlePollIntervalEnv = "EXECD_JUPYTER_IDLE_POLL_INTERVAL"
+	jupyterIdleGracePeriodEnv  = "EXECD_JUPYTER_IDLE_GRACE_PERIOD"
 	isolationConfigEnv         = "EXECD_ISOLATION_CONFIG"
 )
 
@@ -41,6 +42,7 @@ func InitFlags() {
 	ServerAccessToken = ""
 	ApiGracefulShutdownTimeout = time.Second * 1
 	JupyterIdlePollInterval = 100 * time.Millisecond
+	JupyterIdleGracePeriod = 5 * time.Second
 	IsolationConfigPath = ""
 
 	// First, set default values from environment variables
@@ -86,8 +88,21 @@ func InitFlags() {
 		}
 	}
 
+	if idleGracePeriod := os.Getenv(jupyterIdleGracePeriodEnv); idleGracePeriod != "" {
+		duration, err := time.ParseDuration(idleGracePeriod)
+		if err != nil {
+			stdlog.Panicf("Failed to parse jupyter idle grace period from env: %v", err)
+		}
+		if duration <= 0 {
+			stdlog.Printf("Invalid %s=%s; fallback to default %s", jupyterIdleGracePeriodEnv, idleGracePeriod, JupyterIdleGracePeriod)
+		} else {
+			JupyterIdleGracePeriod = duration
+		}
+	}
+
 	flag.DurationVar(&ApiGracefulShutdownTimeout, "graceful-shutdown-timeout", ApiGracefulShutdownTimeout, "API graceful shutdown timeout duration (default: 1s)")
 	flag.DurationVar(&JupyterIdlePollInterval, "jupyter-idle-poll-interval", JupyterIdlePollInterval, "Polling interval after Jupyter idle status before closing stream (default: 100ms)")
+	flag.DurationVar(&JupyterIdleGracePeriod, "jupyter-idle-grace-period", JupyterIdleGracePeriod, "Maximum time to wait after Jupyter idle status for a late execute_reply/error before giving up and closing the stream with a synthetic error (default: 5s)")
 
 	// Isolation config
 	if v := os.Getenv(isolationConfigEnv); v != "" {
@@ -100,6 +115,10 @@ func InitFlags() {
 	if JupyterIdlePollInterval <= 0 {
 		stdlog.Printf("Invalid --jupyter-idle-poll-interval=%s; fallback to default %s", JupyterIdlePollInterval, 100*time.Millisecond)
 		JupyterIdlePollInterval = 100 * time.Millisecond
+	}
+	if JupyterIdleGracePeriod <= 0 {
+		stdlog.Printf("Invalid --jupyter-idle-grace-period=%s; fallback to default %s", JupyterIdleGracePeriod, 5*time.Second)
+		JupyterIdleGracePeriod = 5 * time.Second
 	}
 
 	// Log final values

--- a/components/execd/pkg/jupyter/execute/execute.go
+++ b/components/execd/pkg/jupyter/execute/execute.go
@@ -373,14 +373,6 @@ func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState
 func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan *ExecutionResult) {
 	defer c.clearActiveStream(state)
 
-	state.resultMutex.Lock()
-	state.result.ExecutionTime = time.Since(state.startTime)
-	notify := &ExecutionResult{
-		ExecutionTime: state.result.ExecutionTime,
-	}
-	state.resultMutex.Unlock()
-	state.trySend(notify)
-
 	pollInterval := execdflag.JupyterIdlePollInterval
 	if pollInterval <= 0 {
 		pollInterval = 100 * time.Millisecond
@@ -414,6 +406,19 @@ func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan 
 		time.Sleep(pollInterval)
 	}
 
+	// Record ExecutionTime and, on the success path (no error observed and no
+	// synthetic error), emit a terminal ExecutionTime-only notify so runtime
+	// dispatches OnExecuteComplete. On error paths, terminate() pushes the
+	// error notify — do NOT precede it with a success signal (issue #1206).
+	state.resultMutex.Lock()
+	state.result.ExecutionTime = time.Since(state.startTime)
+	isSuccess := state.result.Error == nil && syntheticErr == nil
+	execTime := state.result.ExecutionTime
+	state.resultMutex.Unlock()
+
+	if isSuccess {
+		state.trySend(&ExecutionResult{ExecutionTime: execTime})
+	}
 	state.terminate(syntheticErr)
 }
 

--- a/components/execd/pkg/jupyter/execute/execute.go
+++ b/components/execd/pkg/jupyter/execute/execute.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alibaba/opensandbox/internal/safego"
@@ -57,6 +58,10 @@ type Client struct {
 
 	// WebSocket URL for kernel connection
 	wsURL string
+
+	// activeStream is the in-flight streaming execution, if any. Used by
+	// receiveMessages/Disconnect to fail it when the WebSocket goes away.
+	activeStream *streamExecutionState
 }
 
 // NewClient creates a new code execution client
@@ -99,11 +104,26 @@ func (c *Client) Connect(wsURL string) error {
 // Disconnect disconnects the WebSocket connection to the kernel
 func (c *Client) Disconnect() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.conn != nil {
 		c.conn.Close()
 		c.conn = nil
+	}
+	active := c.activeStream
+	c.mu.Unlock()
+
+	// Fail any in-flight execution not yet in finalization; otherwise
+	// finalizeExecution's grace period will wind it down on its own.
+	if active != nil {
+		active.executeMutex.Lock()
+		alreadyFinalizing := active.executeDone
+		active.executeMutex.Unlock()
+		if !alreadyFinalizing {
+			c.clearActiveStream(active)
+			active.terminate(&ErrorOutput{
+				EName:  "KernelDisconnected",
+				EValue: "kernel WebSocket was disconnected before execution completed",
+			})
+		}
 	}
 }
 
@@ -120,9 +140,16 @@ type streamExecutionState struct {
 	executeDone  bool
 	executeMutex sync.Mutex
 	resultMutex  sync.Mutex
+
+	// resultChan is the terminal result channel; closed exactly once.
+	resultChan chan *ExecutionResult
+	// closed lets concurrent senders skip after terminate() has closed the chan.
+	closed atomic.Bool
+	// closeOnce guards the single close + terminal-error injection.
+	closeOnce sync.Once
 }
 
-func newStreamExecutionState(startTime time.Time) *streamExecutionState {
+func newStreamExecutionState(startTime time.Time, resultChan chan *ExecutionResult) *streamExecutionState {
 	return &streamExecutionState{
 		startTime: startTime,
 		result: &ExecutionResult{
@@ -130,7 +157,40 @@ func newStreamExecutionState(startTime time.Time) *streamExecutionState {
 			Stream:        make([]*StreamOutput, 0),
 			ExecutionTime: 0,
 		},
+		resultChan: resultChan,
 	}
+}
+
+// trySend delivers a result to resultChan, safe against a concurrent terminate().
+func (s *streamExecutionState) trySend(r *ExecutionResult) {
+	if s.closed.Load() {
+		return
+	}
+	// terminate() may close the chan between the check above and the send below.
+	defer func() { _ = recover() }()
+	s.resultChan <- r
+}
+
+// terminate optionally injects a synthetic error and closes resultChan. Idempotent.
+func (s *streamExecutionState) terminate(errOutput *ErrorOutput) {
+	s.closeOnce.Do(func() {
+		if errOutput != nil {
+			s.resultMutex.Lock()
+			if s.result.Error == nil {
+				s.result.Error = errOutput
+				s.result.Status = "error"
+			}
+			s.resultMutex.Unlock()
+
+			// Best-effort; if reader is gone, skip rather than block.
+			select {
+			case s.resultChan <- &ExecutionResult{Status: "error", Error: errOutput}:
+			default:
+			}
+		}
+		s.closed.Store(true)
+		close(s.resultChan)
+	})
 }
 
 // ExecuteCodeStream executes code in streaming mode, sending results to the provided channel
@@ -144,17 +204,37 @@ func (c *Client) ExecuteCodeStream(code string, resultChan chan *ExecutionResult
 		return err
 	}
 
-	state := newStreamExecutionState(time.Now())
+	state := newStreamExecutionState(time.Now(), resultChan)
 
 	// Clear temporary handlers
 	c.clearTemporaryHandlers()
 	c.registerExecuteCodeStreamHandlers(state, resultChan)
 
+	// Publish before the write so receive/Disconnect can fail it if the WS dies.
+	c.mu.Lock()
+	c.activeStream = state
+	c.mu.Unlock()
+
 	if err := c.writeMessage(msg); err != nil {
+		c.clearActiveStream(state)
 		return fmt.Errorf("failed to send execution request: %w", err)
 	}
 
 	return nil
+}
+
+func (c *Client) clearActiveStream(state *streamExecutionState) {
+	c.mu.Lock()
+	if c.activeStream == state {
+		c.activeStream = nil
+	}
+	c.mu.Unlock()
+}
+
+func (c *Client) currentActiveStream() *streamExecutionState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.activeStream
 }
 
 func (c *Client) buildExecuteMessage(code string) (*Message, error) {
@@ -237,7 +317,7 @@ func (c *Client) handleExecuteResult(msg *Message, state *streamExecutionState, 
 		ExecutionCount: execResult.ExecutionCount,
 		ExecutionData:  execResult.Data,
 	}
-	resultChan <- notify
+	state.trySend(notify)
 }
 
 func (c *Client) handleStreamOutput(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -252,7 +332,7 @@ func (c *Client) handleStreamOutput(msg *Message, state *streamExecutionState, r
 	notify := &ExecutionResult{
 		Stream: []*StreamOutput{&stream},
 	}
-	resultChan <- notify
+	state.trySend(notify)
 }
 
 func (c *Client) handleExecutionError(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -269,7 +349,7 @@ func (c *Client) handleExecutionError(msg *Message, state *streamExecutionState,
 		Error:  &errOutput,
 		Status: "error",
 	}
-	resultChan <- notify
+	state.trySend(notify)
 }
 
 func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -291,19 +371,29 @@ func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState
 }
 
 func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan *ExecutionResult) {
+	defer c.clearActiveStream(state)
+
 	state.resultMutex.Lock()
 	state.result.ExecutionTime = time.Since(state.startTime)
 	notify := &ExecutionResult{
 		ExecutionTime: state.result.ExecutionTime,
 	}
-	resultChan <- notify
 	state.resultMutex.Unlock()
+	state.trySend(notify)
 
 	pollInterval := execdflag.JupyterIdlePollInterval
 	if pollInterval <= 0 {
 		pollInterval = 100 * time.Millisecond
 	}
+	gracePeriod := execdflag.JupyterIdleGracePeriod
+	if gracePeriod <= 0 {
+		gracePeriod = 5 * time.Second
+	}
 
+	// Wait for a late execute_reply/error, but bail out after gracePeriod
+	// with a synthetic error rather than hanging forever. See issue #1206.
+	deadline := time.Now().Add(gracePeriod)
+	var syntheticErr *ErrorOutput
 	for {
 		state.resultMutex.Lock()
 		done := state.result.ExecutionCount > 0 || state.result.Error != nil
@@ -311,10 +401,20 @@ func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan 
 		if done {
 			break
 		}
+		if time.Now().After(deadline) {
+			syntheticErr = &ErrorOutput{
+				EName: "KernelReplyTimeout",
+				EValue: fmt.Sprintf(
+					"kernel reported idle but no execute_reply arrived within %s; the shell-channel reply was likely lost",
+					gracePeriod,
+				),
+			}
+			break
+		}
 		time.Sleep(pollInterval)
 	}
 
-	close(resultChan)
+	state.terminate(syntheticErr)
 }
 
 func (c *Client) writeMessage(msg *Message) error {
@@ -460,6 +560,7 @@ func (c *Client) clearTemporaryHandlers() {
 
 // Receive WebSocket messages
 func (c *Client) receiveMessages() {
+	var readErr error
 	for {
 		c.mu.Lock()
 		conn := c.conn
@@ -471,14 +572,33 @@ func (c *Client) receiveMessages() {
 
 		// Receive message
 		var msg Message
-		err := conn.ReadJSON(&msg)
-		if err != nil {
+		if err := conn.ReadJSON(&msg); err != nil {
 			// connection may already be closed
+			readErr = err
 			break
 		}
 
 		// Process message
 		c.handleMessage(&msg)
+	}
+
+	// If the read loop exited before idle was observed, fail the in-flight
+	// execution; otherwise finalizeExecution's grace period owns the close.
+	if state := c.currentActiveStream(); state != nil {
+		state.executeMutex.Lock()
+		alreadyFinalizing := state.executeDone
+		state.executeMutex.Unlock()
+		if !alreadyFinalizing {
+			errOutput := &ErrorOutput{
+				EName:  "KernelStreamAborted",
+				EValue: "kernel message stream was closed before execution completed",
+			}
+			if readErr != nil {
+				errOutput.EValue = fmt.Sprintf("kernel message stream was closed before execution completed: %v", readErr)
+			}
+			state.terminate(errOutput)
+			c.clearActiveStream(state)
+		}
 	}
 }
 

--- a/components/execd/pkg/jupyter/execute/execute_test.go
+++ b/components/execd/pkg/jupyter/execute/execute_test.go
@@ -298,3 +298,153 @@ func TestExecuteCodeStreamFallsBackWhenPollIntervalIsNonPositive(t *testing.T) {
 	require.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "expected non-positive poll interval to fall back to runtime default (100ms)")
 	require.Less(t, elapsed, 300*time.Millisecond, "expected fallback poll interval to still close stream promptly")
 }
+
+// Reproduces issue #1206: kernel goes idle but no execute_reply/error ever
+// arrives. finalizeExecution must bail out within JupyterIdleGracePeriod
+// with a synthetic error instead of polling forever.
+func TestExecuteCodeStreamGivesUpWhenExecuteReplyNeverArrives(t *testing.T) {
+	previousPollInterval := execdflag.JupyterIdlePollInterval
+	previousGracePeriod := execdflag.JupyterIdleGracePeriod
+	execdflag.JupyterIdlePollInterval = 5 * time.Millisecond
+	execdflag.JupyterIdleGracePeriod = 60 * time.Millisecond
+	t.Cleanup(func() {
+		execdflag.JupyterIdlePollInterval = previousPollInterval
+		execdflag.JupyterIdleGracePeriod = previousGracePeriod
+	})
+
+	// Mock kernel only publishes idle; no execute_reply/execute_result/error.
+	server := createTestServer(t, func(conn *websocket.Conn) {
+		var executeRequest Message
+		require.NoError(t, conn.ReadJSON(&executeRequest))
+
+		statusContent, _ := json.Marshal(StatusUpdate{ExecutionState: StateIdle})
+		require.NoError(t, conn.WriteJSON(Message{
+			Header: Header{
+				MessageID:   "status-msg-id",
+				Session:     executeRequest.Header.Session,
+				MessageType: string(MsgStatus),
+			},
+			ParentHeader: executeRequest.Header,
+			Content:      json.RawMessage(statusContent),
+		}))
+
+		// Hold the WS open so the grace-period path runs, not the disconnect path.
+		time.Sleep(500 * time.Millisecond)
+	})
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/kernels/test-kernel-id/channels"
+	executor := NewExecutor(wsURL, nil)
+	require.NoError(t, executor.Connect())
+	defer executor.Disconnect()
+
+	resultChan := make(chan *ExecutionResult, 10)
+	require.NoError(t, executor.ExecuteCodeStream("print('missing reply')", resultChan))
+
+	start := time.Now()
+	var terminalErr *ErrorOutput
+	for result := range resultChan {
+		if result != nil && result.Error != nil {
+			terminalErr = result.Error
+		}
+	}
+	elapsed := time.Since(start)
+
+	require.NotNil(t, terminalErr, "expected a synthetic error when execute_reply never arrives")
+	require.Equal(t, "KernelReplyTimeout", terminalErr.EName,
+		"expected KernelReplyTimeout to be surfaced when idle grace period expires")
+	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond,
+		"expected finalizeExecution to wait roughly one grace period before giving up")
+	require.Less(t, elapsed, 400*time.Millisecond,
+		"expected finalizeExecution to close the stream shortly after the grace period")
+}
+
+// WebSocket dies before idle: receiveMessages must fail the stream instead
+// of silently break-ing and leaving the caller blocked on resultChan.
+func TestExecuteCodeStreamFailsWhenWebSocketDiesBeforeIdle(t *testing.T) {
+	server := createTestServer(t, func(conn *websocket.Conn) {
+		var executeRequest Message
+		require.NoError(t, conn.ReadJSON(&executeRequest))
+		// Drop the connection with no idle/reply.
+		_ = conn.Close()
+	})
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/kernels/test-kernel-id/channels"
+	executor := NewExecutor(wsURL, nil)
+	require.NoError(t, executor.Connect())
+	defer executor.Disconnect()
+
+	resultChan := make(chan *ExecutionResult, 10)
+	require.NoError(t, executor.ExecuteCodeStream("print('lost socket')", resultChan))
+
+	done := make(chan *ErrorOutput, 1)
+	go func() {
+		var terminalErr *ErrorOutput
+		for result := range resultChan {
+			if result != nil && result.Error != nil {
+				terminalErr = result.Error
+			}
+		}
+		done <- terminalErr
+	}()
+
+	select {
+	case terminalErr := <-done:
+		require.NotNil(t, terminalErr, "expected a synthetic error when WebSocket dies mid-execution")
+		require.Equal(t, "KernelStreamAborted", terminalErr.EName,
+			"expected KernelStreamAborted when the read loop exits before idle")
+	case <-time.After(2 * time.Second):
+		t.Fatal("resultChan was never closed after WebSocket death — codes.run() would hang")
+	}
+}
+
+// Explicit Disconnect() mid-execution must release the caller with a typed
+// error instead of leaking resultChan.
+func TestExecuteCodeStreamFailsWhenDisconnectedMidExecution(t *testing.T) {
+	serverReady := make(chan struct{})
+	server := createTestServer(t, func(conn *websocket.Conn) {
+		var executeRequest Message
+		require.NoError(t, conn.ReadJSON(&executeRequest))
+		close(serverReady)
+		// Block until the client Disconnects.
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				return
+			}
+		}
+	})
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/kernels/test-kernel-id/channels"
+	executor := NewExecutor(wsURL, nil)
+	require.NoError(t, executor.Connect())
+
+	resultChan := make(chan *ExecutionResult, 10)
+	require.NoError(t, executor.ExecuteCodeStream("print('will be interrupted')", resultChan))
+
+	<-serverReady
+
+	done := make(chan *ErrorOutput, 1)
+	go func() {
+		var terminalErr *ErrorOutput
+		for result := range resultChan {
+			if result != nil && result.Error != nil {
+				terminalErr = result.Error
+			}
+		}
+		done <- terminalErr
+	}()
+
+	executor.Disconnect()
+
+	select {
+	case terminalErr := <-done:
+		require.NotNil(t, terminalErr, "expected a synthetic error when Disconnect races an in-flight execution")
+		// Disconnect and receiveMessages exit races; either terminal is valid.
+		require.Contains(t, []string{"KernelDisconnected", "KernelStreamAborted"}, terminalErr.EName,
+			"expected a documented disconnect-related terminal error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("resultChan was never closed after Disconnect — codes.run() would hang")
+	}
+}

--- a/components/execd/pkg/jupyter/execute/execute_test.go
+++ b/components/execd/pkg/jupyter/execute/execute_test.go
@@ -359,6 +359,69 @@ func TestExecuteCodeStreamGivesUpWhenExecuteReplyNeverArrives(t *testing.T) {
 		"expected finalizeExecution to close the stream shortly after the grace period")
 }
 
+// Regression for PR #1321 review: on the idle-grace timeout path, no
+// ExecutionTime-only "completion" notify may be emitted before the error.
+// dispatchExecutionResultHooks would otherwise fire OnExecuteComplete first
+// and misreport a hung execution as successful.
+func TestExecuteCodeStreamDoesNotSignalCompletionBeforeSyntheticError(t *testing.T) {
+	previousPollInterval := execdflag.JupyterIdlePollInterval
+	previousGracePeriod := execdflag.JupyterIdleGracePeriod
+	execdflag.JupyterIdlePollInterval = 5 * time.Millisecond
+	execdflag.JupyterIdleGracePeriod = 40 * time.Millisecond
+	t.Cleanup(func() {
+		execdflag.JupyterIdlePollInterval = previousPollInterval
+		execdflag.JupyterIdleGracePeriod = previousGracePeriod
+	})
+
+	server := createTestServer(t, func(conn *websocket.Conn) {
+		var executeRequest Message
+		require.NoError(t, conn.ReadJSON(&executeRequest))
+
+		statusContent, _ := json.Marshal(StatusUpdate{ExecutionState: StateIdle})
+		require.NoError(t, conn.WriteJSON(Message{
+			Header: Header{
+				MessageID:   "status-msg-id",
+				Session:     executeRequest.Header.Session,
+				MessageType: string(MsgStatus),
+			},
+			ParentHeader: executeRequest.Header,
+			Content:      json.RawMessage(statusContent),
+		}))
+
+		time.Sleep(300 * time.Millisecond)
+	})
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/kernels/test-kernel-id/channels"
+	executor := NewExecutor(wsURL, nil)
+	require.NoError(t, executor.Connect())
+	defer executor.Disconnect()
+
+	resultChan := make(chan *ExecutionResult, 10)
+	require.NoError(t, executor.ExecuteCodeStream("print('missing reply')", resultChan))
+
+	var results []*ExecutionResult
+	for r := range resultChan {
+		if r != nil {
+			results = append(results, r)
+		}
+	}
+
+	require.NotEmpty(t, results, "expected at least one terminal result")
+	for i, r := range results {
+		// A pre-error "success completion" notify has ExecutionTime > 0 and
+		// no Error. That is exactly the shape dispatchExecutionResultHooks
+		// treats as OnExecuteComplete — must never appear on the error path.
+		if r.Error == nil && r.ExecutionTime > 0 {
+			t.Fatalf("result[%d] looks like a success-completion notify on the error path: %+v (all results: %+v)", i, r, results)
+		}
+	}
+	// The final notify must carry the synthetic error.
+	last := results[len(results)-1]
+	require.NotNil(t, last.Error, "final notify on the error path must carry the error")
+	require.Equal(t, "KernelReplyTimeout", last.Error.EName)
+}
+
 // WebSocket dies before idle: receiveMessages must fail the stream instead
 // of silently break-ing and leaving the caller blocked on resultChan.
 func TestExecuteCodeStreamFailsWhenWebSocketDiesBeforeIdle(t *testing.T) {

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -109,6 +109,7 @@ override it.
 | `--access-token` | `""` | Optional shared API access token. |
 | `--graceful-shutdown-timeout` | `1s` | SSE tail-drain wait window before closing. |
 | `--jupyter-idle-poll-interval` | `100ms` | Poll interval after Jupyter reports idle. |
+| `--jupyter-idle-grace-period` | `5s` | Maximum wait after Jupyter idle for a late `execute_reply`/error before closing the stream with a synthetic `KernelReplyTimeout` error. |
 | `--isolation-config` | `""` | Path to the isolation TOML config (see below). |
 
 ### Environment Variables
@@ -120,6 +121,7 @@ override it.
 | `EXECD_ACCESS_TOKEN` | Same as `--access-token` (overridden by explicit flag). |
 | `EXECD_API_GRACE_SHUTDOWN` | Same as `--graceful-shutdown-timeout`. |
 | `EXECD_JUPYTER_IDLE_POLL_INTERVAL` | Same as `--jupyter-idle-poll-interval`. |
+| `EXECD_JUPYTER_IDLE_GRACE_PERIOD` | Same as `--jupyter-idle-grace-period`. |
 | `EXECD_ISOLATION_CONFIG` | Same as `--isolation-config`. |
 | `EXECD_CLONE3_COMPAT` | Linux clone3 compatibility switch (see below). |
 | `EXECD_LOG_FILE` | Optional log output file path; default is stdout. |


### PR DESCRIPTION
# Summary

Fixes #1206: \`CodeInterpreter.codes.run()\` intermittently hangs while the Jupyter kernel is idle, and secondarily fails with \`RemoteProtocolError: peer closed connection without sending complete message body\`.

## Root cause

Two related silent-hang paths in \`components/execd/pkg/jupyter/execute\`:

1. **\`finalizeExecution\` polled without an upper bound.** After the kernel published \`status: idle\`, the code waited for a late \`execute_reply\`/\`error\` by looping \`state.result.ExecutionCount > 0 || state.result.Error != nil\` with a \`time.Sleep(pollInterval)\` and **no deadline**. If the shell-channel reply was lost (WS re-connect, kernel drop, out-of-order delivery, etc.), \`ExecutionCount\` stayed 0 forever, \`resultChan\` was never closed, \`runJupyterCode\` blocked on \`<-results\`, \`RunCode\` never returned, and the SDK's chunked SSE stream was never terminated.
2. **\`receiveMessages\` break-ed silently on WS read errors.** If the kernel WebSocket died mid-execution, the read loop exited without notifying the in-flight stream, so callers of \`ExecuteCodeStream\` waited on \`resultChan\` forever.

Once either path stalled long enough, the server-side proxy's 180s read timeout would eventually tear the chunked response down mid-flight, surfacing as \`incomplete chunked read\` on the SDK — matching the second failure mode in the issue.

## Fix

- Introduce \`JupyterIdleGracePeriod\` (default \`5s\`, env \`EXECD_JUPYTER_IDLE_GRACE_PERIOD\`, flag \`--jupyter-idle-grace-period\`) to bound the post-idle wait. When it expires, \`finalizeExecution\` injects a \`KernelReplyTimeout\` \`ErrorOutput\` and closes the stream so the SDK gets a typed error instead of hanging.
- Track the currently in-flight stream on \`Client.activeStream\`. \`receiveMessages\` and \`Disconnect\` fail it explicitly with \`KernelStreamAborted\` / \`KernelDisconnected\` when the WS goes away **before** idle. When idle has already been observed, \`finalizeExecution\` owns the terminal close within its grace period, so the disconnect path stands down to avoid racing it.
- Add \`streamExecutionState.terminate\` / \`trySend\` to guarantee \`resultChan\` is closed exactly once and to make concurrent handler sends safe under \`-race\`.

# Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

New tests in \`components/execd/pkg/jupyter/execute/execute_test.go\`:

- \`TestExecuteCodeStreamGivesUpWhenExecuteReplyNeverArrives\` — mock kernel publishes only \`idle\`; asserts \`KernelReplyTimeout\` within grace period.
- \`TestExecuteCodeStreamFailsWhenWebSocketDiesBeforeIdle\` — kernel drops WS after reading the request; asserts \`KernelStreamAborted\` and stream close.
- \`TestExecuteCodeStreamFailsWhenDisconnectedMidExecution\` — client \`Disconnect()\` mid-execution releases the caller with a typed error.

Existing tests still pass:

\`\`\`
go test ./pkg/jupyter/execute/... ./pkg/flag/... ./pkg/runtime/... ./pkg/web/controller/... -race -count=5
ok
\`\`\`

(\`pkg/isolation\` failures on macOS reproduce on \`main\` — unrelated \`/var\` symlink issue.)

# Breaking Changes

- [x] None

Additive only: new flag/env with a safe default. Existing behavior for successful executions is unchanged. Callers that previously would have hung now get a typed terminal error, which the SDK already surfaces via the normal error path.

# Checklist

- [x] Linked Issue or clearly described motivation (#1206)
- [ ] Added/updated docs (if needed) — new flag documented via \`flag.DurationVar\` help text; can add to \`docs/components/execd\` on request
- [x] Added/updated tests (if needed)
- [x] Security impact considered — none; only affects execution stream shutdown semantics
- [x] Backward compatibility considered — additive, safe defaults

# Not included (happy to follow up in separate PRs)

- Map \`httpx.RemoteProtocolError\` to \`HTTPX_NETWORK_ERROR_TYPES\` in the Python SDK for a clearer typed error
- Relax the server-side proxy's 180s read timeout for SSE routes
- SSE ping goroutine race (see #1216)
- Wire \`runtime/ctrl.go\` to the request context so client disconnects propagate