### PR TITLE
fix(server): preserve label-incompatible sandbox metadata

### DIFF
--- a/server/opensandbox_server/services/constants.py
+++ b/server/opensandbox_server/services/constants.py
@@ -34,6 +34,7 @@ OPEN_SANDBOX_EGRESS_AUTH_HEADER = "OPENSANDBOX-EGRESS-AUTH"
 SANDBOX_EGRESS_AUTH_TOKEN_METADATA_KEY = "opensandbox.io/egress-auth-token"
 OPEN_SANDBOX_SECURE_ACCESS_HEADER = "OpenSandbox-Secure-Access"
 SANDBOX_SECURE_ACCESS_TOKEN_METADATA_KEY = "opensandbox.io/secure-access-token"
+SANDBOX_USER_METADATA_ANNOTATION = "opensandbox.io/user-metadata"
 
 # Environment variable name for passing network policy to egress sidecar
 EGRESS_RULES_ENV = "OPENSANDBOX_EGRESS_RULES"

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -116,9 +116,9 @@ from opensandbox_server.services.validators import (
     calculate_expiration_or_raise,
     ensure_entrypoint,
     ensure_future_expiration,
-    ensure_metadata_labels,
     ensure_platform_valid,
     ensure_timeout_within_limit,
+    split_metadata_labels_annotations,
 )
 logger = logging.getLogger(__name__)
 
@@ -623,7 +623,10 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
             )
         request = resolve_sandbox_image_from_request(request)
         ensure_entrypoint(request.entrypoint or [])
-        ensure_metadata_labels(request.metadata)
+        # Docker/Podman label values are not constrained by Kubernetes' 63
+        # character limit. Validate metadata keys and reserved namespaces while
+        # retaining the original values losslessly.
+        split_metadata_labels_annotations(request.metadata)
         ensure_platform_valid(request.platform)
         ensure_timeout_within_limit(
             request.timeout,

--- a/server/opensandbox_server/services/k8s/create_helpers.py
+++ b/server/opensandbox_server/services/k8s/create_helpers.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -28,9 +29,13 @@ from opensandbox_server.services.constants import (
     SANDBOX_ID_LABEL,
     SANDBOX_MANUAL_CLEANUP_LABEL,
     SANDBOX_SNAPSHOT_ID_LABEL,
+    SANDBOX_USER_METADATA_ANNOTATION,
 )
 from opensandbox_server.services.helpers import split_egress_env
-from opensandbox_server.services.validators import calculate_expiration_or_raise
+from opensandbox_server.services.validators import (
+    calculate_expiration_or_raise,
+    split_metadata_labels_annotations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,10 +73,19 @@ def _build_create_workload_context(
         labels[SANDBOX_MANUAL_CLEANUP_LABEL] = "true"
     if request.snapshot_id:
         labels[SANDBOX_SNAPSHOT_ID_LABEL] = request.snapshot_id
-    if request.metadata:
-        labels.update(request.metadata)
+    metadata_labels, metadata_annotations = split_metadata_labels_annotations(
+        request.metadata
+    )
+    labels.update(metadata_labels)
 
     annotations: Dict[str, str] = {}
+    if metadata_annotations:
+        annotations[SANDBOX_USER_METADATA_ANNOTATION] = json.dumps(
+            metadata_annotations,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
     secure_access_token = None
     if request.secure_access:
         secure_access_token = secure_access_token_factory()

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -85,10 +85,10 @@ from opensandbox_server.services.validators import (
     ensure_egress_configured,
     ensure_egress_runtime_compatible,
     ensure_future_expiration,
-    ensure_metadata_labels,
     ensure_platform_valid,
     ensure_timeout_within_limit,
     ensure_volumes_valid,
+    split_metadata_labels_annotations,
 )
 from opensandbox_server.services.k8s.client import (
     K8sClient,
@@ -736,7 +736,7 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
         if not has_pool_ref:
             request = resolve_sandbox_image_from_request(request)
             ensure_entrypoint(request.entrypoint or [])
-        ensure_metadata_labels(request.metadata)
+        split_metadata_labels_annotations(request.metadata)
         ensure_platform_valid(request.platform)
         ensure_timeout_within_limit(
             request.timeout,

--- a/server/opensandbox_server/services/k8s/workload_mapper.py
+++ b/server/opensandbox_server/services/k8s/workload_mapper.py
@@ -14,11 +14,16 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Optional
 
 from opensandbox_server.api.schema import ImageSpec, PlatformSpec, Sandbox, SandboxStatus
 from opensandbox_server.extensions import extract_extensions_from_mapping
-from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SANDBOX_SNAPSHOT_ID_LABEL
+from opensandbox_server.services.constants import (
+    SANDBOX_ID_LABEL,
+    SANDBOX_SNAPSHOT_ID_LABEL,
+    SANDBOX_USER_METADATA_ANNOTATION,
+)
 
 
 def _is_opensandbox_label(label_key: str) -> bool:
@@ -47,6 +52,20 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
     user_metadata = {
         k: v for k, v in labels.items() if not _is_opensandbox_label(k)
     }
+    encoded_metadata = annotations.get(SANDBOX_USER_METADATA_ANNOTATION)
+    if isinstance(encoded_metadata, str):
+        try:
+            annotation_metadata = json.loads(encoded_metadata)
+        except (TypeError, ValueError):
+            annotation_metadata = None
+        if isinstance(annotation_metadata, dict):
+            user_metadata.update(
+                {
+                    str(key): str(value)
+                    for key, value in annotation_metadata.items()
+                    if isinstance(value, str)
+                }
+            )
 
     image_uri = ""
     entrypoint = []

--- a/server/opensandbox_server/services/validators.py
+++ b/server/opensandbox_server/services/validators.py
@@ -97,15 +97,21 @@ def _is_valid_label_value(value: str) -> bool:
     return bool(LABEL_VALUE_RE.match(value))
 
 
-def ensure_metadata_labels(metadata: Optional[Dict[str, str]]) -> None:
-    """
-    Validate metadata keys/values against Kubernetes label rules.
+def split_metadata_labels_annotations(
+    metadata: Optional[Dict[str, str]],
+) -> tuple[Dict[str, str], Dict[str, str]]:
+    """Split user metadata without losing label-incompatible values.
 
-    Raises:
-        HTTPException: When a key/value is invalid.
+    Kubernetes annotations use the same key syntax as labels but allow
+    arbitrary string values. Invalid or reserved keys remain request errors;
+    only values that cannot be represented as labels are moved to annotations.
+    Docker callers use this helper for key validation while retaining the
+    original metadata as container labels.
     """
     if not metadata:
-        return
+        return {}, {}
+    labels: Dict[str, str] = {}
+    annotations: Dict[str, str] = {}
     for key, value in metadata.items():
         if key.startswith(RESERVED_LABEL_PREFIX):
             raise HTTPException(
@@ -113,8 +119,9 @@ def ensure_metadata_labels(metadata: Optional[Dict[str, str]]) -> None:
                 detail={
                     "code": SandboxErrorCodes.INVALID_METADATA_LABEL,
                     "message": (
-                        f"Metadata key '{key}' uses the reserved prefix '{RESERVED_LABEL_PREFIX}'. "
-                        "Keys under this prefix are managed by the system and cannot be set via metadata."
+                        f"Metadata key '{key}' uses the reserved prefix "
+                        f"'{RESERVED_LABEL_PREFIX}'. Keys under this prefix are "
+                        "managed by the system and cannot be set via metadata."
                     ),
                 },
             )
@@ -126,14 +133,28 @@ def ensure_metadata_labels(metadata: Optional[Dict[str, str]]) -> None:
                     "message": f"Metadata key '{key}' is invalid: must be either a name or a DNS-subdomain prefix and name separated by /, where the name is up to 63 characters and matches [A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?, and the optional prefix is a valid DNS subdomain up to 253 characters.",
                 },
             )
-        if not _is_valid_label_value(value):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "code": SandboxErrorCodes.INVALID_METADATA_LABEL,
-                    "message": f"Metadata value '{value}' is invalid: must be 63 characters or less, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.' characters.",
-                },
-            )
+        target = labels if _is_valid_label_value(value) else annotations
+        target[key] = value
+    return labels, annotations
+
+
+def ensure_metadata_labels(metadata: Optional[Dict[str, str]]) -> None:
+    """
+    Validate metadata keys/values against Kubernetes label rules.
+
+    Raises:
+        HTTPException: When a key/value is invalid.
+    """
+    _, annotations = split_metadata_labels_annotations(metadata)
+    if annotations:
+        value = next(iter(annotations.values()))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_METADATA_LABEL,
+                "message": f"Metadata value '{value}' is invalid: must be 63 characters or less, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.' characters.",
+            },
+        )
 
 
 def ensure_future_expiration(expires_at: datetime) -> datetime:
@@ -767,6 +788,7 @@ __all__ = [
     "ensure_valid_port",
     "ensure_platform_valid",
     "ensure_metadata_labels",
+    "split_metadata_labels_annotations",
     "ensure_egress_configured",
     "ensure_credential_proxy_configured",
     "ensure_valid_volume_name",

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 import pytest
 from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
@@ -131,6 +133,45 @@ class TestKubernetesSandboxServiceCreate:
         assert response.id is not None
         assert response.status.state == "Running"
         k8s_service.workload_provider.create_workload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_sandbox_routes_long_metadata_value_to_annotation(
+        self, k8s_service, create_sandbox_request, mock_workload
+    ):
+        long_job_id = (
+            "uni-agent-terminalbench-qwen35-fullnode-split-pt-"
+            "7781f9828ce144f5b041abd33ea419cc"
+        )
+        create_sandbox_request.metadata = {
+            "team": "training",
+            "job_id": long_job_id,
+        }
+        k8s_service.workload_provider.create_workload.return_value = {
+            "name": "test-sandbox-123",
+            "uid": "abc-123",
+        }
+        k8s_service.workload_provider.get_workload.return_value = mock_workload
+        k8s_service.workload_provider.get_status.return_value = {
+            "state": "Running",
+            "reason": "",
+            "message": "Pod is running",
+            "last_transition_at": datetime.now(timezone.utc),
+        }
+        k8s_service.workload_provider.get_endpoint_info.return_value = (
+            "10.244.0.5:8080"
+        )
+        k8s_service.workload_provider.get_expiration.return_value = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+
+        await k8s_service.create_sandbox(create_sandbox_request)
+
+        kwargs = k8s_service.workload_provider.create_workload.call_args.kwargs
+        assert kwargs["labels"]["team"] == "training"
+        assert "job_id" not in kwargs["labels"]
+        assert json.loads(
+            kwargs["annotations"]["opensandbox.io/user-metadata"]
+        ) == {"job_id": long_job_id}
 
     @pytest.mark.asyncio
     async def test_create_sandbox_response_restores_extensions_from_workload(

--- a/server/tests/test_agent_sandbox_service.py
+++ b/server/tests/test_agent_sandbox_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -28,7 +29,11 @@ from opensandbox_server.config import (
     AgentSandboxRuntimeConfig,
 )
 from opensandbox_server.services.k8s.kubernetes_service import KubernetesSandboxService
-from opensandbox_server.services.constants import SANDBOX_SNAPSHOT_ID_LABEL, SandboxErrorCodes
+from opensandbox_server.services.constants import (
+    SANDBOX_SNAPSHOT_ID_LABEL,
+    SANDBOX_USER_METADATA_ANNOTATION,
+    SandboxErrorCodes,
+)
 
 @pytest.fixture
 def agent_sandbox_runtime_config():
@@ -170,6 +175,11 @@ class TestAgentSandboxServiceBuildSandbox:
                     "opensandbox.io.evil/key": "public",
                     "team": "platform",
                 },
+                "annotations": {
+                    SANDBOX_USER_METADATA_ANNOTATION: json.dumps(
+                        {"job_id": "job-" + "x" * 80}
+                    )
+                },
                 "creationTimestamp": "2025-12-31T09:00:00Z",
             },
             "spec": {
@@ -192,7 +202,11 @@ class TestAgentSandboxServiceBuildSandbox:
         assert sandbox.id == "sandbox-id"
         assert sandbox.image.uri == "python:3.11"
         assert sandbox.entrypoint == ["/bin/bash"]
-        assert sandbox.metadata == {"opensandbox.io.evil/key": "public", "team": "platform"}
+        assert sandbox.metadata == {
+            "opensandbox.io.evil/key": "public",
+            "team": "platform",
+            "job_id": "job-" + "x" * 80,
+        }
         assert isinstance(sandbox.status, SandboxStatus)
         assert sandbox.status.state == "Running"
 

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -29,6 +29,7 @@ from opensandbox_server.services.validators import (
     ensure_valid_sub_path,
     ensure_valid_volume_name,
     ensure_volumes_valid,
+    split_metadata_labels_annotations,
 )
 
 def test_ensure_platform_valid_accepts_windows_amd64():
@@ -107,6 +108,29 @@ def test_ensure_metadata_labels_rejects_value_too_long():
         assert ensure_metadata_labels({"app": long_value}) is None
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["code"] == SandboxErrorCodes.INVALID_METADATA_LABEL
+
+
+def test_split_metadata_labels_annotations_preserves_long_job_id():
+    long_job_id = (
+        "uni-agent-terminalbench-qwen35-fullnode-split-pt-"
+        "7781f9828ce144f5b041abd33ea419cc"
+    )
+
+    labels, annotations = split_metadata_labels_annotations(
+        {"team": "training", "job_id": long_job_id}
+    )
+
+    assert labels == {"team": "training"}
+    assert annotations == {"job_id": long_job_id}
+
+
+def test_split_metadata_labels_annotations_rejects_invalid_key():
+    with pytest.raises(HTTPException) as exc_info:
+        split_metadata_labels_annotations({"invalid key": "value"})
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == SandboxErrorCodes.INVALID_METADATA_LABEL
+
 
 def test_ensure_metadata_labels_rejects_key_with_empty_prefix():
     """Key with an empty prefix (starts with '/') should be rejected."""


### PR DESCRIPTION
## Summary
- keep existing Kubernetes-label validation for metadata keys and reserved namespaces
- retain short label-compatible values as labels
- preserve long or otherwise label-incompatible values losslessly: Docker/Podman keeps the original labels, while Kubernetes stores them in a dedicated system annotation
- restore annotation-backed values into metadata on GET/LIST

## Backward compatibility
Existing valid short metadata follows the exact same label path. Existing invalid keys and reserved keys are still rejected. The change only converts previously rejected values into losslessly stored metadata.

## Verification
- targeted server suite: 310 passed
- Ruff checks passed
- rebased onto current upstream `main`