### PR TITLE
fix(execd): Skip redundant setpriv for non-root sessions

### DIFF
--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -126,8 +126,10 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 
 	// In userns mode, uid/gid are set via --uid/--gid in segment 1.
 	if !useUserns {
-		uid := uint32(os.Getuid())
-		gid := uint32(os.Getgid())
+		currentUID := uint32(os.Geteuid())
+		currentGID := uint32(os.Getegid())
+		uid := currentUID
+		gid := currentGID
 		if opts.Uid != nil {
 			uid = *opts.Uid
 		}
@@ -135,18 +137,35 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 			gid = *opts.Gid
 		}
 
-		if uid != 0 || gid != 0 {
-			setprivArgv := []string{
-				"setpriv",
-				fmt.Sprintf("--reuid=%d", uid),
-				fmt.Sprintf("--regid=%d", gid),
-				"--clear-groups",
-			}
-			argv = append(argv, setprivArgv...)
+		identityArgv, err := identitySwitchArgv(currentUID, currentGID, uid, gid)
+		if err != nil {
+			return nil, err
 		}
+		argv = append(argv, identityArgv...)
 	}
 
 	return argv, nil
+}
+
+func identitySwitchArgv(effectiveUID, effectiveGID, targetUID, targetGID uint32) ([]string, error) {
+	// setpriv is redundant when the requested identity already matches execd.
+	// In particular, --clear-groups calls setgroups(2), which a non-root process
+	// cannot use in a locked-down container.
+	if targetUID == effectiveUID && targetGID == effectiveGID {
+		return nil, nil
+	}
+	if effectiveUID != 0 {
+		return nil, fmt.Errorf(
+			"isolation: cannot switch identity from %d:%d to %d:%d as non-root; use uid_mode=userns",
+			effectiveUID, effectiveGID, targetUID, targetGID,
+		)
+	}
+	return []string{
+		"setpriv",
+		fmt.Sprintf("--reuid=%d", targetUID),
+		fmt.Sprintf("--regid=%d", targetGID),
+		"--clear-groups",
+	}, nil
 }
 
 // validateWrapOptions checks for invalid or conflicting options.

--- a/components/execd/pkg/isolation/bwrap_test.go
+++ b/components/execd/pkg/isolation/bwrap_test.go
@@ -321,37 +321,62 @@ func TestBuildArgv_Binds(t *testing.T) {
 }
 
 func TestBuildArgv_Setpriv(t *testing.T) {
-	t.Run("default_uid_gid", func(t *testing.T) {
+	t.Run("matching_process_identity_omits_setpriv", func(t *testing.T) {
 		opts := basicWrapOpts()
-		argv, err := buildArgv(opts, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := strings.Join(argv, " ")
-		if !strings.Contains(s, "setpriv") {
-			t.Error("missing setpriv")
-		}
-		if !strings.Contains(s, "--clear-groups") {
-			t.Error("missing --clear-groups")
-		}
-	})
-
-	t.Run("explicit_uid_gid", func(t *testing.T) {
-		opts := basicWrapOpts()
-		u, g := uint32(1001), uint32(1002)
+		u, g := uint32(os.Geteuid()), uint32(os.Getegid())
 		opts.Uid = &u
 		opts.Gid = &g
 		argv, err := buildArgv(opts, "")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		s := strings.Join(argv, " ")
-		if !strings.Contains(s, "--reuid=1001") {
-			t.Error("missing --reuid=1001")
-		}
-		if !strings.Contains(s, "--regid=1002") {
-			t.Error("missing --regid=1002")
-		}
+		assert.NotContains(t, s, "setpriv")
+		assert.NotContains(t, s, "--clear-groups")
+	})
+
+	t.Run("default_uid_gid", func(t *testing.T) {
+		opts := basicWrapOpts()
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.NotContains(t, s, "setpriv")
+		assert.NotContains(t, s, "--clear-groups")
+	})
+
+	t.Run("explicit_matching_uid_gid", func(t *testing.T) {
+		opts := basicWrapOpts()
+		u, g := uint32(os.Geteuid()), uint32(os.Getegid())
+		opts.Uid = &u
+		opts.Gid = &g
+		argv, err := buildArgv(opts, "")
+		require.NoError(t, err)
+		s := strings.Join(argv, " ")
+		assert.NotContains(t, s, "setpriv")
+	})
+}
+
+func TestIdentitySwitchArgv(t *testing.T) {
+	t.Run("matching_non_root_identity_omits_setpriv", func(t *testing.T) {
+		argv, err := identitySwitchArgv(1000, 1000, 1000, 1000)
+		require.NoError(t, err)
+		assert.Empty(t, argv)
+	})
+
+	t.Run("non_root_cannot_switch_uid", func(t *testing.T) {
+		argv, err := identitySwitchArgv(1000, 1000, 1001, 1000)
+		require.ErrorContains(t, err, "cannot switch identity")
+		assert.Empty(t, argv)
+	})
+
+	t.Run("non_root_cannot_switch_gid", func(t *testing.T) {
+		argv, err := identitySwitchArgv(1000, 1000, 1000, 1001)
+		require.ErrorContains(t, err, "cannot switch identity")
+		assert.Empty(t, argv)
+	})
+
+	t.Run("root_switches_identity_and_clears_groups", func(t *testing.T) {
+		argv, err := identitySwitchArgv(0, 0, 1000, 1000)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"setpriv", "--reuid=1000", "--regid=1000", "--clear-groups"}, argv)
 	})
 }
 
@@ -402,9 +427,9 @@ func TestBuildArgv_Userns(t *testing.T) {
 		assert.NotContains(t, s, "--regid", "userns mode must not include --regid")
 	})
 
-	t.Run("setpriv_mode_no_unshare_user", func(t *testing.T) {
+	t.Run("setpriv_mode_matching_identity_omits_setpriv", func(t *testing.T) {
 		opts := basicWrapOpts()
-		u, g := uint32(1000), uint32(1000)
+		u, g := uint32(os.Geteuid()), uint32(os.Getegid())
 		opts.Uid = &u
 		opts.Gid = &g
 		opts.UidMode = UidModeSetpriv
@@ -414,23 +439,22 @@ func TestBuildArgv_Userns(t *testing.T) {
 
 		assert.NotContains(t, s, "--unshare-user", "setpriv mode must not include --unshare-user")
 		assert.NotContains(t, s, "--disable-userns", "setpriv mode must not include --disable-userns")
-		assert.Contains(t, s, "setpriv", "setpriv mode must include setpriv")
-		assert.Contains(t, s, "--reuid=1000", "setpriv mode must include --reuid")
-		assert.Contains(t, s, "--regid=1000", "setpriv mode must include --regid")
+		assert.NotContains(t, s, "setpriv", "matching identity must not invoke setpriv")
 	})
 
-	t.Run("empty_uid_mode_defaults_to_setpriv", func(t *testing.T) {
+	t.Run("empty_uid_mode_matching_identity_omits_setpriv", func(t *testing.T) {
 		opts := basicWrapOpts()
-		u, g := uint32(1000), uint32(1000)
+		u, g := uint32(os.Geteuid()), uint32(os.Getegid())
 		opts.Uid = &u
 		opts.Gid = &g
-		// UidMode is empty string — should behave like setpriv.
+		// Empty UidMode follows setpriv-mode identity rules, including omitting
+		// setpriv when no identity change is required.
 		argv, err := buildArgv(opts, "")
 		require.NoError(t, err)
 		s := strings.Join(argv, " ")
 
 		assert.NotContains(t, s, "--unshare-user")
-		assert.Contains(t, s, "setpriv")
+		assert.NotContains(t, s, "setpriv")
 	})
 
 	t.Run("userns_namespace_flag_order", func(t *testing.T) {
@@ -502,7 +526,7 @@ func TestBuildArgv_SegmentOrder(t *testing.T) {
 		{"8.extra_writable", "--bind"},
 		{"9.env", "--unsetenv"},
 		{"10.seccomp", "--seccomp"},
-		{"11.setpriv", "setpriv"},
+		{"11.lifecycle", "--die-with-parent"},
 	}
 
 	lastIdx := -1


### PR DESCRIPTION
## Summary

Fix bubblewrap isolated-session startup when execd already runs as the requested non-root UID/GID.

- Compare the target identity with the effective UID/GID.
- Omit `setpriv` entirely when the identities already match, avoiding an unnecessary `setgroups(2)` call from `--clear-groups`.
- Fail explicitly when a non-root process requests a different identity and recommend `uid_mode=userns`.
- Preserve `setpriv --clear-groups` for root-driven identity changes.
- Do not use a wrapper script.

## Validation

- `TMPDIR=/private/tmp go test ./pkg/isolation -count=1`
- `GOOS=linux go test -c ./pkg/isolation`
- `git diff --check`