### PR TITLE
docs: surface official container image provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ OpenSandbox is a **general-purpose sandbox platform** for AI applications, offer
 - 🔑 **Credential Vault**: Secure credential injection for sandbox outbound requests without exposing real secrets to workloads. See [Credential Vault](docs/guides/credential-vault.md).
 - 🏰 **Strong Isolation**: Supports secure container runtimes like gVisor, Kata Containers, and Firecracker microVM for enhanced isolation between sandbox workloads and the host. See [Secure Container Runtime Guide](docs/guides/secure-container.md) for details.
 
+## Official Container Images
+
+OpenSandbox release images are published under the same component name in
+three official registries:
+
+- Docker Hub: `docker.io/opensandbox/<component>`
+- GitHub Container Registry: `ghcr.io/opensandbox-group/opensandbox/<component>`
+- Alibaba Cloud Container Registry: `sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/<component>`
+
+Tagged release images are signed keylessly with Cosign and include provenance
+attestations. Pin production images by digest and follow the
+[release verification guide](docs/community/release-verification.md) to verify
+the image against the OpenSandbox GitHub Actions identity before deployment.
+
 ## SDKs
 
 Python:

--- a/docs/community/release-verification.md
+++ b/docs/community/release-verification.md
@@ -147,8 +147,8 @@ three official registries:
 | Alibaba Cloud Container Registry | `sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/<component>` |
 
 The component can be `execd`, `code-interpreter`, `ingress`, `egress`,
-`controller`, `task-executor`, or `image-committer`. The server image uses the
-component name `server`.
+`controller`, `task-executor`, `image-committer`, or `nodeagent`. The server
+image uses the component name `server`.
 
 ```bash
 IMAGE="docker.io/opensandbox/execd"

--- a/docs/community/release-verification.md
+++ b/docs/community/release-verification.md
@@ -19,9 +19,10 @@ OpenSandbox uses these signing paths:
 - Source code releases: the Generic Release workflow uploads an explicit
   `opensandbox-<tag>.tar.gz` source archive and `SHA256SUMS` file to the GitHub
   Release, then creates GitHub/Sigstore provenance attestations for both files.
-- Container images: the component and server image workflows sign Docker Hub
-  and ACR image digests with `cosign` keyless signing, and publish provenance
-  attestations to the registries.
+- Container images: the component and server image workflows sign Docker Hub,
+  GitHub Container Registry (GHCR), and Alibaba Cloud Container Registry (ACR)
+  image digests with `cosign` keyless signing, and publish provenance
+  attestations to all three registries.
 - Python and CLI packages: wheels and source distributions are attested before
   `uv publish`.
 - JavaScript packages: the workflow runs `pnpm pack`, attests the generated npm
@@ -83,9 +84,9 @@ If you run the release workflows from a downstream fork, replace
 `opensandbox-group/OpenSandbox` in the verification commands with that fork's
 `owner/repository` identity.
 
-Private signing material is not stored in GitHub Releases, Docker Hub, ACR,
-PyPI, npm, Maven Central, NuGet, or Helm chart downloads. Java/Kotlin Maven
-Central signing keys are held only in GitHub Actions secrets.
+Private signing material is not stored in GitHub Releases, Docker Hub, GHCR,
+ACR, PyPI, npm, Maven Central, NuGet, or Helm chart downloads. Java/Kotlin
+Maven Central signing keys are held only in GitHub Actions secrets.
 
 ## Verify Source Releases
 
@@ -136,6 +137,19 @@ provenance `source-ref` is the ref selected when the workflow was dispatched
 Install `cosign` and `gh`, then resolve the image digest. Always verify by
 digest, not by mutable tag alone.
 
+Release images are published with the same component name and digest in all
+three official registries:
+
+| Registry | Image name pattern |
+| --- | --- |
+| Docker Hub | `docker.io/opensandbox/<component>` |
+| GitHub Container Registry | `ghcr.io/opensandbox-group/opensandbox/<component>` |
+| Alibaba Cloud Container Registry | `sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/<component>` |
+
+The component can be `execd`, `code-interpreter`, `ingress`, `egress`,
+`controller`, `task-executor`, or `image-committer`. The server image uses the
+component name `server`.
+
 ```bash
 IMAGE="docker.io/opensandbox/execd"
 TAG="v1.0.15"
@@ -173,10 +187,12 @@ cosign verify "$IMAGE_REF" \
   --certificate-identity-regexp "^${WORKFLOW_REPOSITORY_URL}/.github/workflows/publish-server.yml@refs/tags/server/v[0-9].*$"
 ```
 
-ACR images use the same digest and identity checks with the ACR image name, for
-example:
+GHCR and ACR images use the same digest and identity checks with their
+respective image names, for example:
 
 ```bash
+IMAGE="ghcr.io/opensandbox-group/opensandbox/execd"
+# or
 IMAGE="sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd"
 ```
 


### PR DESCRIPTION
## Summary

- add a prominent root README section naming the three official container registries
- link production users directly to the release-verification guide and recommend digest pinning
- document GHCR alongside Docker Hub and Alibaba Cloud ACR in the signing and verification flow
- list the published component image names and example GHCR/ACR verification targets

## Why

OpenSandbox already publishes keyless-signed images and provenance attestations, but the official registry locations and verification path were hard to discover before deployment. The verification guide also omitted GHCR even though the release workflows sign and attest it alongside the other registries.

## Impact

Documentation only. This does not change release workflows, image contents, runtime behavior, or public APIs.

The Docker Hub organization/profile/badge trust signals mentioned in #1265 require account-admin access and cannot be changed through this repository PR.

## Validation

- `cd docs && corepack pnpm install --frozen-lockfile`
- `cd docs && corepack pnpm docs:build`
- `git diff --check`

Addresses the repository-scoped portion of #1265.
