### PR TITLE
docs: add isolation sessions guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,7 @@ export default defineConfig({
             { text: "Credential Vault", link: "/guides/credential-vault" },
             { text: "Secure Container", link: "/guides/secure-container" },
             { text: "Multi-Tenancy", link: "/guides/multi-tenancy" },
+            { text: "Isolation Sessions", link: "/guides/isolation-sessions" },
             { text: "Pause & Resume", link: "/guides/pause-resume" },
             { text: "Windows Sandbox", link: "/guides/windows-sandbox" },
             { text: "SDK Telemetry", link: "/guides/sdk-telemetry" },

--- a/docs/guides/isolation-sessions.md
+++ b/docs/guides/isolation-sessions.md
@@ -1,0 +1,407 @@
+---
+title: Isolation Sessions
+description: Per-execution bubblewrap-isolated bash sessions inside a sandbox for fast, contained code runs.
+---
+
+# Isolation Sessions
+
+Isolation sessions run a **long-lived `bash` inside a
+[bubblewrap](https://github.com/containers/bubblewrap) namespace**, so one
+sandbox pod can host many mutually isolated task runs without spinning up a
+new container. Each session gets its own PID, mount, tmpfs, and env
+namespaces; startup is sub-millisecond.
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Session Lifecycle](#session-lifecycle)
+- [Workspace Modes](#workspace-modes)
+- [Bind Mounts and Allowlist](#bind-mounts-and-allowlist)
+- [Profiles and Defaults](#profiles-and-defaults)
+- [Environment, UID, and Networking](#environment-uid-and-networking)
+- [Filesystem Proxy](#filesystem-proxy)
+- [Capabilities and Probing](#capabilities-and-probing)
+- [Server Configuration](#server-configuration)
+- [Limitations](#limitations)
+- [See Also](#see-also)
+
+---
+
+## Requirements
+
+Component versions needed for the features covered by this guide:
+
+- `execd` >= 1.0.20 for base isolation session support; **>= 1.0.21
+  recommended** for `binds`, `List sessions`, `uid_mode: "userns"`, and the
+  default writable allowlist (`/workspace`, `/mnt`, `/media`, `/data`)
+- `opensandbox-server` >= 0.2.1 — the server injects `CAP_SYS_ADMIN`,
+  `apparmor=unconfined`, and the tmpfs mount required by `bwrap` when the
+  execd image declares `bootstrap.execd.isolation`
+- Python SDK >= 0.1.14 (`isolation.run_once` / `isolation.session` context
+  manager); >= 0.1.13 for the generated isolation client only
+- JavaScript / TypeScript SDK >= 0.1.10 (`isolation.runOnce` /
+  `isolation.withSession`)
+- Kotlin / Java SDK >= 1.0.16 (`isolation.runOnce()` /
+  `isolation.withSession { ... }`); >= 1.0.15 for the generated isolation
+  client only
+- C# SDK >= 0.1.4 (`RunOnceAsync` / `WithSessionAsync`)
+- Go SDK >= 1.0.4 (`IsolationRunOnce` / `IsolationWithSession`)
+
+The `setpriv_available` / `userns_available` fields on
+[`/capabilities`](#capabilities-and-probing) were added after execd v1.0.21
+and are only present on execd builds from `main` at the time of writing;
+older execd omits both fields (clients must tolerate their absence).
+
+Host requirements (`bwrap` binary, `CAP_SYS_ADMIN`, `overlayfs`, etc.) are
+listed under [Server Configuration → Host Requirements](#server-configuration).
+
+---
+
+## Overview
+
+| Concept | Boundary | Startup | Typical Use |
+|---|---|---|---|
+| **Isolation session** | bubblewrap namespaces inside one sandbox | ~100 ms to create; subsequent `run` in an existing session is near-zero overhead | Many short, mutually isolated task runs reusing one long-lived session |
+| Bash session (`/session`) | bash process, no extra namespaces | ms | Interactive REPL-style command sequences |
+| Sandbox | container or pod | 100s of ms to seconds | Tenant, workspace, or user boundary |
+| Secure runtime (gVisor / Kata) | user-space kernel or VM per sandbox | 10–500 ms | Hardware-level protection against container escape |
+
+::: info Session creation vs. per-run cost
+Creating a session takes about 100 ms because execd waits briefly after
+starting `bwrap` to detect an immediately-exiting child. Once the session
+exists, each `POST /run` reuses the same bash process, so per-run overhead
+is negligible. Design workloads that amortize the create cost across many
+`run` calls in one session.
+:::
+
+Good fits: **RL rollouts**, **batch code grading**, **multi-tool agent
+runs** — one sandbox per worker, many isolated tasks inside.
+
+Not a fit: cross-language kernels (use `/code`), interactive REPLs (use
+`/session`), or hard trust boundaries against kernel exploits (use gVisor /
+Kata; see [Secure Container Runtime](/guides/secure-container)).
+
+---
+
+## How It Works
+
+`execd` forks one `bwrap` child per session; `bwrap` sets up Linux
+namespaces, then `exec`s a long-lived `bash` inside them.
+
+![Isolation session runtime layout](../public/images/isolation-sessions-layout.svg)
+
+Two things the diagram doesn't show:
+
+- `bash` is long-lived, so `export X=1` in one `run` is visible to the next
+  `run` **in the same session** (never in another session).
+- The FS proxy reads and writes the merged workspace view from **outside**
+  the namespace, so uploads and downloads work while `bash` is busy.
+
+### `run` request flow
+
+![Isolation session run flow](../public/images/isolation-sessions-run-flow.svg)
+
+Non-happy paths:
+
+| Event | What happens |
+|---|---|
+| Run `timeout_seconds` elapsed | execd cancels the run context, which sends `SIGINT` to the bwrap process group and emits an `IsolatedError` SSE event; the session itself stays alive. |
+| `bwrap` process exited | The next `run` returns an `IsolatedError` SSE event with `session process has exited`; only `ErrContextNotFound` (session ID unknown) becomes an HTTP-level error. `DELETE` + recreate. |
+| Idle timeout reached | GC runs the same teardown as `DELETE`. |
+| Client disconnects mid-SSE | The Gin request context is cancelled and execd sends `SIGINT` to the running command; the run does **not** continue in the background. |
+
+---
+
+## Quick Start
+
+### curl
+
+```bash
+# Probe.
+curl -s http://localhost:44772/v1/isolated/capabilities
+
+# Create.
+SESSION=$(curl -s -X POST http://localhost:44772/v1/isolated/session \
+  -H "Content-Type: application/json" \
+  -d '{
+    "profile": "strict",
+    "workspace": {"path": "/workspace", "mode": "overlay"},
+    "idle_timeout_seconds": 300
+  }' | jq -r .session_id)
+
+# Run (SSE: stdout / error / complete).
+curl -N -X POST "http://localhost:44772/v1/isolated/session/$SESSION/run" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "export X=1; echo $X", "timeout_seconds": 30}'
+
+# Second run reuses shell state.
+curl -N -X POST "http://localhost:44772/v1/isolated/session/$SESSION/run" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "echo $X"}'  # prints 1
+
+# Delete.
+curl -X DELETE "http://localhost:44772/v1/isolated/session/$SESSION"
+```
+
+### Python SDK
+
+```python
+from opensandbox import Sandbox
+from opensandbox.models.isolated import (
+    CreateIsolatedSessionRequest, IsolatedWorkspaceSpec, IsolatedRunOpts,
+)
+
+# Sandbox.create is an async classmethod, so await it before entering
+# the async context manager.
+async with (await Sandbox.create("python:3.11")) as sandbox:
+    # One-shot.
+    await sandbox.isolation.run_once(
+        "python -c 'print(42)'", workspace="/workspace", profile="strict",
+    )
+
+    # Persistent session.
+    async with sandbox.isolation.session(
+        CreateIsolatedSessionRequest(
+            workspace=IsolatedWorkspaceSpec(path="/workspace", mode="overlay"),
+            profile="strict",
+            idle_timeout_seconds=300,
+        )
+    ) as session:
+        await session.run("export STAGE=train")
+        await session.run("python train.py", opts=IsolatedRunOpts(timeout_seconds=600))
+        await session.files.write_file("/workspace/data.csv", data_bytes)
+
+    # Reattach after a client restart.
+    handle = await sandbox.isolation.attach(known_session_id)
+```
+
+### JavaScript / TypeScript SDK
+
+```ts
+await sandbox.isolation.runOnce("node -e 'console.log(1)'", "/workspace", {
+  profile: "strict",
+});
+
+await sandbox.isolation.withSession(
+  { profile: "strict", workspace: { path: "/workspace", mode: "overlay" } },
+  async (session) => { await session.run("npm test"); },
+);
+```
+
+### Kotlin SDK
+
+```kotlin
+sandbox.isolation().runOnce(code = "python -c 'print(1)'", workspace = "/workspace")
+
+sandbox.isolation().withSession(request) { session ->
+    session.run("ls /workspace")
+}
+```
+
+---
+
+## Session Lifecycle
+
+Under `/v1/isolated/` on execd. Use `X-EXECD-ACCESS-TOKEN` when execd has
+an access token configured.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/session` | Create; returns `{session_id, created_at}`. |
+| `GET` | `/sessions` | List active sessions. |
+| `GET` | `/session/{id}` | Full state; echoes creation params so a stateless client can rebuild the handle. |
+| `POST` | `/session/{id}/run` | SSE stream: `stdout` / `error` / `complete`. Runs on the same session are serialized. |
+| `DELETE` | `/session/{id}` | Destroy. |
+| `GET` | `/capabilities` | Probe. |
+
+`idle_timeout_seconds > 0` destroys idle sessions automatically; set to `0`
+to disable idle GC and always `DELETE` explicitly.
+
+---
+
+## Workspace Modes
+
+| Mode | Semantics |
+|---|---|
+| `rw` | Bind-mount read-write; writes persist on the host. |
+| `overlay` (default) | Copy-on-write via overlayfs; writes go to a per-session upper dir and vanish on `DELETE`. |
+| `ro` | Bind-mount read-only; writes fail with `EROFS`. |
+
+Overlay upper dirs live under `upper_root` (default `/var/lib/execd/isolation`).
+
+```json
+{ "workspace": { "path": "/workspace", "mode": "overlay" } }
+```
+
+---
+
+## Bind Mounts and Allowlist
+
+- **`extra_writable`** — paths bind-mounted read-write at the same path
+  (`source == destination`).
+- **`binds`** — explicit `source` → `dest` mappings, optionally `readonly`.
+  `source` must already exist; `dest` must already exist inside the
+  namespace (bake it into the sandbox image).
+
+```json
+{
+  "workspace": { "path": "/workspace", "mode": "rw" },
+  "extra_writable": ["/data/scratch"],
+  "binds": [
+    { "source": "/data/in",  "dest": "/mnt/in",  "readonly": true },
+    { "source": "/data/out", "dest": "/mnt/out" }
+  ]
+}
+```
+
+Every `source` is checked against the operator-configured `allowed_writable`
+allowlist **after** symlink resolution, so symlinks cannot escape it. Default
+allowlist: `/workspace`, `/mnt`, `/media`, `/data` (subpaths allowed). Empty
+allowlist rejects all extra binds.
+
+---
+
+## Profiles and Defaults
+
+The `profile` field currently controls only how `/tmp` is exposed inside the
+namespace:
+
+| Profile | `/tmp` |
+|---|---|
+| `strict` (default) | Private tmpfs (`--tmpfs /tmp`) |
+| `balanced` | Shared with the sandbox (`--bind /tmp /tmp`) |
+
+`workspace.mode` and `env_passthrough` are **independent** of the profile:
+when they are omitted, execd normalizes `workspace.mode` to `overlay` and
+`env_passthrough.mode` to `deny` regardless of which profile you pick. Set
+those fields explicitly if you want persistent workspace writes (`"rw"`) or
+host env passthrough (`"allow"`).
+
+---
+
+## Environment, UID, and Networking
+
+- **`env_passthrough`** — `mode: "allow"` + `keys` whitelists host env vars;
+  default `deny`. Per-run overrides go in `IsolatedRunRequest.envs`.
+- **`uid` / `gid`** with **`uid_mode: "setpriv"`** (default, real
+  setuid/setgid drop) or **`"userns"`** (user namespace remap). Check
+  `setpriv_available` / `userns_available` from
+  [`/capabilities`](#capabilities-and-probing) before requesting a mode.
+- **`share_net: true`** shares the sandbox's network namespace. Sandbox-level
+  egress and Credential Vault policies still apply.
+
+---
+
+## Filesystem Proxy
+
+Reads and writes the session's **merged** workspace view from outside the
+namespace — this is how SDKs `upload`, `download`, and `list` without
+spawning a shell. All paths are per session under
+`/v1/isolated/session/{id}/`:
+
+| Method | Path |
+|---|---|
+| `GET` | `files/info?path=...` |
+| `GET` | `files/download?path=...` (supports `Range` and `offset`/`limit`) |
+| `POST` | `files/upload` (multipart: `metadata` + `file`) |
+| `DELETE` | `files?path=...` |
+| `POST` | `files/mv` |
+| `POST` | `files/permissions` |
+| `POST` | `files/replace?verbose=true` |
+| `GET` | `files/search?path=...&pattern=...` |
+| `GET` | `directories/list?path=...&depth=N` |
+| `POST` | `directories` |
+| `DELETE` | `directories?path=...` |
+
+Writes on a `ro` workspace fail; writes on `overlay` land in the upper dir
+and vanish on `DELETE`.
+
+---
+
+## Capabilities and Probing
+
+```bash
+curl -s http://localhost:44772/v1/isolated/capabilities
+```
+
+```json
+{
+  "available": true,
+  "isolator": "bwrap",
+  "version": "0.9.0",
+  "setpriv_available": true,
+  "userns_available": false,
+  "commit_supported": false,
+  "diff_supported": false
+}
+```
+
+- `available: false` — bubblewrap is missing or the host can't create the
+  required namespaces (missing `CAP_SYS_ADMIN`, restricted user-ns sysctl, etc.).
+- `setpriv_available` / `userns_available` — whether sessions with
+  `uid_mode: "setpriv"` or `"userns"` can be created. `setpriv_available`
+  reflects only execd's **default** UID/GID; a session that requests a
+  different UID/GID may still return `503 NOT_SUPPORTED` when identity
+  switching is unavailable.
+- `commit_supported` / `diff_supported` — Phase 2 stubs, currently return `503`.
+
+---
+
+## Server Configuration
+
+Point execd at an optional TOML file:
+
+| Flag | Env |
+|---|---|
+| `--isolation-config` | `EXECD_ISOLATION_CONFIG` |
+
+```toml
+# Parent directory for per-session overlay upper dirs.
+upper_root = "/var/lib/execd/isolation"
+
+# Hard limit on total upper directory size across all sessions (bytes).
+# Default: 8 GiB. Set to 0 only if you want to disable the quota entirely.
+upper_max_bytes = 8589934592  # 8 GiB
+
+# Sources allowed for extra_writable / binds (symlink-resolved).
+# Default: ["/workspace", "/mnt", "/media", "/data"]. Empty = reject all.
+allowed_writable = ["/workspace", "/mnt", "/media", "/data"]
+```
+
+Example: `components/execd/configs/isolation.example.toml`.
+
+**Host requirements:** `bwrap` binary in the execd image; `CAP_SYS_ADMIN`
+(and `kernel.unprivileged_userns_clone=1` for `uid_mode: "userns"`);
+`overlayfs` in the kernel for `overlay` workspaces.
+
+Note: `/capabilities` reports `available: false` only when bwrap itself
+cannot be started at all (missing binary or missing namespace capabilities).
+A missing `overlayfs` does **not** flip `available` — the overlay probe only
+influences Phase 2 `commit`/`diff` support, and default overlay-mode session
+creation can still fail at runtime on such hosts. If you rely on
+`workspace.mode: "overlay"`, verify `overlayfs` support directly on the
+host.
+
+---
+
+## Limitations
+
+- **`diff` / `commit` are Phase 2 stubs**, currently return `503`. Tracked
+  in [OSEP-0013](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0013-isolated-execution-api.md).
+- **No hardware-level guarantee.** Namespaces + seccomp only; pair with a
+  secure runtime for kernel-exploit defense.
+- **Linux only.** Non-Linux builds return `available: false`.
+- **Serialized runs per session** — create multiple sessions for parallelism.
+- **Bind destinations must pre-exist** in the sandbox image.
+
+---
+
+## See Also
+
+- [OSEP-0013 — Isolated Execution API](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0013-isolated-execution-api.md)
+- [execd](/components/execd)
+- [Secure Container Runtime](/guides/secure-container)
+- [execd OpenAPI spec](/api/)

--- a/docs/public/images/isolation-sessions-layout.svg
+++ b/docs/public/images/isolation-sessions-layout.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="620" viewBox="0 0 1100 620" role="img" aria-labelledby="title desc">
+  <title id="title">Isolation Session Runtime Layout</title>
+  <desc id="desc">Inside a single sandbox, execd forks one bwrap child per isolation session. Each bwrap runs a long-lived bash isolated by Linux namespaces. Overlay upper directories live on the host, so the filesystem proxy operates outside the namespaces.</desc>
+  <defs>
+    <marker id="a-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#047857"/>
+    </marker>
+    <marker id="a-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+    <marker id="a-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c2410c"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 22px; font-weight: 700; fill: #1e40af; }
+      .panel-title { font-size: 16px; font-weight: 700; fill: #1e40af; }
+      .box-title { font-size: 15px; font-weight: 700; fill: #1e3a5f; }
+      .mono { font-size: 13px; font-weight: 600; fill: #374151; }
+      .detail { font-size: 12px; font-weight: 600; fill: #64748b; }
+      .line { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1100" height="620" fill="#ffffff"/>
+  <text class="title" x="30" y="40">Isolation Session Runtime Layout</text>
+
+  <!-- Sandbox boundary -->
+  <rect x="30" y="70" width="1040" height="470" rx="10" ry="10" fill="#dbeafe" stroke="#1e40af" stroke-width="2.5"/>
+  <text class="panel-title" x="50" y="98">Sandbox  (one container, one kernel)</text>
+
+  <!-- execd -->
+  <rect x="60" y="120" width="980" height="80" rx="8" ry="8" fill="#a7f3d0" stroke="#047857" stroke-width="2"/>
+  <text class="box-title" x="80" y="145">execd  (parent process)</text>
+  <text class="mono" x="80" y="168">POST /session · POST /session/{id}/run · DELETE /session/{id} · /files (FS proxy)</text>
+  <text class="detail" x="80" y="187">forks one bwrap per session, streams stdout back to clients as SSE</text>
+
+  <!-- Session A -->
+  <rect x="60" y="240" width="300" height="270" rx="8" ry="8" fill="#ffffff" stroke="#1e3a5f" stroke-width="2"/>
+  <text class="box-title" x="80" y="268">bwrap · Session A</text>
+  <text class="detail" x="80" y="286">ns: PID · mount · IPC · UTS</text>
+
+  <rect x="80" y="304" width="260" height="70" rx="6" ry="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text class="box-title" x="95" y="326">bash (PID 1 in ns)</text>
+  <text class="mono" x="95" y="346">stdin  ← pipe ← execd</text>
+  <text class="mono" x="95" y="364">stdout → pipe → execd</text>
+
+  <rect x="80" y="388" width="260" height="105" rx="6" ry="6" fill="#ddd6fe" stroke="#6d28d9" stroke-width="1.5"/>
+  <text class="box-title" x="95" y="410" fill="#6d28d9">mounts inside ns</text>
+  <text class="mono" x="95" y="432">/workspace = overlay(</text>
+  <text class="mono" x="95" y="450">    lower = host workspace,</text>
+  <text class="mono" x="95" y="468">    upper = A/upper</text>
+  <text class="mono" x="95" y="486">)</text>
+
+  <!-- Session B -->
+  <rect x="390" y="240" width="300" height="270" rx="8" ry="8" fill="#ffffff" stroke="#1e3a5f" stroke-width="2"/>
+  <text class="box-title" x="410" y="268">bwrap · Session B</text>
+  <text class="detail" x="410" y="286">isolated from A</text>
+
+  <rect x="410" y="304" width="260" height="70" rx="6" ry="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text class="box-title" x="425" y="326">bash (PID 1 in ns)</text>
+  <text class="mono" x="425" y="346">state is per-session:</text>
+  <text class="mono" x="425" y="364">  export X=1 in A ≠ seen in B</text>
+
+  <rect x="410" y="388" width="260" height="105" rx="6" ry="6" fill="#ddd6fe" stroke="#6d28d9" stroke-width="1.5"/>
+  <text class="box-title" x="425" y="410" fill="#6d28d9">mounts inside ns</text>
+  <text class="mono" x="425" y="432">/workspace = overlay(</text>
+  <text class="mono" x="425" y="450">    lower = host workspace,</text>
+  <text class="mono" x="425" y="468">    upper = B/upper</text>
+  <text class="mono" x="425" y="486">)</text>
+
+  <!-- Host-side state -->
+  <rect x="720" y="240" width="320" height="270" rx="8" ry="8" fill="#fef3c7" stroke="#b45309" stroke-width="2"/>
+  <text class="box-title" x="740" y="268" fill="#b45309">Host-side  (outside ns)</text>
+  <text class="detail" x="740" y="286">same container FS as execd</text>
+
+  <rect x="740" y="304" width="280" height="90" rx="6" ry="6" fill="#ffffff" stroke="#b45309" stroke-width="1.5"/>
+  <text class="box-title" x="755" y="326" fill="#b45309">overlay upper dirs</text>
+  <text class="mono" x="755" y="348">/var/lib/execd/isolation/</text>
+  <text class="mono" x="755" y="366">  ├── A/upper/    ← A's writes</text>
+  <text class="mono" x="755" y="384">  └── B/upper/    ← B's writes</text>
+
+  <rect x="740" y="408" width="280" height="86" rx="6" ry="6" fill="#ffffff" stroke="#b45309" stroke-width="1.5"/>
+  <text class="box-title" x="755" y="430" fill="#b45309">FS proxy path</text>
+  <text class="mono" x="755" y="452">execd reads/writes merged view</text>
+  <text class="mono" x="755" y="470">from host — no ns entry needed</text>
+  <text class="mono" x="755" y="488">(works during long-running runs)</text>
+
+  <!-- Client -->
+  <rect x="380" y="555" width="340" height="50" rx="8" ry="8" fill="#ddd6fe" stroke="#6d28d9" stroke-width="2"/>
+  <text class="box-title" x="550" y="586" text-anchor="middle">SDK  /  curl  /  lifecycle server</text>
+
+  <!-- Arrows -->
+  <path class="line" d="M 550 555 V 205" stroke="#6d28d9" stroke-width="2.5" marker-end="url(#a-purple)"/>
+  <path class="line" d="M 210 205 V 240" stroke="#047857" stroke-width="2.5" marker-end="url(#a-green)"/>
+  <path class="line" d="M 540 205 V 240" stroke="#047857" stroke-width="2.5" marker-end="url(#a-green)"/>
+  <path class="line" d="M 880 205 V 240" stroke="#c2410c" stroke-width="2.5" stroke-dasharray="6 6" marker-end="url(#a-orange)"/>
+
+  <!-- Legend -->
+  <g transform="translate(50, 588)">
+    <line x1="0" y1="-4" x2="30" y2="-4" stroke="#6d28d9" stroke-width="2.5" marker-end="url(#a-purple)"/>
+    <text class="detail" x="38" y="0">HTTP</text>
+    <line x1="90" y1="-4" x2="120" y2="-4" stroke="#047857" stroke-width="2.5" marker-end="url(#a-green)"/>
+    <text class="detail" x="128" y="0">fork + pipes</text>
+    <line x1="220" y1="-4" x2="250" y2="-4" stroke="#c2410c" stroke-width="2.5" stroke-dasharray="6 6" marker-end="url(#a-orange)"/>
+    <text class="detail" x="258" y="0">FS proxy</text>
+  </g>
+</svg>

--- a/docs/public/images/isolation-sessions-run-flow.svg
+++ b/docs/public/images/isolation-sessions-run-flow.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="560" viewBox="0 0 1100 560" role="img" aria-labelledby="title desc">
+  <title id="title">Isolation Session Run Flow</title>
+  <desc id="desc">A POST /run request: execd acquires the per-session runMu, writes the user code to bash stdin, streams stdout back as SSE, then detects the end marker and emits complete.</desc>
+  <defs>
+    <marker id="a-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#047857"/>
+    </marker>
+    <marker id="a-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 22px; font-weight: 700; fill: #1e40af; }
+      .actor-title { font-size: 15px; font-weight: 700; fill: #1e3a5f; }
+      .actor-sub { font-size: 12px; font-weight: 600; fill: #64748b; }
+      .step-num { font-size: 14px; font-weight: 700; fill: #ffffff; }
+      .step-label { font-size: 14px; font-weight: 700; fill: #1e3a5f; }
+      .mono { font-size: 12px; font-weight: 600; fill: #374151; }
+      .line { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1100" height="560" fill="#ffffff"/>
+  <text class="title" x="30" y="40">POST /session/{id}/run  —  request flow</text>
+
+  <!-- Actors -->
+  <rect x="50" y="70" width="200" height="55" rx="8" ry="8" fill="#ddd6fe" stroke="#6d28d9" stroke-width="2"/>
+  <text class="actor-title" x="150" y="95" text-anchor="middle">Client</text>
+  <text class="actor-sub" x="150" y="113" text-anchor="middle">SDK / curl</text>
+
+  <rect x="330" y="70" width="200" height="55" rx="8" ry="8" fill="#a7f3d0" stroke="#047857" stroke-width="2"/>
+  <text class="actor-title" x="430" y="95" text-anchor="middle">execd</text>
+  <text class="actor-sub" x="430" y="113" text-anchor="middle">per-session runMu</text>
+
+  <rect x="610" y="70" width="240" height="55" rx="8" ry="8" fill="#ffffff" stroke="#1e3a5f" stroke-width="2"/>
+  <text class="actor-title" x="730" y="95" text-anchor="middle">bwrap → bash</text>
+  <text class="actor-sub" x="730" y="113" text-anchor="middle">long-lived shell (PID 1 in ns)</text>
+
+  <!-- Lifelines -->
+  <line x1="150" y1="125" x2="150" y2="530" stroke="#6d28d9" stroke-width="1.5" stroke-dasharray="4 6"/>
+  <line x1="430" y1="125" x2="430" y2="530" stroke="#047857" stroke-width="1.5" stroke-dasharray="4 6"/>
+  <line x1="730" y1="125" x2="730" y2="530" stroke="#1e3a5f" stroke-width="1.5" stroke-dasharray="4 6"/>
+
+  <!-- Step 1 -->
+  <circle cx="70" cy="170" r="13" fill="#6d28d9"/>
+  <text class="step-num" x="70" y="175" text-anchor="middle">1</text>
+  <text class="step-label" x="92" y="167">POST .../run  { code, envs, timeout }</text>
+  <path class="line" d="M 150 195 H 420" stroke="#6d28d9" stroke-width="2.5" marker-end="url(#a-purple)"/>
+
+  <!-- Step 2 -->
+  <circle cx="345" cy="230" r="13" fill="#047857"/>
+  <text class="step-num" x="345" y="235" text-anchor="middle">2</text>
+  <text class="step-label" x="368" y="227">acquire per-session runMu</text>
+  <text class="mono" x="368" y="245">(concurrent runs queue here)</text>
+
+  <!-- Step 3 -->
+  <circle cx="345" cy="290" r="13" fill="#047857"/>
+  <text class="step-num" x="345" y="295" text-anchor="middle">3</text>
+  <text class="step-label" x="368" y="287">write to bash stdin pipe</text>
+  <text class="mono" x="368" y="305">  export KEY=VAL       # from envs</text>
+  <text class="mono" x="368" y="323">  &lt;user code&gt;</text>
+  <text class="mono" x="368" y="341">  echo &lt;END_MARKER&gt; $?</text>
+  <path class="line" d="M 450 350 H 720" stroke="#047857" stroke-width="2.5" marker-end="url(#a-green)"/>
+
+  <!-- bash exec block -->
+  <rect x="618" y="370" width="230" height="50" rx="6" ry="6" fill="#eff6ff" stroke="#1e3a5f" stroke-width="1.5"/>
+  <text class="step-label" x="630" y="392">bash executes in namespaces</text>
+  <text class="mono" x="630" y="410">writes → overlay upper dir</text>
+
+  <!-- Step 4 -->
+  <circle cx="345" cy="450" r="13" fill="#047857"/>
+  <text class="step-num" x="345" y="455" text-anchor="middle">4</text>
+  <text class="step-label" x="368" y="447">stream stdout as SSE</text>
+  <path class="line" d="M 720 430 H 450" stroke="#047857" stroke-width="2.5" marker-end="url(#a-green)"/>
+  <path class="line" d="M 410 470 H 170" stroke="#6d28d9" stroke-width="2.5" marker-end="url(#a-purple)"/>
+
+  <!-- Step 5 -->
+  <circle cx="345" cy="510" r="13" fill="#047857"/>
+  <text class="step-num" x="345" y="515" text-anchor="middle">5</text>
+  <text class="step-label" x="368" y="507">detect END_MARKER → SSE complete</text>
+  <text class="mono" x="368" y="525">release runMu, reset idle timer</text>
+  <path class="line" d="M 410 525 H 170" stroke="#6d28d9" stroke-width="2.5" marker-end="url(#a-purple)"/>
+</svg>


### PR DESCRIPTION
## What

Adds a user-facing guide for execd **isolation sessions** at `docs/guides/isolation-sessions.md`, plus two SVG diagrams and a sidebar entry.

## Why

Isolation sessions (per-execution bubblewrap-isolated bash sessions inside a sandbox) are currently only briefly mentioned in `docs/components/execd.md` and fully specified in [OSEP-0013](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0013-isolated-execution-api.md). This guide gives SDK/API users a single entry point covering:

- Overview and comparison with adjacent concepts (bash sessions, sandboxes, secure runtimes)
- Runtime layout and `run` request flow, illustrated with two SVG diagrams (fork model, per-session `runMu`, SSE stream)
- Quick start via curl and Python / TypeScript / Kotlin SDKs
- Session lifecycle, workspace modes (`rw` / `overlay` / `ro`), bind mounts and the writable allowlist, profiles, env / UID / networking
- Filesystem proxy endpoints
- Server configuration (`--isolation-config` TOML) and host requirements
- Limitations (Phase 2 `diff`/`commit` stubs, Linux-only, serialized runs)

The guide is wired into the Guides sidebar between Secure Container and Pause & Resume.

## Files

- `docs/guides/isolation-sessions.md` — new guide
- `docs/public/images/isolation-sessions-layout.svg` — runtime layout diagram
- `docs/public/images/isolation-sessions-run-flow.svg` — request flow diagram
- `docs/.vitepress/config.mts` — sidebar wiring

## Verification

- `pnpm docs:build` completes with zero errors
- Verified locally via `pnpm docs:dev` — both SVGs load and page renders as expected

## Notes

Docs-only change. No spec, server, SDK, or CLI impact.