### PR TITLE
docs(server): drop experimental markers from renew_intent

### DIFF
--- a/server/configuration.md
+++ b/server/configuration.md
@@ -31,7 +31,7 @@ Example files in this repository:
 10. [`[storage]`](#storage)
 11. [`[store]`](#store)
 12. [`[secure_runtime]`](#secure_runtime)
-13. [`[renew_intent]`](#renew_intent--experimental)
+13. [`[renew_intent]`](#renew_intent)
 14. [`[otel]`](#otel)
 15. [Environment variables (outside TOML)](#environment-variables-outside-toml)
 16. [Cross-field validation rules](#cross-field-validation-rules)
@@ -53,7 +53,7 @@ Example files in this repository:
 | `[storage]` | No | Host bind mounts / OSSFS mount root |
 | `[store]` | No | Server-managed persistent metadata backend |
 | `[secure_runtime]` | No | gVisor / Kata / Firecracker |
-| `[renew_intent]` | No | Experimental auto-renew on access |
+| `[renew_intent]` | No | Auto-renew on access |
 | `[otel]` | No | OTLP export for ingested SDK metrics |
 
 ---
@@ -279,9 +279,9 @@ See [`docs/guides/secure-container.md`](../docs/guides/secure-container.md) for 
 
 ---
 
-## `[renew_intent]` — **experimental**
+## `[renew_intent]`
 
-**🧪 Experimental:** auto-renew sandbox expiration when access is observed (lifecycle proxy and/or Redis queue). Off by default. Full design: [OSEP-0009](../oseps/0009-auto-renew-sandbox-on-ingress-access.md).
+Auto-renew sandbox expiration when access is observed (lifecycle proxy and/or Redis queue). Off by default. Full design: [OSEP-0009](../oseps/0009-auto-renew-sandbox-on-ingress-access.md).
 
 Use **dotted keys** under the same table for Redis (valid in TOML):
 

--- a/server/opensandbox_server/config.py
+++ b/server/opensandbox_server/config.py
@@ -104,31 +104,31 @@ def _is_wildcard_domain(host: str) -> bool:
 
 
 class RenewIntentRedisConfig(BaseModel):
-    """🧪 [EXPERIMENTAL] Redis list consumer for renew-intent queue (ingress gateway path)."""
+    """Redis list consumer for renew-intent queue (ingress gateway path)."""
 
     enabled: bool = Field(
         default=False,
         description=(
-            "🧪 [EXPERIMENTAL] When true, server workers consume renew intents from Redis "
+            "When true, server workers consume renew intents from Redis "
             "(ingress gateway path)."
         ),
     )
     dsn: Optional[str] = Field(
         default=None,
         description=(
-            '🧪 [EXPERIMENTAL] Redis DSN (e.g. "redis://127.0.0.1:6379/0"). '
+            'Redis DSN (e.g. "redis://127.0.0.1:6379/0"). '
             "Required when redis.enabled is true."
         ),
     )
     queue_key: str = Field(
         default="opensandbox:renew:intent",
         min_length=1,
-        description="🧪 [EXPERIMENTAL] Redis List key for LPUSH/BRPOP renew-intent JSON payloads.",
+        description="Redis List key for LPUSH/BRPOP renew-intent JSON payloads.",
     )
     consumer_concurrency: int = Field(
         default=8,
         ge=1,
-        description="🧪 [EXPERIMENTAL] Number of concurrent BRPOP worker tasks.",
+        description="Number of concurrent BRPOP worker tasks.",
     )
 
     @model_validator(mode="after")
@@ -168,12 +168,12 @@ class OtelConfig(BaseModel):
 
 
 class RenewIntentConfig(BaseModel):
-    """🧪 [EXPERIMENTAL] Renew sandbox expiration when access is observed (proxy and/or Redis queue)."""
+    """Renew sandbox expiration when access is observed (proxy and/or Redis queue)."""
 
     enabled: bool = Field(
         default=False,
         description=(
-            "🧪 [EXPERIMENTAL] Master switch for auto-renew on reverse-proxy access and/or Redis "
+            "Master switch for auto-renew on reverse-proxy access and/or Redis "
             "ingress intents. When false, renew-intent logic is off."
         ),
     )
@@ -181,14 +181,14 @@ class RenewIntentConfig(BaseModel):
         default=60,
         ge=1,
         description=(
-            "🧪 [EXPERIMENTAL] Minimum seconds between successful renewals for the same sandbox "
+            "Minimum seconds between successful renewals for the same sandbox "
             "(cooldown)."
         ),
     )
     redis: RenewIntentRedisConfig = Field(
         default_factory=RenewIntentRedisConfig,
         description=(
-            "🧪 [EXPERIMENTAL] Redis queue consumer for ingress gateway renew-intent mode. "
+            "Redis queue consumer for ingress gateway renew-intent mode. "
             "In TOML, set keys under the same [renew_intent] table as redis.enabled, "
             "redis.dsn, redis.queue_key, redis.consumer_concurrency (dotted keys)."
         ),

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -80,7 +80,7 @@ mode = "dns"
 # Default is true (recommended for dual-stack CNI). Set false only if you need IPv6 in the netns (see server/configuration.md).
 # disable_ipv6 = false
 
-# 🧪 [EXPERIMENTAL] Renew-on-access. Off by default — see server/README.md.
+# Renew-on-access. Off by default — see server/README.md.
 [renew_intent]
 enabled = false
 min_interval_seconds = 60

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -81,7 +81,7 @@ mode = "dns"
 # Default is true (recommended for dual-stack CNI). Set false only if you need IPv6 in the netns (see server/configuration.md).
 # disable_ipv6 = false
 
-# 🧪 [EXPERIMENTAL] 按访问续期。默认关闭 — 见 server/README_zh.md。
+# 按访问续期。默认关闭 — 见 server/README_zh.md。
 [renew_intent]
 enabled = false
 min_interval_seconds = 60

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -71,7 +71,7 @@ mode = "direct"
 image = "opensandbox/egress:v1.1.4"
 mode = "dns"
 
-# 🧪 [EXPERIMENTAL] Renew-on-access. Off by default — see server/README.md.
+# Renew-on-access. Off by default — see server/README.md.
 [renew_intent]
 enabled = false
 min_interval_seconds = 60

--- a/server/opensandbox_server/examples/example.config.zh.toml
+++ b/server/opensandbox_server/examples/example.config.zh.toml
@@ -69,7 +69,7 @@ mode = "direct"
 image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/egress:v1.1.4"
 mode = "dns"
 
-# 🧪 [EXPERIMENTAL] 按访问续期。默认关闭 — 见 server/README_zh.md。
+# 按访问续期。默认关闭 — 见 server/README_zh.md。
 [renew_intent]
 enabled = false
 min_interval_seconds = 60

--- a/server/opensandbox_server/integrations/renew_intent/consumer.py
+++ b/server/opensandbox_server/integrations/renew_intent/consumer.py
@@ -140,13 +140,13 @@ class RenewIntentConsumer:
                 queue_key=consumer._queue_key,
             )
             logger.info(
-                f"🧪 [EXPERIMENTAL] renew_intent is enabled: Redis BRPOP feeders + "
+                f"renew_intent is enabled: Redis BRPOP feeders + "
                 f"unified processors started ({line})",
                 extra=ex,
             )
         else:
             logger.info(
-                "🧪 [EXPERIMENTAL] renew_intent is enabled: unified in-process renew pipeline "
+                "renew_intent is enabled: unified in-process renew pipeline "
                 "(proxy path only; no Redis BRPOP)"
             )
         return consumer


### PR DESCRIPTION
## Summary

The renew-on-access feature (OSEP-0009) is now stable. This PR removes the
\`[EXPERIMENTAL]\` / flask emoji prefixes so the server config, examples and
docs reflect its current status.

## Changes

- \`opensandbox_server/config.py\`: \`RenewIntentConfig\` and
  \`RenewIntentRedisConfig\` class docstrings and 6 \`Field\` descriptions
- \`opensandbox_server/integrations/renew_intent/consumer.py\`: 2 startup log
  lines
- \`opensandbox_server/examples/example.config{,.k8s}{,.zh}.toml\`: comment
  above the \`[renew_intent]\` block
- \`configuration.md\`: TOC anchor (\`#renew_intent--experimental\` →
  \`#renew_intent\`), the top-level section table entry, the section heading
  and its intro paragraph

## Not changed

- \`server/RELEASE_NOTES.md\` — already-released 0.1.9 changelog entry
- \`configuration.md\` line 355 — generic "release notes cover experimental
  flags and breaking changes" guidance, unrelated to \`renew_intent\`
- \`docs/\`, \`oseps/\`, SDKs — out of scope for this doc/log wording pass

## Verification

- \`uv run ruff check\` on the touched Python files — clean
- \`uv run pytest tests/test_config.py tests/test_routes_renew_expiration.py\`
  — 86 passed
- \`uv run pytest tests -k renew\` — 39 passed
- Repo-wide grep for \`EXPERIMENTAL|🧪\` under \`server/opensandbox_server\`
  returns no matches after the change

No behavior change; documentation and log wording only.