### PR TITLE
feat(sdk,server): report resume/pause/kill latency via metrics events

### DIFF
--- a/docs/guides/sdk-telemetry.md
+++ b/docs/guides/sdk-telemetry.md
@@ -1,38 +1,40 @@
 ---
 title: SDK Telemetry
-description: What sandbox create latency metrics the SDKs report, when they fire, and how to disable them.
+description: What sandbox lifecycle latency metrics the SDKs report, when they fire, and how to disable them.
 ---
 
 # SDK Telemetry
 
-OpenSandbox SDKs optionally report sandbox creation latency to the lifecycle server. Reporting is best-effort: failures never affect `Sandbox.create`, and the payload contains no user content.
+OpenSandbox SDKs optionally report sandbox lifecycle latency (create, resume, pause, kill) to the lifecycle server. Reporting is best-effort: failures never affect the lifecycle operations, and the payload contains no user content.
 
 ## What is sent
 
-After create succeeds or fails, the SDK fire-and-forget posts to `POST /v1/metrics/events`:
+After a lifecycle operation succeeds or fails, the SDK fire-and-forget posts to `POST /v1/metrics/events`:
 
 ```json
 {
   "eventType": "sandbox.create",
   "sandboxId": "sbx_...",
   "image": "python:3.12",
-  "createDurationMs": 1842,
+  "durationMs": 1842,
   "success": true
 }
 ```
 
-- `sandboxId` / `image` may be omitted when create fails early.
+`eventType` is one of `sandbox.create`, `sandbox.resume`, `sandbox.pause`, `sandbox.kill`; all report latency via `durationMs`.
+
+- `sandboxId` / `image` may be omitted when create fails early; `image` is only sent for create events.
 - SDK language and version come from the HTTP `User-Agent` header (for example `OpenSandbox-Python-SDK/0.1.14`), not from body fields.
 
-The server accepts the event with `204` and, when `[otel]` is enabled, records an OTEL histogram. See [server configuration](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#otel).
+The server accepts each event with `204` and, when `[otel]` is enabled, records per-operation OTEL histograms (`opensandbox.sandbox.create.duration`, `opensandbox.sandbox.resume.duration`, `opensandbox.sandbox.pause.duration`, `opensandbox.sandbox.kill.duration`). See [server configuration](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#otel).
 
 ## When it runs
 
 | SDK | Trigger |
 |-----|---------|
-| Python (async + sync) | After `Sandbox.create` / sync create completes or raises |
-| JavaScript / TypeScript | After `Sandbox.create` completes or fails |
-| Go | After `CreateSandbox` completes or fails |
+| Python (async + sync) | After `Sandbox.create` / `resume` / `pause` / `kill` (and sync equivalents) completes or raises |
+| JavaScript / TypeScript | After `Sandbox.create` / `resume` / `pause` / `kill` completes or fails |
+| Go | After `CreateSandbox` / `ResumeSandbox` / `Pause` / `Kill` completes or fails |
 
 ## How to disable
 

--- a/sdks/sandbox/go/lifecycle_metrics.go
+++ b/sdks/sandbox/go/lifecycle_metrics.go
@@ -26,12 +26,12 @@ import (
 
 const disableMetricsEnv = "OPENSANDBOX_DISABLE_METRICS"
 
-type sandboxCreateMetricsEvent struct {
-	EventType        string `json:"eventType"`
-	SandboxID        string `json:"sandboxId,omitempty"`
-	Image            string `json:"image,omitempty"`
-	CreateDurationMs int64  `json:"createDurationMs"`
-	Success          bool   `json:"success"`
+type sandboxLifecycleMetricsEvent struct {
+	EventType  string `json:"eventType"`
+	SandboxID  string `json:"sandboxId,omitempty"`
+	Image      string `json:"image,omitempty"`
+	DurationMs int64  `json:"durationMs"`
+	Success    bool   `json:"success"`
 }
 
 func metricsDisabled(cfg ConnectionConfig) bool {
@@ -41,19 +41,19 @@ func metricsDisabled(cfg ConnectionConfig) bool {
 	return strings.TrimSpace(os.Getenv(disableMetricsEnv)) == "1"
 }
 
-// reportSandboxCreateMetric best-effort posts create latency to the lifecycle server.
-// Failures are ignored and the call never blocks CreateSandbox.
-func reportSandboxCreateMetric(cfg ConnectionConfig, sandboxID, image string, durationMs int64, success bool) {
+// reportSandboxLifecycleMetric best-effort posts lifecycle operation latency to
+// the lifecycle server. Failures are ignored and the call never blocks callers.
+func reportSandboxLifecycleMetric(cfg ConnectionConfig, eventType, sandboxID, image string, durationMs int64, success bool) {
 	if metricsDisabled(cfg) {
 		return
 	}
 
-	payload := sandboxCreateMetricsEvent{
-		EventType:        "sandbox.create",
-		SandboxID:        sandboxID,
-		Image:            image,
-		CreateDurationMs: durationMs,
-		Success:          success,
+	payload := sandboxLifecycleMetricsEvent{
+		EventType:  eventType,
+		SandboxID:  sandboxID,
+		Image:      image,
+		DurationMs: durationMs,
+		Success:    success,
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/sdks/sandbox/go/lifecycle_metrics_test.go
+++ b/sdks/sandbox/go/lifecycle_metrics_test.go
@@ -35,12 +35,15 @@ func TestReportSandboxCreateMetricPostsEvent(t *testing.T) {
 			t.Errorf("unexpected method %s", r.Method)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var event sandboxCreateMetricsEvent
+		var event sandboxLifecycleMetricsEvent
 		if err := json.Unmarshal(body, &event); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
 		if event.EventType != "sandbox.create" || !event.Success {
 			t.Fatalf("unexpected event: %+v", event)
+		}
+		if event.DurationMs != 42 {
+			t.Fatalf("expected durationMs=42, got %d", event.DurationMs)
 		}
 		if gotUA := r.Header.Get("User-Agent"); !strings.HasPrefix(gotUA, "OpenSandbox-Go-SDK/") {
 			t.Fatalf("unexpected User-Agent: %q", gotUA)
@@ -53,7 +56,7 @@ func TestReportSandboxCreateMetricPostsEvent(t *testing.T) {
 	cfg := ConnectionConfig{Domain: server.URL, Protocol: "http", APIKey: "k"}
 	// Domain already has scheme via server.URL
 	cfg.Domain = server.URL
-	reportSandboxCreateMetric(cfg, "sbx", "python:3.12", 42, true)
+	reportSandboxLifecycleMetric(cfg, "sandbox.create", "sbx", "python:3.12", 42, true)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -65,10 +68,39 @@ func TestReportSandboxCreateMetricPostsEvent(t *testing.T) {
 	t.Fatal("metrics POST was not received")
 }
 
+func TestReportSandboxLifecycleMetricUsesDurationMs(t *testing.T) {
+	events := make(chan sandboxLifecycleMetricsEvent, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var event sandboxLifecycleMetricsEvent
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Errorf("unmarshal: %v", err)
+		}
+		events <- event
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cfg := ConnectionConfig{Domain: server.URL, Protocol: "http", APIKey: "k"}
+	reportSandboxLifecycleMetric(cfg, "sandbox.pause", "sbx", "", 77, true)
+
+	select {
+	case event := <-events:
+		if event.EventType != "sandbox.pause" || !event.Success {
+			t.Fatalf("unexpected event: %+v", event)
+		}
+		if event.DurationMs != 77 {
+			t.Fatalf("expected durationMs=77, got %d", event.DurationMs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("metrics POST was not received")
+	}
+}
+
 func TestReportSandboxCreateMetricIgnoresFailure(t *testing.T) {
 	cfg := ConnectionConfig{Domain: "http://127.0.0.1:1", Protocol: "http"}
 	// Should not panic or block.
-	reportSandboxCreateMetric(cfg, "", "img", 1, false)
+	reportSandboxLifecycleMetric(cfg, "sandbox.create", "", "img", 1, false)
 	time.Sleep(50 * time.Millisecond)
 }
 
@@ -81,7 +113,7 @@ func TestReportSandboxCreateMetricDisabledByConfig(t *testing.T) {
 	defer server.Close()
 
 	cfg := ConnectionConfig{Domain: server.URL, DisableMetrics: true}
-	reportSandboxCreateMetric(cfg, "sbx", "img", 1, true)
+	reportSandboxLifecycleMetric(cfg, "sandbox.create", "sbx", "img", 1, true)
 	time.Sleep(100 * time.Millisecond)
 	if got.Load() {
 		t.Fatal("expected metrics POST to be skipped when DisableMetrics is set")
@@ -99,7 +131,7 @@ func TestReportSandboxCreateMetricDisabledByEnv(t *testing.T) {
 	defer server.Close()
 
 	cfg := ConnectionConfig{Domain: server.URL}
-	reportSandboxCreateMetric(cfg, "sbx", "img", 1, true)
+	reportSandboxLifecycleMetric(cfg, "sandbox.create", "sbx", "img", 1, true)
 	time.Sleep(100 * time.Millisecond)
 	if got.Load() {
 		t.Fatal("expected metrics POST to be skipped when OPENSANDBOX_DISABLE_METRICS=1")

--- a/sdks/sandbox/go/sandbox.go
+++ b/sdks/sandbox/go/sandbox.go
@@ -159,7 +159,7 @@ func CreateSandbox(ctx context.Context, config ConnectionConfig, opts SandboxCre
 
 	created, err := lc.CreateSandbox(ctx, req)
 	if err != nil {
-		reportSandboxCreateMetric(config, "", startupSource, time.Since(started).Milliseconds(), false)
+		reportSandboxLifecycleMetric(config, "sandbox.create", "", startupSource, time.Since(started).Milliseconds(), false)
 		return nil, fmt.Errorf("opensandbox: create sandbox: %w", err)
 	}
 
@@ -172,13 +172,13 @@ func CreateSandbox(ctx context.Context, config ConnectionConfig, opts SandboxCre
 	if err := sb.waitForRunning(ctx, opts.ReadyTimeout); err != nil {
 		// Best-effort cleanup
 		_ = lc.DeleteSandbox(context.Background(), created.ID)
-		reportSandboxCreateMetric(config, created.ID, startupSource, time.Since(started).Milliseconds(), false)
+		reportSandboxLifecycleMetric(config, "sandbox.create", created.ID, startupSource, time.Since(started).Milliseconds(), false)
 		return nil, err
 	}
 
 	if err := sb.resolveExecd(ctx); err != nil {
 		_ = lc.DeleteSandbox(context.Background(), created.ID)
-		reportSandboxCreateMetric(config, created.ID, startupSource, time.Since(started).Milliseconds(), false)
+		reportSandboxLifecycleMetric(config, "sandbox.create", created.ID, startupSource, time.Since(started).Milliseconds(), false)
 		return nil, fmt.Errorf("opensandbox: resolve execd: %w", err)
 	}
 
@@ -190,11 +190,11 @@ func CreateSandbox(ctx context.Context, config ConnectionConfig, opts SandboxCre
 		}
 		if err := sb.WaitUntilReady(ctx, readyOpts); err != nil {
 			_ = lc.DeleteSandbox(context.Background(), created.ID)
-			reportSandboxCreateMetric(config, created.ID, startupSource, time.Since(started).Milliseconds(), false)
+			reportSandboxLifecycleMetric(config, "sandbox.create", created.ID, startupSource, time.Since(started).Milliseconds(), false)
 			return nil, err
 		}
 	}
-	reportSandboxCreateMetric(config, created.ID, startupSource, time.Since(started).Milliseconds(), true)
+	reportSandboxLifecycleMetric(config, "sandbox.create", created.ID, startupSource, time.Since(started).Milliseconds(), true)
 
 	return sb, nil
 }
@@ -234,11 +234,15 @@ func ConnectSandbox(ctx context.Context, config ConnectionConfig, sandboxID stri
 
 // ResumeSandbox resumes a paused sandbox and reconnects to it.
 func ResumeSandbox(ctx context.Context, config ConnectionConfig, sandboxID string, opts ...ReadyOptions) (*Sandbox, error) {
+	started := time.Now()
 	lc := config.lifecycleClient()
 	if err := lc.ResumeSandbox(ctx, sandboxID); err != nil {
+		reportSandboxLifecycleMetric(config, "sandbox.resume", sandboxID, "", time.Since(started).Milliseconds(), false)
 		return nil, fmt.Errorf("opensandbox: resume sandbox: %w", err)
 	}
-	return ConnectSandbox(ctx, config, sandboxID, opts...)
+	sb, err := ConnectSandbox(ctx, config, sandboxID, opts...)
+	reportSandboxLifecycleMetric(config, "sandbox.resume", sandboxID, "", time.Since(started).Milliseconds(), err == nil)
+	return sb, err
 }
 
 // Resume resumes this sandbox if it was paused and reconnects to it.
@@ -251,7 +255,17 @@ func (s *Sandbox) Kill(ctx context.Context) error {
 	if s.lifecycle.cache != nil {
 		s.lifecycle.cache.Invalidate(s.id)
 	}
-	return s.lifecycle.DeleteSandbox(ctx, s.id)
+	started := time.Now()
+	err := s.lifecycle.DeleteSandbox(ctx, s.id)
+	s.reportLifecycleMetric("sandbox.kill", started, err == nil)
+	return err
+}
+
+func (s *Sandbox) reportLifecycleMetric(eventType string, started time.Time, success bool) {
+	if s.config == nil {
+		return
+	}
+	reportSandboxLifecycleMetric(*s.config, eventType, s.id, "", time.Since(started).Milliseconds(), success)
 }
 
 // Close releases local HTTP resources. Does NOT terminate the sandbox.
@@ -267,7 +281,10 @@ func (s *Sandbox) Pause(ctx context.Context) error {
 	if s.lifecycle.cache != nil {
 		s.lifecycle.cache.Invalidate(s.id)
 	}
-	return s.lifecycle.PauseSandbox(ctx, s.id)
+	started := time.Now()
+	err := s.lifecycle.PauseSandbox(ctx, s.id)
+	s.reportLifecycleMetric("sandbox.pause", started, err == nil)
+	return err
 }
 
 // GetInfo returns the sandbox's current info (status, metadata, image, etc.).

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -29,10 +29,11 @@ export interface paths {
         put?: never;
         /**
          * Report an SDK metrics event
-         * @description Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+         * @description Accepts best-effort telemetry from SDKs covering sandbox lifecycle
+         *     latency (create, resume, pause, kill).
          *
-         *     SDKs SHOULD fire-and-forget this call after `create` + readiness complete
-         *     (or after a failed creation attempt). Failures to report MUST NOT affect
+         *     SDKs SHOULD fire-and-forget this call after the lifecycle operation
+         *     completes (successfully or not). Failures to report MUST NOT affect
          *     sandbox usability. The server accepts events even when OpenTelemetry
          *     export is disabled (noop recording).
          *
@@ -770,8 +771,8 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
-         * @description SDK-reported metrics event. Phase 1 covers sandbox creation latency from
-         *     the start of create until readiness succeeds or creation fails.
+         * @description SDK-reported metrics event covering sandbox lifecycle latency measured
+         *     from the start of the operation until it succeeds or fails.
          *
          *     SDK language and package version are identified via the request
          *     `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
@@ -781,14 +782,14 @@ export interface components {
              * @description Metric event type
              * @enum {string}
              */
-            eventType: "sandbox.create";
+            eventType: "sandbox.create" | "sandbox.resume" | "sandbox.pause" | "sandbox.kill";
             /** @description Sandbox identifier when available (may be omitted if create failed before an ID was assigned) */
             sandboxId?: string;
             /** @description Container image URI or snapshot startup source label */
             image?: string;
-            /** @description Wall-clock duration in milliseconds from create start to ready or failure */
-            createDurationMs: number;
-            /** @description Whether create + readiness completed successfully */
+            /** @description Wall-clock duration in milliseconds of the lifecycle operation, measured from start until success or failure */
+            durationMs: number;
+            /** @description Whether the lifecycle operation completed successfully */
             success: boolean;
         };
         ListSandboxesResponse: {
@@ -1562,7 +1563,7 @@ export interface operations {
                  *       "eventType": "sandbox.create",
                  *       "sandboxId": "sbx_01HZYEXAMPLE",
                  *       "image": "python:3.12",
-                 *       "createDurationMs": 1842,
+                 *       "durationMs": 1842,
                  *       "success": true
                  *     }
                  */

--- a/sdks/sandbox/javascript/src/internal/lifecycleMetrics.ts
+++ b/sdks/sandbox/javascript/src/internal/lifecycleMetrics.ts
@@ -17,11 +17,17 @@ import type { ConnectionConfig } from "../config/connection.js";
 
 const DISABLE_METRICS_ENV = "OPENSANDBOX_DISABLE_METRICS";
 
-export interface SandboxCreateMetricsPayload {
-  eventType: "sandbox.create";
+export type SandboxLifecycleEventType =
+  | "sandbox.create"
+  | "sandbox.resume"
+  | "sandbox.pause"
+  | "sandbox.kill";
+
+export interface SandboxLifecycleMetricsPayload {
+  eventType: SandboxLifecycleEventType;
   sandboxId?: string;
   image?: string;
-  createDurationMs: number;
+  durationMs: number;
   success: boolean;
 }
 
@@ -41,16 +47,17 @@ function metricsDisabled(connectionConfig: ConnectionConfig): boolean {
 }
 
 /**
- * Best-effort fire-and-forget report of sandbox create latency.
+ * Best-effort fire-and-forget report of a sandbox lifecycle operation latency.
  * Never throws and never awaits for callers.
  * SDK identity is conveyed via the User-Agent header.
  */
-export function reportSandboxCreateMetric(
+export function reportSandboxLifecycleMetric(
   connectionConfig: ConnectionConfig,
   opts: {
+    eventType: SandboxLifecycleEventType;
     sandboxId?: string;
     image?: string;
-    createDurationMs: number;
+    durationMs: number;
     success: boolean;
   }
 ): void {
@@ -58,9 +65,9 @@ export function reportSandboxCreateMetric(
     return;
   }
 
-  const payload: SandboxCreateMetricsPayload = {
-    eventType: "sandbox.create",
-    createDurationMs: Math.max(0, Math.floor(opts.createDurationMs)),
+  const payload: SandboxLifecycleMetricsPayload = {
+    eventType: opts.eventType,
+    durationMs: Math.max(0, Math.floor(opts.durationMs)),
     success: opts.success,
   };
   if (opts.sandboxId) {

--- a/sdks/sandbox/javascript/src/sandbox.ts
+++ b/sdks/sandbox/javascript/src/sandbox.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_TIMEOUT_SECONDS,
 } from "./core/constants.js";
 import { ConnectionConfig, type ConnectionConfigOptions } from "./config/connection.js";
-import { reportSandboxCreateMetric } from "./internal/lifecycleMetrics.js";
+import { reportSandboxLifecycleMetric } from "./internal/lifecycleMetrics.js";
 import type { SandboxFiles } from "./services/filesystem.js";
 import type { CredentialVault, Egress } from "./services/egress.js";
 import { createDefaultAdapterFactory } from "./factory/defaultAdapterFactory.js";
@@ -476,19 +476,21 @@ export class Sandbox {
         });
       }
 
-      reportSandboxCreateMetric(connectionConfig, {
+      reportSandboxLifecycleMetric(connectionConfig, {
+        eventType: "sandbox.create",
         sandboxId,
         image: startupSource,
-        createDurationMs: Date.now() - createStarted,
+        durationMs: Date.now() - createStarted,
         success: true,
       });
 
       return sbx;
     } catch (err) {
-      reportSandboxCreateMetric(connectionConfig, {
+      reportSandboxLifecycleMetric(connectionConfig, {
+        eventType: "sandbox.create",
         sandboxId,
         image: startupSource,
-        createDurationMs: Date.now() - createStarted,
+        durationMs: Date.now() - createStarted,
         success: false,
       });
       if (sandboxId) {
@@ -602,7 +604,27 @@ export class Sandbox {
 
   async pause(): Promise<void> {
     this.sandboxes.invalidateEndpointCache?.(this.id);
-    await this.sandboxes.pauseSandbox(this.id);
+    const started = Date.now();
+    try {
+      await this.sandboxes.pauseSandbox(this.id);
+    } catch (err) {
+      this.reportLifecycleMetric("sandbox.pause", started, false);
+      throw err;
+    }
+    this.reportLifecycleMetric("sandbox.pause", started, true);
+  }
+
+  private reportLifecycleMetric(
+    eventType: "sandbox.pause" | "sandbox.kill",
+    started: number,
+    success: boolean
+  ): void {
+    reportSandboxLifecycleMetric(this.connectionConfig, {
+      eventType,
+      sandboxId: this.id,
+      durationMs: Date.now() - started,
+      success,
+    });
   }
 
   /**
@@ -618,15 +640,33 @@ export class Sandbox {
       healthCheckPollingInterval?: number;
     } = {}
   ): Promise<Sandbox> {
-    await this.sandboxes.resumeSandbox(this.id);
-    return await Sandbox.connect({
-      sandboxId: this.id,
-      connectionConfig: this.connectionConfig,
-      adapterFactory: Sandbox._priv.get(this)!.adapterFactory,
-      skipHealthCheck: opts.skipHealthCheck ?? false,
-      readyTimeoutSeconds: opts.readyTimeoutSeconds,
-      healthCheckPollingInterval: opts.healthCheckPollingInterval,
-    });
+    const started = Date.now();
+    try {
+      await this.sandboxes.resumeSandbox(this.id);
+      const sbx = await Sandbox.connect({
+        sandboxId: this.id,
+        connectionConfig: this.connectionConfig,
+        adapterFactory: Sandbox._priv.get(this)!.adapterFactory,
+        skipHealthCheck: opts.skipHealthCheck ?? false,
+        readyTimeoutSeconds: opts.readyTimeoutSeconds,
+        healthCheckPollingInterval: opts.healthCheckPollingInterval,
+      });
+      reportSandboxLifecycleMetric(this.connectionConfig, {
+        eventType: "sandbox.resume",
+        sandboxId: this.id,
+        durationMs: Date.now() - started,
+        success: true,
+      });
+      return sbx;
+    } catch (err) {
+      reportSandboxLifecycleMetric(this.connectionConfig, {
+        eventType: "sandbox.resume",
+        sandboxId: this.id,
+        durationMs: Date.now() - started,
+        success: false,
+      });
+      throw err;
+    }
   }
 
   /**
@@ -640,6 +680,14 @@ export class Sandbox {
     const adapterFactory = opts.adapterFactory ?? createDefaultAdapterFactory();
     const resumeConnectionConfig = baseConnectionConfig.withTransportIfMissing();
     const lifecycleBaseUrl = resumeConnectionConfig.getBaseUrl();
+    const started = Date.now();
+    const reportResume = (success: boolean) =>
+      reportSandboxLifecycleMetric(baseConnectionConfig, {
+        eventType: "sandbox.resume",
+        sandboxId: opts.sandboxId,
+        durationMs: Date.now() - started,
+        success,
+      });
 
     let sandboxes: Sandboxes;
     try {
@@ -649,17 +697,32 @@ export class Sandbox {
       }).sandboxes;
       await sandboxes.resumeSandbox(opts.sandboxId);
     } catch (err) {
+      reportResume(false);
       await resumeConnectionConfig.closeTransport();
       throw err;
     }
 
     await resumeConnectionConfig.closeTransport();
-    return await Sandbox.connect({ ...opts, connectionConfig: baseConnectionConfig, adapterFactory });
+    try {
+      const sbx = await Sandbox.connect({ ...opts, connectionConfig: baseConnectionConfig, adapterFactory });
+      reportResume(true);
+      return sbx;
+    } catch (err) {
+      reportResume(false);
+      throw err;
+    }
   }
 
   async kill(): Promise<void> {
     this.sandboxes.invalidateEndpointCache?.(this.id);
-    await this.sandboxes.deleteSandbox(this.id);
+    const started = Date.now();
+    try {
+      await this.sandboxes.deleteSandbox(this.id);
+    } catch (err) {
+      this.reportLifecycleMetric("sandbox.kill", started, false);
+      throw err;
+    }
+    this.reportLifecycleMetric("sandbox.kill", started, true);
   }
 
   /**

--- a/sdks/sandbox/python/src/opensandbox/internal/lifecycle_metrics.py
+++ b/sdks/sandbox/python/src/opensandbox/internal/lifecycle_metrics.py
@@ -51,19 +51,20 @@ def _env_metrics_disabled() -> bool:
 
 
 def _metrics_disabled(config: _MetricsConnection) -> bool:
-    return bool(config.disable_metrics) or _env_metrics_disabled()
+    return bool(getattr(config, "disable_metrics", False)) or _env_metrics_disabled()
 
 
 def _build_payload(
     *,
+    event_type: str,
     sandbox_id: str | None,
     image: str | None,
-    create_duration_ms: int,
+    duration_ms: int,
     success: bool,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
-        "eventType": "sandbox.create",
-        "createDurationMs": max(0, int(create_duration_ms)),
+        "eventType": event_type,
+        "durationMs": max(0, int(duration_ms)),
         "success": bool(success),
     }
     if sandbox_id:
@@ -102,22 +103,24 @@ async def _post_async(config: _MetricsConnection, payload: dict[str, Any]) -> No
         await client.post(url, json=payload, headers=_headers(config))
 
 
-def report_sandbox_create_metric(
+def report_sandbox_lifecycle_metric(
     config: _MetricsConnection,
     *,
+    event_type: str,
     sandbox_id: str | None,
-    image: str | None,
-    create_duration_ms: int,
+    duration_ms: int,
     success: bool,
+    image: str | None = None,
 ) -> None:
-    """Fire-and-forget create latency report. Never raises or blocks callers."""
+    """Fire-and-forget lifecycle latency report. Never raises or blocks callers."""
     if _metrics_disabled(config):
         return
 
     payload = _build_payload(
+        event_type=event_type,
         sandbox_id=sandbox_id,
         image=image,
-        create_duration_ms=create_duration_ms,
+        duration_ms=duration_ms,
         success=success,
     )
 
@@ -128,7 +131,7 @@ def report_sandbox_create_metric(
             try:
                 _post_sync(config, payload)
             except Exception:
-                logger.debug("Failed to report sandbox.create metrics", exc_info=True)
+                logger.debug("Failed to report %s metrics", event_type, exc_info=True)
 
         threading.Thread(target=_thread_run, daemon=True).start()
         return
@@ -137,7 +140,7 @@ def report_sandbox_create_metric(
         try:
             await _post_async(config, payload)
         except Exception:
-            logger.debug("Failed to report sandbox.create metrics", exc_info=True)
+            logger.debug("Failed to report %s metrics", event_type, exc_info=True)
 
     task = loop.create_task(_run())
     _pending.add(task)

--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -33,7 +33,7 @@ from opensandbox.exceptions import (
     SandboxInternalException,
     SandboxReadyTimeoutException,
 )
-from opensandbox.internal.lifecycle_metrics import report_sandbox_create_metric
+from opensandbox.internal.lifecycle_metrics import report_sandbox_lifecycle_metric
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
@@ -355,7 +355,13 @@ class Sandbox:
         """
         logger.info(f"Pausing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
-        await self._sandbox_service.pause_sandbox(self.id)
+        started = time.monotonic()
+        try:
+            await self._sandbox_service.pause_sandbox(self.id)
+        except BaseException:
+            self._report_lifecycle_metric("sandbox.pause", started, success=False)
+            raise
+        self._report_lifecycle_metric("sandbox.pause", started, success=True)
 
     async def kill(self) -> None:
         """
@@ -371,7 +377,24 @@ class Sandbox:
         """
         logger.info(f"Killing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
-        await self._sandbox_service.kill_sandbox(self.id)
+        started = time.monotonic()
+        try:
+            await self._sandbox_service.kill_sandbox(self.id)
+        except BaseException:
+            self._report_lifecycle_metric("sandbox.kill", started, success=False)
+            raise
+        self._report_lifecycle_metric("sandbox.kill", started, success=True)
+
+    def _report_lifecycle_metric(
+        self, event_type: str, started: float, *, success: bool
+    ) -> None:
+        report_sandbox_lifecycle_metric(
+            self._connection_config,
+            event_type=event_type,
+            sandbox_id=self.id,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            success=success,
+        )
 
     async def close(self) -> None:
         """
@@ -634,21 +657,23 @@ class Sandbox:
                     f"Sandbox {sandbox.id} created (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
-            report_sandbox_create_metric(
+            report_sandbox_lifecycle_metric(
                 config,
+                event_type="sandbox.create",
                 sandbox_id=sandbox.id,
                 image=startup_source,
-                create_duration_ms=int((time.monotonic() - create_started) * 1000),
+                duration_ms=int((time.monotonic() - create_started) * 1000),
                 success=True,
             )
 
             return sandbox
         except BaseException as e:
-            report_sandbox_create_metric(
+            report_sandbox_lifecycle_metric(
                 config,
+                event_type="sandbox.create",
                 sandbox_id=sandbox_id,
                 image=startup_source,
-                create_duration_ms=int((time.monotonic() - create_started) * 1000),
+                duration_ms=int((time.monotonic() - create_started) * 1000),
                 success=False,
             )
             if sandbox_id and sandbox_service:
@@ -790,6 +815,7 @@ class Sandbox:
 
         logger.info(f"Resuming sandbox: {sandbox_id}")
         factory = AdapterFactory(config)
+        resume_started = time.monotonic()
 
         try:
             sandbox_service = factory.create_sandbox_service()
@@ -825,8 +851,23 @@ class Sandbox:
                     f"Resumed sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
+            report_sandbox_lifecycle_metric(
+                config,
+                event_type="sandbox.resume",
+                sandbox_id=sandbox_id,
+                duration_ms=int((time.monotonic() - resume_started) * 1000),
+                success=True,
+            )
+
             return sandbox
         except Exception as e:
+            report_sandbox_lifecycle_metric(
+                config,
+                event_type="sandbox.resume",
+                sandbox_id=sandbox_id,
+                duration_ms=int((time.monotonic() - resume_started) * 1000),
+                success=False,
+            )
             await config.close_transport_if_owned()
             if isinstance(e, SandboxException):
                 raise

--- a/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/sandbox.py
@@ -31,7 +31,7 @@ from opensandbox.exceptions import (
     SandboxInternalException,
     SandboxReadyTimeoutException,
 )
-from opensandbox.internal.lifecycle_metrics import report_sandbox_create_metric
+from opensandbox.internal.lifecycle_metrics import report_sandbox_lifecycle_metric
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import (
     CreateSnapshotRequest,
@@ -359,7 +359,13 @@ class SandboxSync:
         """
         logger.info(f"Pausing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
-        self._sandbox_service.pause_sandbox(self.id)
+        started = time.monotonic()
+        try:
+            self._sandbox_service.pause_sandbox(self.id)
+        except BaseException:
+            self._report_lifecycle_metric("sandbox.pause", started, success=False)
+            raise
+        self._report_lifecycle_metric("sandbox.pause", started, success=True)
 
     def kill(self) -> None:
         """
@@ -375,7 +381,24 @@ class SandboxSync:
         """
         logger.info(f"Killing sandbox: {self.id}")
         self._sandbox_service.invalidate_endpoint_cache(self.id)
-        self._sandbox_service.kill_sandbox(self.id)
+        started = time.monotonic()
+        try:
+            self._sandbox_service.kill_sandbox(self.id)
+        except BaseException:
+            self._report_lifecycle_metric("sandbox.kill", started, success=False)
+            raise
+        self._report_lifecycle_metric("sandbox.kill", started, success=True)
+
+    def _report_lifecycle_metric(
+        self, event_type: str, started: float, *, success: bool
+    ) -> None:
+        report_sandbox_lifecycle_metric(
+            self._connection_config,
+            event_type=event_type,
+            sandbox_id=self.id,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            success=success,
+        )
 
     def close(self) -> None:
         """
@@ -619,21 +642,23 @@ class SandboxSync:
                     f"Sandbox {sandbox.id} created (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
-            report_sandbox_create_metric(
+            report_sandbox_lifecycle_metric(
                 config,
+                event_type="sandbox.create",
                 sandbox_id=sandbox.id,
                 image=startup_source,
-                create_duration_ms=int((time.monotonic() - create_started) * 1000),
+                duration_ms=int((time.monotonic() - create_started) * 1000),
                 success=True,
             )
 
             return sandbox
         except Exception as e:
-            report_sandbox_create_metric(
+            report_sandbox_lifecycle_metric(
                 config,
+                event_type="sandbox.create",
                 sandbox_id=sandbox_id,
                 image=startup_source,
-                create_duration_ms=int((time.monotonic() - create_started) * 1000),
+                duration_ms=int((time.monotonic() - create_started) * 1000),
                 success=False,
             )
             if sandbox_id and sandbox_service:
@@ -767,6 +792,7 @@ class SandboxSync:
 
         logger.info(f"Resuming sandbox: {sandbox_id}")
         factory = AdapterFactorySync(config)
+        resume_started = time.monotonic()
 
         try:
             sandbox_service = factory.create_sandbox_service()
@@ -802,8 +828,23 @@ class SandboxSync:
                     f"Resumed sandbox {sandbox_id} (skip_health_check=true, sandbox may not be ready yet)"
                 )
 
+            report_sandbox_lifecycle_metric(
+                config,
+                event_type="sandbox.resume",
+                sandbox_id=sandbox_id,
+                duration_ms=int((time.monotonic() - resume_started) * 1000),
+                success=True,
+            )
+
             return sandbox
         except Exception as e:
+            report_sandbox_lifecycle_metric(
+                config,
+                event_type="sandbox.resume",
+                sandbox_id=sandbox_id,
+                duration_ms=int((time.monotonic() - resume_started) * 1000),
+                success=False,
+            )
             config.close_transport_if_owned()
             if isinstance(e, SandboxException):
                 raise

--- a/sdks/sandbox/python/tests/test_lifecycle_metrics.py
+++ b/sdks/sandbox/python/tests/test_lifecycle_metrics.py
@@ -24,24 +24,65 @@ import pytest
 from opensandbox.config import ConnectionConfig
 from opensandbox.internal.lifecycle_metrics import (
     _build_payload,
-    report_sandbox_create_metric,
+    report_sandbox_lifecycle_metric,
 )
 
 
 def test_build_payload_omits_optional_fields():
     payload = _build_payload(
+        event_type="sandbox.create",
         sandbox_id=None,
         image=None,
-        create_duration_ms=12,
+        duration_ms=12,
         success=False,
     )
     assert payload["eventType"] == "sandbox.create"
-    assert payload["createDurationMs"] == 12
+    assert payload["durationMs"] == 12
     assert payload["success"] is False
     assert "sandboxId" not in payload
     assert "image" not in payload
     assert "sdkLanguage" not in payload
     assert "sdkVersion" not in payload
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    ["sandbox.create", "sandbox.resume", "sandbox.pause", "sandbox.kill"],
+)
+def test_build_payload_uses_duration_ms_for_all_events(event_type):
+    payload = _build_payload(
+        event_type=event_type,
+        sandbox_id="sbx",
+        image=None,
+        duration_ms=34,
+        success=True,
+    )
+    assert payload["eventType"] == event_type
+    assert payload["durationMs"] == 34
+    assert payload["sandboxId"] == "sbx"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_report_posts_expected_payload():
+    config = ConnectionConfig(
+        domain="127.0.0.1:9",
+        protocol="http",
+        request_timeout=timedelta(milliseconds=50),
+    )
+    with patch("opensandbox.internal.lifecycle_metrics._post_async") as post:
+        report_sandbox_lifecycle_metric(
+            config,
+            event_type="sandbox.pause",
+            sandbox_id="sbx",
+            duration_ms=42,
+            success=True,
+        )
+        await asyncio.sleep(0.05)
+    post.assert_called_once()
+    payload = post.call_args.args[1]
+    assert payload["eventType"] == "sandbox.pause"
+    assert payload["durationMs"] == 42
+    assert payload["success"] is True
 
 
 @pytest.mark.asyncio
@@ -56,11 +97,12 @@ async def test_report_does_not_raise_when_post_fails():
         "opensandbox.internal.lifecycle_metrics._post_async",
         side_effect=httpx.ConnectError("boom"),
     ):
-        report_sandbox_create_metric(
+        report_sandbox_lifecycle_metric(
             config,
+            event_type="sandbox.create",
             sandbox_id="sbx",
             image="python:3.12",
-            create_duration_ms=100,
+            duration_ms=100,
             success=True,
         )
         # Allow the scheduled task to run and finish.
@@ -84,11 +126,12 @@ def test_sync_report_swallows_errors_in_thread():
         side_effect=_boom,
     ):
         # No running loop → thread path.
-        report_sandbox_create_metric(
+        report_sandbox_lifecycle_metric(
             config,
+            event_type="sandbox.create",
             sandbox_id=None,
             image="img",
-            create_duration_ms=1,
+            duration_ms=1,
             success=False,
         )
         import time
@@ -108,11 +151,11 @@ async def test_report_skipped_when_disable_metrics():
         disable_metrics=True,
     )
     with patch("opensandbox.internal.lifecycle_metrics._post_async") as post:
-        report_sandbox_create_metric(
+        report_sandbox_lifecycle_metric(
             config,
+            event_type="sandbox.kill",
             sandbox_id="sbx",
-            image="python:3.12",
-            create_duration_ms=100,
+            duration_ms=1,
             success=True,
         )
         await asyncio.sleep(0.05)
@@ -123,11 +166,12 @@ def test_report_skipped_when_env_disables_metrics(monkeypatch):
     monkeypatch.setenv("OPENSANDBOX_DISABLE_METRICS", "1")
     config = ConnectionConfig(domain="127.0.0.1:9", protocol="http")
     with patch("opensandbox.internal.lifecycle_metrics._post_sync") as post:
-        report_sandbox_create_metric(
+        report_sandbox_lifecycle_metric(
             config,
+            event_type="sandbox.create",
             sandbox_id=None,
             image="img",
-            create_duration_ms=1,
+            duration_ms=1,
             success=False,
         )
         import time
@@ -152,11 +196,12 @@ async def test_async_report_keeps_strong_task_ref():
         await asyncio.sleep(0.05)
 
     with patch.object(metrics_mod, "_post_async", side_effect=_slow_post):
-        report_sandbox_create_metric(
+        report_sandbox_lifecycle_metric(
             config,
+            event_type="sandbox.create",
             sandbox_id="sbx",
             image="img",
-            create_duration_ms=10,
+            duration_ms=10,
             success=True,
         )
         assert len(metrics_mod._pending) == 1

--- a/server/configuration.md
+++ b/server/configuration.md
@@ -300,7 +300,7 @@ Per-sandbox enablement uses create request extensions (see OSEP-0009 and `exampl
 
 ## `[otel]`
 
-Optional OpenTelemetry metrics export for SDK-reported sandbox creation latency (`POST /v1/metrics/events`). Off by default; the ingestion endpoint still accepts events and records them as noop.
+Optional OpenTelemetry metrics export for SDK-reported sandbox lifecycle latency — create, resume, pause, and kill (`POST /v1/metrics/events`). Off by default; the ingestion endpoint still accepts events and records them as noop.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/server/opensandbox_server/api/metrics.py
+++ b/server/opensandbox_server/api/metrics.py
@@ -23,7 +23,7 @@ from typing import Optional
 from fastapi import APIRouter, Header, Response, status
 
 from opensandbox_server.api.schema import MetricsEvent
-from opensandbox_server.integrations.otel import record_sandbox_create_duration
+from opensandbox_server.integrations.otel import record_sandbox_lifecycle_duration
 
 logger = logging.getLogger(__name__)
 
@@ -62,22 +62,23 @@ def report_metrics_event(
 ) -> Response:
     """Accept best-effort SDK metrics and record to OTEL (noop when disabled)."""
     _ = x_request_id
-    if event.event_type == "sandbox.create":
-        sdk_language, sdk_version = parse_sdk_user_agent(user_agent)
-        record_sandbox_create_duration(
-            create_duration_ms=event.create_duration_ms,
-            sdk_language=sdk_language,
-            sdk_version=sdk_version,
-            success=event.success,
-        )
-        logger.debug(
-            "Accepted sandbox.create metrics event sandbox_id=%s image=%s "
-            "duration_ms=%s sdk=%s/%s success=%s",
-            event.sandbox_id,
-            event.image,
-            event.create_duration_ms,
-            sdk_language,
-            sdk_version,
-            event.success,
-        )
+    sdk_language, sdk_version = parse_sdk_user_agent(user_agent)
+    record_sandbox_lifecycle_duration(
+        event_type=event.event_type,
+        duration_ms=event.duration_ms,
+        sdk_language=sdk_language,
+        sdk_version=sdk_version,
+        success=event.success,
+    )
+    logger.debug(
+        "Accepted %s metrics event sandbox_id=%s image=%s "
+        "duration_ms=%s sdk=%s/%s success=%s",
+        event.event_type,
+        event.sandbox_id,
+        event.image,
+        event.duration_ms,
+        sdk_language,
+        sdk_version,
+        event.success,
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -987,10 +987,15 @@ class ListPoolsResponse(BaseModel):
 
 class MetricsEvent(BaseModel):
     """
-    SDK-reported metrics event (Phase 1: sandbox creation latency).
+    SDK-reported metrics event covering sandbox lifecycle latency.
     """
 
-    event_type: Literal["sandbox.create"] = Field(
+    event_type: Literal[
+        "sandbox.create",
+        "sandbox.resume",
+        "sandbox.pause",
+        "sandbox.kill",
+    ] = Field(
         ...,
         alias="eventType",
         description="Metric event type",
@@ -1004,15 +1009,18 @@ class MetricsEvent(BaseModel):
         default=None,
         description="Container image URI or snapshot startup source label",
     )
-    create_duration_ms: int = Field(
+    duration_ms: int = Field(
         ...,
-        alias="createDurationMs",
+        alias="durationMs",
         ge=0,
-        description="Wall-clock duration in milliseconds from create start to ready or failure",
+        description=(
+            "Wall-clock duration in milliseconds of the lifecycle operation, "
+            "measured from start until success or failure"
+        ),
     )
     success: bool = Field(
         ...,
-        description="Whether create + readiness completed successfully",
+        description="Whether the lifecycle operation completed successfully",
     )
 
     class Config:

--- a/server/opensandbox_server/integrations/otel/__init__.py
+++ b/server/opensandbox_server/integrations/otel/__init__.py
@@ -15,13 +15,13 @@
 """Optional OpenTelemetry integration for SDK metrics ingestion."""
 
 from opensandbox_server.integrations.otel.metrics import (
-    record_sandbox_create_duration,
+    record_sandbox_lifecycle_duration,
     setup_otel_metrics,
     shutdown_otel_metrics,
 )
 
 __all__ = [
-    "record_sandbox_create_duration",
+    "record_sandbox_lifecycle_duration",
     "setup_otel_metrics",
     "shutdown_otel_metrics",
 ]

--- a/server/opensandbox_server/integrations/otel/metrics.py
+++ b/server/opensandbox_server/integrations/otel/metrics.py
@@ -30,12 +30,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CREATE_DURATION_HISTOGRAM_NAME = "opensandbox.sandbox.create.duration"
-_CREATE_DURATION_UNIT = "ms"
-_CREATE_DURATION_DESCRIPTION = (
-    "Sandbox creation latency from SDK create start until ready or failure"
-)
-_CREATE_DURATION_BOUNDARIES = (
+_DURATION_UNIT = "ms"
+_DURATION_BOUNDARIES = (
     100.0,
     250.0,
     500.0,
@@ -47,25 +43,49 @@ _CREATE_DURATION_BOUNDARIES = (
     60000.0,
 )
 
+# Lifecycle event type -> (histogram name, description)
+_LIFECYCLE_HISTOGRAMS = {
+    "sandbox.create": (
+        "opensandbox.sandbox.create.duration",
+        "Sandbox creation latency from SDK create start until ready or failure",
+    ),
+    "sandbox.resume": (
+        "opensandbox.sandbox.resume.duration",
+        "Sandbox resume latency from SDK resume start until ready or failure",
+    ),
+    "sandbox.pause": (
+        "opensandbox.sandbox.pause.duration",
+        "Sandbox pause latency from SDK pause start until completion or failure",
+    ),
+    "sandbox.kill": (
+        "opensandbox.sandbox.kill.duration",
+        "Sandbox kill latency from SDK kill start until completion or failure",
+    ),
+}
+
 _meter_provider: Optional[MeterProvider] = None
-_create_duration_histogram = None
+_duration_histograms: dict[str, object] = {}
 
 
-def _histogram_from_provider(provider: MeterProvider):
-    return provider.get_meter("opensandbox.server").create_histogram(
-        name=_CREATE_DURATION_HISTOGRAM_NAME,
-        unit=_CREATE_DURATION_UNIT,
-        description=_CREATE_DURATION_DESCRIPTION,
-    )
+def _histograms_from_provider(provider: MeterProvider) -> dict[str, object]:
+    meter = provider.get_meter("opensandbox.server")
+    return {
+        event_type: meter.create_histogram(
+            name=name,
+            unit=_DURATION_UNIT,
+            description=description,
+        )
+        for event_type, (name, description) in _LIFECYCLE_HISTOGRAMS.items()
+    }
 
 
 def setup_otel_metrics(config: OtelConfig) -> None:
     """Configure OTEL metrics export when enabled; otherwise keep recording as noop."""
-    global _meter_provider, _create_duration_histogram
+    global _meter_provider, _duration_histograms
 
     # Disabled: do not attach instruments to any global provider (may already export).
     if not config.enabled:
-        _create_duration_histogram = None
+        _duration_histograms = {}
         logger.info(
             "OpenTelemetry metrics export disabled; SDK events are accepted but not exported"
         )
@@ -93,11 +113,12 @@ def setup_otel_metrics(config: OtelConfig) -> None:
     resource = Resource.create({"service.name": config.service_name})
     views = [
         View(
-            instrument_name=_CREATE_DURATION_HISTOGRAM_NAME,
+            instrument_name=name,
             aggregation=ExplicitBucketHistogramAggregation(
-                boundaries=list(_CREATE_DURATION_BOUNDARIES)
+                boundaries=list(_DURATION_BOUNDARIES)
             ),
         )
+        for name, _ in _LIFECYCLE_HISTOGRAMS.values()
     ]
     provider = MeterProvider(
         resource=resource,
@@ -117,7 +138,7 @@ def setup_otel_metrics(config: OtelConfig) -> None:
     # Always bind instruments to *this* provider so export uses our OTLP reader,
     # even when set_meter_provider() cannot override a preexisting global provider.
     _meter_provider = provider
-    _create_duration_histogram = _histogram_from_provider(provider)
+    _duration_histograms = _histograms_from_provider(provider)
     logger.info(
         "OpenTelemetry metrics enabled (service=%s, endpoint=%s)",
         config.service_name,
@@ -127,10 +148,10 @@ def setup_otel_metrics(config: OtelConfig) -> None:
 
 def shutdown_otel_metrics() -> None:
     """Flush and shut down the configured MeterProvider if any."""
-    global _meter_provider, _create_duration_histogram
+    global _meter_provider, _duration_histograms
     provider = _meter_provider
     _meter_provider = None
-    _create_duration_histogram = None
+    _duration_histograms = {}
     if provider is None:
         return
     try:
@@ -139,23 +160,25 @@ def shutdown_otel_metrics() -> None:
         logger.exception("Failed to shut down OpenTelemetry MeterProvider")
 
 
-def record_sandbox_create_duration(
+def record_sandbox_lifecycle_duration(
     *,
-    create_duration_ms: int,
+    event_type: str,
+    duration_ms: int,
     sdk_language: str,
     sdk_version: str,
     success: bool,
 ) -> None:
-    """Record a sandbox.create duration sample. Never raises.
+    """Record a sandbox lifecycle duration sample. Never raises.
 
-    No-ops when OTEL export is disabled or setup has not installed a histogram.
+    No-ops when OTEL export is disabled, setup has not installed histograms,
+    or the event type is unknown.
     """
-    hist = _create_duration_histogram
+    hist = _duration_histograms.get(event_type)
     if hist is None:
         return
     try:
-        hist.record(
-            float(create_duration_ms),
+        hist.record(  # type: ignore[attr-defined]
+            float(duration_ms),
             attributes={
                 "sdk.language": sdk_language,
                 "sdk.version": sdk_version,
@@ -163,4 +186,4 @@ def record_sandbox_create_duration(
             },
         )
     except Exception:
-        logger.exception("Failed to record sandbox create duration metric")
+        logger.exception("Failed to record %s duration metric", event_type)

--- a/server/tests/test_metrics_api.py
+++ b/server/tests/test_metrics_api.py
@@ -16,6 +16,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 import opensandbox_server.integrations.otel.metrics as otel_metrics
@@ -26,7 +27,7 @@ def _event_body(**overrides):
         "eventType": "sandbox.create",
         "sandboxId": "sbx_test",
         "image": "python:3.12",
-        "createDurationMs": 1234,
+        "durationMs": 1234,
         "success": True,
     }
     body.update(overrides)
@@ -54,7 +55,7 @@ class TestReportMetricsEvent:
             "User-Agent": "OpenSandbox-Python-SDK/0.1.0",
         }
         with patch(
-            "opensandbox_server.api.metrics.record_sandbox_create_duration"
+            "opensandbox_server.api.metrics.record_sandbox_lifecycle_duration"
         ) as record:
             response = client.post(
                 "/v1/metrics/events",
@@ -64,7 +65,8 @@ class TestReportMetricsEvent:
         assert response.status_code == 204
         assert response.content == b""
         record.assert_called_once_with(
-            create_duration_ms=1234,
+            event_type="sandbox.create",
+            duration_ms=1234,
             sdk_language="python",
             sdk_version="0.1.0",
             success=True,
@@ -78,7 +80,7 @@ class TestReportMetricsEvent:
             "User-Agent": "OpenSandbox-Kotlin-SDK/1.2.3",
         }
         with patch(
-            "opensandbox_server.api.metrics.record_sandbox_create_duration"
+            "opensandbox_server.api.metrics.record_sandbox_lifecycle_duration"
         ) as record:
             response = client.post(
                 "/v1/metrics/events",
@@ -87,7 +89,8 @@ class TestReportMetricsEvent:
             )
         assert response.status_code == 204
         record.assert_called_once_with(
-            create_duration_ms=1234,
+            event_type="sandbox.create",
+            duration_ms=1234,
             sdk_language="kotlin",
             sdk_version="1.2.3",
             success=True,
@@ -98,7 +101,7 @@ class TestReportMetricsEvent:
     ):
         headers = {**auth_headers, "User-Agent": "curl/8.0"}
         with patch(
-            "opensandbox_server.api.metrics.record_sandbox_create_duration"
+            "opensandbox_server.api.metrics.record_sandbox_lifecycle_duration"
         ) as record:
             response = client.post(
                 "/v1/metrics/events",
@@ -107,7 +110,8 @@ class TestReportMetricsEvent:
             )
         assert response.status_code == 204
         record.assert_called_once_with(
-            create_duration_ms=1234,
+            event_type="sandbox.create",
+            duration_ms=1234,
             sdk_language="unknown",
             sdk_version="unknown",
             success=True,
@@ -123,7 +127,7 @@ class TestReportMetricsEvent:
             "User-Agent": "OpenSandbox-Go-SDK/0.1.0",
         }
         with patch(
-            "opensandbox_server.api.metrics.record_sandbox_create_duration"
+            "opensandbox_server.api.metrics.record_sandbox_lifecycle_duration"
         ) as record:
             response = client.post(
                 "/v1/metrics/events",
@@ -132,16 +136,61 @@ class TestReportMetricsEvent:
             )
         assert response.status_code == 204
         record.assert_called_once_with(
-            create_duration_ms=1234,
+            event_type="sandbox.create",
+            duration_ms=1234,
             sdk_language="go",
             sdk_version="0.1.0",
             success=False,
         )
 
-    def test_invalid_body_returns_422(self, client: TestClient, auth_headers: dict):
+    @pytest.mark.parametrize(
+        "event_type",
+        ["sandbox.resume", "sandbox.pause", "sandbox.kill"],
+    )
+    def test_accepts_lifecycle_events(
+        self, client: TestClient, auth_headers: dict, event_type: str
+    ):
+        headers = {
+            **auth_headers,
+            "User-Agent": "OpenSandbox-Python-SDK/0.1.0",
+        }
+        body = _event_body(eventType=event_type, durationMs=456)
+        body.pop("image")
+        with patch(
+            "opensandbox_server.api.metrics.record_sandbox_lifecycle_duration"
+        ) as record:
+            response = client.post(
+                "/v1/metrics/events",
+                json=body,
+                headers=headers,
+            )
+        assert response.status_code == 204
+        record.assert_called_once_with(
+            event_type=event_type,
+            duration_ms=456,
+            sdk_language="python",
+            sdk_version="0.1.0",
+            success=True,
+        )
+
+    def test_missing_duration_returns_422(
+        self, client: TestClient, auth_headers: dict
+    ):
+        body = _event_body()
+        body.pop("durationMs")
         response = client.post(
             "/v1/metrics/events",
-            json={"eventType": "sandbox.create"},
+            json=body,
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+    def test_unknown_event_type_returns_422(
+        self, client: TestClient, auth_headers: dict
+    ):
+        response = client.post(
+            "/v1/metrics/events",
+            json=_event_body(eventType="sandbox.unknown"),
             headers=auth_headers,
         )
         assert response.status_code == 422
@@ -149,11 +198,28 @@ class TestReportMetricsEvent:
     def test_record_helper_swallows_errors(self):
         mock_hist = MagicMock()
         mock_hist.record.side_effect = RuntimeError("boom")
-        with patch.object(otel_metrics, "_create_duration_histogram", mock_hist):
-            otel_metrics.record_sandbox_create_duration(
-                create_duration_ms=1,
+        with patch.object(
+            otel_metrics, "_duration_histograms", {"sandbox.create": mock_hist}
+        ):
+            otel_metrics.record_sandbox_lifecycle_duration(
+                event_type="sandbox.create",
+                duration_ms=1,
                 sdk_language="python",
                 sdk_version="0.0.0",
                 success=False,
             )
         mock_hist.record.assert_called_once()
+
+    def test_record_helper_ignores_unknown_event_type(self):
+        mock_hist = MagicMock()
+        with patch.object(
+            otel_metrics, "_duration_histograms", {"sandbox.create": mock_hist}
+        ):
+            otel_metrics.record_sandbox_lifecycle_duration(
+                event_type="sandbox.other",
+                duration_ms=1,
+                sdk_language="python",
+                sdk_version="0.0.0",
+                success=True,
+            )
+        mock_hist.record.assert_not_called()

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -55,10 +55,11 @@ paths:
       operationId: reportMetricsEvent
       summary: Report an SDK metrics event
       description: |
-        Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+        Accepts best-effort telemetry from SDKs covering sandbox lifecycle
+        latency (create, resume, pause, kill).
 
-        SDKs SHOULD fire-and-forget this call after `create` + readiness complete
-        (or after a failed creation attempt). Failures to report MUST NOT affect
+        SDKs SHOULD fire-and-forget this call after the lifecycle operation
+        completes (successfully or not). Failures to report MUST NOT affect
         sandbox usability. The server accepts events even when OpenTelemetry
         export is disabled (noop recording).
 
@@ -74,7 +75,7 @@ paths:
               eventType: sandbox.create
               sandboxId: sbx_01HZYEXAMPLE
               image: python:3.12
-              createDurationMs: 1842
+              durationMs: 1842
               success: true
       responses:
         '204':
@@ -825,8 +826,8 @@ components:
     MetricsEvent:
       type: object
       description: |
-        SDK-reported metrics event. Phase 1 covers sandbox creation latency from
-        the start of create until readiness succeeds or creation fails.
+        SDK-reported metrics event covering sandbox lifecycle latency measured
+        from the start of the operation until it succeeds or fails.
 
         SDK language and package version are identified via the request
         `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
@@ -834,21 +835,21 @@ components:
         eventType:
           type: string
           description: Metric event type
-          enum: [sandbox.create]
+          enum: [sandbox.create, sandbox.resume, sandbox.pause, sandbox.kill]
         sandboxId:
           type: string
           description: Sandbox identifier when available (may be omitted if create failed before an ID was assigned)
         image:
           type: string
           description: Container image URI or snapshot startup source label
-        createDurationMs:
+        durationMs:
           type: integer
           minimum: 0
-          description: Wall-clock duration in milliseconds from create start to ready or failure
+          description: Wall-clock duration in milliseconds of the lifecycle operation, measured from start until success or failure
         success:
           type: boolean
-          description: Whether create + readiness completed successfully
-      required: [eventType, createDurationMs, success]
+          description: Whether the lifecycle operation completed successfully
+      required: [eventType, durationMs, success]
     ListSandboxesResponse:
       type: object
       properties:

--- a/tests/go/lifecycle_metrics_e2e_test.go
+++ b/tests/go/lifecycle_metrics_e2e_test.go
@@ -36,7 +36,7 @@ func TestLifecycleMetrics_EndpointAcceptsEvent(t *testing.T) {
 		"eventType":        "sandbox.create",
 		"sandboxId":        "e2e-metrics-direct-go",
 		"image":            getSandboxImage(),
-		"createDurationMs": 42,
+		"durationMs": 42,
 		"success":          true,
 	}
 	body, err := json.Marshal(payload)
@@ -52,6 +52,33 @@ func TestLifecycleMetrics_EndpointAcceptsEvent(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestLifecycleMetrics_EndpointAcceptsLifecycleEvents(t *testing.T) {
+	cfg := getConnectionConfig(t)
+	url := cfg.GetBaseURL() + "/" + opensandbox.APIVersion + "/metrics/events"
+
+	for _, eventType := range []string{"sandbox.resume", "sandbox.pause", "sandbox.kill"} {
+		payload := map[string]any{
+			"eventType":  eventType,
+			"sandboxId":  "e2e-metrics-direct-go",
+			"durationMs": 42,
+			"success":    true,
+		}
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "OpenSandbox-Go-SDK/e2e")
+		req.Header.Set(cfg.GetAuthHeader(), cfg.GetAPIKey())
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusNoContent, resp.StatusCode, "eventType=%s", eventType)
+	}
 }
 
 func TestSandbox_CreateReportsLifecycleMetrics(t *testing.T) {
@@ -125,10 +152,105 @@ func TestSandbox_CreateReportsLifecycleMetrics(t *testing.T) {
 	require.False(t, hasLang)
 	require.False(t, hasVer)
 	require.True(t, strings.HasPrefix(userAgent, "OpenSandbox-Go-SDK/"))
-	duration, ok := event["createDurationMs"].(float64)
+	duration, ok := event["durationMs"].(float64)
 	require.True(t, ok)
 	require.Greater(t, duration, float64(0))
-	t.Logf("sandbox.create metrics createDurationMs=%.0fms sandboxId=%s", duration, sb.ID())
+	t.Logf("sandbox.create metrics durationMs=%.0fms sandboxId=%s", duration, sb.ID())
+}
+
+func TestSandbox_LifecycleOpsReportMetrics(t *testing.T) {
+	cfg := getConnectionConfig(t)
+
+	var (
+		mu       sync.Mutex
+		captured []map[string]any
+	)
+	base := http.DefaultTransport
+	cfg.HTTPClient = &http.Client{
+		Timeout: 3 * time.Minute,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.HasSuffix(req.URL.Path, "/metrics/events") {
+				raw, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				req.Body = io.NopCloser(bytes.NewReader(raw))
+				var event map[string]any
+				if err := json.Unmarshal(raw, &event); err == nil {
+					mu.Lock()
+					captured = append(captured, event)
+					mu.Unlock()
+				}
+			}
+			return base.RoundTrip(req)
+		}),
+	}
+
+	eventsOf := func(eventType string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var out []map[string]any
+		for _, e := range captured {
+			if e["eventType"] == eventType {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+	waitFor := func(eventType string) {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if len(eventsOf(eventType)) >= 1 {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s metrics event", eventType)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	sb, err := opensandbox.CreateSandbox(ctx, cfg, opensandbox.SandboxCreateOptions{
+		Image:      getSandboxImage(),
+		Entrypoint: []string{"tail", "-f", "/dev/null"},
+		Env:        map[string]string{"EXECD_API_GRACE_SHUTDOWN": "3s"},
+		ResourceLimits: opensandbox.ResourceLimits{
+			"cpu":    "500m",
+			"memory": "256Mi",
+		},
+		Metadata: map[string]string{"tag": "e2e-lifecycle-metrics-ops"},
+	})
+	require.NoError(t, err)
+	killed := false
+	defer func() {
+		if !killed {
+			_ = sb.Kill(context.Background())
+		}
+	}()
+
+	require.NoError(t, sb.Pause(ctx))
+	waitFor("sandbox.pause")
+
+	resumed, err := opensandbox.ResumeSandbox(ctx, cfg, sb.ID())
+	require.NoError(t, err)
+	waitFor("sandbox.resume")
+
+	require.NoError(t, resumed.Kill(ctx))
+	killed = true
+	waitFor("sandbox.kill")
+
+	for _, eventType := range []string{"sandbox.pause", "sandbox.resume", "sandbox.kill"} {
+		events := eventsOf(eventType)
+		require.GreaterOrEqual(t, len(events), 1, "eventType=%s", eventType)
+		event := events[0]
+		require.Equal(t, true, event["success"], "eventType=%s", eventType)
+		require.Equal(t, sb.ID(), event["sandboxId"], "eventType=%s", eventType)
+		duration, ok := event["durationMs"].(float64)
+		require.True(t, ok, "eventType=%s", eventType)
+		require.GreaterOrEqual(t, duration, float64(0))
+		t.Logf("%s metrics durationMs=%.0fms sandboxId=%s", eventType, duration, sb.ID())
+	}
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/tests/javascript/tests/test_lifecycle_metrics_e2e.test.ts
+++ b/tests/javascript/tests/test_lifecycle_metrics_e2e.test.ts
@@ -36,11 +36,31 @@ test("lifecycle metrics endpoint accepts SDK-shaped events", async () => {
       eventType: "sandbox.create",
       sandboxId: "e2e-metrics-direct-js",
       image: getSandboxImage(),
-      createDurationMs: 42,
+      durationMs: 42,
       success: true,
     }),
   });
   expect(response.status).toBe(204);
+});
+
+test("lifecycle metrics endpoint accepts durationMs-based events", async () => {
+  const url = `${TEST_PROTOCOL}://${TEST_DOMAIN}/v1/metrics/events`;
+  for (const eventType of ["sandbox.resume", "sandbox.pause", "sandbox.kill"]) {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OPEN-SANDBOX-API-KEY": TEST_API_KEY,
+      },
+      body: JSON.stringify({
+        eventType,
+        sandboxId: "e2e-metrics-direct-js",
+        durationMs: 42,
+        success: true,
+      }),
+    });
+    expect(response.status, `eventType=${eventType}`).toBe(204);
+  }
 });
 
 test(
@@ -88,9 +108,9 @@ test(
       expect(event.sandboxId).toBe(sandbox.id);
       expect(event.sdkLanguage).toBeUndefined();
       expect(event.sdkVersion).toBeUndefined();
-      expect(event.createDurationMs).toBeGreaterThan(0);
+      expect(event.durationMs).toBeGreaterThan(0);
       console.log(
-        `sandbox.create metrics createDurationMs=${event.createDurationMs}ms sandboxId=${event.sandboxId}`
+        `sandbox.create metrics durationMs=${event.durationMs}ms sandboxId=${event.sandboxId}`
       );
       expect(event.image).toBeTruthy();
       expect(metricsPosts[0].url).toMatch(/\/v1\/metrics\/events$/);
@@ -100,6 +120,85 @@ test(
       } catch {
         // best-effort cleanup
       }
+    }
+  },
+  5 * 60_000
+);
+
+test(
+  "pause/resume/kill report lifecycle metrics to lifecycle server",
+  async () => {
+    const metricsPosts: Array<Record<string, unknown>> = [];
+
+    // Same intercepted config is reused by pause/resume/kill, so every
+    // fire-and-forget metrics POST goes through this fetch wrapper.
+    const connectionConfig = createConnectionConfig().withTransportIfMissing();
+    const baseFetch = connectionConfig.fetch.bind(connectionConfig);
+    Object.defineProperty(connectionConfig, "fetch", {
+      configurable: true,
+      get() {
+        return async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.includes("/metrics/events")) {
+            metricsPosts.push(JSON.parse(String(init?.body ?? "{}")));
+          }
+          return baseFetch(input, init);
+        };
+      },
+    });
+
+    const eventsOf = (eventType: string) =>
+      metricsPosts.filter((e) => e.eventType === eventType);
+    const waitFor = async (eventType: string) => {
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline && eventsOf(eventType).length < 1) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(eventsOf(eventType).length, `eventType=${eventType}`).toBeGreaterThanOrEqual(1);
+    };
+
+    const sandbox = await Sandbox.create({
+      connectionConfig,
+      image: getSandboxImage(),
+      timeoutSeconds: 5 * 60,
+      readyTimeoutSeconds: 60,
+      entrypoint: ["tail", "-f", "/dev/null"],
+      env: { EXECD_API_GRACE_SHUTDOWN: "3s" },
+      metadata: { tag: "e2e-lifecycle-metrics-ops" },
+      healthCheckPollingInterval: 200,
+    });
+
+    let killed = false;
+    let resumed: Sandbox | undefined;
+    try {
+      await sandbox.pause();
+      await waitFor("sandbox.pause");
+
+      resumed = await sandbox.resume();
+      await waitFor("sandbox.resume");
+
+      await resumed.kill();
+      killed = true;
+      await waitFor("sandbox.kill");
+    } finally {
+      if (!killed) {
+        try {
+          await (resumed ?? sandbox).kill();
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+
+    for (const eventType of ["sandbox.pause", "sandbox.resume", "sandbox.kill"]) {
+      const event = eventsOf(eventType)[0];
+      expect(event.success, `eventType=${eventType}`).toBe(true);
+      expect(event.sandboxId, `eventType=${eventType}`).toBe(sandbox.id);
+      expect(typeof event.durationMs, `eventType=${eventType}`).toBe("number");
+      expect(event.durationMs as number).toBeGreaterThanOrEqual(0);
+      console.log(
+        `${eventType} metrics durationMs=${event.durationMs}ms sandboxId=${event.sandboxId}`
+      );
     }
   },
   5 * 60_000

--- a/tests/python/tests/test_lifecycle_metrics_e2e.py
+++ b/tests/python/tests/test_lifecycle_metrics_e2e.py
@@ -62,7 +62,33 @@ async def test_server_accepts_metrics_event():
         "eventType": "sandbox.create",
         "sandboxId": "e2e-metrics-direct",
         "image": get_sandbox_image(),
-        "createDurationMs": 42,
+        "durationMs": 42,
+        "success": True,
+    }
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            _metrics_url(),
+            json=payload,
+            headers={
+                "OPEN-SANDBOX-API-KEY": TEST_API_KEY,
+                "User-Agent": "OpenSandbox-Python-SDK/e2e",
+            },
+        )
+    assert response.status_code == 204, response.text
+    assert response.content == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_type",
+    ["sandbox.resume", "sandbox.pause", "sandbox.kill"],
+)
+async def test_server_accepts_lifecycle_metrics_events(event_type):
+    """Direct lifecycle endpoint smoke for the durationMs-based event types."""
+    payload = {
+        "eventType": event_type,
+        "sandboxId": "e2e-metrics-direct",
+        "durationMs": 42,
         "success": True,
     }
     async with httpx.AsyncClient(timeout=30.0) as client:
@@ -121,14 +147,81 @@ async def test_sandbox_create_reports_lifecycle_metrics():
     assert event["sandboxId"] == sandbox.id
     assert "sdkLanguage" not in event
     assert "sdkVersion" not in event
-    assert isinstance(event["createDurationMs"], int)
-    assert event["createDurationMs"] > 0
+    assert isinstance(event["durationMs"], int)
+    assert event["durationMs"] > 0
     logger.info(
-        "sandbox.create metrics createDurationMs=%s ms sandboxId=%s",
-        event["createDurationMs"],
+        "sandbox.create metrics durationMs=%s ms sandboxId=%s",
+        event["durationMs"],
         event["sandboxId"],
     )
     assert event.get("image")
+
+
+@pytest.mark.asyncio
+async def test_sandbox_lifecycle_operations_report_metrics():
+    """pause → resume → kill each fire-and-forget a durationMs metrics event."""
+    captured: list[dict] = []
+    original = lifecycle_metrics._post_async
+
+    async def _capture(config, payload):
+        captured.append(dict(payload))
+        await original(config, payload)
+
+    def _events(event_type: str) -> list[dict]:
+        return [e for e in captured if e["eventType"] == event_type]
+
+    connection_config = create_connection_config()
+    with patch.object(lifecycle_metrics, "_post_async", side_effect=_capture):
+        sandbox = await Sandbox.create(
+            image=SandboxImageSpec(get_sandbox_image()),
+            resource=get_e2e_sandbox_resource(),
+            connection_config=connection_config,
+            timeout=timedelta(minutes=5),
+            ready_timeout=timedelta(seconds=60),
+            entrypoint=["tail", "-f", "/dev/null"],
+            env={"EXECD_API_GRACE_SHUTDOWN": "3s"},
+            metadata={"tag": "e2e-lifecycle-metrics-ops"},
+        )
+        resumed = None
+        try:
+            await sandbox.pause()
+            await _wait_until(lambda: len(_events("sandbox.pause")) >= 1)
+
+            resumed = await Sandbox.resume(
+                sandbox.id,
+                connection_config=create_connection_config(),
+                resume_timeout=timedelta(seconds=60),
+            )
+            await _wait_until(lambda: len(_events("sandbox.resume")) >= 1)
+        finally:
+            target = resumed or sandbox
+            try:
+                await target.kill()
+            except Exception:
+                logger.warning("cleanup kill failed", exc_info=True)
+            try:
+                await _wait_until(lambda: len(_events("sandbox.kill")) >= 1)
+            finally:
+                for sbx in {id(sandbox): sandbox, id(target): target}.values():
+                    try:
+                        await sbx.close()
+                    except Exception:
+                        logger.warning("cleanup close failed", exc_info=True)
+
+    for event_type in ("sandbox.pause", "sandbox.resume", "sandbox.kill"):
+        events = _events(event_type)
+        assert events, f"missing {event_type} metrics event"
+        event = events[0]
+        assert event["success"] is True
+        assert event["sandboxId"] == sandbox.id
+        assert isinstance(event["durationMs"], int)
+        assert event["durationMs"] > 0
+        logger.info(
+            "%s metrics durationMs=%s ms sandboxId=%s",
+            event_type,
+            event["durationMs"],
+            event["sandboxId"],
+        )
 
 
 @pytest.mark.asyncio
@@ -216,9 +309,9 @@ def test_sandbox_sync_create_reports_lifecycle_metrics():
     assert event["success"] is True
     assert event["sandboxId"] == sandbox.id
     assert "sdkLanguage" not in event
-    assert event["createDurationMs"] > 0
+    assert event["durationMs"] > 0
     logger.info(
-        "sandbox.create metrics (sync) createDurationMs=%s ms sandboxId=%s",
-        event["createDurationMs"],
+        "sandbox.create metrics (sync) durationMs=%s ms sandboxId=%s",
+        event["durationMs"],
         event["sandboxId"],
     )


### PR DESCRIPTION
# Summary
- What is changing and why?
part of https://github.com/opensandbox-group/OpenSandbox/issues/870
refer to https://github.com/opensandbox-group/OpenSandbox/pull/1307#issuecomment-4993331161
Extend SDK metrics reporting to cover resume, pause, and kill (in addition to create) across the Python, Go, and JavaScript SDKs, unifying the payload on a single durationMs field, so the server can observe latency for all sandbox lifecycle operations rather than creation only.

## e2e test


Language | Test Name | Purpose
-- | -- | --
Python | test_server_accepts_lifecycle_metrics_events | Parameterized smoke test posting resume/pause/kill events directly to /v1/metrics/events, asserting the server returns 204
Python | test_sandbox_lifecycle_operations_report_metrics | Runs pause/resume/kill through the SDK and verifies each operation auto-reports a metrics event with durationMs
Go | TestLifecycleMetrics_EndpointAcceptsLifecycleEvents | Smoke test sending the three new event types to the metrics endpoint, asserting the server accepts them
Go | TestSandbox_LifecycleOpsReportMetrics | Runs the full pause/resume/kill flow via the Go SDK, intercepting and validating the three reported metrics events
JavaScript | lifecycle metrics endpoint accepts durationMs-based events | Smoke test verifying the server accepts the three new event types using the durationMs field
JavaScript | pause/resume/kill report lifecycle metrics to lifecycle server | Runs pause/resume/kill via the JS SDK and verifies each step reports the correct event type and duration

## test result
```
2026-07-17 13:37:39 [INFO] opensandbox.adapters.sandboxes_adapter - Successfully created sandbox: 627a4750-22a9-44ca-985d-e12d14fd9ebc
2026-07-17 13:37:39 [INFO] httpx - HTTP Request: GET http://127.0.0.1:8080/v1/sandboxes/627a4750-22a9-44ca-985d-e12d14fd9ebc/endpoints/44772?use_server_proxy=false "HTTP/1.1 200 OK"
2026-07-17 13:37:39 [INFO] httpx - HTTP Request: GET http://127.0.0.1:8080/v1/sandboxes/627a4750-22a9-44ca-985d-e12d14fd9ebc/endpoints/18080?use_server_proxy=false "HTTP/1.1 200 OK"
2026-07-17 13:37:39 [INFO] opensandbox.sandbox - Waiting for sandbox 627a4750-22a9-44ca-985d-e12d14fd9ebc to pass health check (timeout: 60.0s)
2026-07-17 13:37:39 [INFO] httpx - HTTP Request: GET http://127.0.0.1:43159/proxy/44772/ping "HTTP/1.1 200 OK"
2026-07-17 13:37:39 [INFO] opensandbox.sandbox - Sandbox 627a4750-22a9-44ca-985d-e12d14fd9ebc passed health check after 1 attempts
2026-07-17 13:37:39 [INFO] opensandbox.sandbox - Sandbox 627a4750-22a9-44ca-985d-e12d14fd9ebc is ready
2026-07-17 13:37:39 [INFO] opensandbox.sandbox - Killing sandbox: 627a4750-22a9-44ca-985d-e12d14fd9ebc
2026-07-17 13:37:39 [INFO] opensandbox.adapters.sandboxes_adapter - Terminating sandbox: 627a4750-22a9-44ca-985d-e12d14fd9ebc
2026-07-17 13:37:39 [INFO] httpx - HTTP Request: DELETE http://127.0.0.1:8080/v1/sandboxes/627a4750-22a9-44ca-985d-e12d14fd9ebc "HTTP/1.1 204 No Content"
2026-07-17 13:37:40 [INFO] opensandbox.adapters.sandboxes_adapter - Successfully terminated sandbox: 627a4750-22a9-44ca-985d-e12d14fd9ebc
PASSED
tests/test_lifecycle_metrics_e2e.py::test_sandbox_sync_create_reports_lifecycle_metrics 
-------------------------------- live log call ---------------------------------
2026-07-17 13:37:40 [INFO] opensandbox.sync.sandbox - Creating sandbox with startup source: opensandbox/code-interpreter:latest (timeout: 300.0s)
2026-07-17 13:37:40 [INFO] opensandbox.sync.adapters.sandboxes_adapter - Creating sandbox with startup source: opensandbox/code-interpreter:latest
2026-07-17 13:37:40 [INFO] httpx - HTTP Request: POST http://127.0.0.1:8080/v1/sandboxes "HTTP/1.1 202 Accepted"
2026-07-17 13:37:40 [INFO] httpx - HTTP Request: GET http://127.0.0.1:8080/v1/sandboxes/b9309ae1-a26d-4ea2-b62b-a44588e26e03/endpoints/44772?use_server_proxy=false "HTTP/1.1 200 OK"
2026-07-17 13:37:40 [INFO] httpx - HTTP Request: GET http://127.0.0.1:8080/v1/sandboxes/b9309ae1-a26d-4ea2-b62b-a44588e26e03/endpoints/18080?use_server_proxy=false "HTTP/1.1 200 OK"
2026-07-17 13:37:40 [INFO] opensandbox.sync.sandbox - Waiting for sandbox b9309ae1-a26d-4ea2-b62b-a44588e26e03 to pass health check (timeout: 60.0s)
2026-07-17 13:37:40 [INFO] httpx - HTTP Request: GET http://127.0.0.1:48923/proxy/44772/ping "HTTP/1.1 200 OK"
2026-07-17 13:37:40 [INFO] opensandbox.sync.sandbox - Sandbox b9309ae1-a26d-4ea2-b62b-a44588e26e03 passed health check after 1 attempts
2026-07-17 13:37:40 [INFO] opensandbox.sync.sandbox - Sandbox b9309ae1-a26d-4ea2-b62b-a44588e26e03 is ready
2026-07-17 13:37:40 [INFO] opensandbox.sync.sandbox - Killing sandbox: b9309ae1-a26d-4ea2-b62b-a44588e26e03
2026-07-17 13:37:40 [INFO] httpx - HTTP Request: POST http://127.0.0.1:8080/v1/metrics/events "HTTP/1.1 204 No Content"
2026-07-17 13:37:41 [INFO] httpx - HTTP Request: DELETE http://127.0.0.1:8080/v1/sandboxes/b9309ae1-a26d-4ea2-b62b-a44588e26e03 "HTTP/1.1 204 No Content"
2026-07-17 13:37:41 [INFO] tests.test_lifecycle_metrics_e2e - sandbox.create metrics (sync) durationMs=941 ms sandboxId=b9309ae1-a26d-4ea2-b62b-a44588e26e03
PASSED

============================== 8 passed in 53.94s ==============================
```

```
== RUN   TestLifecycleMetrics_EndpointAcceptsEvent
--- PASS: TestLifecycleMetrics_EndpointAcceptsEvent (0.01s)
=== RUN   TestLifecycleMetrics_EndpointAcceptsLifecycleEvents
--- PASS: TestLifecycleMetrics_EndpointAcceptsLifecycleEvents (0.00s)
=== RUN   TestSandbox_CreateReportsLifecycleMetrics
    lifecycle_metrics_e2e_test.go:158: sandbox.create metrics durationMs=16515ms sandboxId=23e528f1-80ba-467a-ab7d-836deeab5f5b
--- PASS: TestSandbox_CreateReportsLifecycleMetrics (16.71s)
=== RUN   TestSandbox_LifecycleOpsReportMetrics
    lifecycle_metrics_e2e_test.go:252: sandbox.pause metrics durationMs=42ms sandboxId=3ba6d986-55c4-4f47-aa2b-ac54ee4da6e1
    lifecycle_metrics_e2e_test.go:252: sandbox.resume metrics durationMs=48ms sandboxId=3ba6d986-55c4-4f47-aa2b-ac54ee4da6e1
    lifecycle_metrics_e2e_test.go:252: sandbox.kill metrics durationMs=94ms sandboxId=3ba6d986-55c4-4f47-aa2b-ac54ee4da6e1
--- PASS: TestSandbox_LifecycleOpsReportMetrics (1.50s)
PASS
ok  	github.com/alibaba/OpenSandbox/tests/go	18.629s
```

```
npm warn Unknown env config "devdir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.

 RUN  v4.1.0 /Users/zhoujinyu/CursorProject/OpenSandbox/tests/javascript


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  13:38:28
   Duration  2.29s (transform 64ms, setup 0ms, import 76ms, tests 2.10s, environment 0ms)

npm notice
npm notice New major version of npm available! 11.13.0 -> 12.0.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.1
npm notice To update run: npm install -g npm@12.0.1
npm notice
```


# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
