### PR TITLE
osep: human-in-the-loop approval gates

### DIFF
--- a/oseps/0015-human-in-the-loop-approval-gates.md
+++ b/oseps/0015-human-in-the-loop-approval-gates.md
@@ -1,0 +1,685 @@
+---
+title: Human-in-the-Loop Approval Gates
+authors:
+  - "@GodBlf"
+creation-date: 2026-07-17
+last-updated: 2026-07-17
+status: draft
+---
+
+# OSEP-0015: Human-in-the-Loop Approval Gates
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Requirements](#requirements)
+- [Proposal](#proposal)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Terminology](#terminology)
+  - [Architecture and Ownership](#architecture-and-ownership)
+  - [Lifecycle Policy](#lifecycle-policy)
+  - [Command Matching and Execution Flow](#command-matching-and-execution-flow)
+  - [New-Domain Egress Flow](#new-domain-egress-flow)
+  - [Approval State Machine](#approval-state-machine)
+  - [Runtime Approval APIs](#runtime-approval-apis)
+  - [Events and Reviewer Notification](#events-and-reviewer-notification)
+  - [SDK and CLI](#sdk-and-cli)
+  - [Authentication and Sensitive Data](#authentication-and-sensitive-data)
+  - [Capacity, Cleanup, and Observability](#capacity-cleanup-and-observability)
+  - [Runtime Delivery](#runtime-delivery)
+- [Test Plan](#test-plan)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed](#infrastructure-needed)
+- [Upgrade & Migration Strategy](#upgrade--migration-strategy)
+<!-- /toc -->
+
+## Summary
+
+This proposal introduces an optional, fail-closed approval gate that can pause
+selected sandbox actions until an authorized reviewer allows or denies them.
+The first phase covers execd commands selected by policy and egress requests to
+new FQDNs. It gives autonomous agents a supervised boundary without changing
+the behavior of sandboxes that do not configure an approval policy.
+
+Approval state remains in the data-plane component that owns the blocked
+action. Execd owns command approvals and egress owns domain approvals. Both
+components expose the same approval resource model, while SDK and CLI facades
+present a sandbox-scoped view across the two endpoints.
+
+This proposal addresses [issue #1288](https://github.com/opensandbox-group/OpenSandbox/issues/1288).
+
+## Motivation
+
+OpenSandbox currently applies policy before a sandbox starts or rejects an
+action immediately at runtime. Egress allow and deny rules are static until a
+caller updates them, and the egress deny webhook only reports a request after
+it has already been denied. Execd does not have an approval concept.
+
+That model is suitable for fixed policy but not for supervising autonomous
+agents. An operator may want an agent to continue independently until it
+attempts a selected command or reaches a destination that has not yet been
+reviewed. Rejecting every such action forces the agent to restart it manually,
+while allowing it unconditionally removes the review boundary.
+
+A blocking approval gate fills this gap: the runtime holds the action, exposes
+sanitized context to an authorized reviewer, and resumes only after an explicit
+allow decision. Missing decisions, component failures, and timeouts deny the
+action.
+
+### Goals
+
+1. Let users opt into approval gates at sandbox creation time without changing
+   existing sandbox behavior by default.
+2. Pause selected execd commands before process creation and resume the same
+   request after an allow decision.
+3. Pause DNS handling for a new FQDN before the egress sidecar makes the
+   destination reachable.
+4. Provide consistent list, get, allow, and deny operations through runtime
+   APIs, supported SDKs, and `osb`.
+5. Fail closed on timeout, component shutdown, sandbox deletion, capacity
+   exhaustion, or decision-channel failure.
+6. Keep Docker and Kubernetes user-visible semantics aligned.
+7. Preserve the precedence of operator and explicit deny policy.
+8. Bound approval state and avoid leaking command or request secrets through
+   logs, metrics, webhooks, or API error text.
+
+### Non-Goals
+
+1. This proposal does not turn command patterns into a security isolation
+   boundary. An allowed command, code execution request, or child process can
+   perform equivalent work through another mechanism.
+2. The first phase does not inspect code execution, child processes created by
+   an allowed command, file API operations, diffs, or generic "destructive"
+   behavior.
+3. The first phase does not gate direct-IP egress or individual TCP/HTTP
+   connections. Domain approval occurs at DNS resolution time.
+4. Credential Vault use approval is deferred. The design leaves room for a
+   future `credential_use` approval kind but does not define its policy or API
+   context here.
+5. Browser review pages, scoped share links, push notification services, and a
+   global cross-sandbox approval inbox are deferred.
+6. Approval history is not a durable audit ledger. Terminal records are held
+   only for a bounded time in the owning component.
+7. Reviewers cannot edit or replace the command, domain, or other pending
+   action context through the decision API.
+
+## Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| R1 | No configured approval policy preserves current behavior | Must Have |
+| R2 | Matching commands are held before process creation | Must Have |
+| R3 | New FQDNs are held before DNS resolution makes them reachable | Must Have |
+| R4 | Timeout and runtime failure deny the held action | Must Have |
+| R5 | Operator and explicit deny rules cannot be overridden by approval | Must Have |
+| R6 | Execd and egress expose a common approval resource and decision contract | Must Have |
+| R7 | Decisions are atomic, terminal, and idempotent for identical retries | Must Have |
+| R8 | Pending and remembered state is bounded and sandbox-local | Must Have |
+| R9 | Existing execd and egress endpoint authentication protects approval APIs | Must Have |
+| R10 | Logs, metrics, errors, and notifications expose no more action context than their documented reviewer purpose requires | Must Have |
+| R11 | Docker and Kubernetes implement the same public behavior | Must Have |
+| R12 | SDK and CLI users can review and decide approvals for one sandbox | Must Have |
+| R13 | Concurrent DNS requests for one normalized FQDN share one pending approval | Must Have |
+| R14 | Allow decisions may remember an exact command or FQDN for a bounded TTL | Should Have |
+
+## Proposal
+
+Add an optional `approvalPolicy` to sandbox creation. The server validates and
+delivers the relevant policy subset to execd and egress when it creates the
+sandbox. It does not store pending approvals or participate in their state
+transitions.
+
+Execd evaluates each command immediately after request validation and before
+starting a process. Egress evaluates a normalized DNS question after fixed deny
+rules and existing allow rules. When an action needs review, the owning
+component creates a local approval record and waits for a terminal decision.
+
+Reviewers resolve the sandbox's existing execd and egress endpoints and use the
+approval APIs protected by those endpoints' existing authentication. SDKs and
+the CLI hide endpoint discovery and combine records from both components.
+
+```
+                                create sandbox
+Client --------------------------------------------------------> Server
+  |                                                               |
+  |                                                    validates and splits
+  |                                                    approvalPolicy
+  |                                                               |
+  |                                      +------------------------+------------------+
+  |                                      |                                           |
+  |                                      v                                           v
+  |                           +---------------------+                      +---------------------+
+  | command request           | execd               |                      | egress              |
+  +-------------------------->| - command matcher   |                      | - DNS policy        |
+  |                           | - approval store    |                      | - approval store    |
+  |                           +----------+----------+                      +----------+----------+
+  |                                      |                                            ^
+  |                                      | wait                                       | DNS request
+  |                                      v                                            | from sandbox
+  |                           +---------------------+                                  |
+  | approvals facade         | pending command     |                       sandbox ---+
+  +------------------------->| allow/deny/expire   |
+  |                           +---------------------+
+  |
+  +-------------------------------> egress approval APIs
+```
+
+Approval decisions are data-plane local by design. This avoids a reverse
+dependency from sandbox components to the lifecycle server, avoids giving
+components a server-wide credential, and avoids introducing distributed
+persistence or multi-replica coordination into the lifecycle control plane.
+
+### Notes/Constraints/Caveats
+
+1. The command matcher sees the exact command string accepted by the execd API;
+   it does not parse shell syntax or infer semantic equivalence.
+2. DNS approval controls when the sidecar resolves and admits a domain. Once an
+   answer has been returned, the runtime cannot provide per-connection or
+   one-packet approval semantics through DNS interception alone.
+3. Egress approval requires an egress sidecar and therefore requires
+   `networkPolicy`. A create request that configures egress approval without
+   `networkPolicy` is invalid.
+4. Approval cannot override `/var/egress/rules/deny.always` or an explicit user
+   deny rule. Such requests are denied immediately and retain existing blocked
+   event behavior.
+5. Approval state is lost on execd or egress restart. Waiting actions are
+   denied before shutdown where possible; after an abrupt restart they fail by
+   connection loss or DNS failure and are never implicitly allowed.
+6. A reviewer with approval access can see action context that may itself be
+   sensitive. Approval access is equivalent to existing authenticated access
+   to the corresponding sandbox runtime endpoint and must not be exposed
+   through an unauthenticated share link in the first phase.
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Glob patterns are bypassed by alternate spelling or indirection | A risky command does not pause | Document this as supervision, not isolation; match the complete raw string predictably; recommend broad patterns and static sandbox controls for enforcement |
+| Reviewer approves misleading context | Unintended action runs | Do not permit context mutation; display exact bounded command or normalized FQDN; include kind and timestamps |
+| Commands contain secrets | Secrets appear in logs or notifications | Return context only from authenticated get/list APIs; omit full context from logs, metrics, errors, and webhooks |
+| Pending requests exhaust memory or goroutines | Runtime availability degrades | Enforce configurable hard caps and reject excess actions immediately |
+| Runtime restart loses an allow decision | Agent action fails and may be retried | Keep state local and fail closed; expose restart/expiration outcomes clearly; do not claim durable approvals |
+| Runtime restart loses a deny decision | A retry creates another review request | Deny decisions are not durable; callers that need permanent denial must update static policy |
+| Approval overrides an operator restriction | Security policy is weakened | Evaluate always-deny and explicit deny before the approval layer and never create an approval for them |
+| DNS cache outlives an approval TTL | Traffic continues after remembered approval expires | Cap returned DNS TTL to the remaining approval TTL and remove temporary nft state at expiry where applicable |
+| Multiple DNS questions race | Duplicate prompts or inconsistent results | Normalize the FQDN and use single-flight pending records per domain |
+| Webhook is mistaken for an authorization channel | Spoofed callback affects execution | Webhooks are notification-only; decisions require authenticated runtime API calls |
+| Component APIs drift | SDK and CLI behavior differs by approval kind | Define common schemas and conformance tests in both OpenAPI contracts |
+
+## Design Details
+
+### Terminology
+
+- **Approval policy**: Optional sandbox creation policy that selects actions for
+  human review.
+- **Approval**: A runtime resource representing one held command or normalized
+  FQDN.
+- **Decision**: An immutable terminal `allow` or `deny` operation applied to an
+  approval.
+- **Remembered decision**: A temporary in-memory allow cache entry for one exact
+  command string or normalized FQDN.
+- **Owning component**: Execd for command approvals and egress for domain
+  approvals.
+
+### Architecture and Ownership
+
+Each owning component implements the same logical `ApprovalStore` behavior:
+
+```
+Create(kind, context, expiresAt) -> Approval
+List(status?)                    -> []Approval
+Get(id)                          -> Approval | not found
+Decide(id, decision, ttl?)       -> Approval | conflict | expired
+Expire(now)
+Close()                          -> deny all pending waiters
+```
+
+The store owns synchronization between request handlers, timers, and blocked
+runtime operations. A decision updates the record and wakes waiters atomically.
+An allow is observed by the held operation only after the terminal state is
+committed. Closing the store wakes every waiter with deny.
+
+The lifecycle server remains responsible only for:
+
+1. validating the public create policy;
+2. rejecting egress approval without `networkPolicy`;
+3. serializing the command subset into execd startup configuration;
+4. serializing the egress subset into egress startup configuration; and
+5. configuring component limits consistently for Docker and Kubernetes.
+
+### Lifecycle Policy
+
+The proposed additive lifecycle shape is:
+
+```yaml
+approvalPolicy:
+  timeoutSeconds: 300
+  commands:
+    patterns:
+      - "rm -rf*"
+      - "curl*"
+  egress:
+    mode: new_domains
+```
+
+`approvalPolicy` is optional. Its fields have these semantics:
+
+| Field | Semantics |
+|-------|-----------|
+| `timeoutSeconds` | Time a new approval may remain pending; default `300`; must be positive and is bounded by an implementation-defined server maximum |
+| `commands.patterns` | Non-empty shell-style glob patterns matched against the complete command string; any match requires approval |
+| `egress.mode` | The first phase accepts only `new_domains`; omitted egress configuration disables domain approval |
+
+Pattern matching is case-sensitive and anchored to the complete command string.
+`*`, `?`, and bracket expressions follow the selected standard-library glob
+implementation; a backslash escapes the next metacharacter. The specification
+and each SDK must use examples to make this behavior explicit. Empty patterns
+and invalid bracket expressions are rejected at sandbox creation.
+
+Unknown fields follow the existing lifecycle API validation policy. An empty
+`approvalPolicy` is rejected because it cannot gate an action and is likely a
+configuration mistake.
+
+Component capacity limits are operator configuration, not per-sandbox public
+API fields in the first phase. Initial defaults are 128 pending records and
+1,024 remembered decisions per component. Operators may lower these values;
+raising them must remain subject to documented hard maximums.
+
+### Command Matching and Execution Flow
+
+The command gate applies to:
+
+- regular foreground and background command execution;
+- commands run in an existing bash session; and
+- commands run in an isolated execution session.
+
+The flow is:
+
+1. Execd authenticates and validates the request as it does today.
+2. Execd checks the exact command against unexpired remembered allows.
+3. If there is no remembered allow, execd evaluates every configured glob.
+4. A miss proceeds through the current execution path unchanged.
+5. A match creates a unique `command` approval before allocating or starting
+   the child process.
+6. Foreground/session SSE emits `approval_required` and remains connected.
+   Background execution exposes `pending_approval` through command status.
+7. Allow resumes the original in-memory request once. Deny or expiry returns a
+   typed approval-denied or approval-expired execution error without starting
+   the process.
+8. A positive decision `ttlSeconds` also remembers the exact, byte-for-byte
+   command string. It does not remember the glob or authorize other commands
+   matched by that glob.
+
+Each matching command invocation gets its own approval. This preserves the
+request's session, working directory, environment, and cancellation context and
+prevents one prompt from authorizing multiple concurrent executions. Interrupt
+and request cancellation remove the waiter and make its approval terminal;
+later allow attempts cannot start the canceled command.
+
+### New-Domain Egress Flow
+
+Domain approval is inserted into the DNS policy path with this precedence:
+
+1. operator `deny.always` match: deny immediately;
+2. operator `allow.always` match: allow immediately;
+3. the first matching explicit user rule: apply its allow or deny immediately;
+4. unexpired remembered approval for the normalized FQDN: allow temporarily;
+5. `new_domains` enabled: create or join a pending approval;
+6. no approval policy: apply the current default action unchanged.
+
+This retains the existing `deny.always`, `allow.always`, then user-rule overlay
+order. In particular, the approval layer never changes which static rule wins.
+The egress component normalizes the cache key exactly as current policy matching
+does: lowercase the DNS wire name and remove one trailing dot. Policy target and
+DNS-question normalization must stay shared so equivalent names cannot create
+separate decisions.
+
+Concurrent questions for the same normalized FQDN join one pending record and
+receive the same result. Deny or expiry returns a DNS refusal and does not add
+temporary nft state. Allow resumes the held resolution, updates the dynamic
+address set as required by the current egress mode, and remembers the domain
+for the decision TTL. When `ttlSeconds` is omitted, the domain is remembered
+for the smaller of the configured approval timeout and the upstream DNS TTL.
+
+The effective DNS TTL and temporary address-set lifetime must not exceed the
+remaining remembered-decision TTL. Direct-IP traffic, reverse DNS questions,
+and non-address DNS record types are not turned into approval requests in the
+first phase and continue through existing policy behavior.
+
+### Approval State Machine
+
+```
+                        allow
+                    +-----------> allowed
+                    |
+created ----------> pending
+                    |             denied
+                    +-----------> denied
+                    |
+                    | timeout / cancellation / shutdown
+                    +-----------> expired
+```
+
+`allowed`, `denied`, and `expired` are terminal. The API uses `expired` for
+timeout, request cancellation, and owning-component shutdown because in every
+case the original action is no longer available to resume. An optional terminal
+`reason` distinguishes those cases without exposing sensitive context.
+
+Submitting the same decision again returns `200` and the existing terminal
+record. Submitting the opposite decision to an allowed or denied record returns
+`409 Conflict`. Deciding an expired record returns `410 Gone`. An unknown or
+evicted identifier returns `404 Not Found`.
+
+Terminal records remain listable for a bounded retention window to make retries
+and immediate diagnosis possible. Retention does not extend a remembered allow
+and is not an audit guarantee.
+
+### Runtime Approval APIs
+
+Execd and egress add equivalent operations to their respective public specs:
+
+| Method and path | Behavior |
+|-----------------|----------|
+| `GET /approvals?status=pending` | List local approvals, optionally filtered by one status |
+| `GET /approvals/{approvalId}` | Return one local approval |
+| `POST /approvals/{approvalId}/decision` | Atomically allow or deny one pending approval |
+
+The common response shape is:
+
+```json
+{
+  "id": "execd_apr_01J...",
+  "source": "execd",
+  "kind": "command",
+  "status": "pending",
+  "context": {
+    "command": "rm -rf ./build"
+  },
+  "createdAt": "2026-07-17T08:00:00Z",
+  "expiresAt": "2026-07-17T08:05:00Z"
+}
+```
+
+`source` is `execd` or `egress`, and IDs use the corresponding
+`execd_apr_` or `egress_apr_` namespace. This makes an ID globally routable
+within a sandbox without querying or submitting a decision to both components.
+The unpredictable suffix, not the prefix, supplies collision resistance.
+
+`kind` is `command` or `egress_domain` in the first phase. Context is a tagged
+union: command records include a length-bounded command string; domain records
+include only the normalized FQDN. Implementations report truncation explicitly
+and never silently substitute a different value for the action being approved.
+The original full value remains internal to the blocked operation.
+
+Terminal responses additionally contain `decidedAt`, `decision`, and optional
+`reason`. They do not identify the reviewer in the first phase because runtime
+endpoint authentication does not currently provide a stable reviewer identity.
+
+The decision request is:
+
+```json
+{
+  "decision": "allow",
+  "ttlSeconds": 600
+}
+```
+
+`decision` is required and is `allow` or `deny`. `ttlSeconds` is optional,
+non-negative, and bounded by an operator maximum. Zero or omission is a
+single-use command decision. For an egress allow, omission uses the bounded DNS
+default described above. `ttlSeconds` on deny is rejected in the first phase;
+durable or remembered denial belongs in static policy.
+
+List responses use the component's existing pagination conventions where they
+exist; otherwise the new specs define a stable cursor and bounded page size.
+Ordering is newest creation time first with `id` as a deterministic tie-breaker.
+
+### Events and Reviewer Notification
+
+Execd adds an `approval_required` SSE event containing the approval ID, kind,
+creation time, and expiry time. It does not duplicate the full command in event
+logs. Existing completion and error events remain the source of the final
+execution result after allow, deny, or expiry.
+
+Background command status adds `pending_approval` and the approval ID without
+changing the meaning of existing terminal statuses.
+
+Egress extends the existing asynchronous blocked-event infrastructure with an
+approval-pending notification. The notification contains the approval ID,
+normalized FQDN, and expiry time and is emitted once per pending record, not
+once per joined DNS question. The webhook is notification-only: response bodies
+and status codes cannot allow or deny the request. Existing deny webhooks keep
+their current payload and already-denied semantics.
+
+### SDK and CLI
+
+Sandbox SDKs expose a sandbox-scoped approval facade with equivalent operations
+in each supported language:
+
+```
+sandbox.approvals.list(status = pending)
+sandbox.approvals.get(approval_id)
+sandbox.approvals.allow(approval_id, ttl = ...)
+sandbox.approvals.deny(approval_id)
+```
+
+For list operations, the facade resolves both execd and egress endpoints,
+queries them concurrently, and merges results by creation time. Get and decision
+operations route directly from the component namespace in the approval ID; an
+unknown prefix is rejected locally. Public durations use each language's
+established native duration convention while the wire format remains seconds.
+
+The stable CLI surface is:
+
+```text
+osb approvals list <sandbox-id> [--status pending] [-o table|json|yaml]
+osb approvals get <sandbox-id> <approval-id> [-o table|json|yaml]
+osb approvals allow <sandbox-id> <approval-id> [--ttl SECONDS] [-o table|json|yaml]
+osb approvals deny <sandbox-id> <approval-id> [-o table|json|yaml]
+```
+
+CLI commands call the Python SDK facade rather than reconstructing endpoint
+paths. If only one component exists or is reachable, list returns its records
+and reports the unavailable source through the SDK's established partial-error
+model. Get and decision operations fail with the owning endpoint's error and
+never fall back to the other component. The final SDK design must make this
+partial-result behavior explicit and consistent across languages before the
+OSEP becomes `implementable`.
+
+### Authentication and Sensitive Data
+
+Approval APIs use the current authentication for the owning runtime endpoint.
+This proposal does not add an unauthenticated decision route. Lifecycle server
+proxy and signed-endpoint access must preserve the same scope as direct execd
+or egress access and must not turn a sandbox application credential into a
+reviewer credential.
+
+Command strings are inherently capable of containing tokens, URLs, and inline
+secrets. Therefore:
+
+- authenticated get/list responses may return a bounded command because a
+  reviewer needs the action context;
+- logs, traces, metrics, generic error messages, and capacity warnings contain
+  only approval ID, kind, state, and timing data;
+- notification webhooks must support an operator option to omit command context
+  and default to omission;
+- URL query strings, HTTP headers, DNS answers, environment variables, and
+  Credential Vault material are never approval context in the first phase; and
+- OpenTelemetry attributes use low-cardinality kind/status/reason labels only.
+
+Approval ID suffixes are unpredictable but IDs are not authorization secrets.
+All API access still requires endpoint authentication.
+
+### Capacity, Cleanup, and Observability
+
+Each component enforces separate caps for pending records, retained terminal
+records, and remembered allows. A request that would exceed the pending cap is
+denied immediately with a typed capacity error. It is not queued outside the
+store and does not evict an existing pending action.
+
+Expiration uses a deadline-aware timer or heap rather than one unbounded
+goroutine per retained record. Terminal records and remembered decisions are
+removed after their respective deadlines. Sandbox or component shutdown closes
+the store, wakes waiters, and clears remembered state.
+
+The initial metrics are counters and gauges for:
+
+- approvals created by kind;
+- terminal decisions by kind, decision, and reason;
+- pending approval count;
+- decision latency;
+- capacity rejections; and
+- remembered-decision hits and expirations.
+
+No metric label contains approval ID, command, FQDN, sandbox ID, or reviewer
+input. Structured logs follow the same restriction.
+
+### Runtime Delivery
+
+The server serializes validated policy as component-specific startup
+configuration. Docker passes it when creating the execd and egress containers.
+Kubernetes places it in the corresponding container environment or mounted
+configuration using the existing workload-building path. Policy is immutable
+for the sandbox lifetime in the first phase.
+
+Both runtimes must apply the same defaults, validation, capacity behavior, and
+failure semantics. Runtime-specific endpoint discovery and token delivery are
+implementation details hidden by the SDK. The public lifecycle request and
+runtime approval schemas remain the sources of truth and generated consumers
+must be regenerated from them during implementation.
+
+## Test Plan
+
+**Contract and unit tests:**
+
+- Lifecycle schema accepts valid command-only, egress-only, and combined
+  policies and rejects empty policies, invalid globs, invalid timeouts, and
+  egress approval without `networkPolicy`.
+- Glob matching is anchored, case-sensitive, deterministic, and covers escaping
+  and invalid bracket expressions.
+- FQDN normalization, invalid-name rejection, explicit deny, `deny.always`,
+  explicit allow, and remembered-allow precedence are verified.
+- State transitions cover allow, deny, timeout, cancellation, shutdown,
+  identical retry, conflicting retry, expired record, unknown record, and
+  terminal-record eviction.
+- TTL caching covers exact-command isolation, FQDN expiry, DNS TTL capping, and
+  temporary nft cleanup.
+- Concurrent questions for one FQDN create one approval; concurrent commands
+  create independent approvals.
+- Capacity limits reject new actions without evicting waiters, leaking
+  goroutines, or logging sensitive context.
+
+**Execd integration tests:**
+
+- Foreground, background, bash-session, and isolated-session commands pause
+  before process creation and resume only after allow.
+- Deny and timeout produce typed execution failures and never start a process.
+- SSE disconnect, interrupt, session deletion, and execd shutdown wake or clean
+  up waiters without later execution.
+- Commands that do not match and commands covered by remembered exact allows
+  retain expected streaming and status behavior.
+
+**Egress integration tests:**
+
+- A new domain remains unresolved while pending; allow resumes resolution and
+  traffic, while deny and timeout return failure without leaking packets.
+- Static allow rules bypass approval, and explicit/always deny rules cannot be
+  overridden.
+- Concurrent DNS requests share a prompt and all waiters receive one result.
+- Existing deny webhook behavior is unchanged and the pending webhook cannot
+  decide an approval.
+
+**SDK and CLI tests:**
+
+- Generated models match both specs and handwritten facades route decisions to
+  the owning component.
+- Cross-language duration conversion, error mapping, pagination, ordering, and
+  partial endpoint failure are consistent.
+- CLI help, SDK call arguments, table/JSON/YAML output, and allow/deny exit codes
+  are covered with mocked SDK calls.
+
+**End-to-end tests:**
+
+- Docker and Kubernetes each create a sandbox with combined approval policy,
+  exercise command and domain approvals through SDK and CLI, and verify cleanup
+  at sandbox deletion.
+- Existing create, command, egress policy, deny webhook, and SDK flows are run
+  without `approvalPolicy` to demonstrate backward compatibility.
+
+## Drawbacks
+
+1. Two local approval stores require common schemas and conformance tests and
+   cannot provide a naturally global inbox.
+2. Approval records and remembered decisions disappear on component restart.
+3. Holding SSE requests and DNS questions consumes bounded runtime resources and
+   adds latency at review boundaries.
+4. Raw-command glob matching is understandable but cannot reliably classify the
+   semantic risk of arbitrary shell behavior.
+5. DNS-level approval is coarse: it approves temporary reachability to a domain,
+   not one application-layer request.
+6. SDK aggregation must represent partial failures when only one component is
+   reachable.
+
+## Alternatives
+
+**Central lifecycle-server coordinator.** The server could store every approval
+and expose one global API. This simplifies listing but requires runtime
+components to call back to the server, distributes a new service credential,
+and introduces persistence and multi-replica consistency into the blocking
+path. Data-plane ownership is smaller and fails closed naturally.
+
+**External approval broker or synchronous webhook.** An external service could
+own decisions. This is useful for enterprise integration but makes a new
+dependency part of the action hot path and leaves standalone OpenSandbox
+without a complete workflow. A future adapter can mirror local pending events
+to an external system without making it the core state owner.
+
+**Update static policy and retry the action.** A reviewer could edit egress
+policy or command configuration after denial. This does not hold and resume the
+original action, is prone to races, and broadens a one-time approval into a
+configuration change.
+
+**HTTP interception for all egress approval.** Transparent MITM can approve
+individual HTTP requests and show richer context, but it excludes non-HTTP
+traffic and adds CA, encryption, privacy, and protocol concerns. DNS-level new
+domain approval matches the first-phase requirement with the current egress
+architecture.
+
+**Semantic command parsing.** Parsing shell ASTs or classifying commands with a
+model may produce richer prompts, but shell dialects, expansion, scripts, and
+indirection make it unsuitable as the deterministic first policy primitive.
+
+## Infrastructure Needed
+
+No new external service or persistent database is required. Implementation will
+require additive lifecycle, execd, and egress OpenAPI changes; regenerated SDK
+clients; component-local in-memory stores; and Docker and Kubernetes end-to-end
+coverage. Existing endpoint authentication, SSE, egress DNS policy, and webhook
+infrastructure are reused.
+
+## Upgrade & Migration Strategy
+
+The feature is additive and opt-in:
+
+1. Servers and generated clients add the optional `approvalPolicy` field.
+2. Execd and egress add approval resources without changing existing paths.
+3. A missing policy runs the existing command and egress paths without creating
+   approval state or events.
+4. Existing `OPENSANDBOX_EGRESS_DENY_WEBHOOK`, static network policies,
+   `deny.always`, and Credential Vault behavior remain unchanged.
+5. During a mixed-version rollout, the server must not accept an approval policy
+   unless the selected runtime images advertise support; it fails sandbox
+   creation rather than silently ignoring the policy.
+6. SDK and CLI additions do not remove or rename existing methods or commands.
+7. Rollback is performed by omitting `approvalPolicy` and using runtime images
+   without the additive endpoints; no stored approval data needs migration.
+
+The proposal must reach `implementable` before public contracts or runtime code
+are changed. Credential-use approvals, share links, a durable audit store, and a
+global approval service require follow-up design review rather than being
+silently added to the first implementation.

--- a/oseps/0015-human-in-the-loop-approval-gates.md
+++ b/oseps/0015-human-in-the-loop-approval-gates.md
@@ -3,7 +3,7 @@ title: Human-in-the-Loop Approval Gates
 authors:
   - "@GodBlf"
 creation-date: 2026-07-17
-last-updated: 2026-07-17
+last-updated: 2026-07-21
 status: draft
 ---
 
@@ -21,12 +21,15 @@ status: draft
 - [Design Details](#design-details)
   - [Terminology](#terminology)
   - [Architecture and Ownership](#architecture-and-ownership)
+  - [Reviewer Registry](#reviewer-registry)
   - [Lifecycle Policy](#lifecycle-policy)
   - [Command Matching and Execution Flow](#command-matching-and-execution-flow)
   - [New-Domain Egress Flow](#new-domain-egress-flow)
   - [Approval State Machine](#approval-state-machine)
-  - [Runtime Approval APIs](#runtime-approval-apis)
-  - [Events and Reviewer Notification](#events-and-reviewer-notification)
+  - [Broker Protocol](#broker-protocol)
+  - [Reviewer Grants](#reviewer-grants)
+  - [Reviewer API and Review Page](#reviewer-api-and-review-page)
+  - [Events and Notifications](#events-and-notifications)
   - [SDK and CLI](#sdk-and-cli)
   - [Authentication and Sensitive Data](#authentication-and-sensitive-data)
   - [Capacity, Cleanup, and Observability](#capacity-cleanup-and-observability)
@@ -40,16 +43,18 @@ status: draft
 
 ## Summary
 
-This proposal introduces an optional, fail-closed approval gate that can pause
-selected sandbox actions until an authorized reviewer allows or denies them.
-The first phase covers execd commands selected by policy and egress requests to
-new FQDNs. It gives autonomous agents a supervised boundary without changing
-the behavior of sandboxes that do not configure an approval policy.
+This proposal introduces an optional, fail-closed approval gate that pauses
+selected sandbox actions until a distinct, authorized human reviewer allows or
+denies them. The first phase covers execd commands selected by policy and egress
+requests to new FQDNs. It gives autonomous agents a supervised boundary without
+changing sandboxes that do not configure an approval policy.
 
-Approval state remains in the data-plane component that owns the blocked
-action. Execd owns command approvals and egress owns domain approvals. Both
-components expose the same approval resource model, while SDK and CLI facades
-present a sandbox-scoped view across the two endpoints.
+Execd and egress retain the pending action and enforce the final decision. The
+lifecycle server provides the reviewer control plane: it authenticates a
+pre-registered reviewer, sends a scoped review link through a configured
+webhook, serves a minimal review page, and brokers the decision to the owning
+component. Agent endpoint credentials and reviewer credentials are separate and
+cannot be substituted for one another.
 
 This proposal addresses [issue #1288](https://github.com/opensandbox-group/OpenSandbox/issues/1288).
 
@@ -57,8 +62,8 @@ This proposal addresses [issue #1288](https://github.com/opensandbox-group/OpenS
 
 OpenSandbox currently applies policy before a sandbox starts or rejects an
 action immediately at runtime. Egress allow and deny rules are static until a
-caller updates them, and the egress deny webhook only reports a request after
-it has already been denied. Execd does not have an approval concept.
+caller updates them, and the egress deny webhook reports a request after it has
+already been denied. Execd does not have an approval concept.
 
 That model is suitable for fixed policy but not for supervising autonomous
 agents. An operator may want an agent to continue independently until it
@@ -66,47 +71,55 @@ attempts a selected command or reaches a destination that has not yet been
 reviewed. Rejecting every such action forces the agent to restart it manually,
 while allowing it unconditionally removes the review boundary.
 
-A blocking approval gate fills this gap: the runtime holds the action, exposes
-sanitized context to an authorized reviewer, and resumes only after an explicit
-allow decision. Missing decisions, component failures, and timeouts deny the
-action.
+A human-in-the-loop gate requires more than a remotely unblockable pause. The
+reviewer must be a principal distinct from the action initiator, must receive a
+notification and usable entry point, must hold a credential scoped only to the
+pending action, and must be recorded on the decision. This proposal makes those
+properties part of the first-phase contract.
 
 ### Goals
 
-1. Let users opt into approval gates at sandbox creation time without changing
+1. Let users opt into approval gates at sandbox creation without changing
    existing sandbox behavior by default.
 2. Pause selected execd commands before process creation and resume the same
    request after an allow decision.
 3. Pause DNS handling for a new FQDN before the egress sidecar makes the
    destination reachable.
-4. Provide consistent list, get, allow, and deny operations through runtime
-   APIs, supported SDKs, and `osb`.
-5. Fail closed on timeout, component shutdown, sandbox deletion, capacity
-   exhaustion, or decision-channel failure.
-6. Keep Docker and Kubernetes user-visible semantics aligned.
-7. Preserve the precedence of operator and explicit deny policy.
-8. Bound approval state and avoid leaking command or request secrets through
-   logs, metrics, webhooks, or API error text.
+4. Require at least one operator-registered reviewer whose identity is distinct
+   from the agent or sandbox endpoint caller.
+5. Notify reviewers through a configured webhook carrying a short-lived,
+   single-approval review link.
+6. Provide a minimal browser review page plus grant-authenticated API, SDK, and
+   CLI decision paths.
+7. Attribute every allow or deny decision to the verified reviewer identity.
+8. Fail closed on timeout, component shutdown, sandbox deletion, capacity
+   exhaustion, notification failure, or broker failure.
+9. Keep Docker and Kubernetes user-visible semantics aligned.
+10. Preserve operator and explicit egress rule precedence.
+11. Bound approval state and avoid leaking commands, request secrets, reviewer
+    grants, or webhook credentials through logs, metrics, or error text.
 
 ### Non-Goals
 
-1. This proposal does not turn command patterns into a security isolation
-   boundary. An allowed command, code execution request, or child process can
-   perform equivalent work through another mechanism.
+1. Command patterns are not a security isolation boundary. An allowed command,
+   code execution request, or child process may perform equivalent work through
+   another mechanism.
 2. The first phase does not inspect code execution, child processes created by
    an allowed command, file API operations, diffs, or generic "destructive"
    behavior.
 3. The first phase does not gate direct-IP egress or individual TCP/HTTP
    connections. Domain approval occurs at DNS resolution time.
-4. Credential Vault use approval is deferred. The design leaves room for a
-   future `credential_use` approval kind but does not define its policy or API
-   context here.
-5. Browser review pages, scoped share links, push notification services, and a
-   global cross-sandbox approval inbox are deferred.
-6. Approval history is not a durable audit ledger. Terminal records are held
-   only for a bounded time in the owning component.
-7. Reviewers cannot edit or replace the command, domain, or other pending
-   action context through the decision API.
+4. Credential Vault use approval is deferred. A future `credential_use` kind
+   may reuse the reviewer model but requires separate context and policy design.
+5. A global cross-sandbox inbox, mobile application, email provider, and native
+   integrations for specific chat systems are deferred. Webhook delivery and
+   the built-in review page form the first-phase entry point.
+6. Approval history is not a durable audit ledger. Terminal records are retained
+   for a bounded period by the owning component.
+7. Reviewer self-service enrollment, OIDC federation, and runtime reviewer CRUD
+   are deferred. Operators register reviewer identities in server configuration.
+8. Reviewers cannot edit or replace the command, domain, or other pending action
+   context through the decision API.
 
 ## Requirements
 
@@ -115,149 +128,205 @@ action.
 | R1 | No configured approval policy preserves current behavior | Must Have |
 | R2 | Matching commands are held before process creation | Must Have |
 | R3 | New FQDNs are held before DNS resolution makes them reachable | Must Have |
-| R4 | Timeout and runtime failure deny the held action | Must Have |
+| R4 | Timeout and runtime or broker failure deny the held action | Must Have |
 | R5 | Operator and explicit deny rules cannot be overridden by approval | Must Have |
-| R6 | Execd and egress expose a common approval resource and decision contract | Must Have |
-| R7 | Decisions are atomic, terminal, and idempotent for identical retries | Must Have |
-| R8 | Pending and remembered state is bounded and sandbox-local | Must Have |
-| R9 | Existing execd and egress endpoint authentication protects approval APIs | Must Have |
-| R10 | Logs, metrics, errors, and notifications expose no more action context than their documented reviewer purpose requires | Must Have |
-| R11 | Docker and Kubernetes implement the same public behavior | Must Have |
-| R12 | SDK and CLI users can review and decide approvals for one sandbox | Must Have |
-| R13 | Concurrent DNS requests for one normalized FQDN share one pending approval | Must Have |
-| R14 | Allow decisions may remember an exact command or FQDN for a bounded TTL | Should Have |
+| R6 | Execd and egress expose a common broker-only approval contract | Must Have |
+| R7 | Normal execd, egress, sandbox, and agent credentials cannot read or decide approvals | Must Have |
+| R8 | Every decision is authenticated as a pre-registered reviewer and records that reviewer ID | Must Have |
+| R9 | Reviewer grants are signed, short-lived, and scoped to one sandbox and one approval | Must Have |
+| R10 | A pending action triggers an authenticated webhook notification with a browser review entry point | Must Have |
+| R11 | Decisions are atomic, terminal, and idempotent only for the same reviewer replaying the same decision | Must Have |
+| R12 | Pending, terminal, and remembered state is bounded and sandbox-local | Must Have |
+| R13 | Logs, metrics, errors, and notifications expose no more context than their documented purpose requires | Must Have |
+| R14 | Docker and Kubernetes implement the same public behavior | Must Have |
+| R15 | Concurrent DNS requests for one normalized FQDN share one pending approval | Must Have |
+| R16 | Allow decisions may remember an exact command or FQDN for a bounded TTL | Should Have |
 
 ## Proposal
 
-Add an optional `approvalPolicy` to sandbox creation. The server validates and
-delivers the relevant policy subset to execd and egress when it creates the
-sandbox. It does not store pending approvals or participate in their state
-transitions.
+Add an optional `approvalPolicy` to sandbox creation. A policy references one or
+more reviewer IDs that the operator has registered in server configuration. The
+server rejects unknown or disabled reviewers, generates a per-sandbox broker
+token, and delivers component-specific policy and broker configuration to execd
+and egress.
 
-Execd evaluates each command immediately after request validation and before
-starting a process. Egress evaluates a normalized DNS question after fixed deny
-rules and existing allow rules. When an action needs review, the owning
-component creates a local approval record and waits for a terminal decision.
+Execd evaluates commands before process creation. Egress evaluates a normalized
+DNS question after fixed rules. When an action requires review, the owning
+component creates a local approval record and notifies the lifecycle server over
+an authenticated internal callback. The server signs one grant per configured
+reviewer and sends each reviewer a webhook containing a review URL. The grant is
+bound to the reviewer, sandbox, component, approval, scopes, and expiration.
 
-Reviewers resolve the sandbox's existing execd and egress endpoints and use the
-approval APIs protected by those endpoints' existing authentication. SDKs and
-the CLI hide endpoint discovery and combine records from both components.
+The browser review page keeps the grant in the URL fragment and uses it as a
+Bearer credential for the public reviewer API. After validation, the server
+uses the sandbox's separate broker token to read or decide the component-local
+approval. The component records the verified reviewer ID and wakes the blocked
+action. A normal action client never receives the reviewer grant or broker
+token and cannot approve its own request.
 
 ```
-                                create sandbox
-Client --------------------------------------------------------> Server
-  |                                                               |
-  |                                                    validates and splits
-  |                                                    approvalPolicy
-  |                                                               |
-  |                                      +------------------------+------------------+
-  |                                      |                                           |
-  |                                      v                                           v
-  |                           +---------------------+                      +---------------------+
-  | command request           | execd               |                      | egress              |
-  +-------------------------->| - command matcher   |                      | - DNS policy        |
-  |                           | - approval store    |                      | - approval store    |
-  |                           +----------+----------+                      +----------+----------+
-  |                                      |                                            ^
-  |                                      | wait                                       | DNS request
-  |                                      v                                            | from sandbox
-  |                           +---------------------+                                  |
-  | approvals facade         | pending command     |                       sandbox ---+
-  +------------------------->| allow/deny/expire   |
-  |                           +---------------------+
-  |
-  +-------------------------------> egress approval APIs
+ Operator config                     Lifecycle server
+ reviewer ID + webhook       +--------------------------------+
+            ---------------->| reviewer registry              |
+                             | grant signer + review page     |
+                             | reviewer API + broker proxy    |
+                             +-------+----------------+-------+
+                                     ^                |
+                    broker callback  |                | reviewer webhook
+                    + broker token   |                | scoped review URL
+                                     |                v
+                              +------+-----+      +-----------+
+ Agent command ------------->| execd      |      | Reviewer  |
+                              | local wait |      | browser   |
+                              +------+-----+      +-----+-----+
+                                     ^                  |
+                                     | broker decision  | grant-authenticated
+                                     +------------------+ server API
+
+ Sandbox DNS -------------> egress follows the same callback and decision flow.
 ```
 
-Approval decisions are data-plane local by design. This avoids a reverse
-dependency from sandbox components to the lifecycle server, avoids giving
-components a server-wide credential, and avoids introducing distributed
-persistence or multi-replica coordination into the lifecycle control plane.
+Approval state remains data-plane local. The lifecycle server authenticates and
+routes reviewer operations but does not persist pending actions or become the
+wait primitive. This keeps process and DNS resumption atomic with component
+state while providing an identity-aware control plane.
 
 ### Notes/Constraints/Caveats
 
 1. The command matcher sees the exact command string accepted by the execd API;
    it does not parse shell syntax or infer semantic equivalence.
 2. DNS approval controls when the sidecar resolves and admits a domain. Once an
-   answer has been returned, the runtime cannot provide per-connection or
-   one-packet approval semantics through DNS interception alone.
-3. Egress approval requires an egress sidecar and therefore requires
-   `networkPolicy`. A create request that configures egress approval without
-   `networkPolicy` is invalid.
+   answer has been returned, DNS interception cannot provide per-connection or
+   one-packet approval semantics.
+3. Egress approval requires an egress sidecar and therefore `networkPolicy`.
 4. Approval cannot override `/var/egress/rules/deny.always` or an explicit user
-   deny rule. Such requests are denied immediately and retain existing blocked
-   event behavior.
-5. Approval state is lost on execd or egress restart. Waiting actions are
-   denied before shutdown where possible; after an abrupt restart they fail by
-   connection loss or DNS failure and are never implicitly allowed.
-6. A reviewer with approval access can see action context that may itself be
-   sensitive. Approval access is equivalent to existing authenticated access
-   to the corresponding sandbox runtime endpoint and must not be exposed
-   through an unauthenticated share link in the first phase.
+   deny rule. Such requests are denied immediately.
+5. Approval state is lost on execd or egress restart. Waiting actions are denied
+   before graceful shutdown where possible and never implicitly allowed after
+   an abrupt restart.
+6. Reviewer IDs are operator-controlled stable identifiers. A sandbox creator
+   selects registered reviewers but cannot submit a new identity, webhook URL,
+   webhook secret, signing key, reviewer grant, or broker token.
+7. Anyone holding a review link is acting as the reviewer named by its grant.
+   HTTPS, short expiry, single-approval scope, fragment transport, and careful
+   webhook access control are therefore mandatory.
+8. The lifecycle server is trusted to authenticate reviewers and broker their
+   decisions. Compromise of the control plane is outside the sandbox threat
+   boundary.
 
 ### Risks and Mitigations
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Glob patterns are bypassed by alternate spelling or indirection | A risky command does not pause | Document this as supervision, not isolation; match the complete raw string predictably; recommend broad patterns and static sandbox controls for enforcement |
-| Reviewer approves misleading context | Unintended action runs | Do not permit context mutation; display exact bounded command or normalized FQDN; include kind and timestamps |
-| Commands contain secrets | Secrets appear in logs or notifications | Return context only from authenticated get/list APIs; omit full context from logs, metrics, errors, and webhooks |
-| Pending requests exhaust memory or goroutines | Runtime availability degrades | Enforce configurable hard caps and reject excess actions immediately |
-| Runtime restart loses an allow decision | Agent action fails and may be retried | Keep state local and fail closed; expose restart/expiration outcomes clearly; do not claim durable approvals |
-| Runtime restart loses a deny decision | A retry creates another review request | Deny decisions are not durable; callers that need permanent denial must update static policy |
-| Approval overrides an operator restriction | Security policy is weakened | Evaluate always-deny and explicit deny before the approval layer and never create an approval for them |
-| DNS cache outlives an approval TTL | Traffic continues after remembered approval expires | Cap returned DNS TTL to the remaining approval TTL and remove temporary nft state at expiry where applicable |
-| Multiple DNS questions race | Duplicate prompts or inconsistent results | Normalize the FQDN and use single-flight pending records per domain |
-| Webhook is mistaken for an authorization channel | Spoofed callback affects execution | Webhooks are notification-only; decisions require authenticated runtime API calls |
-| Component APIs drift | SDK and CLI behavior differs by approval kind | Define common schemas and conformance tests in both OpenAPI contracts |
+| Agent approves its own action with its endpoint token | Human boundary is bypassed | Approval routes require a non-empty, per-sandbox broker token; only server-issued reviewer grants reach the public reviewer API |
+| Review link is leaked | Attacker acts as the named reviewer | Put grant in URL fragment, require HTTPS, bind it to one approval, cap it at pending expiry, suppress referrers, and never log it |
+| Reviewer registry is misconfigured | Wrong or unreachable reviewer is selected | Validate reviewer IDs and enabled state at sandbox creation; reject policy when none remain |
+| Webhook delivery fails | Reviewer does not learn about the action | Retry with bounded backoff and stable event ID; action remains pending and expires deny |
+| Duplicate webhooks cause repeated decisions | Confusing reviewer experience | Idempotency key is derived from sandbox, approval, and reviewer; terminal decision handling is atomic |
+| Glob patterns are bypassed by alternate spelling | Risky command does not pause | Document supervision rather than isolation; match the complete raw string deterministically; retain static controls |
+| Commands contain secrets | Secret appears in notification or UI | Default webhook to summary metadata; full bounded context is fetched only through the grant-authenticated API |
+| Pending requests exhaust resources | Runtime availability degrades | Enforce hard caps and reject excess actions immediately |
+| DNS cache outlives an approval TTL | Traffic continues after grant intent expires | Cap DNS and temporary nft lifetimes to the remembered allow TTL |
+| Multiple reviewers race | Attribution or result is ambiguous | First terminal decision wins; only the same reviewer replaying the same decision is idempotent; all other attempts return `409` |
+| Broker token is omitted or confused with normal auth | Approval route becomes unprotected | Broker middleware always fails closed when its token is empty and ignores normal endpoint credentials |
+| Component APIs drift | Server routes kinds differently | Define common schemas and conformance tests in execd and egress specs |
 
 ## Design Details
 
 ### Terminology
 
-- **Approval policy**: Optional sandbox creation policy that selects actions for
-  human review.
-- **Approval**: A runtime resource representing one held command or normalized
-  FQDN.
-- **Decision**: An immutable terminal `allow` or `deny` operation applied to an
-  approval.
-- **Remembered decision**: A temporary in-memory allow cache entry for one exact
-  command string or normalized FQDN.
-- **Owning component**: Execd for command approvals and egress for domain
-  approvals.
+- **Reviewer**: One operator-registered, accountable human principal with a
+  stable ID and webhook destination. Shared team identities are not reviewers
+  in the first phase.
+- **Approval**: A component-local resource representing one held command or
+  normalized FQDN.
+- **Reviewer grant**: A server-signed Bearer credential scoped to one reviewer,
+  sandbox, source component, approval, permission set, and expiration.
+- **Broker token**: A random per-sandbox secret shared only between the server
+  and owning components for internal callback, read, and decision operations.
+- **Decision**: An immutable terminal `allow` or `deny` operation attributed to
+  the verified reviewer.
+- **Remembered allow**: A temporary component-local allow cache entry for one
+  exact command or normalized FQDN.
 
 ### Architecture and Ownership
 
-Each owning component implements the same logical `ApprovalStore` behavior:
+Each owning component implements the same logical store:
 
 ```
-Create(kind, context, expiresAt) -> Approval
-List(status?)                    -> []Approval
-Get(id)                          -> Approval | not found
-Decide(id, decision, ttl?)       -> Approval | conflict | expired
+Create(kind, context, expiresAt)          -> Approval
+Get(id)                                   -> Approval | not found
+Decide(id, decision, ttl, reviewerId)     -> Approval | conflict | expired
 Expire(now)
-Close()                          -> deny all pending waiters
+Close()                                   -> expire all pending waiters
 ```
 
-The store owns synchronization between request handlers, timers, and blocked
-runtime operations. A decision updates the record and wakes waiters atomically.
-An allow is observed by the held operation only after the terminal state is
-committed. Closing the store wakes every waiter with deny.
+The component owns synchronization between request handlers, timers, and the
+blocked action. A broker-authenticated decision commits the terminal record,
+including `decidedBy`, before waking the waiter. Closing the store wakes every
+waiter without allowing it.
 
-The lifecycle server remains responsible only for:
+The lifecycle server owns:
 
-1. validating the public create policy;
-2. rejecting egress approval without `networkPolicy`;
-3. serializing the command subset into execd startup configuration;
-4. serializing the egress subset into egress startup configuration; and
-5. configuring component limits consistently for Docker and Kubernetes.
+1. reviewer registration and webhook credentials;
+2. approval signing keys;
+3. lifecycle policy validation and reviewer selection;
+4. per-sandbox broker token creation and runtime delivery;
+5. pending-event authentication and webhook delivery;
+6. reviewer grant validation and minimal review UI; and
+7. broker-authenticated routing to execd or egress.
+
+The server does not store pending or terminal approval state. It resolves the
+current owning component from sandbox runtime metadata for every reviewer
+request. Pending notifications may be retried without creating server state.
+
+### Reviewer Registry
+
+Reviewers are registered in server configuration, conceptually:
+
+```toml
+[approval]
+active_signing_key = "a"
+
+[[approval.signing_keys]]
+key_id = "a"
+secret = "env:OPENSANDBOX_APPROVAL_SIGNING_KEY_A"
+
+[[approval.reviewers]]
+id = "alice"
+enabled = true
+webhook_url = "https://review-notify.example/hooks/alice"
+webhook_authorization = "env:OPENSANDBOX_ALICE_WEBHOOK_TOKEN"
+```
+
+Exact secret-provider syntax should follow the server's established config
+conventions when implemented. The contract requires that signing and webhook
+secrets can be supplied without embedding them in lifecycle requests, workload
+metadata, logs, or generated examples.
+
+Reviewer IDs are unique and immutable within one server configuration. Startup
+rejects duplicate IDs, missing active keys, malformed HTTPS webhook URLs, or
+missing referenced secrets. Disabled reviewers remain valid historical
+identities but cannot be selected for a new sandbox.
+
+Each entry represents one human who is accountable for decisions under that ID.
+Operators must not register a shared team or service identity as a reviewer. A
+team workflow registers its human decision makers separately, even if their
+notifications pass through the same integration service.
+
+Signing keys are server-only and support an active key plus verification keys
+for rotation. They are separate from OSEP-0011 ingress route keys because a
+reviewer grant conveys a different authority and must not be verifiable or
+mintable by ingress.
 
 ### Lifecycle Policy
 
-The proposed additive lifecycle shape is:
+The additive lifecycle shape is:
 
 ```yaml
 approvalPolicy:
+  reviewers:
+    - alice
   timeoutSeconds: 300
   commands:
     patterns:
@@ -267,129 +336,211 @@ approvalPolicy:
     mode: new_domains
 ```
 
-`approvalPolicy` is optional. Its fields have these semantics:
-
 | Field | Semantics |
 |-------|-----------|
-| `timeoutSeconds` | Time a new approval may remain pending; default `300`; must be positive and is bounded by an implementation-defined server maximum |
-| `commands.patterns` | Non-empty shell-style glob patterns matched against the complete command string; any match requires approval |
-| `egress.mode` | The first phase accepts only `new_domains`; omitted egress configuration disables domain approval |
+| `reviewers` | Required non-empty list of unique, enabled reviewer IDs from server configuration |
+| `timeoutSeconds` | Positive pending lifetime; default `300`; bounded by the server maximum |
+| `commands.patterns` | Non-empty shell-style glob patterns matched against the complete command string |
+| `egress.mode` | First phase accepts only `new_domains`; omission disables domain approval |
 
-Pattern matching is case-sensitive and anchored to the complete command string.
-`*`, `?`, and bracket expressions follow the selected standard-library glob
-implementation; a backslash escapes the next metacharacter. The specification
-and each SDK must use examples to make this behavior explicit. Empty patterns
-and invalid bracket expressions are rejected at sandbox creation.
+The server rejects an empty policy, unknown or disabled reviewer, invalid glob,
+invalid timeout, egress approval without `networkPolicy`, unavailable signing
+configuration, or a runtime that cannot establish the broker channel. It never
+silently drops an invalid reviewer or approval capability.
 
-Unknown fields follow the existing lifecycle API validation policy. An empty
-`approvalPolicy` is rejected because it cannot gate an action and is likely a
-configuration mistake.
+Pattern matching is case-sensitive and anchored to the full command string.
+`*`, `?`, bracket expressions, and escaping follow the selected cross-component
+glob contract. Empty patterns and malformed bracket expressions are rejected.
 
-Component capacity limits are operator configuration, not per-sandbox public
-API fields in the first phase. Initial defaults are 128 pending records and
-1,024 remembered decisions per component. Operators may lower these values;
-raising them must remain subject to documented hard maximums.
+Capacity limits remain operator configuration rather than lifecycle fields.
+Initial defaults are 128 pending approvals and 1,024 remembered allows per
+component, subject to documented hard maximums.
 
 ### Command Matching and Execution Flow
 
-The command gate applies to:
+The command gate applies to regular foreground and background commands, bash
+session commands, and isolated-session commands.
 
-- regular foreground and background command execution;
-- commands run in an existing bash session; and
-- commands run in an isolated execution session.
+1. Execd authenticates and validates the action request using normal endpoint
+   credentials.
+2. It checks an unexpired remembered allow and then the configured globs.
+3. A miss follows the existing execution path unchanged.
+4. A match creates a unique `command` approval before allocating or starting a
+   child process.
+5. Execd sends one broker-authenticated pending event to the server and retries
+   retryable delivery failures with a stable event ID.
+6. Foreground/session SSE emits `approval_required`; background status exposes
+   `pending_approval`. Neither surface contains reviewer credentials.
+7. A broker-authenticated allow resumes the original in-memory action. Deny or
+   expiry returns a typed error without starting a process.
+8. Omitted `ttlSeconds` or explicit `0` permits only this command invocation. A
+   positive TTL also remembers the exact byte-for-byte command, never its glob.
 
-The flow is:
-
-1. Execd authenticates and validates the request as it does today.
-2. Execd checks the exact command against unexpired remembered allows.
-3. If there is no remembered allow, execd evaluates every configured glob.
-4. A miss proceeds through the current execution path unchanged.
-5. A match creates a unique `command` approval before allocating or starting
-   the child process.
-6. Foreground/session SSE emits `approval_required` and remains connected.
-   Background execution exposes `pending_approval` through command status.
-7. Allow resumes the original in-memory request once. Deny or expiry returns a
-   typed approval-denied or approval-expired execution error without starting
-   the process.
-8. A positive decision `ttlSeconds` also remembers the exact, byte-for-byte
-   command string. It does not remember the glob or authorize other commands
-   matched by that glob.
-
-Each matching command invocation gets its own approval. This preserves the
-request's session, working directory, environment, and cancellation context and
-prevents one prompt from authorizing multiple concurrent executions. Interrupt
-and request cancellation remove the waiter and make its approval terminal;
-later allow attempts cannot start the canceled command.
+Every command invocation has a distinct approval. Interrupt, session deletion,
+or action cancellation expires the record, and a later decision cannot start
+the canceled command.
 
 ### New-Domain Egress Flow
 
-Domain approval is inserted into the DNS policy path with this precedence:
+Domain approval uses this precedence:
 
-1. operator `deny.always` match: deny immediately;
-2. operator `allow.always` match: allow immediately;
-3. the first matching explicit user rule: apply its allow or deny immediately;
+1. operator `deny.always`: deny immediately;
+2. operator `allow.always`: allow immediately;
+3. first matching user rule: apply its allow or deny immediately;
 4. unexpired remembered approval for the normalized FQDN: allow temporarily;
-5. `new_domains` enabled: create or join a pending approval;
-6. no approval policy: apply the current default action unchanged.
+5. `new_domains`: create or join a pending approval;
+6. no approval policy: apply the existing default action.
 
-This retains the existing `deny.always`, `allow.always`, then user-rule overlay
-order. In particular, the approval layer never changes which static rule wins.
-The egress component normalizes the cache key exactly as current policy matching
-does: lowercase the DNS wire name and remove one trailing dot. Policy target and
-DNS-question normalization must stay shared so equivalent names cannot create
-separate decisions.
+This retains the existing static overlay order. The cache key uses the same
+normalization as policy matching: lowercase the DNS wire name and remove one
+trailing dot.
 
-Concurrent questions for the same normalized FQDN join one pending record and
-receive the same result. Deny or expiry returns a DNS refusal and does not add
-temporary nft state. Allow resumes the held resolution, updates the dynamic
-address set as required by the current egress mode, and remembers the domain
-for the decision TTL. When `ttlSeconds` is omitted, the domain is remembered
-for the smaller of the configured approval timeout and the upstream DNS TTL.
+Concurrent questions for one normalized FQDN join one pending record. Deny or
+expiry returns DNS refusal and adds no temporary nft state. Allow resumes the
+held resolution and updates the dynamic address set when required.
 
-The effective DNS TTL and temporary address-set lifetime must not exceed the
-remaining remembered-decision TTL. Direct-IP traffic, reverse DNS questions,
-and non-address DNS record types are not turned into approval requests in the
-first phase and continue through existing policy behavior.
+For egress allow, omitted `ttlSeconds` uses the smaller of the approval timeout
+and upstream DNS TTL. A positive value is bounded by the operator maximum and
+the upstream DNS TTL. Explicit `ttlSeconds: 0` is invalid and returns `400`
+because DNS cannot provide useful single-request reachability with a zero
+lifetime. Deny requests reject `ttlSeconds` entirely.
+
+The effective DNS TTL and temporary address-set lifetime never exceed the
+remembered allow. Direct-IP traffic, reverse DNS questions, and non-address
+questions are not turned into approval requests in the first phase.
 
 ### Approval State Machine
 
 ```
-                        allow
-                    +-----------> allowed
+                         reviewer allow
+                    +--------------------> allowed
                     |
 created ----------> pending
-                    |             denied
-                    +-----------> denied
                     |
-                    | timeout / cancellation / shutdown
-                    +-----------> expired
+                    +--------------------> denied
+                         reviewer deny
+                    |
+                    +--------------------> expired
+                         timeout / cancellation / shutdown
 ```
 
-`allowed`, `denied`, and `expired` are terminal. The API uses `expired` for
-timeout, request cancellation, and owning-component shutdown because in every
-case the original action is no longer available to resume. An optional terminal
-`reason` distinguishes those cases without exposing sensitive context.
+`allowed`, `denied`, and `expired` are terminal. Terminal records include
+`decidedAt`, `decision`, and `decidedBy` for reviewer decisions; expiration has
+an internal reason and no reviewer.
 
-Submitting the same decision again returns `200` and the existing terminal
-record. Submitting the opposite decision to an allowed or denied record returns
-`409 Conflict`. Deciding an expired record returns `410 Gone`. An unknown or
-evicted identifier returns `404 Not Found`.
+The same reviewer replaying the same decision returns `200` with the terminal
+record. An opposite decision, or any decision from another reviewer after a
+terminal reviewer decision, returns `409 Conflict` and the sanitized existing
+decision metadata. Expired returns `410 Gone`; unknown or evicted returns `404`.
 
-Terminal records remain listable for a bounded retention window to make retries
-and immediate diagnosis possible. Retention does not extend a remembered allow
-and is not an audit guarantee.
+Terminal records remain available for a bounded diagnostic window. Retention
+does not extend a remembered allow and is not a durable audit guarantee.
 
-### Runtime Approval APIs
+### Broker Protocol
 
-Execd and egress add equivalent operations to their respective public specs:
+The server generates a cryptographically random broker token for every sandbox
+with approval enabled. It stores the token using the same protected runtime
+metadata pattern as other internal endpoint tokens and injects it only into
+execd and egress. It also injects an internal server callback URL that works for
+the selected Docker or Kubernetes runtime.
+
+The broker token is never returned by lifecycle responses, endpoint discovery,
+diagnostics, logs, or SDK models and is never mounted into the sandbox workload.
+
+The components expose equivalent broker-only operations:
 
 | Method and path | Behavior |
 |-----------------|----------|
-| `GET /approvals?status=pending` | List local approvals, optionally filtered by one status |
-| `GET /approvals/{approvalId}` | Return one local approval |
-| `POST /approvals/{approvalId}/decision` | Atomically allow or deny one pending approval |
+| `GET /internal/approvals/{approvalId}` | Read one local approval for the server proxy |
+| `POST /internal/approvals/{approvalId}/decision` | Apply a server-verified reviewer decision |
 
-The common response shape is:
+Components call:
+
+| Method and path | Behavior |
+|-----------------|----------|
+| `POST /internal/sandboxes/{sandboxId}/approval-events` | Notify the server that an approval is pending |
+
+All three operations require the per-sandbox broker token in a dedicated
+header. Broker middleware is independent of normal component authentication,
+uses constant-time comparison, and rejects an empty configured token. Supplying
+a normal execd/egress access token, sandbox API key, reviewer grant, or signed
+endpoint credential never authorizes a broker route.
+
+The pending event contains `eventId`, approval ID, source, kind, bounded summary
+context, `createdAt`, and `expiresAt`. The server verifies that token, sandbox,
+source, ID prefix, and runtime metadata agree before notifying reviewers. Event
+retries reuse an ID derived from sandbox, approval, and event type.
+
+The server decision request to a component includes the verified `reviewerId`.
+Components accept that field only on a broker-authenticated request and record
+it as `decidedBy`.
+
+### Reviewer Grants
+
+The server signs a separate grant for every pending approval and selected
+reviewer. The compact, URL-safe token contains at least:
+
+```json
+{
+  "version": 1,
+  "keyId": "a",
+  "reviewerId": "alice",
+  "sandboxId": "sandbox-123",
+  "approvalId": "execd_apr_01J...",
+  "source": "execd",
+  "scopes": ["approval:read", "approval:decide"],
+  "expiresAt": 1784606700
+}
+```
+
+The signature covers a canonical encoding of all claims and uses a server-only
+HMAC-SHA256 key selected by `keyId`. The exact wire encoding must be documented
+and shared by grant issue and verify code. `expiresAt` is never later than the
+pending approval expiration.
+
+Grant verification requires a valid signature and key, current time not past
+expiry, both required scopes, exact path approval ID, matching source prefix,
+and current sandbox ownership of the approval. A valid grant cannot access a
+different approval, sandbox, or component. Once the approval is terminal,
+deleted, or expired, the grant cannot authorize another action. No first-phase
+revocation list is needed.
+
+Reviewer identity comes exclusively from the verified grant. The decision body
+cannot supply or override `reviewerId`.
+
+### Reviewer API and Review Page
+
+The lifecycle server exposes:
+
+| Method and path | Behavior |
+|-----------------|----------|
+| `GET /v1/reviewer/approvals/{approvalId}` | Read the single approval named by the grant |
+| `POST /v1/reviewer/approvals/{approvalId}/decision` | Allow or deny that approval |
+| `GET /approvals/review` | Serve the minimal static browser reviewer UI |
+
+Reviewer API calls use `Authorization: Bearer <reviewer-grant>`. A lifecycle API
+key or normal sandbox credential is not an alternative authorization path. The
+server validates the grant, resolves the owning component from the ID prefix and
+sandbox metadata, and calls the broker-only data-plane API.
+
+The webhook review URL is:
+
+```text
+https://server.example/approvals/review#grant=<url-encoded-grant>
+```
+
+Fragments are not sent in the initial HTTP request. The page uses local script
+to extract the grant and sends it only in the Authorization header. It renders
+the verified reviewer ID, kind, bounded context, creation and expiry time,
+terminal state, allow/deny controls, and a TTL control appropriate to the kind.
+It cannot edit action context or navigate to other approvals.
+
+The review page ships no third-party script, uses a restrictive Content Security
+Policy, sets `Referrer-Policy: no-referrer`, does not persist the grant in local
+storage or cookies, clears it from memory after a terminal response, and avoids
+analytics and error reporting that could capture it.
+
+The public approval response includes:
 
 ```json
 {
@@ -397,289 +548,272 @@ The common response shape is:
   "source": "execd",
   "kind": "command",
   "status": "pending",
-  "context": {
-    "command": "rm -rf ./build"
-  },
-  "createdAt": "2026-07-17T08:00:00Z",
-  "expiresAt": "2026-07-17T08:05:00Z"
+  "context": {"command": "rm -rf ./build", "truncated": false},
+  "createdAt": "2026-07-21T03:00:00Z",
+  "expiresAt": "2026-07-21T03:05:00Z"
 }
 ```
 
-`source` is `execd` or `egress`, and IDs use the corresponding
-`execd_apr_` or `egress_apr_` namespace. This makes an ID globally routable
-within a sandbox without querying or submitting a decision to both components.
-The unpredictable suffix, not the prefix, supplies collision resistance.
+Terminal responses additionally include `decision`, `decidedAt`, and
+`decidedBy`. The decision request remains `{decision, ttlSeconds?}`. Command
+allows accept omission, zero, or a positive bounded TTL. Egress allows accept
+omission or a positive bounded TTL and return `400` for zero. Deny rejects TTL.
 
-`kind` is `command` or `egress_domain` in the first phase. Context is a tagged
-union: command records include a length-bounded command string; domain records
-include only the normalized FQDN. Implementations report truncation explicitly
-and never silently substitute a different value for the action being approved.
-The original full value remains internal to the blocked operation.
+### Events and Notifications
 
-Terminal responses additionally contain `decidedAt`, `decision`, and optional
-`reason`. They do not identify the reviewer in the first phase because runtime
-endpoint authentication does not currently provide a stable reviewer identity.
+Execd SSE emits `approval_required` with approval ID, kind, creation time, and
+expiry. Background status exposes `pending_approval`. These agent-facing events
+do not include reviewer IDs, review links, grants, broker tokens, webhook
+destinations, or full secret-bearing context.
 
-The decision request is:
+After validating a pending callback, the server sends one webhook per selected
+reviewer. The payload includes a stable event ID, reviewer ID, approval ID,
+source, kind, safe summary, expiry, and review URL. It omits full commands by
+default; the reviewer fetches authoritative context through the grant.
 
-```json
-{
-  "decision": "allow",
-  "ttlSeconds": 600
-}
-```
+Webhook delivery requires HTTPS, uses the reviewer registry's authorization
+secret, applies bounded timeout and retry with backoff, and treats any non-2xx
+response as failure. Retries preserve event ID and review grant. The webhook
+response cannot decide an approval. Failure is observable but never allows the
+action; the pending action eventually expires.
 
-`decision` is required and is `allow` or `deny`. `ttlSeconds` is optional,
-non-negative, and bounded by an operator maximum. Zero or omission is a
-single-use command decision. For an egress allow, omission uses the bounded DNS
-default described above. `ttlSeconds` on deny is rejected in the first phase;
-durable or remembered denial belongs in static policy.
-
-List responses use the component's existing pagination conventions where they
-exist; otherwise the new specs define a stable cursor and bounded page size.
-Ordering is newest creation time first with `id` as a deterministic tie-breaker.
-
-### Events and Reviewer Notification
-
-Execd adds an `approval_required` SSE event containing the approval ID, kind,
-creation time, and expiry time. It does not duplicate the full command in event
-logs. Existing completion and error events remain the source of the final
-execution result after allow, deny, or expiry.
-
-Background command status adds `pending_approval` and the approval ID without
-changing the meaning of existing terminal statuses.
-
-Egress extends the existing asynchronous blocked-event infrastructure with an
-approval-pending notification. The notification contains the approval ID,
-normalized FQDN, and expiry time and is emitted once per pending record, not
-once per joined DNS question. The webhook is notification-only: response bodies
-and status codes cannot allow or deny the request. Existing deny webhooks keep
-their current payload and already-denied semantics.
+The existing egress deny webhook keeps its current already-denied semantics and
+does not carry reviewer grants.
 
 ### SDK and CLI
 
-Sandbox SDKs expose a sandbox-scoped approval facade with equivalent operations
-in each supported language:
+Reviewer clients are separate from normal sandbox clients so endpoint headers
+cannot be accidentally reused. Supported SDKs expose a reviewer approval client
+constructed from the lifecycle server URL and reviewer grant:
 
 ```
-sandbox.approvals.list(status = pending)
-sandbox.approvals.get(approval_id)
-sandbox.approvals.allow(approval_id, ttl = ...)
-sandbox.approvals.deny(approval_id)
+reviewer_approvals.get(approval_id, grant)
+reviewer_approvals.allow(approval_id, grant, ttl = ...)
+reviewer_approvals.deny(approval_id, grant)
 ```
 
-For list operations, the facade resolves both execd and egress endpoints,
-queries them concurrently, and merges results by creation time. Get and decision
-operations route directly from the component namespace in the approval ID; an
-unknown prefix is rejected locally. Public durations use each language's
-established native duration convention while the wire format remains seconds.
+The client sends the grant only to the lifecycle reviewer API. It never resolves
+or calls execd/egress endpoints directly. Public duration types follow each
+language's established convention; wire TTL remains seconds.
 
-The stable CLI surface is:
+The first-phase CLI surface is:
 
 ```text
-osb approvals list <sandbox-id> [--status pending] [-o table|json|yaml]
-osb approvals get <sandbox-id> <approval-id> [-o table|json|yaml]
-osb approvals allow <sandbox-id> <approval-id> [--ttl SECONDS] [-o table|json|yaml]
-osb approvals deny <sandbox-id> <approval-id> [-o table|json|yaml]
+OPENSANDBOX_REVIEWER_GRANT=... osb approvals get <approval-id>
+OPENSANDBOX_REVIEWER_GRANT=... osb approvals allow <approval-id> [--ttl SECONDS]
+OPENSANDBOX_REVIEWER_GRANT=... osb approvals deny <approval-id>
 ```
 
-CLI commands call the Python SDK facade rather than reconstructing endpoint
-paths. If only one component exists or is reachable, list returns its records
-and reports the unavailable source through the SDK's established partial-error
-model. Get and decision operations fail with the owning endpoint's error and
-never fall back to the other component. The final SDK design must make this
-partial-result behavior explicit and consistent across languages before the
-OSEP becomes `implementable`.
+The environment variable is preferred over a command-line grant to avoid shell
+history and process-list exposure. CLI commands call the Python reviewer client,
+reject a missing grant locally, and do not fall back to the normal sandbox API
+key. The browser link remains the primary human entry point.
 
 ### Authentication and Sensitive Data
 
-Approval APIs use the current authentication for the owning runtime endpoint.
-This proposal does not add an unauthenticated decision route. Lifecycle server
-proxy and signed-endpoint access must preserve the same scope as direct execd
-or egress access and must not turn a sandbox application credential into a
-reviewer credential.
+The design has three non-interchangeable credentials:
 
-Command strings are inherently capable of containing tokens, URLs, and inline
-secrets. Therefore:
+| Credential | Holder | Authority |
+|------------|--------|-----------|
+| Normal execd/egress token | Agent or sandbox client | Existing action APIs only; never approval read or decision |
+| Per-sandbox broker token | Lifecycle server and runtime components | Internal pending callback and component approval proxy only |
+| Per-reviewer grant | Notified reviewer | Read and decide one named approval until expiry |
 
-- authenticated get/list responses may return a bounded command because a
-  reviewer needs the action context;
-- logs, traces, metrics, generic error messages, and capacity warnings contain
-  only approval ID, kind, state, and timing data;
-- notification webhooks must support an operator option to omit command context
-  and default to omission;
-- URL query strings, HTTP headers, DNS answers, environment variables, and
-  Credential Vault material are never approval context in the first phase; and
-- OpenTelemetry attributes use low-cardinality kind/status/reason labels only.
+Command strings can contain tokens, URLs, and inline secrets. Authenticated
+reviewer responses may return bounded context, but logs, traces, metrics,
+generic errors, agent events, and default webhook payloads omit the full value.
+Truncated context reports original length and a digest so the UI never implies
+that the visible prefix is the complete action.
 
-Approval ID suffixes are unpredictable but IDs are not authorization secrets.
-All API access still requires endpoint authentication.
+Reviewer grants, signing secrets, broker tokens, webhook authorization, URL
+fragments, request Authorization headers, URL queries, environment variables,
+and Credential Vault material are never logged or used as telemetry attributes.
+Approval IDs are unpredictable but are not authorization credentials.
 
 ### Capacity, Cleanup, and Observability
 
 Each component enforces separate caps for pending records, retained terminal
-records, and remembered allows. A request that would exceed the pending cap is
-denied immediately with a typed capacity error. It is not queued outside the
-store and does not evict an existing pending action.
+records, and remembered allows. Exceeding the pending cap rejects the new action
+without evicting an existing waiter.
 
 Expiration uses a deadline-aware timer or heap rather than one unbounded
-goroutine per retained record. Terminal records and remembered decisions are
-removed after their respective deadlines. Sandbox or component shutdown closes
-the store, wakes waiters, and clears remembered state.
+goroutine per retained record. Terminal records and remembered allows are
+removed after their deadlines. Sandbox or component shutdown closes the store,
+wakes waiters, and clears remembered state.
 
-The initial metrics are counters and gauges for:
+Metrics cover approvals created, decisions by kind and result, pending count,
+decision latency, expiry reason, capacity rejection, broker callback outcomes,
+webhook delivery outcomes, and remembered-allow hits. Labels never contain
+approval ID, reviewer ID, command, FQDN, sandbox ID, webhook URL, or secrets.
 
-- approvals created by kind;
-- terminal decisions by kind, decision, and reason;
-- pending approval count;
-- decision latency;
-- capacity rejections; and
-- remembered-decision hits and expirations.
-
-No metric label contains approval ID, command, FQDN, sandbox ID, or reviewer
-input. Structured logs follow the same restriction.
+Audit-oriented structured logs may include approval ID, sandbox ID, source,
+kind, terminal status, and verified reviewer ID, but never action context or any
+credential. Reviewer ID is bounded operator-controlled data and is not a metric
+label.
 
 ### Runtime Delivery
 
-The server serializes validated policy as component-specific startup
-configuration. Docker passes it when creating the execd and egress containers.
-Kubernetes places it in the corresponding container environment or mounted
-configuration using the existing workload-building path. Policy is immutable
-for the sandbox lifetime in the first phase.
+The server serializes validated component policy, broker callback URL, and
+broker token into component-specific startup configuration. Docker uses a
+server-reachable host address; Kubernetes uses the server Service address.
+Reviewer registry entries, webhook URLs and secrets, signing keys, and reviewer
+grants are never injected into the sandbox workload.
 
-Both runtimes must apply the same defaults, validation, capacity behavior, and
-failure semantics. Runtime-specific endpoint discovery and token delivery are
-implementation details hidden by the SDK. The public lifecycle request and
-runtime approval schemas remain the sources of truth and generated consumers
-must be regenerated from them during implementation.
+Both runtimes apply the same defaults, validation, broker authorization,
+capacity behavior, and fail-closed semantics. Runtime-specific endpoint
+discovery is hidden behind the server broker proxy. Public lifecycle, reviewer,
+execd, and egress contracts remain sources of truth and generated consumers are
+regenerated during implementation.
 
 ## Test Plan
 
 **Contract and unit tests:**
 
-- Lifecycle schema accepts valid command-only, egress-only, and combined
-  policies and rejects empty policies, invalid globs, invalid timeouts, and
-  egress approval without `networkPolicy`.
-- Glob matching is anchored, case-sensitive, deterministic, and covers escaping
-  and invalid bracket expressions.
-- FQDN normalization, invalid-name rejection, explicit deny, `deny.always`,
-  explicit allow, and remembered-allow precedence are verified.
-- State transitions cover allow, deny, timeout, cancellation, shutdown,
-  identical retry, conflicting retry, expired record, unknown record, and
-  terminal-record eviction.
-- TTL caching covers exact-command isolation, FQDN expiry, DNS TTL capping, and
-  temporary nft cleanup.
-- Concurrent questions for one FQDN create one approval; concurrent commands
-  create independent approvals.
-- Capacity limits reject new actions without evicting waiters, leaking
-  goroutines, or logging sensitive context.
+- Lifecycle validation accepts valid command-only, egress-only, and combined
+  policies and rejects empty policies, no reviewers, duplicate reviewers,
+  unknown or disabled reviewers, invalid globs/timeouts, egress approval without
+  `networkPolicy`, and missing signing or broker configuration.
+- Reviewer registry rejects duplicate IDs, non-HTTPS webhooks, missing secrets,
+  and invalid signing-key rotation state.
+- Grant tests cover canonical signing, valid verification, tampering, unknown
+  key, expiry, missing scope, path mismatch, source mismatch, cross-sandbox use,
+  and cross-approval use.
+- State transitions cover allow, deny, timeout, cancellation, shutdown, same
+  reviewer replay, opposite replay, different reviewer race, eviction, and
+  attribution.
+- Normal agent, execd, egress, lifecycle, and signed-endpoint credentials receive
+  `401` or `403` on reviewer and broker operations.
+- Empty broker-token configuration fails closed; valid broker comparison is
+  constant time.
+- Command omission and zero TTL are single-use; egress omission uses the bounded
+  DNS default; egress zero returns `400`; deny with TTL returns `400`.
+- FQDN normalization, static rule precedence, remembered expiry, DNS TTL cap,
+  concurrency deduplication, and temporary nft cleanup are verified.
+- Capacity tests reject new actions without evicting waiters, leaking goroutines,
+  or exposing sensitive context.
 
-**Execd integration tests:**
+**Reviewer entry and notification tests:**
 
-- Foreground, background, bash-session, and isolated-session commands pause
-  before process creation and resume only after allow.
-- Deny and timeout produce typed execution failures and never start a process.
-- SSE disconnect, interrupt, session deletion, and execd shutdown wake or clean
-  up waiters without later execution.
-- Commands that do not match and commands covered by remembered exact allows
-  retain expected streaming and status behavior.
+- Pending callback validation checks broker token, sandbox, source, ID prefix,
+  timestamps, and replayed event IDs.
+- Webhook delivery signs one grant per approval/reviewer, preserves event ID and
+  grant across retries, authenticates the request, and never treats a response
+  as a decision.
+- Delivery failure leaves the action pending until default deny timeout.
+- Review page tests verify fragment-only grant transport, no Referer, restrictive
+  CSP, no third-party resources, no storage/cookies, correct controls by kind,
+  and removal of grant state after a terminal response.
+- Browser and API decisions record the reviewer ID from the grant, not request
+  input, and the server forwards it only through broker authentication.
 
-**Egress integration tests:**
+**Execd and egress integration tests:**
 
-- A new domain remains unresolved while pending; allow resumes resolution and
-  traffic, while deny and timeout return failure without leaking packets.
-- Static allow rules bypass approval, and explicit/always deny rules cannot be
-  overridden.
-- Concurrent DNS requests share a prompt and all waiters receive one result.
-- Existing deny webhook behavior is unchanged and the pending webhook cannot
-  decide an approval.
+- Foreground, background, bash-session, and isolated commands pause before
+  process creation and resume only after brokered reviewer allow.
+- Deny, timeout, callback failure, interrupt, disconnect, session deletion, and
+  shutdown never start a canceled or denied command.
+- A new domain stays unresolved while pending; allow resumes resolution, while
+  deny, zero-TTL error, and timeout do not leak traffic.
+- Static allow bypasses approval; explicit and always deny cannot be overridden;
+  concurrent DNS questions share one approval.
 
-**SDK and CLI tests:**
+**SDK, CLI, and end-to-end tests:**
 
-- Generated models match both specs and handwritten facades route decisions to
-  the owning component.
-- Cross-language duration conversion, error mapping, pagination, ordering, and
-  partial endpoint failure are consistent.
-- CLI help, SDK call arguments, table/JSON/YAML output, and allow/deny exit codes
-  are covered with mocked SDK calls.
-
-**End-to-end tests:**
-
-- Docker and Kubernetes each create a sandbox with combined approval policy,
-  exercise command and domain approvals through SDK and CLI, and verify cleanup
-  at sandbox deletion.
-- Existing create, command, egress policy, deny webhook, and SDK flows are run
-  without `approvalPolicy` to demonstrate backward compatibility.
+- Generated and handwritten reviewer clients send grants only to lifecycle
+  reviewer APIs and map `400`, `401`, `403`, `409`, `410`, and component errors
+  consistently across languages.
+- CLI help, missing-grant behavior, environment-based grant loading, output
+  formats, TTL validation, and exit codes are covered.
+- Docker and Kubernetes each create a sandbox with configured reviewers, receive
+  a webhook, open the review page, decide command and domain approvals, verify
+  reviewer attribution, and clean up at sandbox deletion.
+- Existing create, command, egress policy, deny webhook, and SDK flows run
+  without `approvalPolicy` to demonstrate compatibility.
 
 ## Drawbacks
 
-1. Two local approval stores require common schemas and conformance tests and
-   cannot provide a naturally global inbox.
-2. Approval records and remembered decisions disappear on component restart.
-3. Holding SSE requests and DNS questions consumes bounded runtime resources and
-   adds latency at review boundaries.
-4. Raw-command glob matching is understandable but cannot reliably classify the
-   semantic risk of arbitrary shell behavior.
-5. DNS-level approval is coarse: it approves temporary reachability to a domain,
-   not one application-layer request.
-6. SDK aggregation must represent partial failures when only one component is
-   reachable.
+1. The server gains reviewer configuration, signing, a small browser surface,
+   internal callbacks, and a broker proxy.
+2. Two local approval stores still cannot provide a durable global inbox, and
+   state disappears on component restart.
+3. Webhook availability affects whether a reviewer learns about a pending action,
+   although failure remains safe by default.
+4. Bearer review links require careful operational control even with short,
+   single-approval scope.
+5. Holding SSE requests and DNS questions consumes bounded runtime resources and
+   adds review latency.
+6. Raw-command globs cannot classify semantic shell risk.
+7. DNS approval authorizes temporary domain reachability, not one application
+   request.
 
 ## Alternatives
 
-**Central lifecycle-server coordinator.** The server could store every approval
-and expose one global API. This simplifies listing but requires runtime
-components to call back to the server, distributes a new service credential,
-and introduces persistence and multi-replica consistency into the blocking
-path. Data-plane ownership is smaller and fails closed naturally.
+**Reuse normal runtime endpoint authentication.** This lets an autonomous client
+approve its own action and cannot attribute decisions. It is rejected because
+it does not establish a human review boundary.
 
-**External approval broker or synchronous webhook.** An external service could
-own decisions. This is useful for enterprise integration but makes a new
-dependency part of the action hot path and leaves standalone OpenSandbox
-without a complete workflow. A future adapter can mirror local pending events
-to an external system without making it the core state owner.
+**Runtime pause/resume primitive only.** Renaming the feature would accurately
+describe the original unauthenticated reviewer model, but it would not satisfy
+issue #1288's human supervision goal. The first phase instead includes the
+minimum identity, entry point, notification, and authority separation required
+to retain the human-in-the-loop name.
 
-**Update static policy and retry the action.** A reviewer could edit egress
-policy or command configuration after denial. This does not hold and resume the
-original action, is prone to races, and broadens a one-time approval into a
-configuration change.
+**Persist every approval in the lifecycle server.** A fully central coordinator
+could provide a global inbox, but it duplicates live component state and adds
+distributed persistence and multi-replica consistency to action resumption. The
+selected server broker authenticates reviewers while components remain the
+source of truth for held actions.
 
-**HTTP interception for all egress approval.** Transparent MITM can approve
-individual HTTP requests and show richer context, but it excludes non-HTTP
-traffic and adds CA, encryption, privacy, and protocol concerns. DNS-level new
-domain approval matches the first-phase requirement with the current egress
-architecture.
+**External approval broker or OIDC provider.** These can offer enterprise
+identity and workflow integration but make an external dependency mandatory.
+The operator registry and signed grant are a self-contained first phase; future
+providers can replace registration without changing component stores.
 
-**Semantic command parsing.** Parsing shell ASTs or classifying commands with a
-model may produce richer prompts, but shell dialects, expansion, scripts, and
-indirection make it unsuitable as the deterministic first policy primitive.
+**Operator-supplied reviewer public keys in each create request.** This is more
+tenant-dynamic but complicates enrollment, webhook secret ownership, rotation,
+and cross-language signing. Server registration gives identities stable meaning
+and keeps secrets away from the agent-facing request.
+
+**HTTP interception for all egress approval.** Transparent MITM can show richer
+request context, but excludes non-HTTP traffic and adds CA and privacy concerns.
+DNS-level new-domain approval matches the first phase.
+
+**Semantic command parsing.** Shell AST or model classification is richer but
+not deterministic across dialects, expansion, scripts, and indirection.
 
 ## Infrastructure Needed
 
-No new external service or persistent database is required. Implementation will
-require additive lifecycle, execd, and egress OpenAPI changes; regenerated SDK
-clients; component-local in-memory stores; and Docker and Kubernetes end-to-end
-coverage. Existing endpoint authentication, SSE, egress DNS policy, and webhook
-infrastructure are reused.
+No new OpenSandbox-managed service or approval database is required. Operators
+need an HTTPS webhook receiver capable of delivering the review URL to the named
+reviewer. Implementation adds server approval signing and reviewer
+configuration, a small static review page, internal broker connectivity,
+additive lifecycle/execd/egress contracts, regenerated SDK clients,
+component-local stores, and Docker and Kubernetes end-to-end coverage.
 
 ## Upgrade & Migration Strategy
 
 The feature is additive and opt-in:
 
-1. Servers and generated clients add the optional `approvalPolicy` field.
-2. Execd and egress add approval resources without changing existing paths.
-3. A missing policy runs the existing command and egress paths without creating
-   approval state or events.
-4. Existing `OPENSANDBOX_EGRESS_DENY_WEBHOOK`, static network policies,
-   `deny.always`, and Credential Vault behavior remain unchanged.
-5. During a mixed-version rollout, the server must not accept an approval policy
-   unless the selected runtime images advertise support; it fails sandbox
-   creation rather than silently ignoring the policy.
-6. SDK and CLI additions do not remove or rename existing methods or commands.
-7. Rollback is performed by omitting `approvalPolicy` and using runtime images
-   without the additive endpoints; no stored approval data needs migration.
+1. Operators configure approval signing keys and reviewers before accepting an
+   `approvalPolicy`.
+2. Lifecycle clients add optional approval policy and reviewer references.
+3. The server accepts approval policy only when selected runtime images support
+   the broker protocol; mixed versions fail sandbox creation rather than ignore
+   policy.
+4. Execd and egress add broker-only internal routes without changing existing
+   action routes or their credentials.
+5. The reviewer API, review page, SDK client, and CLI commands are additive.
+6. A missing approval policy follows existing command and egress paths without
+   grants, callbacks, notifications, or approval state.
+7. Existing `OPENSANDBOX_EGRESS_DENY_WEBHOOK`, static policies, `deny.always`,
+   OSEP-0011 signed endpoints, and Credential Vault behavior remain unchanged.
+8. Signing-key rotation keeps old verification keys until all issued grants have
+   expired. Reviewer disablement blocks new selection and webhook delivery; an
+   already issued grant remains bounded by its single approval and expiry.
+9. Rollback omits `approvalPolicy` and uses runtime images without broker routes;
+   no stored approval migration is required.
 
 The proposal must reach `implementable` before public contracts or runtime code
-are changed. Credential-use approvals, share links, a durable audit store, and a
-global approval service require follow-up design review rather than being
-silently added to the first implementation.
+are changed. Credential-use approvals, durable audit storage, global inboxes,
+OIDC reviewer enrollment, and native notification providers require follow-up
+design review.

--- a/oseps/README.md
+++ b/oseps/README.md
@@ -18,3 +18,4 @@ This is the complete list of OpenSandbox Enhancement Proposals:
 | [OSEP-0010](0010-opentelemetry-instrumentation.md)             |      OpenTelemetry Metrics and Logs (execd, egress, and ingress)           |  implemented  |  2026-07-03  |
 | [OSEP-0011](0011-secure-access-endpoint.md)                    |      Secure Access on GetEndpoint and Signed Endpoint                     |  implemented  |  2026-04-25  |
 | [OSEP-0012](0012-credential-vault.md)                          |      Credential Vault and Credential Proxy                                | implementing  |  2026-06-10  |
+| [OSEP-0015](0015-human-in-the-loop-approval-gates.md)          |      Human-in-the-Loop Approval Gates                                     |     draft      |  2026-07-17  |

--- a/oseps/README.md
+++ b/oseps/README.md
@@ -18,4 +18,4 @@ This is the complete list of OpenSandbox Enhancement Proposals:
 | [OSEP-0010](0010-opentelemetry-instrumentation.md)             |      OpenTelemetry Metrics and Logs (execd, egress, and ingress)           |  implemented  |  2026-07-03  |
 | [OSEP-0011](0011-secure-access-endpoint.md)                    |      Secure Access on GetEndpoint and Signed Endpoint                     |  implemented  |  2026-04-25  |
 | [OSEP-0012](0012-credential-vault.md)                          |      Credential Vault and Credential Proxy                                | implementing  |  2026-06-10  |
-| [OSEP-0015](0015-human-in-the-loop-approval-gates.md)          |      Human-in-the-Loop Approval Gates                                     |     draft      |  2026-07-17  |
+| [OSEP-0015](0015-human-in-the-loop-approval-gates.md)          |      Human-in-the-Loop Approval Gates                                     |     draft      |  2026-07-21  |


### PR DESCRIPTION
# Summary
- Add draft OSEP-0015 for optional, fail-closed human approval gates covering selected execd commands and new-domain egress in the first phase.
- Define data-plane-local approval ownership, lifecycle policy, runtime APIs, state transitions, SDK/CLI surfaces, security constraints, compatibility, rollout, and test requirements.
- Add OSEP-0015 to the proposal index.

Relates to #1288. This PR covers the required design phase; runtime implementation remains gated on the OSEP reaching `implementable` status.

# Testing
- [x] Not run (documentation-only OSEP; no executable code changed)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Additional validation:
- `git diff --cached --check`
- Parsed and validated the OSEP YAML frontmatter
- Verified the index entry, issue link, template placeholders, and ASCII content

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
