### PR TITLE
docs: add secure access guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
           text: "Guides",
           items: [
             { text: "Credential Vault", link: "/guides/credential-vault" },
+            { text: "Secure Access", link: "/guides/secure-access" },
             { text: "Secure Container", link: "/guides/secure-container" },
             { text: "Multi-Tenancy", link: "/guides/multi-tenancy" },
             { text: "Pause & Resume", link: "/guides/pause-resume" },

--- a/docs/guides/secure-access.md
+++ b/docs/guides/secure-access.md
@@ -1,0 +1,182 @@
+---
+title: Secure Access
+description: Authenticate inbound HTTP and WebSocket traffic to sandbox endpoints using static header tokens or signed short-lived URLs.
+---
+
+# Secure Access
+
+Secure Access is OpenSandbox's inbound access control for sandbox endpoints.
+When enabled on a sandbox, the ingress gateway (and the server proxy path)
+require every caller to prove they are authorized before HTTP or WebSocket
+traffic reaches the sandbox.
+
+Its counterparts:
+
+- [Credential Vault](/guides/credential-vault) — protects **outbound** requests.
+- [Secure Container Runtime](/guides/secure-container) — isolates the **workload**.
+
+Normative design: [OSEP-0011](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0011-secure-access-endpoint.md).
+
+## Requirements
+
+- Kubernetes runtime (Docker rejects `secureAccess: true` with `400`).
+- `[ingress] mode = "gateway"`.
+- Signed URLs additionally require `[ingress.secure_access]` with at least
+  one signing key.
+
+## How It Works
+
+![Secure Access request flow](/images/secure-access.svg)
+
+On the **control plane**, creating a sandbox with `secureAccess: true` and
+calling `GetEndpoint` yields a per-sandbox opaque `SecureAccessToken`.
+Passing `?expires=<unix_seconds>` also mints a signed, time-limited routing
+token using the active key under `[ingress.secure_access]`.
+
+On the **data plane**, the ingress gateway evaluates two mechanisms in a
+fixed order:
+
+1. **Header present** → constant-time compare against `SecureAccessToken`.
+   Mismatch returns `401` immediately; there is **no** fallback to the
+   signed-URL branch.
+2. **Header absent** → parse the signed token, check `now ≤ expires`, verify
+   the signature.
+
+Requests that pass either check are forwarded upstream with the header or
+signed prefix stripped, so the workload never sees the credential.
+
+## Static Header Token
+
+`GetEndpoint` returns an opaque `SecureAccessToken`. Clients attach it as:
+
+```http
+OpenSandbox-Secure-Access: <token>
+```
+
+SDKs pick this header up from the endpoint response automatically, so
+application code usually does not touch it.
+
+## Signed Short-Lived URLs
+
+Mint a signed URL by adding `?expires=<unix_seconds>` (decimal `uint64`
+epoch seconds, **not** milliseconds):
+
+```
+GET /sandboxes/{sandboxId}/endpoints/{port}?expires=<unix_seconds>
+```
+
+The returned routing token has the shape:
+
+```
+{sandbox_id}-{port}-{expires_b36}-{signature}
+```
+
+where `expires_b36` is base-36 seconds and `signature` is 8 hex digits plus
+the 1-character `key_id` that signed it. The gateway accepts it in three
+routing modes:
+
+| Mode     | Where the token appears |
+|----------|------------------------|
+| wildcard | Host: `{token}.<parent>` |
+| header   | Value of the sandbox routing header |
+| uri      | Path prefix: `/{sandbox_id}/{port}/{expires_b36}/{signature}/…` |
+
+Use signed URLs to hand out shareable, time-limited endpoints without
+exposing the static token.
+
+## Server Configuration
+
+Signed URLs need signing keys; the static header token does not.
+
+```toml
+# ~/.sandbox.toml
+[ingress]
+mode = "gateway"
+
+[ingress.gateway]
+address = "sandbox.example.com"
+
+[ingress.gateway.route]
+mode = "wildcard"   # or "header" or "uri"
+
+[ingress.secure_access]
+active_key = "a"    # 1 char [0-9a-z], must exist in keys
+
+[[ingress.secure_access.keys]]
+key_id = "a"
+key = "base64:<secret>"
+```
+
+The `opensandbox-server` Helm chart exposes the same shape under
+`server.gateway.secureAccess` and wires the keys into both the server and the
+ingress gateway.
+
+**Key rotation.** Add a new key entry, deploy, then flip `active_key`.
+Verification loads every configured key, so tokens signed by older keys stay
+valid until you remove them — keep old entries until the longest possible
+token lifetime has elapsed.
+
+## Enabling It
+
+Set `secureAccess: true` on create. SDK equivalents: Python `secure_access=True`,
+JS/TS `secureAccess: true`, C# `SecureAccess = true`.
+
+```bash
+curl -X POST http://localhost:8080/v1/sandboxes \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": {"uri": "python:3.11"},
+    "resourceLimits": {"cpu": "500m", "memory": "512Mi"},
+    "entrypoint": ["python", "/app/main.py"],
+    "secureAccess": true
+  }'
+```
+
+## Calling a Secured Endpoint
+
+With the static header token:
+
+```bash
+# Fetch endpoint; the response carries OpenSandbox-Secure-Access.
+curl -s http://localhost:8080/v1/sandboxes/${SANDBOX_ID}/endpoints/8080
+
+curl -H "OpenSandbox-Secure-Access: ${TOKEN}" \
+  https://${SANDBOX_ID}-8080.sandbox.example.com/
+```
+
+With a signed URL (valid for one hour):
+
+```bash
+EXPIRES=$(( $(date +%s) + 3600 ))
+curl -s "http://localhost:8080/v1/sandboxes/${SANDBOX_ID}/endpoints/8080?expires=${EXPIRES}"
+# → https://{sandbox_id}-8080-{expires_b36}-{signature}.sandbox.example.com/
+```
+
+## Errors
+
+| Code | Cause |
+|------|-------|
+| `400` | `secureAccess: true` on Docker; malformed `expires` or routing token; invalid `expires_b36` / `port` / `signature`. |
+| `401` | Header mismatch; signed URL expired; bad signature; unknown key ID; secure access required but no credential presented. |
+
+Omitting `expires` on `GetEndpoint` is not a `400` — it returns the unsigned
+response, still carrying the static `SecureAccessToken`.
+
+## Notes
+
+- Enforcement covers both ingress gateway and the server proxy path
+  (`/v1/sandboxes/{id}/proxy/...`), HTTP and WebSocket.
+- The gateway strips `OpenSandbox-Secure-Access` and any signed URI prefix
+  before forwarding.
+- In URI mode, path segments that resemble `expires_b36/signature` are only
+  interpreted as a signed prefix when the sandbox actually has secure access
+  enabled; otherwise the full path is forwarded unchanged.
+- Secure Access is independent of the execd access token
+  (`X-EXECD-ACCESS-TOKEN`) and Credential Vault; all can be used together.
+
+## See Also
+
+- [Credential Vault](/guides/credential-vault)
+- [Secure Container Runtime](/guides/secure-container)
+- [Ingress component](/components/ingress)
+- [OSEP-0011](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0011-secure-access-endpoint.md)

--- a/docs/guides/secure-access.md
+++ b/docs/guides/secure-access.md
@@ -94,7 +94,9 @@ Signed URLs need signing keys; the static header token does not.
 mode = "gateway"
 
 [ingress.gateway]
-address = "sandbox.example.com"
+# Wildcard mode requires a wildcard address (e.g. *.sandbox.example.com);
+# header and uri modes take a plain host (e.g. sandbox.example.com).
+address = "*.sandbox.example.com"
 
 [ingress.gateway.route]
 mode = "wildcard"   # or "header" or "uri"
@@ -104,7 +106,7 @@ active_key = "a"    # 1 char [0-9a-z], must exist in keys
 
 [[ingress.secure_access.keys]]
 key_id = "a"
-key = "base64:<secret>"
+key = "<base64-encoded-secret>"   # raw base64, no "base64:" prefix
 ```
 
 The `opensandbox-server` Helm chart exposes the same shape under

--- a/docs/public/images/secure-access.svg
+++ b/docs/public/images/secure-access.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#334155"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#15803d"/>
+    </marker>
+    <marker id="arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b91c1c"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="480" y="34" text-anchor="middle" font-size="17" font-weight="600" fill="#0f172a">Secure Access — how the two mechanisms cooperate</text>
+
+  <!-- ============ CONTROL PLANE ============ -->
+  <rect x="40" y="60" width="880" height="170" rx="10" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="60" y="82" font-size="12" font-weight="600" fill="#1d4ed8">Control plane</text>
+
+  <!-- Client -->
+  <rect x="80" y="105" width="170" height="90" rx="8" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="165" y="135" text-anchor="middle" font-weight="600" fill="#0f172a">Client / SDK</text>
+  <text x="165" y="160" text-anchor="middle" font-size="12" fill="#475569">CreateSandbox</text>
+  <text x="165" y="178" text-anchor="middle" font-size="12" fill="#475569">GetEndpoint</text>
+
+  <!-- Server -->
+  <rect x="395" y="105" width="200" height="90" rx="8" fill="#ffffff" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="495" y="135" text-anchor="middle" font-weight="600" fill="#1d4ed8">opensandbox-server</text>
+  <text x="495" y="160" text-anchor="middle" font-size="12" fill="#475569">issue token</text>
+  <text x="495" y="178" text-anchor="middle" font-size="12" fill="#475569">sign short-lived URL</text>
+
+  <!-- Keys -->
+  <rect x="740" y="105" width="150" height="90" rx="8" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="815" y="135" text-anchor="middle" font-weight="600" fill="#0f172a">Signing keys</text>
+  <text x="815" y="160" text-anchor="middle" font-size="12" fill="#475569">active_key + keys[]</text>
+  <text x="815" y="178" text-anchor="middle" font-size="11" fill="#64748b">shared with ingress</text>
+
+  <!-- arrows -->
+  <line x1="250" y1="150" x2="390" y2="150" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+  <line x1="595" y1="150" x2="735" y2="150" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+
+  <!-- return arrow -->
+  <path d="M 495 195 Q 330 235 250 175" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-blue)"/>
+  <text x="370" y="222" text-anchor="middle" font-size="11" fill="#1d4ed8">SecureAccessToken and/or signed URL</text>
+
+  <!-- ============ DATA PLANE ============ -->
+  <rect x="40" y="260" width="880" height="330" rx="10" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="60" y="282" font-size="12" font-weight="600" fill="#15803d">Data plane</text>
+
+  <!-- Caller -->
+  <rect x="80" y="315" width="170" height="90" rx="8" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="165" y="345" text-anchor="middle" font-weight="600" fill="#0f172a">Caller</text>
+  <text x="165" y="370" text-anchor="middle" font-size="12" fill="#475569">sends header</text>
+  <text x="165" y="388" text-anchor="middle" font-size="12" fill="#475569">or signed URL</text>
+
+  <!-- Ingress box -->
+  <rect x="310" y="300" width="370" height="290" rx="8" fill="#ffffff" stroke="#15803d" stroke-width="1.5"/>
+  <text x="495" y="325" text-anchor="middle" font-weight="600" fill="#15803d">ingress gateway</text>
+
+  <!-- Decision -->
+  <rect x="335" y="345" width="320" height="46" rx="6" fill="#f0fdf4" stroke="#86efac"/>
+  <text x="495" y="373" text-anchor="middle" font-weight="600" fill="#166534">Header present?</text>
+
+  <!-- Header branch -->
+  <rect x="335" y="415" width="150" height="70" rx="6" fill="#ffffff" stroke="#86efac"/>
+  <text x="410" y="440" text-anchor="middle" font-weight="600" fill="#166534">yes</text>
+  <text x="410" y="462" text-anchor="middle" font-size="12" fill="#475569">constant-time</text>
+  <text x="410" y="478" text-anchor="middle" font-size="12" fill="#475569">compare</text>
+
+  <!-- Signed branch -->
+  <rect x="505" y="415" width="150" height="70" rx="6" fill="#ffffff" stroke="#86efac"/>
+  <text x="580" y="440" text-anchor="middle" font-weight="600" fill="#166534">no</text>
+  <text x="580" y="462" text-anchor="middle" font-size="12" fill="#475569">verify signature</text>
+  <text x="580" y="478" text-anchor="middle" font-size="12" fill="#475569">check expires</text>
+
+  <line x1="450" y1="391" x2="410" y2="413" stroke="#15803d" stroke-width="1.2" marker-end="url(#arrow-green)"/>
+  <line x1="540" y1="391" x2="580" y2="413" stroke="#15803d" stroke-width="1.2" marker-end="url(#arrow-green)"/>
+
+  <!-- Outcomes -->
+  <rect x="335" y="500" width="150" height="38" rx="6" fill="#dcfce7" stroke="#22c55e"/>
+  <text x="410" y="524" text-anchor="middle" font-weight="600" fill="#14532d">match → allow</text>
+
+  <rect x="505" y="500" width="150" height="38" rx="6" fill="#dcfce7" stroke="#22c55e"/>
+  <text x="580" y="524" text-anchor="middle" font-weight="600" fill="#14532d">valid → allow</text>
+
+  <!-- failure notes (kept inside ingress frame) -->
+  <text x="410" y="562" text-anchor="middle" font-size="11" fill="#b91c1c">mismatch → 401</text>
+  <text x="580" y="562" text-anchor="middle" font-size="11" fill="#b91c1c">expired / bad sig → 401</text>
+  <text x="495" y="580" text-anchor="middle" font-size="10" fill="#64748b">header branch is fail-fast — no fallback</text>
+
+  <line x1="410" y1="485" x2="410" y2="498" stroke="#15803d" stroke-width="1.2" marker-end="url(#arrow-green)"/>
+  <line x1="580" y1="485" x2="580" y2="498" stroke="#15803d" stroke-width="1.2" marker-end="url(#arrow-green)"/>
+
+  <!-- Sandbox -->
+  <rect x="720" y="380" width="170" height="110" rx="8" fill="#ffffff" stroke="#94a3b8"/>
+  <text x="805" y="410" text-anchor="middle" font-weight="600" fill="#0f172a">Sandbox pod</text>
+  <text x="805" y="435" text-anchor="middle" font-size="12" fill="#475569">receives cleaned</text>
+  <text x="805" y="453" text-anchor="middle" font-size="12" fill="#475569">request</text>
+  <text x="805" y="475" text-anchor="middle" font-size="11" fill="#64748b">(no auth header)</text>
+
+  <!-- caller -> ingress -->
+  <line x1="250" y1="360" x2="308" y2="360" stroke="#334155" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ingress allow -> sandbox -->
+  <path d="M 680 435 L 718 435" stroke="#15803d" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+</svg>

--- a/docs/public/images/secure-access.svg
+++ b/docs/public/images/secure-access.svg
@@ -98,7 +98,7 @@
 
   <!-- Sandbox -->
   <rect x="720" y="380" width="170" height="110" rx="8" fill="#ffffff" stroke="#94a3b8"/>
-  <text x="805" y="410" text-anchor="middle" font-weight="600" fill="#0f172a">Sandbox pod</text>
+  <text x="805" y="410" text-anchor="middle" font-weight="600" fill="#0f172a">Sandbox</text>
   <text x="805" y="435" text-anchor="middle" font-size="12" fill="#475569">receives cleaned</text>
   <text x="805" y="453" text-anchor="middle" font-size="12" fill="#475569">request</text>
   <text x="805" y="475" text-anchor="middle" font-size="11" fill="#64748b">(no auth header)</text>


### PR DESCRIPTION
# Summary

Adds a dedicated guide for the OSEP-0011 Secure Access feature under `docs/guides/secure-access.md`, plus an SVG diagram and a sidebar entry.

Motivation: Secure Access is fully implemented across server, ingress, SDKs, and Helm, but has only a two-paragraph mention in the architecture doc today. This fills the gap alongside the existing `credential-vault` (outbound) and `secure-container` (isolation) guides.

The guide covers:

- The static `OpenSandbox-Secure-Access` header token
- Signed short-lived endpoint URLs minted via `GetEndpoint?expires=<unix_seconds>`
- Server config (`[ingress.secure_access]`, Helm `server.gateway.secureAccess`) and key rotation
- Enabling `secureAccess` on sandbox create; SDK equivalents (Python/JS/C#)
- Calling secured endpoints with curl for both mechanisms
- Error codes and the URI-mode legacy safeguard for unsecured sandboxes

The included SVG shows the control plane (server issues token / signs URL) and the ingress data-plane decision: header branch is fail-fast, absent-header falls through to signed-URL verification.

Content is verified against:
- `oseps/0011-secure-access-endpoint.md`
- `specs/sandbox-lifecycle.yml` (`CreateSandboxRequest.secureAccess`, `GetEndpoint` `expires`)
- `server/opensandbox_server/config.py` (`SecureAccessConfig`, `IngressConfig` validation)
- `server/opensandbox_server/services/docker/networking.py` (Docker 400 rejection)
- `kubernetes/charts/opensandbox-server/values.yaml` (`server.gateway.secureAccess`)

No source-of-truth files (specs, server, SDK, chart, CRDs) are modified.

# Testing
- [x] Not run (docs-only change; no code paths touched)
- [ ] Unit tests
- [ ] Integration tests
- [x] e2e / manual verification

Verification: `cd docs && pnpm docs:build` completes with zero errors. Rendered locally with `pnpm docs:dev`; sidebar entry appears between Credential Vault and Secure Container, SVG renders correctly.

# Breaking Changes
- [x] None

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [ ] Added/updated tests (if needed) — docs-only
- [x] Security impact considered — documents an existing security feature; no behavior changes
- [x] Backward compatibility considered — additive doc only