### PR TITLE
feat(chart): allow extra env vars on the ingress-gateway container

### DIFF
--- a/kubernetes/charts/opensandbox-server/README.md
+++ b/kubernetes/charts/opensandbox-server/README.md
@@ -51,6 +51,7 @@ Optional: override gateway image, replicas, or resources (see `server.gateway.*`
 | `server.gateway.enabled` | When true: set server config to gateway and deploy components/ingress gateway | `false` |
 | `server.gateway.host` | config `gateway.address` (address returned to clients) | `opensandbox.example.com` |
 | `server.gateway.gatewayRouteMode` | server config and gateway route mode (header/uri) | `header` |
+| `server.gateway.env` | Additional environment variables for the ingress-gateway container (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`) | `[]` |
 | `server.gateway.*` | Gateway image, replicas, port, dataplaneNamespace, providerType, resources | See values.yaml |
 
 Versioning note:

--- a/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/ingress-gateway.yaml
@@ -121,6 +121,10 @@ spec:
             - name: http
               containerPort: {{ .Values.server.gateway.port }}
               protocol: TCP
+          {{- with .Values.server.gateway.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /status.ok

--- a/kubernetes/charts/opensandbox-server/values.yaml
+++ b/kubernetes/charts/opensandbox-server/values.yaml
@@ -71,6 +71,9 @@ server:
     dataplaneNamespace: "opensandbox"
     providerType: "batchsandbox"
     logLevel: "info"
+    # -- Additional environment variables for the ingress-gateway container
+    # (e.g. OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_SERVICE_NAME for OTLP metrics).
+    env: []
     resources:
       limits:
         cpu: "2"


### PR DESCRIPTION
## What

Adds `server.gateway.env` (a list, default `[]`) to the `opensandbox-server` chart and templates it onto the **ingress-gateway** container, mirroring the existing `server.env` pattern.

```yaml
server:
  gateway:
    env:
      - name: OTEL_EXPORTER_OTLP_ENDPOINT
        value: http://otel-collector:4318
      - name: OTEL_SERVICE_NAME
        value: opensandbox-ingress
```

## Why

Fixes #1332. The chart already lets you set env on the server container (`server.env`), but the ingress-gateway container had no equivalent — so there was no way, via Helm, to pass env vars to it. In particular, the ingress OpenTelemetry metrics (OSEP-0010) are configured via env (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, …), which was unreachable for chart users.

## Changes

- `values.yaml`: new `server.gateway.env` (default `[]`).
- `templates/ingress-gateway.yaml`: render an `env:` block on the ingress-gateway container, gated by `{{- with .Values.server.gateway.env }}` (no block when empty).
- `README.md`: values table row for `server.gateway.env`.

## Testing

`helm template` / `helm lint`:

- default (`server.gateway.env` unset) → the ingress-gateway container renders **no** `env:` block (behavior unchanged).
- with `server.gateway.env[0]=OTEL_EXPORTER_OTLP_ENDPOINT=...` → the var is rendered on the ingress-gateway container.
- `helm lint`: 0 failures.
