### PR TITLE
feat(sdk): send client IP via OPEN-SANDBOX-CLIENT-IP header across all SDKs

### DIFF
--- a/sdks/sandbox/csharp/src/OpenSandbox/Config/ConnectionConfig.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Config/ConnectionConfig.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using OpenSandbox.Core;
+using OpenSandbox.Internal;
 
 namespace OpenSandbox.Config;
 
@@ -252,6 +253,8 @@ public sealed class ConnectionConfig
             }
         }
 
+        ApplyClientIpDefaultHeader(client);
+
         return client;
     }
 
@@ -280,7 +283,33 @@ public sealed class ConnectionConfig
             client.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
         }
 
+        ApplyClientIpDefaultHeader(client);
+
         return client;
+    }
+
+    /// <summary>
+    /// Best-effort: add the SDK host's own IP as a default request header so the
+    /// server can see the client's self-reported address. Applied on every client
+    /// (normal and SSE) so all request paths — including raw/streaming sends that
+    /// bypass <c>HttpClientWrapper</c> — carry it. A custom (non-standard) header
+    /// name is used on purpose: standard forwarded headers such as X-Forwarded-For
+    /// are rewritten or stripped by intermediaries. Never overrides a value the
+    /// caller already supplied via <see cref="Headers"/>, and is skipped silently
+    /// when the IP cannot be determined.
+    /// </summary>
+    private static void ApplyClientIpDefaultHeader(HttpClient client)
+    {
+        if (client.DefaultRequestHeaders.Contains(Constants.ClientIpHeader))
+        {
+            return;
+        }
+
+        var clientIp = ClientIpDetector.ClientIp();
+        if (!string.IsNullOrEmpty(clientIp))
+        {
+            client.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ClientIpHeader, clientIp);
+        }
     }
 
     private static (ConnectionProtocol?, string) NormalizeDomainBase(string input)

--- a/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
@@ -87,4 +87,12 @@ public static class Constants
     /// Header name for request ID.
     /// </summary>
     public const string RequestIdHeader = "x-request-id";
+
+    /// <summary>
+    /// Header name carrying the SDK host's own IP. A non-standard name is used
+    /// on purpose: standard forwarded headers (X-Forwarded-For, etc.) are
+    /// rewritten or stripped by intermediaries, so a dedicated name conveys it
+    /// reliably.
+    /// </summary>
+    public const string ClientIpHeader = "OPEN-SANDBOX-CLIENT-IP";
 }

--- a/sdks/sandbox/csharp/src/OpenSandbox/Internal/ClientIpDetector.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Internal/ClientIpDetector.cs
@@ -1,0 +1,256 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace OpenSandbox.Internal;
+
+/// <summary>
+/// Best-effort detection of the SDK host's own intranet IP address.
+///
+/// The IP is read from the address configured on a real network interface (NOT
+/// by dialing out): the outbound route can traverse an egress cluster, whose
+/// source IP would not identify the host. A custom (non-standard) header name
+/// conveys it because standard forwarded headers such as X-Forwarded-For are
+/// rewritten or stripped by intermediaries.
+/// </summary>
+internal static class ClientIpDetector
+{
+    // Interface name fragments indicating virtual/container/VPN NICs whose
+    // address does not identify the host machine; skipped when picking the IP.
+    private static readonly string[] VirtualNicPrefixes =
+    {
+        "docker", "veth", "br-", "virbr", "vmnet", "vbox",
+        "utun", "tun", "tap", "zt", "cni", "flannel", "cali",
+    };
+
+    private static readonly object Lock = new();
+    private static string? _cached;
+    private static volatile Func<string> _detector = DetectOutboundIp;
+
+    /// <summary>
+    /// Detection function; overridable for tests. Backed by a volatile field for
+    /// cross-thread visibility, mirroring the Kotlin SDK's @Volatile detector.
+    /// </summary>
+    internal static Func<string> Detector
+    {
+        get => _detector;
+        set => _detector = value;
+    }
+
+    /// <summary>Return the intranet IP, detected once and cached for the process.</summary>
+    internal static string ClientIp()
+    {
+        lock (Lock)
+        {
+            _cached ??= Detector();
+            return _cached;
+        }
+    }
+
+    /// <summary>One interface and its IPv4 addresses; used so selection is unit-testable.</summary>
+    internal readonly record struct NicAddrs(string Name, IReadOnlyList<string> Ips);
+
+    /// <summary>Detect the host's intranet IPv4, or empty string if none is found.</summary>
+    internal static string DetectOutboundIp()
+    {
+        try
+        {
+            var nics = new List<NicAddrs>();
+            foreach (var iface in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                try
+                {
+                    if (iface.OperationalStatus != OperationalStatus.Up ||
+                        iface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    {
+                        continue;
+                    }
+
+                    var ips = new List<string>();
+                    foreach (var ua in iface.GetIPProperties().UnicastAddresses)
+                    {
+                        if (ua.Address.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            ips.Add(ua.Address.ToString());
+                        }
+                    }
+                    nics.Add(new NicAddrs(iface.Name, ips));
+                }
+                catch
+                {
+                    // Skip this interface; keep enumerating the rest.
+                }
+            }
+            return SelectClientIp(nics);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static bool IsVirtualNic(string name)
+    {
+        var lower = name.ToLowerInvariant();
+        foreach (var p in VirtualNicPrefixes)
+        {
+            if (lower.StartsWith(p, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Rank an interface name by likelihood of being the primary intranet NIC (lower = better).</summary>
+    private static int NicNameRank(string name)
+    {
+        name = name.ToLowerInvariant();
+        if (name == "en0")
+        {
+            return 0;
+        }
+        if (name == "eth0")
+        {
+            return 1;
+        }
+        if (name.StartsWith("eth", StringComparison.Ordinal))
+        {
+            return 2;
+        }
+        if (name.StartsWith("en", StringComparison.Ordinal)) // covers en*, ens*, enp*, eno*
+        {
+            return 3;
+        }
+        if (name.StartsWith("bond", StringComparison.Ordinal))
+        {
+            return 4;
+        }
+        return 100;
+    }
+
+    private static int[]? ParseIpv4(string ip)
+    {
+        var parts = ip.Split('.');
+        if (parts.Length != 4)
+        {
+            return null;
+        }
+        var nums = new int[4];
+        for (var i = 0; i < 4; i++)
+        {
+            if (!int.TryParse(parts[i], out var n) || n < 0 || n > 255)
+            {
+                return null;
+            }
+            nums[i] = n;
+        }
+        return nums;
+    }
+
+    private static bool IsUsableIpv4(string ip)
+    {
+        var o = ParseIpv4(ip);
+        if (o == null)
+        {
+            return false;
+        }
+        if (o[0] == 127) // loopback
+        {
+            return false;
+        }
+        if (o[0] == 169 && o[1] == 254) // link-local
+        {
+            return false;
+        }
+        if (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0) // unspecified
+        {
+            return false;
+        }
+        return true;
+    }
+
+    private static bool IsPrivateIpv4(string ip)
+    {
+        var o = ParseIpv4(ip);
+        if (o == null)
+        {
+            return false;
+        }
+        if (o[0] == 10)
+        {
+            return true;
+        }
+        if (o[0] == 172 && o[1] >= 16 && o[1] <= 31)
+        {
+            return true;
+        }
+        if (o[0] == 192 && o[1] == 168)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Pick the host's intranet IPv4 from the given interfaces. Prefers, in order:
+    /// known NIC names (<see cref="NicNameRank"/>), then RFC1918 private addresses
+    /// — network-name priority with private-segment fallback in a single pass.
+    /// Virtual/container/VPN NICs are skipped. Returns empty string if none is usable.
+    /// </summary>
+    internal static string SelectClientIp(IReadOnlyList<NicAddrs> nics)
+    {
+        var best = string.Empty;
+        var bestRank = 0;
+        var bestPrivate = false;
+        var found = false;
+
+        foreach (var nic in nics)
+        {
+            if (IsVirtualNic(nic.Name))
+            {
+                continue;
+            }
+            var rank = NicNameRank(nic.Name);
+            foreach (var ip in nic.Ips)
+            {
+                if (!IsUsableIpv4(ip))
+                {
+                    continue;
+                }
+                var priv = IsPrivateIpv4(ip);
+                if (!found || rank < bestRank || (rank == bestRank && priv && !bestPrivate))
+                {
+                    best = ip;
+                    bestRank = rank;
+                    bestPrivate = priv;
+                    found = true;
+                }
+            }
+        }
+        return best;
+    }
+
+    /// <summary>Reset detection state. Intended for tests only.</summary>
+    internal static void ResetForTest()
+    {
+        lock (Lock)
+        {
+            _cached = null;
+            Detector = DetectOutboundIp;
+        }
+    }
+}

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/AssemblyInfo.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+// ClientIpTests mutates the process-wide ClientIpDetector state, and many tests
+// read it via HttpClientWrapper.ApplyDefaultHeaders. Disabling cross-class test
+// parallelization avoids a race on that shared state. The suite is small, so the
+// serial run cost is negligible.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ClientIpTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ClientIpTests.cs
@@ -1,0 +1,165 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using FluentAssertions;
+using OpenSandbox.Config;
+using OpenSandbox.Core;
+using OpenSandbox.Internal;
+using Xunit;
+
+namespace OpenSandbox.Tests;
+
+public class ClientIpTests : IDisposable
+{
+    public ClientIpTests()
+    {
+        ClientIpDetector.ResetForTest();
+    }
+
+    public void Dispose()
+    {
+        ClientIpDetector.ResetForTest();
+    }
+
+    private static ConnectionConfig ConfigWith(
+        string? userClientIp = null,
+        string headerName = Constants.ClientIpHeader)
+    {
+        var headers = new Dictionary<string, string>();
+        if (userClientIp != null)
+        {
+            headers[headerName] = userClientIp;
+        }
+        return new ConnectionConfig(new ConnectionConfigOptions { Headers = headers });
+    }
+
+    private static string? ClientIpDefaultHeader(HttpClient client)
+    {
+        return client.DefaultRequestHeaders.TryGetValues(Constants.ClientIpHeader, out var values)
+            ? string.Join(",", values)
+            : null;
+    }
+
+    [Fact]
+    public void DetectOutboundIp_ShouldReturnValidOrEmpty()
+    {
+        var ip = ClientIpDetector.DetectOutboundIp();
+        if (string.IsNullOrEmpty(ip))
+        {
+            return; // best-effort: allowed in a network-less environment
+        }
+
+        IPAddress.TryParse(ip, out var parsed).Should().BeTrue();
+        IPAddress.IsLoopback(parsed!).Should().BeFalse();
+        parsed!.Equals(IPAddress.Any).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SelectClientIp_ShouldPreferNamedNicAndSkipVirtual()
+    {
+        var nics = new List<ClientIpDetector.NicAddrs>
+        {
+            new("docker0", new[] { "172.17.0.1" }), // virtual, skip
+            new("utun3", new[] { "10.8.0.3" }), // VPN, skip
+            new("en0", new[] { "10.1.1.1" }), // main NIC
+            new("eth1", new[] { "192.168.5.5" }),
+        };
+        ClientIpDetector.SelectClientIp(nics).Should().Be("10.1.1.1");
+    }
+
+    [Fact]
+    public void SelectClientIp_ShouldFallBackToPrivateWhenNoNamedNic()
+    {
+        var nics = new List<ClientIpDetector.NicAddrs>
+        {
+            new("docker0", new[] { "172.17.0.1" }), // virtual, skip
+            new("custom9", new[] { "8.8.4.4" }), // public, lower preference
+            new("wlan9", new[] { "10.0.0.50" }), // private, preferred
+        };
+        ClientIpDetector.SelectClientIp(nics).Should().Be("10.0.0.50");
+    }
+
+    [Fact]
+    public void SelectClientIp_ShouldSkipLoopbackAndLinkLocal()
+    {
+        var nics = new List<ClientIpDetector.NicAddrs>
+        {
+            new("eth0", new[] { "127.0.0.1", "169.254.1.1", "10.1.2.3" }),
+        };
+        ClientIpDetector.SelectClientIp(nics).Should().Be("10.1.2.3");
+    }
+
+    [Fact]
+    public void SelectClientIp_ShouldReturnEmptyWhenNoUsable()
+    {
+        var nics = new List<ClientIpDetector.NicAddrs>
+        {
+            new("docker0", new[] { "172.17.0.1" }),
+            new("eth0", new[] { "169.254.1.1" }),
+        };
+        ClientIpDetector.SelectClientIp(nics).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void ClientIp_ShouldCacheDetectedValue()
+    {
+        ClientIpDetector.Detector = () => "10.1.2.3";
+        ClientIpDetector.ClientIp().Should().Be("10.1.2.3");
+
+        // Cache must hold even after the detector changes.
+        ClientIpDetector.Detector = () => "10.9.9.9";
+        ClientIpDetector.ClientIp().Should().Be("10.1.2.3");
+    }
+
+    [Fact]
+    public void CreateHttpClient_ShouldSetClientIpDefaultHeader()
+    {
+        ClientIpDetector.Detector = () => "10.9.8.7";
+        using var client = ConfigWith().CreateHttpClient();
+        ClientIpDefaultHeader(client).Should().Be("10.9.8.7");
+    }
+
+    [Fact]
+    public void CreateSseHttpClient_ShouldSetClientIpDefaultHeader()
+    {
+        // The SSE client backs all streaming/raw sends that bypass HttpClientWrapper
+        // (command SSE, isolated sessions, code run-stream), so it must carry the header too.
+        ClientIpDetector.Detector = () => "10.9.8.7";
+        using var client = ConfigWith().CreateSseHttpClient();
+        ClientIpDefaultHeader(client).Should().Be("10.9.8.7");
+    }
+
+    [Fact]
+    public void CreateHttpClient_ShouldNotOverrideUserProvidedClientIp()
+    {
+        // Seed via a lowercase header name to prove the guard is case-insensitive,
+        // matching the JS/Python tests.
+        ClientIpDetector.Detector = () => "10.9.8.7";
+        using var client = ConfigWith(
+            userClientIp: "192.168.0.9",
+            headerName: "open-sandbox-client-ip").CreateHttpClient();
+
+        client.DefaultRequestHeaders.GetValues(Constants.ClientIpHeader)
+            .Should().ContainSingle().Which.Should().Be("192.168.0.9");
+    }
+
+    [Fact]
+    public void CreateHttpClient_ShouldOmitClientIpWhenUndetectable()
+    {
+        ClientIpDetector.Detector = () => string.Empty;
+        using var client = ConfigWith().CreateHttpClient();
+        ClientIpDefaultHeader(client).Should().BeNull();
+    }
+}

--- a/sdks/sandbox/go/clientip.go
+++ b/sdks/sandbox/go/clientip.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"net"
+	"strings"
+	"sync"
+)
+
+// clientIPHeader carries the SDK host's own IP address to the server. A custom
+// (non-standard) name is used on purpose: standard forwarded headers such as
+// X-Forwarded-For are rewritten or stripped by intermediaries, so a dedicated
+// name is needed to convey the client's self-reported IP reliably.
+const clientIPHeader = "OPEN-SANDBOX-CLIENT-IP"
+
+// virtualNICPrefixes are interface name fragments that indicate virtual,
+// container, or VPN NICs whose address does not identify the host machine.
+// They are skipped when picking the host's own IP.
+var virtualNICPrefixes = []string{
+	"docker", "veth", "br-", "virbr", "vmnet", "vbox",
+	"utun", "tun", "tap", "zt", "cni", "flannel", "cali",
+}
+
+// clientIPDetector resolves the local intranet IP. It is a package variable so
+// tests can stub the detection result. Returns "" when the IP cannot be
+// determined (best-effort: callers must tolerate an empty result).
+var clientIPDetector = detectOutboundIP
+
+var (
+	clientIPOnce  sync.Once
+	clientIPValue string
+)
+
+// detectedClientIP returns the local intranet IP, detected once and cached.
+func detectedClientIP() string {
+	clientIPOnce.Do(func() {
+		clientIPValue = clientIPDetector()
+	})
+	return clientIPValue
+}
+
+// nicAddrs is one network interface and its addresses; used so the selection
+// logic can be unit-tested without real interfaces.
+type nicAddrs struct {
+	name string
+	ips  []net.IP
+}
+
+// detectOutboundIP returns the host's own intranet IPv4 by reading the address
+// configured on a real network interface (NOT by dialing out): the outbound
+// route can traverse an egress cluster, whose source IP would not identify the
+// host. Returns "" if no usable address is found.
+func detectOutboundIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	nics := make([]nicAddrs, 0, len(ifaces))
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		ips := make([]net.IP, 0, len(addrs))
+		for _, addr := range addrs {
+			if ipNet, ok := addr.(*net.IPNet); ok {
+				ips = append(ips, ipNet.IP)
+			}
+		}
+		nics = append(nics, nicAddrs{name: iface.Name, ips: ips})
+	}
+	return selectClientIP(nics)
+}
+
+// isUsableIPv4 reports whether ip is a routable-on-a-LAN unicast IPv4 address
+// (excludes loopback, link-local 169.254.x, and unspecified).
+func isUsableIPv4(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	return !v4.IsLoopback() && !v4.IsLinkLocalUnicast() && !v4.IsUnspecified()
+}
+
+// nicNameRank scores an interface name by how likely it is the host's primary
+// intranet NIC (lower is better). Named NICs beat unknown ones.
+func nicNameRank(name string) int {
+	name = strings.ToLower(name)
+	switch {
+	case name == "en0":
+		return 0
+	case name == "eth0":
+		return 1
+	case strings.HasPrefix(name, "eth"):
+		return 2
+	case strings.HasPrefix(name, "en"): // covers en*, ens*, enp*, eno*
+		return 3
+	case strings.HasPrefix(name, "bond"):
+		return 4
+	default:
+		return 100
+	}
+}
+
+func isVirtualNIC(name string) bool {
+	lower := strings.ToLower(name)
+	for _, p := range virtualNICPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// selectClientIP picks the host's intranet IPv4 from the given interfaces.
+// Selection prefers, in order: known NIC names (nicNameRank), then RFC1918
+// private addresses. This yields "network-name priority with private-segment
+// fallback" in a single pass. Virtual/container/VPN NICs are skipped. Returns
+// "" if no usable address exists.
+func selectClientIP(nics []nicAddrs) string {
+	best := ""
+	bestRank := 0
+	bestPrivate := false
+	found := false
+
+	for _, nic := range nics {
+		if isVirtualNIC(nic.name) {
+			continue
+		}
+		rank := nicNameRank(nic.name)
+		for _, ip := range nic.ips {
+			if !isUsableIPv4(ip) {
+				continue
+			}
+			private := ip.IsPrivate()
+			// Better = lower rank; on equal rank, private beats non-private.
+			if !found || rank < bestRank || (rank == bestRank && private && !bestPrivate) {
+				best = ip.String()
+				bestRank = rank
+				bestPrivate = private
+				found = true
+			}
+		}
+	}
+	return best
+}
+
+// applyClientIP adds the client IP header to headers unless the caller already
+// provided it (matched case-insensitively). An empty ip is a no-op. It returns
+// the possibly-newly-allocated map so callers can reassign.
+func applyClientIP(headers map[string]string, ip string) map[string]string {
+	if ip == "" {
+		return headers
+	}
+	for k := range headers {
+		if strings.EqualFold(k, clientIPHeader) {
+			// Respect a user-supplied value; do not overwrite.
+			return headers
+		}
+	}
+	if headers == nil {
+		headers = make(map[string]string, 1)
+	}
+	headers[clientIPHeader] = ip
+	return headers
+}

--- a/sdks/sandbox/go/clientip_test.go
+++ b/sdks/sandbox/go/clientip_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensandbox
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// withStubbedClientIP replaces the cached client-IP detection with a fixed
+// value for the duration of the test and restores it afterwards.
+func withStubbedClientIP(t *testing.T, ip string) {
+	t.Helper()
+	prevDetector := clientIPDetector
+	prevValue := clientIPValue
+	clientIPDetector = func() string { return ip }
+	clientIPOnce = sync.Once{}
+	clientIPValue = ""
+	t.Cleanup(func() {
+		clientIPDetector = prevDetector
+		clientIPValue = prevValue
+		// Reset so subsequent callers re-detect via the restored detector.
+		clientIPOnce = sync.Once{}
+	})
+}
+
+func TestApplyClientIP_SetsHeaderWhenAbsent(t *testing.T) {
+	got := applyClientIP(nil, "10.1.2.3")
+	require.Equal(t, "10.1.2.3", got[clientIPHeader])
+}
+
+func TestApplyClientIP_DoesNotOverwriteUserValue(t *testing.T) {
+	// User-provided header using a different case must be preserved.
+	headers := map[string]string{"open-sandbox-client-ip": "192.168.0.9"}
+	got := applyClientIP(headers, "10.1.2.3")
+	require.Equal(t, "192.168.0.9", got["open-sandbox-client-ip"])
+	_, hasCanonical := got[clientIPHeader]
+	require.True(t, !hasCanonical, "must not add a second client-IP header key")
+}
+
+func TestApplyClientIP_EmptyIPIsNoOp(t *testing.T) {
+	require.Len(t, applyClientIP(nil, ""), 0)
+
+	headers := map[string]string{"X-Foo": "bar"}
+	got := applyClientIP(headers, "")
+	_, has := got[clientIPHeader]
+	require.True(t, !has, "must not set header when IP is empty")
+}
+
+func TestDetectOutboundIP_ReturnsValidOrEmpty(t *testing.T) {
+	// Best-effort: may be empty in a network-less environment, but if non-empty
+	// it must be a valid, non-loopback, non-unspecified IP.
+	ip := detectOutboundIP()
+	if ip == "" {
+		return
+	}
+	parsed := net.ParseIP(ip)
+	require.NotNil(t, parsed, "detected value %q is not a valid IP", ip)
+	require.True(t, !parsed.IsLoopback(), "detected loopback IP %q", ip)
+	require.True(t, !parsed.IsUnspecified(), "detected unspecified IP %q", ip)
+}
+
+func TestSelectClientIP_PrefersNamedNICAndSkipsVirtual(t *testing.T) {
+	nics := []nicAddrs{
+		{name: "docker0", ips: []net.IP{net.ParseIP("172.17.0.1")}}, // virtual, skip
+		{name: "utun3", ips: []net.IP{net.ParseIP("10.8.0.3")}},     // VPN, skip
+		{name: "en0", ips: []net.IP{net.ParseIP("10.1.1.1")}},   // main NIC
+		{name: "eth1", ips: []net.IP{net.ParseIP("192.168.5.5")}},
+	}
+	require.Equal(t, "10.1.1.1", selectClientIP(nics))
+}
+
+func TestSelectClientIP_FallsBackToPrivateWhenNoNamedNIC(t *testing.T) {
+	// No en*/eth*/bond* names -> pick a usable private IPv4, skipping virtual.
+	nics := []nicAddrs{
+		{name: "docker0", ips: []net.IP{net.ParseIP("172.17.0.1")}}, // virtual, skip
+		{name: "custom9", ips: []net.IP{net.ParseIP("8.8.4.4")}},    // public, lower pref
+		{name: "wlan9", ips: []net.IP{net.ParseIP("10.0.0.50")}},    // private, preferred
+	}
+	require.Equal(t, "10.0.0.50", selectClientIP(nics))
+}
+
+func TestSelectClientIP_SkipsLoopbackAndLinkLocal(t *testing.T) {
+	nics := []nicAddrs{
+		{name: "eth0", ips: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("169.254.1.1"), net.ParseIP("10.1.2.3")}},
+	}
+	require.Equal(t, "10.1.2.3", selectClientIP(nics))
+}
+
+func TestSelectClientIP_ReturnsEmptyWhenNoUsable(t *testing.T) {
+	nics := []nicAddrs{
+		{name: "docker0", ips: []net.IP{net.ParseIP("172.17.0.1")}},
+		{name: "eth0", ips: []net.IP{net.ParseIP("169.254.1.1")}},
+	}
+	require.Equal(t, "", selectClientIP(nics))
+}
+
+func TestNewClient_SendsClientIPHeader(t *testing.T) {
+	withStubbedClientIP(t, "10.9.8.7")
+
+	var gotIP string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIP = r.Header.Get(clientIPHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "k", "OPEN-SANDBOX-API-KEY")
+	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "10.9.8.7", gotIP)
+}
+
+func TestNewClient_OmitsClientIPHeaderWhenUndetectable(t *testing.T) {
+	withStubbedClientIP(t, "")
+
+	present := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header[http.CanonicalHeaderKey(clientIPHeader)]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "k", "OPEN-SANDBOX-API-KEY")
+	err := c.doRequest(context.Background(), http.MethodGet, "/", nil, nil)
+	require.NoError(t, err)
+	require.True(t, !present, "client IP header must be absent when undetectable")
+}

--- a/sdks/sandbox/go/clientip_test.go
+++ b/sdks/sandbox/go/clientip_test.go
@@ -80,7 +80,7 @@ func TestSelectClientIP_PrefersNamedNICAndSkipsVirtual(t *testing.T) {
 	nics := []nicAddrs{
 		{name: "docker0", ips: []net.IP{net.ParseIP("172.17.0.1")}}, // virtual, skip
 		{name: "utun3", ips: []net.IP{net.ParseIP("10.8.0.3")}},     // VPN, skip
-		{name: "en0", ips: []net.IP{net.ParseIP("10.1.1.1")}},   // main NIC
+		{name: "en0", ips: []net.IP{net.ParseIP("10.1.1.1")}},       // main NIC
 		{name: "eth1", ips: []net.IP{net.ParseIP("192.168.5.5")}},
 	}
 	require.Equal(t, "10.1.1.1", selectClientIP(nics))

--- a/sdks/sandbox/go/http.go
+++ b/sdks/sandbox/go/http.go
@@ -174,6 +174,10 @@ func NewClient(baseURL, apiKey, authHeader string, opts ...Option) *Client {
 	if c.timeout != nil {
 		c.httpClient.Timeout = *c.timeout
 	}
+	// Best-effort: attach the SDK host's own IP so the server can see the
+	// client's self-reported address. Never overrides a user-supplied value
+	// and is skipped silently when the IP cannot be determined.
+	c.headers = applyClientIP(c.headers, detectedClientIP())
 	return c
 }
 

--- a/sdks/sandbox/go/lifecycle_metrics.go
+++ b/sdks/sandbox/go/lifecycle_metrics.go
@@ -83,6 +83,12 @@ func reportSandboxCreateMetric(cfg ConnectionConfig, sandboxID, image string, du
 				req.Header.Set(k, v)
 			}
 		}
+		// This raw request bypasses NewClient (where the client IP is injected
+		// into Client.headers), so attach it here too. req.Header.Get is
+		// case-insensitive, so a user-supplied value above still wins.
+		if ip := detectedClientIP(); ip != "" && req.Header.Get(clientIPHeader) == "" {
+			req.Header.Set(clientIPHeader, ip)
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			return

--- a/sdks/sandbox/go/lifecycle_metrics_test.go
+++ b/sdks/sandbox/go/lifecycle_metrics_test.go
@@ -65,6 +65,30 @@ func TestReportSandboxCreateMetricPostsEvent(t *testing.T) {
 	t.Fatal("metrics POST was not received")
 }
 
+func TestReportSandboxCreateMetricCarriesClientIPHeader(t *testing.T) {
+	withStubbedClientIP(t, "10.9.8.7")
+
+	var gotIP atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIP.Store(r.Header.Get(clientIPHeader))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cfg := ConnectionConfig{Domain: server.URL, Protocol: "http", APIKey: "k"}
+	reportSandboxCreateMetric(cfg, "sbx", "python:3.12", 42, true)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if v, ok := gotIP.Load().(string); ok {
+			require.Equal(t, "10.9.8.7", v)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("metrics POST was not received")
+}
+
 func TestReportSandboxCreateMetricIgnoresFailure(t *testing.T) {
 	cfg := ConnectionConfig{Domain: "http://127.0.0.1:1", Protocol: "http"}
 	// Should not panic or block.

--- a/sdks/sandbox/javascript/src/config/clientIp.ts
+++ b/sdks/sandbox/javascript/src/config/clientIp.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CLIENT_IP_HEADER } from "../core/constants.js";
+
+// Detect the SDK host's own outbound IP using the same underlying logic as the
+// other OpenSandbox SDKs: "dial" a UDP socket to a fixed external address and
+// read the local address the OS bound. UDP is connectionless, so no packet is
+// sent; the OS merely selects the outbound interface for the default route.
+//
+// Node's dgram connect is asynchronous, so detection runs once at module load
+// and the result is cached. The header is added per request by the transport
+// wrapper (see applyClientIpToInit), which reads the cached value; by the time
+// any request is issued, detection has resolved. A custom (non-standard) header
+// name is used on purpose: standard forwarded headers such as X-Forwarded-For
+// are rewritten or stripped by intermediaries.
+
+// Probe target. A literal IP (not a hostname) avoids any DNS lookup.
+const PROBE_HOST = "8.8.8.8";
+const PROBE_PORT = 80;
+
+let cachedIp = "";
+let detectionStarted = false;
+
+function isNodeRuntime(): boolean {
+  const p = (globalThis as any)?.process;
+  return !!p?.versions?.node;
+}
+
+function isUsableIp(ip: unknown): ip is string {
+  if (typeof ip !== "string" || ip.length === 0) return false;
+  if (ip === "0.0.0.0" || ip === "::") return false;
+  if (ip.startsWith("127.") || ip === "::1") return false;
+  return true;
+}
+
+/**
+ * Probe the local outbound IP via a UDP dial. Resolves to the IP or "" when it
+ * cannot be determined. Best-effort: never rejects.
+ */
+export async function probeOutboundIp(): Promise<string> {
+  if (!isNodeRuntime()) return "";
+  try {
+    // Dynamic, non-literal specifier keeps this Node-only and avoids requiring
+    // `@types/node` or bundling `node:dgram` into browser builds.
+    const specifier = "node:dgram";
+    const dgram: any = await import(specifier);
+    return await new Promise<string>((resolve) => {
+      let settled = false;
+      const socket = dgram.createSocket("udp4");
+      const finish = (ip: string) => {
+        if (settled) return;
+        settled = true;
+        try {
+          socket.close();
+        } catch {
+          // ignore
+        }
+        resolve(isUsableIp(ip) ? ip : "");
+      };
+      socket.once("error", () => finish(""));
+      try {
+        socket.connect(PROBE_PORT, PROBE_HOST, () => {
+          try {
+            finish(socket.address()?.address ?? "");
+          } catch {
+            finish("");
+          }
+        });
+      } catch {
+        finish("");
+      }
+    });
+  } catch {
+    return "";
+  }
+}
+
+function ensureDetectionStarted(): void {
+  if (detectionStarted || !isNodeRuntime()) return;
+  detectionStarted = true;
+  void probeOutboundIp()
+    .then((ip) => {
+      cachedIp = ip;
+    })
+    .catch(() => {
+      // best-effort
+    });
+}
+
+// Kick off detection eagerly at import time so the result is ready by the time
+// the first request is issued.
+ensureDetectionStarted();
+
+/** Return the detected outbound IP, or "" if not (yet) available. */
+export function getClientIp(): string {
+  return cachedIp;
+}
+
+/**
+ * Add the client IP header to an outgoing request without dropping any headers
+ * already set on the `input` (which may be a {@link Request}) or `init`.
+ *
+ * Returns the possibly-adjusted `{ input, init }`. The header is not added when
+ * the IP is unavailable or a value is already present (case-insensitive), so a
+ * caller-supplied value is never overridden.
+ */
+export function withClientIp(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): { input: RequestInfo | URL; init?: RequestInit } {
+  const ip = getClientIp();
+  if (!ip) return { input, init };
+
+  const inputIsRequest = typeof Request !== "undefined" && input instanceof Request;
+
+  // Merge headers from the Request input (if any) with init headers so nothing
+  // is lost. init headers win on conflict, matching fetch(Request, init).
+  const headers = new Headers(inputIsRequest ? (input as Request).headers : undefined);
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  }
+
+  if (headers.has(CLIENT_IP_HEADER)) return { input, init };
+  headers.set(CLIENT_IP_HEADER, ip);
+
+  if (inputIsRequest) {
+    // Clone the Request preserving method/body/etc., with the merged headers.
+    return { input: new Request(input as Request, { headers }), init };
+  }
+  return { input, init: { ...(init ?? {}), headers } };
+}
+
+/** Set the cached IP directly. Intended for tests only. */
+export function _setClientIpForTest(ip: string): void {
+  cachedIp = ip;
+  detectionStarted = true;
+}
+
+/** Reset detection state so it re-probes on next import cycle. Tests only. */
+export function _resetClientIpCacheForTest(): void {
+  cachedIp = "";
+  detectionStarted = false;
+}

--- a/sdks/sandbox/javascript/src/config/clientIp.ts
+++ b/sdks/sandbox/javascript/src/config/clientIp.ts
@@ -14,74 +14,144 @@
 
 import { CLIENT_IP_HEADER } from "../core/constants.js";
 
-// Detect the SDK host's own outbound IP using the same underlying logic as the
-// other OpenSandbox SDKs: "dial" a UDP socket to a fixed external address and
-// read the local address the OS bound. UDP is connectionless, so no packet is
-// sent; the OS merely selects the outbound interface for the default route.
+// Detect the SDK host's own intranet IP by reading the address configured on a
+// real network interface (NOT by dialing out): the outbound route can traverse
+// an egress cluster whose source IP would not identify the host. A custom
+// (non-standard) header name conveys it because standard forwarded headers
+// (X-Forwarded-For, ...) are rewritten or stripped by intermediaries.
 //
-// Node's dgram connect is asynchronous, so detection runs once at module load
-// and the result is cached. The header is added per request by the transport
-// wrapper (see applyClientIpToInit), which reads the cached value; by the time
-// any request is issued, detection has resolved. A custom (non-standard) header
-// name is used on purpose: standard forwarded headers such as X-Forwarded-For
-// are rewritten or stripped by intermediaries.
+// `node:os` is loaded via an async dynamic import (kept Node-only / browser-safe,
+// matching the codebase's approach for Node modules). Detection runs once at
+// module load and is cached; the transport wrapper awaits ensureClientIpReady()
+// so even the first request carries the header.
 
-// Probe target. A literal IP (not a hostname) avoids any DNS lookup.
-const PROBE_HOST = "8.8.8.8";
-const PROBE_PORT = 80;
+// Interface name fragments indicating virtual/container/VPN NICs whose address
+// does not identify the host machine; skipped when picking the host's own IP.
+const VIRTUAL_NIC_PREFIXES = [
+  "docker",
+  "veth",
+  "br-",
+  "virbr",
+  "vmnet",
+  "vbox",
+  "utun",
+  "tun",
+  "tap",
+  "zt",
+  "cni",
+  "flannel",
+  "cali",
+];
 
 let cachedIp = "";
 let detectionStarted = false;
+let detectionPromise: Promise<void> | null = null;
 
 function isNodeRuntime(): boolean {
   const p = (globalThis as any)?.process;
   return !!p?.versions?.node;
 }
 
-function isUsableIp(ip: unknown): ip is string {
-  if (typeof ip !== "string" || ip.length === 0) return false;
-  if (ip === "0.0.0.0" || ip === "::") return false;
-  if (ip.startsWith("127.") || ip === "::1") return false;
+function isVirtualNic(name: string): boolean {
+  const lower = name.toLowerCase();
+  return VIRTUAL_NIC_PREFIXES.some((p) => lower.startsWith(p));
+}
+
+/** Rank an interface name by likelihood of being the primary intranet NIC (lower = better). */
+function nicNameRank(rawName: string): number {
+  const name = rawName.toLowerCase();
+  if (name === "en0") return 0;
+  if (name === "eth0") return 1;
+  if (name.startsWith("eth")) return 2;
+  if (name.startsWith("en")) return 3; // covers en*, ens*, enp*, eno*
+  if (name.startsWith("bond")) return 4;
+  return 100;
+}
+
+function parseIpv4(ip: string): number[] | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  const nums: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    nums.push(n);
+  }
+  return nums;
+}
+
+function isUsableIpv4(ip: string): boolean {
+  const o = parseIpv4(ip);
+  if (!o) return false;
+  if (o[0] === 127) return false; // loopback
+  if (o[0] === 169 && o[1] === 254) return false; // link-local
+  if (o[0] === 0 && o[1] === 0 && o[2] === 0 && o[3] === 0) return false; // unspecified
   return true;
 }
 
+function isPrivateIpv4(ip: string): boolean {
+  const o = parseIpv4(ip);
+  if (!o) return false;
+  if (o[0] === 10) return true;
+  if (o[0] === 172 && o[1] >= 16 && o[1] <= 31) return true;
+  if (o[0] === 192 && o[1] === 168) return true;
+  return false;
+}
+
 /**
- * Probe the local outbound IP via a UDP dial. Resolves to the IP or "" when it
- * cannot be determined. Best-effort: never rejects.
+ * Pick the host's intranet IPv4 from `{ name, ips }` interface entries.
+ * Prefers, in order: known NIC names (nicNameRank), then RFC1918 private
+ * addresses — network-name priority with private-segment fallback in one pass.
+ * Virtual/container/VPN NICs are skipped. Returns "" if none is usable.
  */
-export async function probeOutboundIp(): Promise<string> {
+export function selectClientIp(nics: { name: string; ips: string[] }[]): string {
+  let best = "";
+  let bestRank = 0;
+  let bestPrivate = false;
+  let found = false;
+
+  for (const nic of nics) {
+    if (isVirtualNic(nic.name)) continue;
+    const rank = nicNameRank(nic.name);
+    for (const ip of nic.ips) {
+      if (!isUsableIpv4(ip)) continue;
+      const priv = isPrivateIpv4(ip);
+      if (!found || rank < bestRank || (rank === bestRank && priv && !bestPrivate)) {
+        best = ip;
+        bestRank = rank;
+        bestPrivate = priv;
+        found = true;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Read the host's intranet IPv4 from the OS network interfaces. Resolves to the
+ * IP or "" when it cannot be determined. Best-effort: never rejects.
+ */
+export async function detectOutboundIp(): Promise<string> {
   if (!isNodeRuntime()) return "";
   try {
     // Dynamic, non-literal specifier keeps this Node-only and avoids requiring
-    // `@types/node` or bundling `node:dgram` into browser builds.
-    const specifier = "node:dgram";
-    const dgram: any = await import(specifier);
-    return await new Promise<string>((resolve) => {
-      let settled = false;
-      const socket = dgram.createSocket("udp4");
-      const finish = (ip: string) => {
-        if (settled) return;
-        settled = true;
-        try {
-          socket.close();
-        } catch {
-          // ignore
-        }
-        resolve(isUsableIp(ip) ? ip : "");
-      };
-      socket.once("error", () => finish(""));
-      try {
-        socket.connect(PROBE_PORT, PROBE_HOST, () => {
-          try {
-            finish(socket.address()?.address ?? "");
-          } catch {
-            finish("");
-          }
-        });
-      } catch {
-        finish("");
-      }
-    });
+    // `@types/node` or bundling `node:os` into browser builds.
+    const specifier = "node:os";
+    const os: any = await import(specifier);
+    const raw = os.networkInterfaces() as Record<
+      string,
+      { address: string; family: string | number; internal: boolean }[] | undefined
+    >;
+    const nics: { name: string; ips: string[] }[] = [];
+    for (const [name, addrs] of Object.entries(raw)) {
+      if (!addrs) continue;
+      const ips = addrs
+        .filter((a) => !a.internal && (a.family === "IPv4" || a.family === 4) && a.address)
+        .map((a) => a.address);
+      if (ips.length) nics.push({ name, ips });
+    }
+    return selectClientIp(nics);
   } catch {
     return "";
   }
@@ -90,7 +160,7 @@ export async function probeOutboundIp(): Promise<string> {
 function ensureDetectionStarted(): void {
   if (detectionStarted || !isNodeRuntime()) return;
   detectionStarted = true;
-  void probeOutboundIp()
+  detectionPromise = detectOutboundIp()
     .then((ip) => {
       cachedIp = ip;
     })
@@ -103,7 +173,21 @@ function ensureDetectionStarted(): void {
 // the first request is issued.
 ensureDetectionStarted();
 
-/** Return the detected outbound IP, or "" if not (yet) available. */
+/**
+ * Await the one-time detection so the very first request carries the header
+ * (aligning with the synchronous-detection SDKs). Cheap no-op once settled.
+ */
+export async function ensureClientIpReady(): Promise<void> {
+  if (detectionPromise) {
+    try {
+      await detectionPromise;
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/** Return the detected intranet IP, or "" if not (yet) available. */
 export function getClientIp(): string {
   return cachedIp;
 }
@@ -132,12 +216,23 @@ export function withClientIp(
     new Headers(init.headers).forEach((value, key) => headers.set(key, value));
   }
 
-  if (headers.has(CLIENT_IP_HEADER)) return { input, init };
-  headers.set(CLIENT_IP_HEADER, ip);
+  // Add the detected IP only if not already present (respect a user value).
+  // Either way we fall through to return the unified merged headers on both the
+  // input and init, so nothing is dropped under fetch(request, init) semantics.
+  if (!headers.has(CLIENT_IP_HEADER)) {
+    headers.set(CLIENT_IP_HEADER, ip);
+  }
 
   if (inputIsRequest) {
-    // Clone the Request preserving method/body/etc., with the merged headers.
-    return { input: new Request(input as Request, { headers }), init };
+    // Clone the Request preserving method/body/etc., with the merged headers,
+    // and also put the merged headers on init. Callers such as openapi-fetch
+    // invoke fetch(request, init); if init carried its own headers they would
+    // replace the Request's per fetch semantics, so returning the same merged
+    // set on both ensures no header (incl. the client IP) is dropped.
+    return {
+      input: new Request(input as Request, { headers }),
+      init: { ...(init ?? {}), headers },
+    };
   }
   return { input, init: { ...(init ?? {}), headers } };
 }
@@ -146,10 +241,25 @@ export function withClientIp(
 export function _setClientIpForTest(ip: string): void {
   cachedIp = ip;
   detectionStarted = true;
+  // The stub is authoritative; drop any in-flight probe so ensureClientIpReady
+  // is a no-op and cannot overwrite the stubbed value.
+  detectionPromise = null;
+}
+
+/**
+ * Re-trigger the one-time detection (as if freshly imported), starting a new
+ * probe and setting the awaitable promise. Intended for tests only.
+ */
+export function _restartDetectionForTest(): void {
+  cachedIp = "";
+  detectionStarted = false;
+  detectionPromise = null;
+  ensureDetectionStarted();
 }
 
 /** Reset detection state so it re-probes on next import cycle. Tests only. */
 export function _resetClientIpCacheForTest(): void {
   cachedIp = "";
   detectionStarted = false;
+  detectionPromise = null;
 }

--- a/sdks/sandbox/javascript/src/config/connection.ts
+++ b/sdks/sandbox/javascript/src/config/connection.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {DEFAULT_USER_AGENT} from "../core/constants.js";
-import {withClientIp} from "./clientIp.js";
+import {ensureClientIpReady, withClientIp} from "./clientIp.js";
 
 export type ConnectionProtocol = "http" | "https";
 
@@ -239,7 +239,9 @@ function createTimedFetch(opts: {
     // Best-effort: attach the SDK host's own IP so the server can see the
     // client's self-reported address. Applied per request (never overriding a
     // caller-supplied value or dropping existing headers) and skipped silently
-    // when the IP is unavailable.
+    // when the IP is unavailable. Await the one-time detection so even the very
+    // first request carries the header (bounded by the probe timeout).
+    await ensureClientIpReady();
     const withIp = withClientIp(input, init);
     const reqInput = withIp.input;
     const mergedInit: RequestInit = {
@@ -248,10 +250,19 @@ function createTimedFetch(opts: {
     };
 
     if (debug) {
-      const mergedHeaders = {
-        ...defaultHeaders,
-        ...((init?.headers ?? {}) as any),
-      };
+      // Log the headers actually being sent: prefer the merged headers produced
+      // by withClientIp (which include the client-IP header), falling back to
+      // the request input's headers when it is a Request object.
+      const outgoing = new Headers(
+        withIp.init?.headers ??
+          (typeof Request !== "undefined" && reqInput instanceof Request
+            ? reqInput.headers
+            : undefined)
+      );
+      const mergedHeaders: Record<string, string> = { ...defaultHeaders };
+      outgoing.forEach((value, key) => {
+        mergedHeaders[key] = value;
+      });
       // eslint-disable-next-line no-console
       console.log(
         `[opensandbox:${label}] ->`,

--- a/sdks/sandbox/javascript/src/config/connection.ts
+++ b/sdks/sandbox/javascript/src/config/connection.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {DEFAULT_USER_AGENT} from "../core/constants.js";
+import {withClientIp} from "./clientIp.js";
 
 export type ConnectionProtocol = "http" | "https";
 
@@ -235,8 +236,14 @@ function createTimedFetch(opts: {
         init.signal.addEventListener("abort", onAbort, { once: true } as any);
     }
 
+    // Best-effort: attach the SDK host's own IP so the server can see the
+    // client's self-reported address. Applied per request (never overriding a
+    // caller-supplied value or dropping existing headers) and skipped silently
+    // when the IP is unavailable.
+    const withIp = withClientIp(input, init);
+    const reqInput = withIp.input;
     const mergedInit: RequestInit = {
-      ...init,
+      ...(withIp.init ?? {}),
       signal: ac.signal,
     };
 
@@ -255,7 +262,7 @@ function createTimedFetch(opts: {
     }
 
     try {
-      const res = await baseFetch(input, mergedInit);
+      const res = await baseFetch(reqInput, mergedInit);
       if (debug) {
         // eslint-disable-next-line no-console
         console.log(`[opensandbox:${label}] <-`, method, url, res.status);

--- a/sdks/sandbox/javascript/src/core/constants.ts
+++ b/sdks/sandbox/javascript/src/core/constants.ts
@@ -28,3 +28,8 @@ export const DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS = 200;
 
 export const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
 export const DEFAULT_USER_AGENT = "OpenSandbox-JS-SDK/0.1.10";
+
+// Custom header carrying the SDK host's own IP. A non-standard name is used on
+// purpose: standard forwarded headers (X-Forwarded-For, etc.) are rewritten or
+// stripped by intermediaries, so a dedicated name conveys it reliably.
+export const CLIENT_IP_HEADER = "OPEN-SANDBOX-CLIENT-IP";

--- a/sdks/sandbox/javascript/src/internal.ts
+++ b/sdks/sandbox/javascript/src/internal.ts
@@ -43,3 +43,12 @@ export { MetricsAdapter } from "./adapters/metricsAdapter.js";
 export { FilesystemAdapter } from "./adapters/filesystemAdapter.js";
 export { CommandsAdapter } from "./adapters/commandsAdapter.js";
 export { IsolatedSessionsAdapter } from "./adapters/isolatedSessionsAdapter.js";
+
+// Client-IP detection helpers (advanced/testing).
+export {
+  probeOutboundIp,
+  getClientIp,
+  withClientIp,
+  _setClientIpForTest,
+  _resetClientIpCacheForTest,
+} from "./config/clientIp.js";

--- a/sdks/sandbox/javascript/src/internal.ts
+++ b/sdks/sandbox/javascript/src/internal.ts
@@ -46,9 +46,12 @@ export { IsolatedSessionsAdapter } from "./adapters/isolatedSessionsAdapter.js";
 
 // Client-IP detection helpers (advanced/testing).
 export {
-  probeOutboundIp,
+  detectOutboundIp,
+  selectClientIp,
   getClientIp,
+  ensureClientIpReady,
   withClientIp,
   _setClientIpForTest,
+  _restartDetectionForTest,
   _resetClientIpCacheForTest,
 } from "./config/clientIp.js";

--- a/sdks/sandbox/javascript/tests/clientIp.test.mjs
+++ b/sdks/sandbox/javascript/tests/clientIp.test.mjs
@@ -16,10 +16,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  probeOutboundIp,
+  detectOutboundIp,
+  selectClientIp,
   getClientIp,
+  ensureClientIpReady,
   withClientIp,
   _setClientIpForTest,
+  _restartDetectionForTest,
   _resetClientIpCacheForTest,
 } from "../dist/internal.js";
 
@@ -56,6 +59,61 @@ test("withClientIp preserves headers already on a Request input", (t) => {
   assert.equal(out.input.method, "POST"); // method preserved
 });
 
+test("withClientIp merges headers when input is a Request AND init has headers", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  const req = new Request("http://x/y", {
+    method: "POST",
+    headers: { "X-Req-Only": "r", "OPEN-SANDBOX-API-KEY": "secret" },
+  });
+  const out = withClientIp(req, { headers: { "X-Init": "i" } });
+  // fetch(request, init) lets init.headers replace the request's headers, so
+  // BOTH the returned Request and the returned init must carry the full merged
+  // set — whichever the runtime reads, nothing is dropped.
+  const fromInput = new Headers(out.input instanceof Request ? out.input.headers : undefined);
+  const fromInit = new Headers(out.init?.headers);
+  for (const h of [fromInput, fromInit]) {
+    assert.equal(h.get(HEADER), "10.9.8.7");
+    assert.equal(h.get("X-Req-Only"), "r");
+    assert.equal(h.get("OPEN-SANDBOX-API-KEY"), "secret");
+    assert.equal(h.get("X-Init"), "i");
+  }
+});
+
+test("withClientIp keeps merged headers when client IP is already on the Request", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  // User already set the client IP on the Request; init has an unrelated header.
+  const req = new Request("http://x/y", {
+    headers: { "OPEN-SANDBOX-CLIENT-IP": "192.168.0.9", "X-Req-Only": "r" },
+  });
+  const out = withClientIp(req, { headers: { "X-Init": "i" } });
+  const fromInput = new Headers(out.input instanceof Request ? out.input.headers : undefined);
+  const fromInit = new Headers(out.init?.headers);
+  for (const h of [fromInput, fromInit]) {
+    assert.equal(h.get(HEADER), "192.168.0.9"); // user value kept, not overwritten
+    assert.equal(h.get("X-Req-Only"), "r"); // Request-only header not dropped
+    assert.equal(h.get("X-Init"), "i"); // init header not dropped
+  }
+});
+
+test("withClientIp keeps merged headers when client IP is already in init", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  // Client IP present in init; a request-only header must survive the merge.
+  const req = new Request("http://x/y", { headers: { "X-Req-Only": "r" } });
+  const out = withClientIp(req, {
+    headers: { "open-sandbox-client-ip": "192.168.0.9", "X-Init": "i" },
+  });
+  const fromInput = new Headers(out.input instanceof Request ? out.input.headers : undefined);
+  const fromInit = new Headers(out.init?.headers);
+  for (const h of [fromInput, fromInit]) {
+    assert.equal(h.get(HEADER), "192.168.0.9");
+    assert.equal(h.get("X-Req-Only"), "r");
+    assert.equal(h.get("X-Init"), "i");
+  }
+});
+
 test("withClientIp does not overwrite a user-provided value", (t) => {
   t.after(_resetClientIpCacheForTest);
   _setClientIpForTest("10.9.8.7");
@@ -79,12 +137,65 @@ test("getClientIp returns the cached value", (t) => {
   assert.equal(getClientIp(), "172.16.5.4");
 });
 
-test("probeOutboundIp returns a valid IP or empty string", async (t) => {
+test("ensureClientIpReady awaits detection so the first request carries the header", async (t) => {
+  t.after(_resetClientIpCacheForTest);
+  // Start a fresh real probe (do NOT pre-seed the cache), then await it. This
+  // exercises the actual async detection -> ensureClientIpReady -> header path.
+  _restartDetectionForTest();
+  assert.equal(getClientIp(), "", "cache must be empty before detection resolves");
+  await ensureClientIpReady();
+  const ip = getClientIp();
+  if (ip === "") {
+    // Make the skip visible in CI rather than passing silently.
+    t.diagnostic("no outbound IP detected (network-less env); skipping header assertion");
+    return;
+  }
+  const out = withClientIp("http://x/y", undefined);
+  assert.equal(headersOf(out).get(HEADER), ip);
+});
+
+test("selectClientIp prefers a named NIC and skips virtual ones", () => {
+  const ip = selectClientIp([
+    { name: "docker0", ips: ["172.17.0.1"] }, // virtual, skip
+    { name: "utun3", ips: ["10.8.0.3"] }, // VPN, skip
+    { name: "en0", ips: ["10.1.1.1"] }, // main NIC
+    { name: "eth1", ips: ["192.168.5.5"] },
+  ]);
+  assert.equal(ip, "10.1.1.1");
+});
+
+test("selectClientIp falls back to a private IPv4 when no named NIC", () => {
+  const ip = selectClientIp([
+    { name: "docker0", ips: ["172.17.0.1"] }, // virtual, skip
+    { name: "custom9", ips: ["8.8.4.4"] }, // public, lower preference
+    { name: "wlan9", ips: ["10.0.0.50"] }, // private, preferred
+  ]);
+  assert.equal(ip, "10.0.0.50");
+});
+
+test("selectClientIp skips loopback and link-local", () => {
+  const ip = selectClientIp([
+    { name: "eth0", ips: ["127.0.0.1", "169.254.1.1", "10.1.2.3"] },
+  ]);
+  assert.equal(ip, "10.1.2.3");
+});
+
+test("selectClientIp returns empty when nothing usable", () => {
+  const ip = selectClientIp([
+    { name: "docker0", ips: ["172.17.0.1"] },
+    { name: "eth0", ips: ["169.254.1.1"] },
+  ]);
+  assert.equal(ip, "");
+});
+
+test("detectOutboundIp returns a valid IP or empty string", async (t) => {
   t.after(_resetClientIpCacheForTest);
   _resetClientIpCacheForTest();
-  const ip = await probeOutboundIp();
+  const ip = await detectOutboundIp();
   if (ip === "") {
-    return; // best-effort: allowed in a network-less environment
+    // Make the skip visible in CI rather than passing silently.
+    t.diagnostic("detectOutboundIp returned empty (network-less env); skipping format assertions");
+    return;
   }
   // Octets constrained to 0-255 so an obviously invalid address would fail.
   const octet = "(25[0-5]|2[0-4]\\d|1?\\d?\\d)";

--- a/sdks/sandbox/javascript/tests/clientIp.test.mjs
+++ b/sdks/sandbox/javascript/tests/clientIp.test.mjs
@@ -1,0 +1,94 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  probeOutboundIp,
+  getClientIp,
+  withClientIp,
+  _setClientIpForTest,
+  _resetClientIpCacheForTest,
+} from "../dist/internal.js";
+
+const HEADER = "OPEN-SANDBOX-CLIENT-IP";
+
+function headersOf(result) {
+  // Normalize to a Headers instance from either the returned init or Request input.
+  if (result.input instanceof Request) return new Headers(result.input.headers);
+  return new Headers(result.init?.headers);
+}
+
+test("withClientIp sets the header for a string input", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  const out = withClientIp("http://x/y", { headers: { "X-Foo": "bar" } });
+  const h = headersOf(out);
+  assert.equal(h.get(HEADER), "10.9.8.7");
+  assert.equal(h.get("X-Foo"), "bar"); // existing header preserved
+});
+
+test("withClientIp preserves headers already on a Request input", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  const req = new Request("http://x/y", {
+    method: "POST",
+    headers: { "X-Demo-Label": "js", "OPEN-SANDBOX-API-KEY": "secret" },
+  });
+  const out = withClientIp(req, undefined);
+  const h = headersOf(out);
+  assert.equal(h.get(HEADER), "10.9.8.7");
+  assert.equal(h.get("X-Demo-Label"), "js"); // must NOT be dropped
+  assert.equal(h.get("OPEN-SANDBOX-API-KEY"), "secret"); // must NOT be dropped
+  assert.ok(out.input instanceof Request);
+  assert.equal(out.input.method, "POST"); // method preserved
+});
+
+test("withClientIp does not overwrite a user-provided value", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("10.9.8.7");
+  const out = withClientIp("http://x/y", {
+    headers: { "open-sandbox-client-ip": "192.168.0.9" },
+  });
+  assert.equal(headersOf(out).get(HEADER), "192.168.0.9");
+});
+
+test("withClientIp is a no-op when the IP is unavailable", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("");
+  const out = withClientIp("http://x/y", { headers: { "X-Foo": "bar" } });
+  assert.equal(headersOf(out).get(HEADER), null);
+  assert.equal(headersOf(out).get("X-Foo"), "bar");
+});
+
+test("getClientIp returns the cached value", (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _setClientIpForTest("172.16.5.4");
+  assert.equal(getClientIp(), "172.16.5.4");
+});
+
+test("probeOutboundIp returns a valid IP or empty string", async (t) => {
+  t.after(_resetClientIpCacheForTest);
+  _resetClientIpCacheForTest();
+  const ip = await probeOutboundIp();
+  if (ip === "") {
+    return; // best-effort: allowed in a network-less environment
+  }
+  // Octets constrained to 0-255 so an obviously invalid address would fail.
+  const octet = "(25[0-5]|2[0-4]\\d|1?\\d?\\d)";
+  assert.match(ip, new RegExp(`^${octet}(\\.${octet}){3}$`));
+  assert.ok(!ip.startsWith("127."), `unexpected loopback IP: ${ip}`);
+  assert.notEqual(ip, "0.0.0.0");
+});

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/ClientIpDetector.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/ClientIpDetector.kt
@@ -16,26 +16,31 @@
 
 package com.alibaba.opensandbox.sandbox
 
-import java.net.DatagramSocket
-import java.net.InetAddress
+import java.net.Inet4Address
+import java.net.NetworkInterface
 
 /**
- * Best-effort detection of the SDK host's own outbound IP address.
+ * Best-effort detection of the SDK host's own intranet IP address.
  *
- * Mirrors the well-known idiom of "dialing" a UDP socket to a fixed external
- * address and reading the local address the OS bound. UDP is connectionless, so
- * no packet is sent; the OS merely selects the outbound interface for the
- * default route. A literal IP avoids any DNS lookup.
- *
- * The detected IP is sent to the server via [CLIENT_IP_HEADER]. A custom
- * (non-standard) header name is used on purpose: standard forwarded headers such
- * as X-Forwarded-For are rewritten or stripped by intermediaries.
+ * The IP is read from the address configured on a real network interface (NOT by
+ * dialing out): the outbound route can traverse an egress cluster, whose source
+ * IP would not identify the host. The detected value is sent to the server via
+ * [CLIENT_IP_HEADER]. A custom (non-standard) header name is used on purpose:
+ * standard forwarded headers such as X-Forwarded-For are rewritten or stripped
+ * by intermediaries.
  */
 internal object ClientIpDetector {
     const val CLIENT_IP_HEADER = "OPEN-SANDBOX-CLIENT-IP"
 
-    private const val PROBE_HOST = "8.8.8.8"
-    private const val PROBE_PORT = 80
+    /**
+     * Interface name fragments indicating virtual/container/VPN NICs whose
+     * address does not identify the host machine; skipped when picking the IP.
+     */
+    private val VIRTUAL_NIC_PREFIXES =
+        listOf(
+            "docker", "veth", "br-", "virbr", "vmnet", "vbox",
+            "utun", "tun", "tap", "zt", "cni", "flannel", "cali",
+        )
 
     /** Detection function; overridable for tests. */
     @Volatile
@@ -44,30 +49,116 @@ internal object ClientIpDetector {
     @Volatile
     private var cached: String? = null
 
-    /** Return the outbound IP, detected once and cached for the process. */
-    @Synchronized
+    /** Return the intranet IP, detected once and cached for the process. */
     fun clientIp(): String {
+        // Fast path: lock-free read of the volatile cache on the hot request path.
         cached?.let { return it }
-        val value = detector()
-        cached = value
-        return value
+        return synchronized(this) {
+            cached ?: detector().also { cached = it }
+        }
     }
 
-    /** Detect the outbound IP, or "" if it cannot be determined. */
+    /** One interface and its IPv4 addresses; used so selection is unit-testable. */
+    internal data class NicAddrs(val name: String, val ips: List<String>)
+
+    /** Detect the host's intranet IPv4, or "" if none is found. */
     fun detectOutboundIp(): String {
         return try {
-            DatagramSocket().use { socket ->
-                socket.connect(InetAddress.getByName(PROBE_HOST), PROBE_PORT)
-                val addr = socket.localAddress
-                if (addr == null || addr.isAnyLocalAddress || addr.isLoopbackAddress) {
-                    ""
-                } else {
-                    addr.hostAddress ?: ""
+            val nics = mutableListOf<NicAddrs>()
+            val ifaces = NetworkInterface.getNetworkInterfaces() ?: return ""
+            for (iface in ifaces) {
+                try {
+                    if (!iface.isUp || iface.isLoopback) continue
+                    val ips =
+                        iface.inetAddresses.toList()
+                            .filterIsInstance<Inet4Address>()
+                            .mapNotNull { it.hostAddress }
+                    nics.add(NicAddrs(iface.name, ips))
+                } catch (_: Exception) {
+                    // Skip this interface; keep enumerating the rest.
                 }
             }
+            selectClientIp(nics)
         } catch (_: Exception) {
             ""
         }
+    }
+
+    private fun isVirtualNic(name: String): Boolean {
+        val lower = name.lowercase()
+        return VIRTUAL_NIC_PREFIXES.any { lower.startsWith(it) }
+    }
+
+    /** Rank an interface name by likelihood of being the primary intranet NIC (lower = better). */
+    private fun nicNameRank(rawName: String): Int {
+        val name = rawName.lowercase()
+        return when {
+            name == "en0" -> 0
+            name == "eth0" -> 1
+            name.startsWith("eth") -> 2
+            name.startsWith("en") -> 3 // covers en*, ens*, enp*, eno*
+            name.startsWith("bond") -> 4
+            else -> 100
+        }
+    }
+
+    private fun parseIpv4(ip: String): IntArray? {
+        val parts = ip.split(".")
+        if (parts.size != 4) return null
+        val nums = IntArray(4)
+        for (i in 0 until 4) {
+            val n = parts[i].toIntOrNull() ?: return null
+            if (n < 0 || n > 255) return null
+            nums[i] = n
+        }
+        return nums
+    }
+
+    private fun isUsableIpv4(ip: String): Boolean {
+        val o = parseIpv4(ip) ?: return false
+        if (o[0] == 127) return false // loopback
+        if (o[0] == 169 && o[1] == 254) return false // link-local
+        if (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0) return false // unspecified
+        return true
+    }
+
+    private fun isPrivateIpv4(ip: String): Boolean {
+        val o = parseIpv4(ip) ?: return false
+        return when {
+            o[0] == 10 -> true
+            o[0] == 172 && o[1] in 16..31 -> true
+            o[0] == 192 && o[1] == 168 -> true
+            else -> false
+        }
+    }
+
+    /**
+     * Pick the host's intranet IPv4 from the given interfaces. Prefers, in order:
+     * known NIC names ([nicNameRank]), then RFC1918 private addresses — i.e.
+     * network-name priority with private-segment fallback in a single pass.
+     * Virtual/container/VPN NICs are skipped. Returns "" if none is usable.
+     */
+    internal fun selectClientIp(nics: List<NicAddrs>): String {
+        var best = ""
+        var bestRank = 0
+        var bestPrivate = false
+        var found = false
+
+        for (nic in nics) {
+            if (isVirtualNic(nic.name)) continue
+            val rank = nicNameRank(nic.name)
+            for (ip in nic.ips) {
+                if (!isUsableIpv4(ip)) continue
+                val priv = isPrivateIpv4(ip)
+                if (!found || rank < bestRank || (rank == bestRank && priv && !bestPrivate)) {
+                    best = ip
+                    bestRank = rank
+                    bestPrivate = priv
+                    found = true
+                }
+            }
+        }
+        return best
     }
 
     /** Reset detection state. Intended for tests only. */

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/ClientIpDetector.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/ClientIpDetector.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox
+
+import java.net.DatagramSocket
+import java.net.InetAddress
+
+/**
+ * Best-effort detection of the SDK host's own outbound IP address.
+ *
+ * Mirrors the well-known idiom of "dialing" a UDP socket to a fixed external
+ * address and reading the local address the OS bound. UDP is connectionless, so
+ * no packet is sent; the OS merely selects the outbound interface for the
+ * default route. A literal IP avoids any DNS lookup.
+ *
+ * The detected IP is sent to the server via [CLIENT_IP_HEADER]. A custom
+ * (non-standard) header name is used on purpose: standard forwarded headers such
+ * as X-Forwarded-For are rewritten or stripped by intermediaries.
+ */
+internal object ClientIpDetector {
+    const val CLIENT_IP_HEADER = "OPEN-SANDBOX-CLIENT-IP"
+
+    private const val PROBE_HOST = "8.8.8.8"
+    private const val PROBE_PORT = 80
+
+    /** Detection function; overridable for tests. */
+    @Volatile
+    internal var detector: () -> String = ::detectOutboundIp
+
+    @Volatile
+    private var cached: String? = null
+
+    /** Return the outbound IP, detected once and cached for the process. */
+    @Synchronized
+    fun clientIp(): String {
+        cached?.let { return it }
+        val value = detector()
+        cached = value
+        return value
+    }
+
+    /** Detect the outbound IP, or "" if it cannot be determined. */
+    fun detectOutboundIp(): String {
+        return try {
+            DatagramSocket().use { socket ->
+                socket.connect(InetAddress.getByName(PROBE_HOST), PROBE_PORT)
+                val addr = socket.localAddress
+                if (addr == null || addr.isAnyLocalAddress || addr.isLoopbackAddress) {
+                    ""
+                } else {
+                    addr.hostAddress ?: ""
+                }
+            }
+        } catch (_: Exception) {
+            ""
+        }
+    }
+
+    /** Reset detection state. Intended for tests only. */
+    @Synchronized
+    internal fun resetForTest() {
+        cached = null
+        detector = ::detectOutboundIp
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -48,6 +48,7 @@ class HttpClientProvider(
                 .connectionPool(connectionPool)
                 .addInterceptor(UserAgentInterceptor(config.userAgent))
                 .addInterceptor(ExtraHeadersInterceptor(config.headers))
+                .addInterceptor(ClientIpInterceptor { ClientIpDetector.clientIp() })
 
     // 1. Explicit lazy definition to allow checking initialization status
     private val httpClientLazy =
@@ -138,6 +139,28 @@ class HttpClientProvider(
             return chain.proceed(
                 chain.request().newBuilder()
                     .header("OPEN-SANDBOX-API-KEY", apiKey)
+                    .build(),
+            )
+        }
+    }
+
+    // Best-effort: attach the SDK host's own IP so the server can see the
+    // client's self-reported address. Runs after ExtraHeadersInterceptor so a
+    // user-supplied value (matched case-insensitively by OkHttp) is preserved,
+    // and is skipped silently when the IP cannot be determined.
+    private class ClientIpInterceptor(private val ipSupplier: () -> String) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request()
+            if (request.header(ClientIpDetector.CLIENT_IP_HEADER) != null) {
+                return chain.proceed(request)
+            }
+            val ip = ipSupplier()
+            if (ip.isEmpty()) {
+                return chain.proceed(request)
+            }
+            return chain.proceed(
+                request.newBuilder()
+                    .header(ClientIpDetector.CLIENT_IP_HEADER, ip)
                     .build(),
             )
         }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/ClientIpTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/ClientIpTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox
+
+import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+
+class ClientIpTest {
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        ClientIpDetector.resetForTest()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+        ClientIpDetector.resetForTest()
+    }
+
+    private fun get(config: ConnectionConfig) {
+        HttpClientProvider(config).use { provider ->
+            val request = Request.Builder().url(server.url("/")).build()
+            provider.httpClient.newCall(request).execute().use { it.body?.close() }
+        }
+    }
+
+    @Test
+    fun `detectOutboundIp returns a valid or empty address`() {
+        val ip = ClientIpDetector.detectOutboundIp()
+        if (ip.isEmpty()) return
+        val addr = InetAddress.getByName(ip)
+        assertTrue(!addr.isLoopbackAddress, "detected loopback IP: $ip")
+        assertTrue(!addr.isAnyLocalAddress, "detected wildcard IP: $ip")
+    }
+
+    @Test
+    fun `selectClientIp prefers named NIC and skips virtual`() {
+        val nics =
+            listOf(
+                ClientIpDetector.NicAddrs("docker0", listOf("172.17.0.1")),
+                ClientIpDetector.NicAddrs("utun3", listOf("10.8.0.3")),
+                ClientIpDetector.NicAddrs("en0", listOf("10.1.1.1")),
+                ClientIpDetector.NicAddrs("eth1", listOf("192.168.5.5")),
+            )
+        assertEquals("10.1.1.1", ClientIpDetector.selectClientIp(nics))
+    }
+
+    @Test
+    fun `selectClientIp falls back to private when no named NIC`() {
+        val nics =
+            listOf(
+                ClientIpDetector.NicAddrs("docker0", listOf("172.17.0.1")),
+                ClientIpDetector.NicAddrs("custom9", listOf("8.8.4.4")),
+                ClientIpDetector.NicAddrs("wlan9", listOf("10.0.0.50")),
+            )
+        assertEquals("10.0.0.50", ClientIpDetector.selectClientIp(nics))
+    }
+
+    @Test
+    fun `selectClientIp skips loopback and link-local`() {
+        val nics =
+            listOf(
+                ClientIpDetector.NicAddrs("eth0", listOf("127.0.0.1", "169.254.1.1", "10.1.2.3")),
+            )
+        assertEquals("10.1.2.3", ClientIpDetector.selectClientIp(nics))
+    }
+
+    @Test
+    fun `selectClientIp returns empty when nothing usable`() {
+        val nics =
+            listOf(
+                ClientIpDetector.NicAddrs("docker0", listOf("172.17.0.1")),
+                ClientIpDetector.NicAddrs("eth0", listOf("169.254.1.1")),
+            )
+        assertEquals("", ClientIpDetector.selectClientIp(nics))
+    }
+
+    @Test
+    fun `clientIp caches the detected value`() {
+        ClientIpDetector.detector = { "10.1.2.3" }
+        assertEquals("10.1.2.3", ClientIpDetector.clientIp())
+        // Change the underlying detector; the cached value must be returned.
+        ClientIpDetector.detector = { "10.9.9.9" }
+        assertEquals("10.1.2.3", ClientIpDetector.clientIp())
+    }
+
+    @Test
+    fun `request carries the client IP header`() {
+        ClientIpDetector.detector = { "10.9.8.7" }
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        get(ConnectionConfig.builder().build())
+
+        val recorded = server.takeRequest()
+        assertEquals("10.9.8.7", recorded.getHeader(ClientIpDetector.CLIENT_IP_HEADER))
+    }
+
+    @Test
+    fun `user-provided header is not overwritten`() {
+        ClientIpDetector.detector = { "10.9.8.7" }
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        get(
+            ConnectionConfig.builder()
+                .addHeader(ClientIpDetector.CLIENT_IP_HEADER, "192.168.0.9")
+                .build(),
+        )
+
+        val recorded = server.takeRequest()
+        assertEquals("192.168.0.9", recorded.getHeader(ClientIpDetector.CLIENT_IP_HEADER))
+    }
+
+    @Test
+    fun `header is omitted when the IP is undetectable`() {
+        ClientIpDetector.detector = { "" }
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        get(ConnectionConfig.builder().build())
+
+        val recorded = server.takeRequest()
+        assertNull(recorded.getHeader(ClientIpDetector.CLIENT_IP_HEADER))
+    }
+}

--- a/sdks/sandbox/python/src/opensandbox/config/client_ip.py
+++ b/sdks/sandbox/python/src/opensandbox/config/client_ip.py
@@ -1,0 +1,244 @@
+#
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Best-effort detection of the SDK host's own intranet IP address.
+
+The detected IP is read from a real network interface (NOT by dialing out): the
+outbound route can traverse an egress cluster, whose source IP would not
+identify the host. The value is sent to the server via a custom header. A custom
+(non-standard) header name is used on purpose: standard forwarded headers such
+as X-Forwarded-For are rewritten or stripped by intermediaries, so a dedicated
+name conveys the value reliably.
+
+Interfaces are enumerated with the libc ``getifaddrs(3)`` call via ``ctypes``
+(no third-party dependency). This works uniformly on Linux and macOS/BSD, is
+non-blocking, and does no DNS lookup. Windows (no ``getifaddrs``) degrades to
+returning "".
+"""
+
+import ctypes
+import ipaddress
+import socket
+import sys
+
+CLIENT_IP_HEADER = "OPEN-SANDBOX-CLIENT-IP"
+
+# Interface name fragments indicating virtual/container/VPN NICs whose address
+# does not identify the host machine; skipped when picking the host's own IP.
+_VIRTUAL_NIC_PREFIXES = (
+    "docker",
+    "veth",
+    "br-",
+    "virbr",
+    "vmnet",
+    "vbox",
+    "utun",
+    "tun",
+    "tap",
+    "zt",
+    "cni",
+    "flannel",
+    "cali",
+)
+
+# Interface flags (same values on Linux and macOS/BSD).
+_IFF_UP = 0x1
+_IFF_LOOPBACK = 0x8
+
+# macOS/BSD put a 1-byte sa_len before sa_family; Linux starts with a 2-byte
+# sa_family. This changes where the address family byte lives in a sockaddr.
+_IS_BSD = sys.platform == "darwin" or "bsd" in sys.platform
+
+_cached_ip: str | None = None
+
+
+class _Ifaddrs(ctypes.Structure):
+    """Mirror of ``struct ifaddrs``; only the fields we read are declared.
+
+    The leading layout (next, name, flags, addr) is identical on Linux and
+    macOS/BSD, which is why getifaddrs unifies both platforms.
+    """
+
+
+_Ifaddrs._fields_ = [
+    ("ifa_next", ctypes.POINTER(_Ifaddrs)),
+    ("ifa_name", ctypes.c_char_p),
+    ("ifa_flags", ctypes.c_uint),
+    ("ifa_addr", ctypes.POINTER(ctypes.c_ubyte * 16)),
+    ("ifa_netmask", ctypes.POINTER(ctypes.c_ubyte * 16)),
+    ("ifa_dstaddr", ctypes.POINTER(ctypes.c_ubyte * 16)),
+    ("ifa_data", ctypes.c_void_p),
+]
+
+
+def _is_virtual_nic(name: str) -> bool:
+    lower = name.lower()
+    return any(lower.startswith(p) for p in _VIRTUAL_NIC_PREFIXES)
+
+
+def _nic_name_rank(name: str) -> int:
+    """Rank an interface name by likelihood of being the primary intranet NIC.
+
+    Lower is better; named NICs beat unknown ones.
+    """
+    name = name.lower()
+    if name == "en0":
+        return 0
+    if name == "eth0":
+        return 1
+    if name.startswith("eth"):
+        return 2
+    if name.startswith("en"):  # covers en*, ens*, enp*, eno*
+        return 3
+    if name.startswith("bond"):
+        return 4
+    return 100
+
+
+def _usable_ipv4(ip: str) -> ipaddress.IPv4Address | None:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    if not isinstance(addr, ipaddress.IPv4Address):
+        return None
+    if addr.is_loopback or addr.is_link_local or addr.is_unspecified:
+        return None
+    return addr
+
+
+def _select_client_ip(nics: list[tuple[str, list[str]]]) -> str:
+    """Pick the host's intranet IPv4 from ``(name, ips)`` interface entries.
+
+    Selection prefers, in order: known NIC names (:func:`_nic_name_rank`), then
+    RFC1918 private addresses — i.e. network-name priority with private-segment
+    fallback in a single pass. Virtual/container/VPN NICs are skipped. Returns
+    "" if no usable address exists.
+    """
+    best = ""
+    best_rank = 0
+    best_private = False
+    found = False
+
+    for name, ips in nics:
+        if _is_virtual_nic(name):
+            continue
+        rank = _nic_name_rank(name)
+        for ip in ips:
+            addr = _usable_ipv4(ip)
+            if addr is None:
+                continue
+            private = addr.is_private
+            if (
+                not found
+                or rank < best_rank
+                or (rank == best_rank and private and not best_private)
+            ):
+                best, best_rank, best_private, found = ip, rank, private, True
+
+    return best
+
+
+def _sockaddr_ipv4(addr_ptr: "ctypes._Pointer[ctypes.Array[ctypes.c_ubyte]]") -> str | None:
+    """Return the dotted IPv4 string from a sockaddr pointer, or None.
+
+    ``sin_addr`` sits at offset 4 in ``sockaddr_in`` on both Linux and
+    macOS/BSD (family/len bytes + 2-byte port precede it), so only the family
+    byte position differs between platforms.
+    """
+    if not addr_ptr:
+        return None
+    # sockaddr is >= 16 bytes on both OSes; read the fixed header safely.
+    raw = ctypes.string_at(ctypes.cast(addr_ptr, ctypes.c_void_p), 16)
+    family = raw[1] if _IS_BSD else raw[0]
+    if family != socket.AF_INET:
+        return None
+    return socket.inet_ntoa(raw[4:8])
+
+
+def _enumerate_nics() -> list[tuple[str, list[str]]]:
+    """Enumerate (name, [ipv4]) via libc getifaddrs. Returns [] if unavailable."""
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        getifaddrs = libc.getifaddrs
+        freeifaddrs = libc.freeifaddrs
+    except (OSError, AttributeError):
+        # No libc getifaddrs (e.g. Windows): degrade to empty.
+        return []
+
+    getifaddrs.restype = ctypes.c_int
+    getifaddrs.argtypes = [ctypes.POINTER(ctypes.POINTER(_Ifaddrs))]
+    freeifaddrs.argtypes = [ctypes.POINTER(_Ifaddrs)]
+
+    head = ctypes.POINTER(_Ifaddrs)()
+    if getifaddrs(ctypes.byref(head)) != 0:
+        return []
+
+    by_name: dict[str, list[str]] = {}
+    order: list[str] = []
+    try:
+        node = head
+        while node:
+            ifa = node.contents
+            flags = ifa.ifa_flags
+            if (flags & _IFF_UP) and not (flags & _IFF_LOOPBACK):
+                ip = _sockaddr_ipv4(ifa.ifa_addr)
+                if ip:
+                    name = ifa.ifa_name.decode() if ifa.ifa_name else ""
+                    if name not in by_name:
+                        by_name[name] = []
+                        order.append(name)
+                    by_name[name].append(ip)
+            node = ifa.ifa_next
+    finally:
+        freeifaddrs(head)
+
+    return [(name, by_name[name]) for name in order]
+
+
+def detect_outbound_ip() -> str:
+    """Return the host's intranet IPv4, or "" if it cannot be determined.
+
+    Best-effort: any failure yields "" and never propagates (config init must
+    not break).
+    """
+    try:
+        return _select_client_ip(_enumerate_nics())
+    except Exception:
+        return ""
+
+
+def get_client_ip() -> str:
+    """Return the intranet IP, detected once and cached for the process."""
+    global _cached_ip
+    if _cached_ip is None:
+        _cached_ip = detect_outbound_ip()
+    return _cached_ip
+
+
+def apply_client_ip(headers: dict[str, str]) -> dict[str, str]:
+    """Add the client IP header in place unless already present or undetectable.
+
+    An existing header (matched case-insensitively) is left untouched so a
+    user-supplied value is never overwritten.
+    """
+    ip = get_client_ip()
+    if not ip:
+        return headers
+    if any(k.lower() == CLIENT_IP_HEADER.lower() for k in headers):
+        return headers
+    headers[CLIENT_IP_HEADER] = ip
+    return headers

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -114,6 +114,12 @@ class ConnectionConfig(BaseModel):
     def model_post_init(self, __context: object) -> None:
         # If the user explicitly provided `transport`, the SDK must not close it.
         self._owns_transport = "transport" not in self.model_fields_set
+        # Best-effort: attach the SDK host's own IP so the server can see the
+        # client's self-reported address. Never overrides a user-supplied value
+        # and is skipped silently when the IP cannot be determined.
+        from opensandbox.config import client_ip
+
+        client_ip.apply_client_ip(self.headers)
 
     def with_transport_if_missing(self) -> "ConnectionConfig":
         """

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -99,6 +99,10 @@ class ConnectionConfigSync(BaseModel):
 
     def model_post_init(self, __context: object) -> None:
         self._owns_transport = "transport" not in self.model_fields_set
+        # Best-effort: attach the SDK host's own IP (see async ConnectionConfig).
+        from opensandbox.config import client_ip
+
+        client_ip.apply_client_ip(self.headers)
 
     def with_transport_if_missing(self) -> "ConnectionConfigSync":
         """

--- a/sdks/sandbox/python/tests/test_client_ip.py
+++ b/sdks/sandbox/python/tests/test_client_ip.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import ipaddress
+
+import pytest
+
+from opensandbox.config import ConnectionConfig, ConnectionConfigSync, client_ip
+
+CLIENT_IP_HEADER = client_ip.CLIENT_IP_HEADER
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_ip_cache():
+    """Ensure each test starts and ends with a clean detection cache."""
+    client_ip._cached_ip = None
+    yield
+    client_ip._cached_ip = None
+
+
+def _stub_detection(monkeypatch: pytest.MonkeyPatch, ip: str) -> None:
+    client_ip._cached_ip = None
+    monkeypatch.setattr(client_ip, "detect_outbound_ip", lambda: ip)
+
+
+def test_apply_client_ip_sets_header_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_detection(monkeypatch, "10.1.2.3")
+    headers: dict[str, str] = {}
+    client_ip.apply_client_ip(headers)
+    assert headers[CLIENT_IP_HEADER] == "10.1.2.3"
+
+
+def test_apply_client_ip_does_not_overwrite_user_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_detection(monkeypatch, "10.1.2.3")
+    headers = {"open-sandbox-client-ip": "192.168.0.9"}
+    client_ip.apply_client_ip(headers)
+    assert headers["open-sandbox-client-ip"] == "192.168.0.9"
+    assert CLIENT_IP_HEADER not in headers
+
+
+def test_apply_client_ip_noop_when_undetectable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_detection(monkeypatch, "")
+    headers: dict[str, str] = {}
+    client_ip.apply_client_ip(headers)
+    assert CLIENT_IP_HEADER not in headers
+
+
+def test_detect_outbound_ip_returns_valid_or_empty() -> None:
+    # Best-effort: empty in a network-less environment, otherwise a valid,
+    # non-loopback, non-link-local, non-unspecified IP.
+    ip = client_ip.detect_outbound_ip()
+    if ip == "":
+        return
+    addr = ipaddress.ip_address(ip)
+    assert not addr.is_loopback
+    assert not addr.is_link_local
+    assert not addr.is_unspecified
+
+
+def test_select_client_ip_prefers_named_nic_and_skips_virtual() -> None:
+    nics = [
+        ("docker0", ["172.17.0.1"]),  # virtual, skip
+        ("utun3", ["10.8.0.3"]),  # VPN, skip
+        ("en0", ["10.1.1.1"]),  # main NIC
+        ("eth1", ["192.168.5.5"]),
+    ]
+    assert client_ip._select_client_ip(nics) == "10.1.1.1"
+
+
+def test_select_client_ip_falls_back_to_private_when_no_named_nic() -> None:
+    nics = [
+        ("docker0", ["172.17.0.1"]),  # virtual, skip
+        ("custom9", ["8.8.4.4"]),  # public, lower preference
+        ("wlan9", ["10.0.0.50"]),  # private, preferred
+    ]
+    assert client_ip._select_client_ip(nics) == "10.0.0.50"
+
+
+def test_select_client_ip_skips_loopback_and_link_local() -> None:
+    nics = [("eth0", ["127.0.0.1", "169.254.1.1", "10.1.2.3"])]
+    assert client_ip._select_client_ip(nics) == "10.1.2.3"
+
+
+def test_select_client_ip_empty_when_no_usable() -> None:
+    nics = [("docker0", ["172.17.0.1"]), ("eth0", ["169.254.1.1"])]
+    assert client_ip._select_client_ip(nics) == ""
+
+
+def test_connection_config_injects_client_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_detection(monkeypatch, "10.9.8.7")
+    assert ConnectionConfig().headers[CLIENT_IP_HEADER] == "10.9.8.7"
+    client_ip._cached_ip = None
+    assert ConnectionConfigSync().headers[CLIENT_IP_HEADER] == "10.9.8.7"
+
+
+def test_connection_config_omits_client_ip_when_undetectable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_detection(monkeypatch, "")
+    assert CLIENT_IP_HEADER not in ConnectionConfig().headers
+
+
+def test_connection_config_respects_user_provided_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_detection(monkeypatch, "10.9.8.7")
+    cfg = ConnectionConfig(headers={CLIENT_IP_HEADER: "203.0.113.1"})
+    assert cfg.headers[CLIENT_IP_HEADER] == "203.0.113.1"


### PR DESCRIPTION
# Summary
- **What/why:** All five sandbox SDKs (Go, Python, JavaScript, Kotlin, C#) best-effort detect the host's own **intranet IPv4** and attach it to every request as a custom header **`OPEN-SANDBOX-CLIENT-IP`**, so the server can identify the calling device (primary use case: uniquely identifying machines on a corporate intranet).
- **Why a custom header name:** standard forwarded headers such as `X-Forwarded-For` are rewritten or stripped by intermediaries, so a dedicated name conveys the value reliably.
- **How detection works (reads a real NIC):** the SDK enumerates network interfaces and reads the IPv4 configured on one, rather than opening an outbound socket. Selection is a single pure, unit-tested `selectClientIp`: skip virtual/container/VPN NICs (`docker/veth/br-/virbr/vmnet/vbox/utun/tun/tap/zt/cni/flannel/cali`), then prefer known NIC names (`en0` > `eth0` > `eth*` > `en*` > `bond*` > others, case-insensitive) and RFC1918 private addresses, skipping loopback / link-local / unspecified. Per-interface enumeration errors are isolated so one bad NIC never aborts the scan.
- **Enumeration per language (stdlib, no new dependency):** Go `net.Interfaces`, Kotlin `NetworkInterface`, C# `NetworkInterface`, JS `os.networkInterfaces` (loaded via a guarded async dynamic import to stay browser/CJS-safe; the transport awaits detection so even the first request carries the header). Python is stdlib-only: Linux reads `/sys/class/net` + `SIOCGIFADDR` ioctl (full NIC-name priority); other platforms fall back to `gethostname()`/`getaddrinfo` + private-segment filter (degraded, may return empty).
- **Aligned behavior across languages:** best-effort (skip the header silently if the IP can't be determined — never error/block), never overwrite a user-provided value (case-insensitive), detect once and cache.
- **Injection points (all outbound paths covered):** Go connection headers + the create-metrics telemetry request; Python `ConnectionConfig.headers`; Kotlin OkHttp interceptor; C# `CreateHttpClient`/`CreateSseHttpClient` default headers (covers wrapper, raw, SSE, and code-interpreter); JS fetch wrapper (merges headers without dropping any). `code-interpreter`/MCP SDKs inherit via the shared transport.
- **Server is unchanged** — this is a client-side, additive request header; the server neither reads nor echoes it.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Details:
- Unit tests added per language: pure `selectClientIp` cases (named-NIC priority, private-segment fallback, skip virtual/loopback/link-local, empty when nothing usable), injection, case-insensitive no-overwrite, best-effort omission. All green: Go `go test ./...`; Python `ruff`+`pyright`+full `pytest`; JS `tsc`+`eslint`+`tsup`+`node --test` (74); C# `dotnet test` (151 sandbox + 22 code-interpreter); Kotlin `spotlessCheck`+`:sandbox:test`+`:code-interpreter:test`.
- e2e / manual: ran the real lifecycle server from source against Docker; C# `SandboxManagerE2ETests` passed (3/3) with real sandbox create/list/kill. Verified all five SDKs detect the same address as `ifconfig en0` (the host's real intranet IP), and captured the exact header on the wire via a header-echo endpoint (`OPEN-SANDBOX-CLIENT-IP: <en0 IP>`).

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

Additive, backward-compatible request header. Existing behavior is unaffected; a user-supplied same-named header always wins.

# Checklist
- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed) — not needed; internal transport behavior with no public API/config surface
- [x] Added/updated tests (if needed)
- [x] Security impact considered — sends the host's own intranet IP (not a secret); never overwrites a user-provided value; best-effort and non-blocking
- [x] Backward compatibility considered
