### PR TITLE
fix(server): Periodically resync informer cache

### DIFF
--- a/server/opensandbox_server/services/k8s/informer.py
+++ b/server/opensandbox_server/services/k8s/informer.py
@@ -15,7 +15,9 @@
 """Lightweight informer-style cache for namespaced custom resources."""
 
 import logging
+import math
 import threading
+import time
 from typing import Any, Callable, Dict, List, Optional
 
 from kubernetes import watch
@@ -40,7 +42,7 @@ class WorkloadInformer:
             list_fn: Callable that lists the custom resource, with signature
                      ``list_fn(**kwargs) -> dict``.  Typically a bound method
                      like ``custom_api.list_namespaced_custom_object``.
-            resync_period_seconds: Full-resync interval when watch is disabled.
+            resync_period_seconds: Full-resync interval for the cache.
             watch_timeout_seconds: Per-stream watch timeout before restart.
             enable_watch: When False only the initial list is performed.
             thread_name: Name for the background thread, used in stack traces
@@ -133,10 +135,12 @@ class WorkloadInformer:
 
     def _run(self) -> None:
         backoff = 1.0
+        last_full_resync_at: Optional[float] = None
         while not self._stop_event.is_set():
             try:
                 if not self._has_synced:
                     self._full_resync()
+                    last_full_resync_at = time.monotonic()
                     backoff = 1.0
 
                 if not self.enable_watch:
@@ -144,7 +148,22 @@ class WorkloadInformer:
                     self._has_synced = False  # trigger a fresh list on next loop
                     continue
 
-                self._run_watch_loop()
+                if last_full_resync_at is None:
+                    last_full_resync_at = time.monotonic()
+                remaining_resync_seconds = self.resync_period_seconds - (
+                    time.monotonic() - last_full_resync_at
+                )
+                if remaining_resync_seconds <= 0:
+                    self._has_synced = False
+                    continue
+
+                watch_timeout_seconds = min(
+                    self.watch_timeout_seconds,
+                    max(1, math.ceil(remaining_resync_seconds)),
+                )
+                self._run_watch_loop(watch_timeout_seconds)
+                if time.monotonic() - last_full_resync_at >= self.resync_period_seconds:
+                    self._has_synced = False
                 backoff = 1.0
             except ApiException as exc:
                 if exc.status == 410:
@@ -183,14 +202,14 @@ class WorkloadInformer:
             self._advance_resource_version(resource_version)
             self._has_synced = True
 
-    def _run_watch_loop(self) -> None:
+    def _run_watch_loop(self, timeout_seconds: int) -> None:
         """Stream watch events to keep the cache fresh."""
         w = watch.Watch()
         try:
             for event in w.stream(
                 self.list_fn,
                 resource_version=self._resource_version,
-                timeout_seconds=self.watch_timeout_seconds,
+                timeout_seconds=timeout_seconds,
             ):
                 if self._stop_event.is_set():
                     break

--- a/server/tests/k8s/test_informer.py
+++ b/server/tests/k8s/test_informer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from opensandbox_server.services.k8s.informer import WorkloadInformer
 
@@ -267,3 +267,80 @@ class TestWorkloadInformerStartStop:
 
         informer.stop()
         assert call_count >= 2, "list_fn should be called more than once in poll mode"
+
+    def test_watch_mode_full_resyncs_after_period(self):
+        """A normal watch timeout triggers a full list when the resync period elapses."""
+        list_fn = MagicMock(
+            side_effect=[
+                _list_response("stale"),
+                _list_response("fresh"),
+            ]
+        )
+        informer = WorkloadInformer(
+            list_fn=list_fn,
+            enable_watch=True,
+            resync_period_seconds=5,
+            watch_timeout_seconds=60,
+        )
+        clock = [0.0]
+        watch_timeouts = []
+        fake_watch = MagicMock()
+
+        def stream(*args, **kwargs):
+            watch_timeouts.append(kwargs["timeout_seconds"])
+            clock[0] += kwargs["timeout_seconds"]
+            if len(watch_timeouts) == 2:
+                informer.stop()
+            return iter(())
+
+        fake_watch.stream.side_effect = stream
+
+        with (
+            patch("time.monotonic", side_effect=lambda: clock[0]),
+            patch(
+                "opensandbox_server.services.k8s.informer.watch.Watch",
+                return_value=fake_watch,
+            ),
+        ):
+            informer._run()
+
+        assert watch_timeouts == [5, 5]
+        assert list_fn.call_count == 2
+        assert informer.get("stale") is None
+        assert informer.get("fresh") is not None
+
+    def test_watch_mode_does_not_resync_before_period(self):
+        """Short watch timeouts resume until the full-resync deadline is reached."""
+        list_fn = MagicMock(return_value=_list_response("sandbox"))
+        informer = WorkloadInformer(
+            list_fn=list_fn,
+            enable_watch=True,
+            resync_period_seconds=5,
+            watch_timeout_seconds=2,
+        )
+        clock = [0.0]
+        list_counts = []
+        watch_timeouts = []
+        fake_watch = MagicMock()
+
+        def stream(*args, **kwargs):
+            watch_timeouts.append(kwargs["timeout_seconds"])
+            list_counts.append(list_fn.call_count)
+            clock[0] += kwargs["timeout_seconds"]
+            if len(watch_timeouts) == 4:
+                informer.stop()
+            return iter(())
+
+        fake_watch.stream.side_effect = stream
+
+        with (
+            patch("time.monotonic", side_effect=lambda: clock[0]),
+            patch(
+                "opensandbox_server.services.k8s.informer.watch.Watch",
+                return_value=fake_watch,
+            ),
+        ):
+            informer._run()
+
+        assert watch_timeouts == [2, 2, 1, 2]
+        assert list_counts == [1, 1, 1, 2]


### PR DESCRIPTION
# Summary
- honor `informer_resync_seconds` while watch mode is enabled
- cap each watch stream by the remaining full-resync interval
- add regressions for both on-deadline cache replacement and no early relist

Fixes #1322.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [ ] e2e / manual verification

`uv run pytest tests/k8s/test_informer.py -q` (29 passed)

`uv run pytest tests/k8s -q` (541 passed)

`uv run pytest -q` (1282 passed)

`uv run ruff check opensandbox_server/services/k8s/informer.py tests/k8s/test_informer.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
