### PR TITLE
docs: add client pool guide with architecture diagrams

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -96,6 +96,7 @@ export default defineConfig({
             { text: "Isolation Sessions", link: "/guides/isolation-sessions" },
             { text: "Pause & Resume", link: "/guides/pause-resume" },
             { text: "Windows Sandbox", link: "/guides/windows-sandbox" },
+            { text: "Client Pool", link: "/guides/client-pool" },
             { text: "SDK Telemetry", link: "/guides/sdk-telemetry" },
           ],
         },

--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -129,11 +129,11 @@ canonical reference; refer to the per-language builder or constructor for exact 
   `DIRECT_CREATE` fallbacks.
 - All nodes sharing one pool must use the same creation and warmup definition. If that
   definition changes, roll out under a **new** `pool_name` (or Redis `key_prefix`) and
-  retire the old pool with `SandboxPoolManager.destroy(...)`. Do not attempt to refill
-  a changed template into the same `pool_name`: `release_all_idle()` does not fence
-  other nodes, does not lower `max_idle`, and does not stop any current leader (which
-  may still be running the old code) from immediately re-publishing old-template
-  sandbox IDs into the shared buffer during a rolling deploy.
+  retire the old one (see "Retiring an old pool namespace" below). Do not attempt to
+  refill a changed template into the same `pool_name`: `release_all_idle()` does not
+  fence other nodes, does not lower `max_idle`, and does not stop any current leader
+  (which may still be running the old code) from immediately re-publishing
+  old-template sandbox IDs into the shared buffer during a rolling deploy.
 - `resize(max_idle)` and `release_all_idle()` can be called from any node.
 
 ## Minimal usage
@@ -285,13 +285,45 @@ Every SDK exposes read-only accessors:
   transient upstream problem. It does **not** change `max_idle`, does **not** fence
   other nodes, and does **not** stop an active leader from immediately replenishing —
   so it is not a safe way to swap creation templates on the same `pool_name`. For that
-  case, roll out under a new `pool_name` and use `SandboxPoolManager.destroy(...)` on
-  the old one.
+  case, retire the whole namespace under a new `pool_name` (see below).
 
-For destructive administrative operations across a whole distributed pool (fence,
-drain, clear-state, tombstone), use `SandboxPoolManager.destroy(poolName)` (Kotlin,
-Python). The manager applies a `DESTROYING → DESTROYED` protocol so an old pool
-namespace cannot be silently recreated.
+### Retiring an old pool namespace
+
+The retirement procedure differs across SDKs because Go does not currently ship a
+`SandboxPoolManager` or the destroy / tombstone primitives that Python and Kotlin
+have.
+
+**Python / Kotlin** — use `SandboxPoolManager.destroy(poolName, options)`. The manager
+applies a full `DESTROYING → DESTROYED` protocol: write a `DESTROYING` fence into the
+state store (so any still-running peer instance sees it), best-effort drain and kill
+every idle sandbox up to `drain_timeout`, clear the persistent per-pool state, then
+write a `DESTROYED` tombstone with `tombstone_ttl` (default 7 days) so future callers
+cannot silently rebind to the same `pool_name`.
+
+**Go** — the Go SDK has no equivalent API and no state-store primitives for
+tombstones or fences. The closest safe approximation is an operator-driven, out-of-band
+sequence:
+
+1. Stop every process that instantiates a pool against the old `pool_name`. Call
+   `pool.Shutdown(ctx, true)` on each. This releases each node's primary lock but
+   leaves idle entries in the store.
+2. From one still-alive pool instance (or a throwaway one bound to the same
+   `PoolName` + `StateStore`), call `pool.ReleaseAllIdle(ctx)` to drain and
+   best-effort kill every idle sandbox.
+3. Set `store.SetMaxIdle(ctx, poolName, 0)` so any peer that races back in cannot
+   warm up new sandboxes.
+4. Move all future callers to a new `PoolName` (for example
+   `orders-v2` → `orders-v3`). This is the Go substitute for the `DESTROYED`
+   tombstone: without a shared marker, name rotation is the only way to guarantee no
+   accidental reuse.
+5. If you are using the Redis store and want to reclaim keys, delete them directly
+   with `DEL` / `SCAN` against your Redis instance — the Go SDK does not expose a
+   destroy helper for this.
+
+Without a fence, steps 2 and 3 race with any surviving peer that has not yet been
+stopped. If you cannot guarantee "all writers stopped" before step 2, the only correct
+option is to rotate `PoolName` first (step 4) and let the old namespace's idle entries
+expire naturally via `idle_timeout`.
 
 ## Further reading
 

--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -1,0 +1,292 @@
+---
+title: Client Pool
+description: How the SDK-side sandbox pool works, how to configure it, and a minimal example for each supported SDK.
+---
+
+# Client Pool
+
+The OpenSandbox SDKs ship an experimental **client-side sandbox pool** that keeps a small
+buffer of ready sandboxes warm on the server so that `acquire()` returns quickly instead
+of paying the full sandbox creation latency on the hot path.
+
+Available in the Python, Kotlin/Java, and Go sandbox SDKs. The JavaScript/TypeScript and
+C# SDKs do not currently ship a client pool.
+
+::: warning Experimental
+The client pool API is marked experimental and may change between minor releases. Pin
+your SDK version if you rely on it in production.
+:::
+
+## What it actually pools
+
+The pool does **not** pool HTTP connections, and it does **not** pool SDK `Sandbox`
+objects. It pools the **IDs of pre-warmed, ready sandboxes** running on the OpenSandbox
+server.
+
+![Client pool architecture](/images/client-pool-architecture.svg)
+
+Two flows happen concurrently:
+
+- **Warmup (leader-only).** A background reconcile loop runs on every node at
+  `reconcile_interval`. Whichever node holds the primary lock in the state store fans
+  new-sandbox creation out onto a small warmup worker pool (`warmup_concurrency`),
+  optionally runs a readiness check, then publishes the ready sandbox ID into the idle
+  buffer with a TTL of `idle_timeout`.
+- **Acquire (any node).** `acquire()` pops an idle ID from the store, connects a
+  `Sandbox` client to it, optionally runs a health check and a `renew()` to the
+  caller-supplied timeout, and hands it to the caller. Non-leader nodes can acquire
+  freely; only replenish and shrink are gated by the leader lock.
+
+The store carries only sandbox IDs and their expiry — no HTTP state, no client-side
+objects. That is what lets Redis-backed pools be truly distributed across processes
+and pods.
+
+The warmup path — the leader-only replenish flow above — is worth zooming in on
+because it is the only part of the pool that is gated by a distributed lock:
+
+![Warmup reconcile sequence](/images/client-pool-warmup-sequence.svg)
+
+### Lifecycle model
+
+Each pool instance moves through `NOT_STARTED → STARTING → RUNNING → DRAINING → STOPPED`.
+Health is tracked separately as `HEALTHY | DEGRADED | DRAINING | STOPPED`; after
+`degraded_threshold` consecutive create failures the pool enters `DEGRADED` and applies
+exponential backoff before retrying warmup. Callers do not need to observe these states
+directly — `snapshot()` exposes them for diagnostics.
+
+![Client pool lifecycle state machine](/images/client-pool-lifecycle.svg)
+
+### There is no `release()`
+
+Sandboxes are ephemeral. Once you have called `acquire()`, the sandbox is yours until you
+`destroy()` / `kill()` it. `max_idle` bounds the **warm buffer**, not the number of
+sandboxes borrowed by application code and not the number of sandboxes produced by
+`DIRECT_CREATE` fallback.
+
+## Empty-buffer behavior: `AcquirePolicy`
+
+`AcquirePolicy` controls what happens when the idle buffer is empty, or when the first
+idle candidate fails its readiness check:
+
+| Policy                    | Fallback on exhaustion                     |
+| ------------------------- | ------------------------------------------ |
+| `FAIL_FAST`               | raise `PoolEmptyException` / `PoolAcquireFailedException` |
+| `DIRECT_CREATE` (default) | create a new sandbox via the lifecycle API |
+
+Under both policies `acquire()` tries **one** idle candidate. If that candidate fails
+its readiness check, `FAIL_FAST` raises and `DIRECT_CREATE` falls back to creating a
+brand-new sandbox via the lifecycle API. A failed candidate still pays up to
+`acquire_ready_timeout`.
+
+![Acquire decision flow](/images/client-pool-acquire-decision.svg)
+
+## Configuration
+
+All three SDKs expose the same knobs with the same defaults. This table is the
+canonical reference; refer to the per-language builder or constructor for exact naming.
+
+| Parameter                             | Default                            | Meaning                                                                          |
+| ------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------- |
+| `pool_name`                           | required                           | Logical namespace shared by all nodes of one distributed pool                    |
+| `owner_id`                            | auto (`pool-owner-<uuid/host/pid>`) | Identity of this process for primary-lock ownership; **must be unique per node** |
+| `max_idle`                            | required (≥ 0)                     | Target size and cap of the idle buffer                                           |
+| `state_store`                         | required (Go builder defaults to in-memory) | `InMemoryPoolStateStore` or Redis-backed store                          |
+| `connection_config`                   | required                           | Used for lifecycle and execd calls                                               |
+| `creation_spec`                       | required (unless `sandbox_creator`) | Template for warmed sandboxes: `image`, `entrypoint`, `env`, `metadata`, `extensions`, `resource`, `network_policy`, `platform`, `volumes`, `secure_access` |
+| `sandbox_creator`                     | `null`                             | Callback that fully overrides `creation_spec`; receives a `PooledSandboxCreateContext` with `reason=WARMUP` or `reason=DIRECT_CREATE` |
+| `warmup_concurrency`                  | `max(1, ceil(max_idle * 0.2))`     | Warmup worker pool size                                                          |
+| `primary_lock_ttl`                    | `60 s`                             | Leader-lock TTL; must exceed `warmup_ready_timeout` + preparer time              |
+| `reconcile_interval`                  | `30 s`                             | Interval between reconcile ticks                                                 |
+| `degraded_threshold`                  | `3`                                | Consecutive create failures before entering `DEGRADED` with backoff              |
+| `acquire_ready_timeout`               | `30 s`                             | Max wait for the returned sandbox to become ready                                |
+| `acquire_health_check_polling_interval` | `200 ms`                         | Ready-poll interval during acquire                                               |
+| `acquire_health_check`                | `null`                             | Custom readiness predicate for acquire                                           |
+| `acquire_skip_health_check`           | `false`                            | Skip the readiness check on acquire                                              |
+| `acquire_min_remaining_ttl`           | `min(60 s, idle_timeout / 2)`      | Discard idles closer to expiry than this on acquire                              |
+| `warmup_ready_timeout`                | `30 s`                             | Max wait for a warmed sandbox to become ready                                    |
+| `warmup_health_check_polling_interval` | `200 ms`                          | Ready-poll interval during warmup                                                |
+| `warmup_health_check`                 | `null`                             | Custom warmup readiness predicate                                                |
+| `warmup_sandbox_preparer`             | `null`                             | Runs after readiness and before publishing to the idle buffer                    |
+| `warmup_skip_health_check`            | `false`                            | Skip readiness check during warmup                                               |
+| `idle_timeout`                        | `24 h`                             | Server-side TTL for pool-created sandboxes                                       |
+| `drain_timeout`                       | `30 s`                             | Max wait for in-flight ops during graceful shutdown                              |
+
+### Choosing a state store
+
+- **`InMemoryPoolStateStore`** — single process only. Suitable for development, tests,
+  and single-instance workers. Not process-wide for gunicorn/uvicorn workers, Celery, or
+  Kubernetes replicas.
+- **Redis-backed store** (`RedisPoolStateStore`, `AsyncRedisPoolStateStore`,
+  `sandbox-pool-redis` on the JVM, `poolredis` in Go) — required for multi-process or
+  multi-pod deployments. All nodes in one logical pool must share the same `pool_name`
+  and Redis `key_prefix`, and each process must use a **unique** `owner_id`.
+
+![Single-node vs distributed pool topology](/images/client-pool-topology.svg)
+
+### Rules that apply to every deployment
+
+- `max_idle` bounds the warm buffer only. It does not cap borrowed sandboxes or
+  `DIRECT_CREATE` fallbacks.
+- All nodes sharing one pool must use the same creation and warmup definition. If that
+  definition changes, use a new `pool_name` (or Redis `key_prefix`) and drain the old
+  pool.
+- `resize(max_idle)` and `release_all_idle()` can be called from any node.
+
+## Minimal usage
+
+### Python (sync)
+
+```python
+from datetime import timedelta
+
+from opensandbox import (
+    AcquirePolicy,
+    InMemoryPoolStateStore,
+    PoolCreationSpec,
+    SandboxPoolSync,
+)
+from opensandbox.config import ConnectionConfigSync
+
+pool = SandboxPoolSync(
+    pool_name="demo-pool",
+    owner_id="worker-1",
+    max_idle=2,
+    state_store=InMemoryPoolStateStore(),
+    connection_config=ConnectionConfigSync(domain="api.opensandbox.io"),
+    creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+    reconcile_interval=timedelta(seconds=5),
+)
+
+pool.start()
+try:
+    sandbox = pool.acquire(
+        sandbox_timeout=timedelta(minutes=30),
+        policy=AcquirePolicy.FAIL_FAST,
+    )
+    try:
+        result = sandbox.commands.run("echo pool-ok")
+        print(result.logs.stdout[0].text)
+    finally:
+        sandbox.destroy()
+finally:
+    pool.shutdown(graceful=True)
+```
+
+### Python (asyncio)
+
+`SandboxPoolAsync` has the same surface plus an `async with` context manager:
+
+```python
+from datetime import timedelta
+
+from opensandbox import (
+    AcquirePolicy,
+    InMemoryAsyncPoolStateStore,
+    PoolCreationSpec,
+    SandboxPoolAsync,
+)
+from opensandbox.config import ConnectionConfig
+
+async with SandboxPoolAsync(
+    pool_name="demo-pool",
+    owner_id="worker-1",
+    max_idle=2,
+    state_store=InMemoryAsyncPoolStateStore(),
+    connection_config=ConnectionConfig(domain="api.opensandbox.io"),
+    creation_spec=PoolCreationSpec(image="ubuntu:22.04"),
+) as pool:
+    sandbox = await pool.acquire(
+        sandbox_timeout=timedelta(minutes=30),
+        policy=AcquirePolicy.FAIL_FAST,
+    )
+    try:
+        result = await sandbox.commands.run("echo pool-ok")
+    finally:
+        await sandbox.destroy()
+```
+
+### Kotlin / Java
+
+```java
+SandboxPool pool = SandboxPool.builder()
+    .poolName("demo-pool")
+    .ownerId("worker-1")
+    .maxIdle(3)
+    .stateStore(new InMemoryPoolStateStore())
+    .connectionConfig(config)
+    .creationSpec(PoolCreationSpec.builder()
+        .image("ubuntu:22.04")
+        .entrypoint(List.of("tail", "-f", "/dev/null"))
+        .build())
+    .warmupReadyTimeout(Duration.ofSeconds(45))
+    .build();
+
+pool.start();
+try {
+    Sandbox sb = pool.acquire(Duration.ofMinutes(10), AcquirePolicy.FAIL_FAST);
+    try {
+        sb.commands().run("echo pool-ok");
+    } finally {
+        sb.kill();
+        sb.close();
+    }
+} finally {
+    pool.shutdown(true);
+}
+```
+
+### Go
+
+```go
+pool, err := opensandbox.NewSandboxPoolBuilder().
+    PoolName("demo-pool").
+    OwnerID("worker-1").
+    MaxIdle(3).
+    ConnectionConfig(opensandbox.ConnectionConfig{Domain: "api.opensandbox.io"}).
+    CreationSpec(opensandbox.PoolCreationSpec{Image: "ubuntu:22.04"}).
+    StateStore(opensandbox.NewInMemoryPoolStateStore()).
+    Build()
+if err != nil {
+    log.Fatal(err)
+}
+if err := pool.Start(ctx); err != nil {
+    log.Fatal(err)
+}
+defer pool.Shutdown(context.Background(), true)
+
+failFast := opensandbox.AcquirePolicyFailFast
+sb, err := pool.Acquire(ctx, opensandbox.AcquireOptions{
+    SandboxTimeout: 10 * time.Minute,
+    Policy:         &failFast,
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer sb.Kill(context.Background())
+
+result, _ := sb.RunCommand(ctx, "echo pool-ok", nil)
+_ = result
+```
+
+## Diagnostics
+
+Every SDK exposes read-only accessors:
+
+- `snapshot()` — pool phase, health, counters (idle size, in-flight warmups,
+  consecutive failures, last error).
+- `snapshot_idle_entries()` — the current idle sandbox IDs with expiry timestamps.
+- `resize(max_idle)` — change the target buffer size at runtime.
+- `release_all_idle()` — drain the idle buffer without stopping the pool (useful when
+  the creation template changes and you want to force a refill on the same
+  `pool_name`).
+
+For destructive administrative operations across a whole distributed pool (fence,
+drain, clear-state, tombstone), use `SandboxPoolManager.destroy(poolName)` (Kotlin,
+Python). The manager applies a `DESTROYING → DESTROYED` protocol so an old pool
+namespace cannot be silently recreated.
+
+## Further reading
+
+- Python: [`/sdks/python`](/sdks/python) &mdash; `SandboxPoolSync`, `SandboxPoolAsync`, Redis store.
+- Kotlin: [`/sdks/kotlin`](/sdks/kotlin) &mdash; `SandboxPool` builder, `sandbox-pool-redis` module.
+- Go: [`/sdks/go`](/sdks/go) &mdash; `SandboxPool` interface, `RedisPoolStateStore`, distributed deployment notes.

--- a/docs/guides/client-pool.md
+++ b/docs/guides/client-pool.md
@@ -92,8 +92,8 @@ canonical reference; refer to the per-language builder or constructor for exact 
 | `max_idle`                            | required (≥ 0)                     | Target size and cap of the idle buffer                                           |
 | `state_store`                         | required (Go builder defaults to in-memory) | `InMemoryPoolStateStore` or Redis-backed store                          |
 | `connection_config`                   | required                           | Used for lifecycle and execd calls                                               |
-| `creation_spec`                       | required (unless `sandbox_creator`) | Template for warmed sandboxes: `image`, `entrypoint`, `env`, `metadata`, `extensions`, `resource`, `network_policy`, `platform`, `volumes`, `secure_access` |
-| `sandbox_creator`                     | `null`                             | Callback that fully overrides `creation_spec`; receives a `PooledSandboxCreateContext` with `reason=WARMUP` or `reason=DIRECT_CREATE` |
+| `creation_spec`                       | required in Python / Kotlin; required in Go only when `sandbox_creator` is unset | Template for warmed sandboxes: `image`, `entrypoint`, `env`, `metadata`, `extensions`, `resource`, `network_policy`, `platform`, `volumes`, `secure_access` |
+| `sandbox_creator`                     | `null`                             | Optional callback that overrides `creation_spec` at runtime. Python and Kotlin still require `creation_spec` to be supplied (it is unused when the creator is set); only Go allows a creator-only pool. Receives a `PooledSandboxCreateContext` whose `reason` field is `WARMUP` for warmup and `DIRECT_CREATE` (Python / Kotlin) or `CreateReasonAcquire` / `"ACQUIRE"` (Go) for the acquire-fallback path. |
 | `warmup_concurrency`                  | `max(1, ceil(max_idle * 0.2))`     | Warmup worker pool size                                                          |
 | `primary_lock_ttl`                    | `60 s`                             | Leader-lock TTL; must exceed `warmup_ready_timeout` + preparer time              |
 | `reconcile_interval`                  | `30 s`                             | Interval between reconcile ticks                                                 |
@@ -128,8 +128,12 @@ canonical reference; refer to the per-language builder or constructor for exact 
 - `max_idle` bounds the warm buffer only. It does not cap borrowed sandboxes or
   `DIRECT_CREATE` fallbacks.
 - All nodes sharing one pool must use the same creation and warmup definition. If that
-  definition changes, use a new `pool_name` (or Redis `key_prefix`) and drain the old
-  pool.
+  definition changes, roll out under a **new** `pool_name` (or Redis `key_prefix`) and
+  retire the old pool with `SandboxPoolManager.destroy(...)`. Do not attempt to refill
+  a changed template into the same `pool_name`: `release_all_idle()` does not fence
+  other nodes, does not lower `max_idle`, and does not stop any current leader (which
+  may still be running the old code) from immediately re-publishing old-template
+  sandbox IDs into the shared buffer during a rolling deploy.
 - `resize(max_idle)` and `release_all_idle()` can be called from any node.
 
 ## Minimal usage
@@ -276,9 +280,13 @@ Every SDK exposes read-only accessors:
   consecutive failures, last error).
 - `snapshot_idle_entries()` — the current idle sandbox IDs with expiry timestamps.
 - `resize(max_idle)` — change the target buffer size at runtime.
-- `release_all_idle()` — drain the idle buffer without stopping the pool (useful when
-  the creation template changes and you want to force a refill on the same
-  `pool_name`).
+- `release_all_idle()` — drain the currently visible idle buffer and best-effort kill
+  each entry, without stopping the pool. Useful to force a fresh set of warmups after a
+  transient upstream problem. It does **not** change `max_idle`, does **not** fence
+  other nodes, and does **not** stop an active leader from immediately replenishing —
+  so it is not a safe way to swap creation templates on the same `pool_name`. For that
+  case, roll out under a new `pool_name` and use `SandboxPoolManager.destroy(...)` on
+  the old one.
 
 For destructive administrative operations across a whole distributed pool (fence,
 drain, clear-state, tombstone), use `SandboxPoolManager.destroy(poolName)` (Kotlin,

--- a/docs/public/images/client-pool-acquire-decision.svg
+++ b/docs/public/images/client-pool-acquire-decision.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="920" viewBox="0 0 1400 920" role="img" aria-labelledby="title desc">
+  <title id="title">Acquire Decision Flow</title>
+  <desc id="desc">Decision flow of pool.acquire. Pop one idle sandbox ID from the store; if the remaining TTL is too small, discard and treat as empty; otherwise connect, run optional health check, renew to the caller-supplied timeout, and return. On empty buffer or candidate failure, FAIL_FAST raises and DIRECT_CREATE falls back to creating a new sandbox via the lifecycle API.</desc>
+  <defs>
+    <marker id="a3-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e3a5f"/>
+    </marker>
+    <marker id="a3-arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b91c1c"/>
+    </marker>
+    <marker id="a3-arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#047857"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 26px; font-weight: 700; fill: #1e40af; }
+      .subtitle { font-size: 13px; fill: #475569; }
+      .step-title { font-size: 13px; font-weight: 700; fill: #0f172a; }
+      .step-body { font-size: 11px; fill: #334155; }
+      .decision-text { font-size: 13px; font-weight: 700; fill: #92400e; }
+      .edge-label { font-size: 11px; fill: #475569; font-weight: 600; }
+      .success-label { font-size: 13px; font-weight: 700; fill: #047857; }
+      .fail-label { font-size: 13px; font-weight: 700; fill: #b91c1c; }
+      .caption { font-size: 12px; fill: #475569; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="700" y="36" class="title" text-anchor="middle">Acquire Decision: FAIL_FAST vs DIRECT_CREATE</text>
+  <text x="700" y="58" class="subtitle" text-anchor="middle">Execution flow of pool.acquire(sandbox_timeout, policy)</text>
+
+  <!-- Start -->
+  <ellipse cx="700" cy="100" rx="150" ry="26" fill="#eff6ff" stroke="#1e3a5f" stroke-width="2"/>
+  <text x="700" y="105" class="step-title" text-anchor="middle">pool.acquire(timeout, policy)</text>
+
+  <!-- Step: pop from store (decision) -->
+  <polygon points="700,160 900,215 700,270 500,215" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="700" y="205" class="decision-text" text-anchor="middle">pop one idle ID</text>
+  <text x="700" y="225" class="decision-text" text-anchor="middle">from the store</text>
+  <text x="700" y="245" class="step-body" text-anchor="middle">buffer empty?</text>
+
+  <!-- edge Start -> pop -->
+  <path d="M 700 126 L 700 158" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a3-arrow)"/>
+
+  <!-- Decision: TTL check -->
+  <polygon points="700,320 940,375 700,430 460,375" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="700" y="365" class="decision-text" text-anchor="middle">remaining TTL ≥</text>
+  <text x="700" y="385" class="decision-text" text-anchor="middle">acquire_min_remaining_ttl?</text>
+
+  <!-- edge pop -> TTL (got id) -->
+  <path d="M 700 270 L 700 318" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a3-arrow-green)"/>
+  <text x="770" y="298" class="edge-label">got id</text>
+
+  <!-- Discard branch (TTL too small) -->
+  <rect x="1000" y="330" width="290" height="90" fill="#fee2e2" stroke="#b91c1c" stroke-width="1.5" rx="6"/>
+  <text x="1145" y="358" class="step-title" text-anchor="middle">discard + best-effort kill</text>
+  <text x="1145" y="378" class="step-body" text-anchor="middle">avoid returning a soon-to-expire</text>
+  <text x="1145" y="396" class="step-body" text-anchor="middle">sandbox; fall through to policy</text>
+
+  <path d="M 940 375 L 998 375" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a3-arrow-red)"/>
+  <text x="965" y="365" class="edge-label" fill="#b91c1c">no</text>
+
+  <!-- Connect + health -->
+  <rect x="530" y="470" width="340" height="130" fill="#ffffff" stroke="#1e3a5f" stroke-width="2" rx="6"/>
+  <text x="700" y="500" class="step-title" text-anchor="middle">Sandbox.connect(id)</text>
+  <text x="700" y="525" class="step-body" text-anchor="middle">acquire_health_check (skippable)</text>
+  <text x="700" y="545" class="step-body" text-anchor="middle">poll within acquire_ready_timeout</text>
+  <text x="700" y="575" class="step-body" text-anchor="middle" font-weight="700">renew(sandbox_timeout)</text>
+
+  <!-- edge TTL -> Connect (yes) -->
+  <path d="M 700 430 L 700 468" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a3-arrow-green)"/>
+  <text x="720" y="452" class="edge-label" fill="#047857">yes</text>
+
+  <!-- Success -->
+  <ellipse cx="700" cy="660" rx="200" ry="30" fill="#ecfdf5" stroke="#047857" stroke-width="2.5"/>
+  <text x="700" y="666" class="success-label" text-anchor="middle">✓ return Sandbox to caller</text>
+
+  <path d="M 700 600 L 700 628" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a3-arrow-green)"/>
+
+  <!-- Fail branch: candidate failed -->
+  <text x="475" y="530" class="fail-label" text-anchor="end">connect fails /</text>
+  <text x="475" y="548" class="fail-label" text-anchor="end">health check times out</text>
+  <path d="M 530 535 Q 260 535 260 375" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a3-arrow-red)"/>
+
+  <!-- Empty branch: policy decision -->
+  <polygon points="200,215 400,275 200,335 60,275" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="200" y="270" class="decision-text" text-anchor="middle">policy?</text>
+  <text x="200" y="290" class="step-body" text-anchor="middle">(buffer empty or candidate failed)</text>
+
+  <!-- edge pop -> policy (empty) -->
+  <path d="M 500 215 L 402 250" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a3-arrow-red)"/>
+  <text x="450" y="220" class="edge-label" fill="#b91c1c">empty</text>
+
+  <!-- edge discard -> policy -->
+  <path d="M 1145 420 Q 1145 720 300 720 Q 200 720 200 336" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a3-arrow-red)" stroke-dasharray="6,4"/>
+  <text x="700" y="740" class="edge-label" fill="#b91c1c" text-anchor="middle">back to policy decision after discard</text>
+
+  <!-- FAIL_FAST branch -->
+  <rect x="40" y="400" width="320" height="120" fill="#fee2e2" stroke="#b91c1c" stroke-width="2" rx="6"/>
+  <text x="200" y="428" class="step-title" text-anchor="middle" fill="#b91c1c">FAIL_FAST</text>
+  <text x="200" y="454" class="step-body" text-anchor="middle">raise PoolEmptyException /</text>
+  <text x="200" y="472" class="step-body" text-anchor="middle">PoolAcquireFailedException</text>
+  <text x="200" y="500" class="step-body" text-anchor="middle" font-style="italic">← caller decides retry / fallback</text>
+
+  <path d="M 160 335 L 160 398" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a3-arrow-red)"/>
+  <text x="120" y="370" class="edge-label" fill="#b91c1c" text-anchor="middle">FAIL_FAST</text>
+
+  <!-- DIRECT_CREATE branch -->
+  <rect x="40" y="560" width="320" height="180" fill="#ecfdf5" stroke="#047857" stroke-width="2" rx="6"/>
+  <text x="200" y="588" class="step-title" text-anchor="middle" fill="#047857">DIRECT_CREATE (default)</text>
+  <text x="200" y="614" class="step-body" text-anchor="middle">create a new sandbox via</text>
+  <text x="200" y="634" class="step-body" text-anchor="middle">create(creation_spec)</text>
+  <text x="200" y="654" class="step-body" text-anchor="middle">→ wait for ready</text>
+  <text x="200" y="674" class="step-body" text-anchor="middle">→ renew(sandbox_timeout)</text>
+  <text x="200" y="702" class="step-body" text-anchor="middle" font-style="italic">← does not count toward max_idle</text>
+
+  <path d="M 240 335 L 240 558" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a3-arrow-green)"/>
+  <text x="280" y="450" class="edge-label" fill="#047857" text-anchor="middle">DIRECT_CREATE</text>
+
+  <!-- Direct create -> Success -->
+  <path d="M 360 660 L 500 660" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a3-arrow-green)"/>
+
+  <!-- footer -->
+  <text x="700" y="810" class="caption" text-anchor="middle">Each acquire tries one idle candidate. A failed candidate still pays up to acquire_ready_timeout.</text>
+  <text x="700" y="832" class="caption" text-anchor="middle">DIRECT_CREATE fallback does not consume max_idle; max_idle only bounds the warm buffer size.</text>
+</svg>

--- a/docs/public/images/client-pool-architecture.svg
+++ b/docs/public/images/client-pool-architecture.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="720" viewBox="0 0 1400 720" role="img" aria-labelledby="title desc">
+  <title id="title">Client Pool Architecture</title>
+  <desc id="desc">Client pool architecture. Multiple application nodes call pool.acquire on a per-node SandboxPool instance. The pool consists of an any-node acquire path and a leader-only reconcile loop that drives a small pool of warmup workers. The shared PoolStateStore holds only sandbox IDs with expiry and a primary lock. All server-side sandboxes are created via the OpenSandbox Lifecycle API.</desc>
+  <defs>
+    <marker id="a1-arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e3a5f"/>
+    </marker>
+    <marker id="a1-arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+    <marker id="a1-arrow-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c2410c"/>
+    </marker>
+    <marker id="a1-arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#047857"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 26px; font-weight: 700; fill: #1e40af; }
+      .group-title { font-size: 15px; font-weight: 700; }
+      .box-title { font-size: 14px; font-weight: 700; fill: #0f172a; }
+      .box-text { font-size: 12px; fill: #334155; }
+      .edge-label { font-size: 11px; fill: #475569; }
+      .caption { font-size: 12px; fill: #475569; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="700" y="38" class="title" text-anchor="middle">Client Pool Architecture</text>
+
+  <!-- Application nodes -->
+  <g>
+    <rect x="40" y="80" width="280" height="360" fill="#eff6ff" stroke="#1e3a5f" stroke-width="2" rx="8"/>
+    <text x="180" y="108" class="group-title" fill="#1e3a5f" text-anchor="middle">Application nodes (N)</text>
+
+    <rect x="70" y="140" width="220" height="120" fill="#ffffff" stroke="#1e3a5f" stroke-width="1.5" rx="6"/>
+    <text x="180" y="168" class="box-title" text-anchor="middle">App code #1</text>
+    <text x="180" y="192" class="box-text" text-anchor="middle">pool.acquire(...)</text>
+    <text x="180" y="212" class="box-text" text-anchor="middle">sandbox.commands.run(...)</text>
+    <text x="180" y="232" class="box-text" text-anchor="middle">sandbox.destroy()</text>
+
+    <rect x="70" y="290" width="220" height="120" fill="#ffffff" stroke="#1e3a5f" stroke-width="1.5" rx="6"/>
+    <text x="180" y="318" class="box-title" text-anchor="middle">App code #2</text>
+    <text x="180" y="342" class="box-text" text-anchor="middle">pool.acquire(...)</text>
+    <text x="180" y="362" class="box-text" text-anchor="middle">...</text>
+  </g>
+
+  <!-- SandboxPool instance -->
+  <g>
+    <rect x="400" y="80" width="380" height="500" fill="#faf5ff" stroke="#6d28d9" stroke-width="2" rx="8"/>
+    <text x="590" y="108" class="group-title" fill="#6d28d9" text-anchor="middle">SandboxPool instance (per node)</text>
+
+    <rect x="430" y="140" width="320" height="120" fill="#ffffff" stroke="#6d28d9" stroke-width="1.5" rx="6"/>
+    <text x="590" y="168" class="box-title" text-anchor="middle">Acquire path</text>
+    <text x="590" y="188" class="box-text" text-anchor="middle">(runs on every node)</text>
+    <text x="590" y="216" class="box-text" text-anchor="middle">pop idle ID → connect → renew</text>
+    <text x="590" y="236" class="box-text" text-anchor="middle">policy = FAIL_FAST | DIRECT_CREATE</text>
+
+    <rect x="430" y="290" width="320" height="120" fill="#ffffff" stroke="#6d28d9" stroke-width="1.5" rx="6"/>
+    <text x="590" y="318" class="box-title" text-anchor="middle">Reconcile loop</text>
+    <text x="590" y="338" class="box-text" text-anchor="middle">(leader-only replenish / shrink)</text>
+    <text x="590" y="366" class="box-text" text-anchor="middle">fires every reconcile_interval</text>
+    <text x="590" y="386" class="box-text" text-anchor="middle">acquire lock → compute gap → dispatch</text>
+
+    <rect x="430" y="440" width="320" height="120" fill="#ffffff" stroke="#6d28d9" stroke-width="1.5" rx="6"/>
+    <text x="590" y="468" class="box-title" text-anchor="middle">Warmup workers</text>
+    <text x="590" y="488" class="box-text" text-anchor="middle">parallelism = warmup_concurrency</text>
+    <text x="590" y="516" class="box-text" text-anchor="middle">create → ready → (preparer)</text>
+    <text x="590" y="536" class="box-text" text-anchor="middle">→ push id into idle buffer</text>
+  </g>
+
+  <!-- PoolStateStore -->
+  <g>
+    <rect x="860" y="80" width="300" height="360" fill="#fff7ed" stroke="#c2410c" stroke-width="2" rx="8"/>
+    <text x="1010" y="108" class="group-title" fill="#c2410c" text-anchor="middle">PoolStateStore (shared)</text>
+
+    <rect x="890" y="140" width="240" height="180" fill="#ffffff" stroke="#c2410c" stroke-width="1.5" rx="6"/>
+    <text x="1010" y="168" class="box-title" text-anchor="middle">Idle buffer</text>
+    <text x="1010" y="196" class="box-text" text-anchor="middle">[sandbox_id, expiry]</text>
+    <text x="1010" y="216" class="box-text" text-anchor="middle">[sandbox_id, expiry]</text>
+    <text x="1010" y="236" class="box-text" text-anchor="middle">[sandbox_id, expiry]</text>
+    <text x="1010" y="266" class="box-text" text-anchor="middle" font-style="italic">only IDs + expiry</text>
+    <text x="1010" y="286" class="box-text" text-anchor="middle" font-style="italic">no HTTP connections</text>
+    <text x="1010" y="306" class="box-text" text-anchor="middle" font-style="italic">no SDK client objects</text>
+
+    <rect x="890" y="345" width="240" height="80" fill="#ffffff" stroke="#c2410c" stroke-width="1.5" rx="6"/>
+    <text x="1010" y="373" class="box-title" text-anchor="middle">Primary lock</text>
+    <text x="1010" y="395" class="box-text" text-anchor="middle">owner_id + TTL</text>
+    <text x="1010" y="415" class="box-text" text-anchor="middle">default 60s</text>
+  </g>
+
+  <!-- Lifecycle API -->
+  <g>
+    <rect x="860" y="480" width="300" height="100" fill="#ecfdf5" stroke="#047857" stroke-width="2" rx="8"/>
+    <text x="1010" y="510" class="group-title" fill="#047857" text-anchor="middle">OpenSandbox Lifecycle API</text>
+    <text x="1010" y="536" class="box-text" text-anchor="middle">create / connect / renew / destroy</text>
+    <text x="1010" y="556" class="box-text" text-anchor="middle">(server-side sandbox lifecycle)</text>
+  </g>
+
+  <!-- Edges -->
+  <!-- App -> Acquire -->
+  <path d="M 290 200 L 428 200" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a1-arrow-blue)"/>
+  <path d="M 290 350 L 428 220" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a1-arrow-blue)"/>
+
+  <!-- Acquire -> Idle Buffer (pop) -->
+  <path d="M 752 200 L 888 220" stroke="#6d28d9" stroke-width="2" fill="none" marker-end="url(#a1-arrow-purple)"/>
+  <text x="820" y="200" class="edge-label" text-anchor="middle">pop id</text>
+
+  <!-- Reconcile -> Primary Lock -->
+  <path d="M 752 360 L 888 385" stroke="#6d28d9" stroke-width="2" fill="none" marker-end="url(#a1-arrow-purple)"/>
+  <text x="820" y="365" class="edge-label" text-anchor="middle">acquire lock</text>
+
+  <!-- Reconcile -> Warmup Workers -->
+  <path d="M 590 410 L 590 438" stroke="#6d28d9" stroke-width="2" fill="none" marker-end="url(#a1-arrow-purple)"/>
+  <text x="640" y="428" class="edge-label" text-anchor="start">dispatch when gap &gt; 0</text>
+
+  <!-- Warmup -> Lifecycle create -->
+  <path d="M 752 500 L 888 510" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a1-arrow-green)"/>
+  <text x="820" y="500" class="edge-label" text-anchor="middle">create()</text>
+
+  <!-- Warmup -> Idle Buffer (push) -->
+  <path d="M 700 440 Q 800 380 890 240" stroke="#c2410c" stroke-width="2" fill="none" marker-end="url(#a1-arrow-orange)" stroke-dasharray="6,4"/>
+  <text x="810" y="380" class="edge-label" text-anchor="middle">push id</text>
+
+  <!-- Acquire -> Lifecycle (connect / renew) -->
+  <path d="M 752 235 Q 820 400 888 510" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a1-arrow-green)" stroke-dasharray="6,4"/>
+  <text x="770" y="455" class="edge-label" text-anchor="middle">connect / renew</text>
+
+  <text x="700" y="620" class="caption" text-anchor="middle">Acquire runs on every node; reconcile only runs on the node that holds the primary lock.</text>
+  <text x="700" y="642" class="caption" text-anchor="middle">The store holds only IDs + expiry, so switching to Redis makes the pool truly shared across processes / pods.</text>
+</svg>

--- a/docs/public/images/client-pool-lifecycle.svg
+++ b/docs/public/images/client-pool-lifecycle.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="720" viewBox="0 0 1400 720" role="img" aria-labelledby="title desc">
+  <title id="title">Client Pool Lifecycle State Machine</title>
+  <desc id="desc">State machine of the client pool. Lifecycle states NOT_STARTED, STARTING, RUNNING, DRAINING and STOPPED, with an inner health substate machine on RUNNING that toggles between HEALTHY and DEGRADED based on consecutive create failures.</desc>
+  <defs>
+    <marker id="a4-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e3a5f"/>
+    </marker>
+    <marker id="a4-arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b91c1c"/>
+    </marker>
+    <marker id="a4-arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#047857"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 26px; font-weight: 700; fill: #1e40af; }
+      .subtitle { font-size: 13px; fill: #475569; }
+      .state-name { font-size: 15px; font-weight: 700; fill: #0f172a; }
+      .state-hint { font-size: 11px; fill: #475569; }
+      .edge-label { font-size: 12px; fill: #1e3a5f; font-weight: 600; }
+      .edge-label-red { font-size: 12px; fill: #b91c1c; font-weight: 600; }
+      .edge-label-green { font-size: 12px; fill: #047857; font-weight: 600; }
+      .frame-label { font-size: 13px; font-weight: 700; fill: #6d28d9; }
+      .caption { font-size: 12px; fill: #475569; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="700" y="38" class="title" text-anchor="middle">Client Pool Lifecycle State Machine</text>
+  <text x="700" y="60" class="subtitle" text-anchor="middle">Outer: pool instance lifecycle. Inner: health substates while RUNNING.</text>
+
+  <!-- initial dot -->
+  <circle cx="90" cy="240" r="9" fill="#0f172a"/>
+
+  <!-- NOT_STARTED -->
+  <rect x="140" y="200" width="180" height="80" rx="14" fill="#f1f5f9" stroke="#334155" stroke-width="2"/>
+  <text x="230" y="235" class="state-name" text-anchor="middle">NOT_STARTED</text>
+  <text x="230" y="258" class="state-hint" text-anchor="middle">constructed, not started</text>
+
+  <path d="M 99 240 L 138 240" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+
+  <!-- STARTING -->
+  <rect x="380" y="200" width="180" height="80" rx="14" fill="#eff6ff" stroke="#1e3a5f" stroke-width="2"/>
+  <text x="470" y="235" class="state-name" text-anchor="middle">STARTING</text>
+  <text x="470" y="258" class="state-hint" text-anchor="middle">init warmup / reconcile</text>
+
+  <path d="M 320 240 L 378 240" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+  <text x="349" y="228" class="edge-label" text-anchor="middle">start()</text>
+
+  <!-- RUNNING frame (contains inner states) -->
+  <rect x="620" y="130" width="440" height="360" rx="14" fill="#ecfdf5" stroke="#047857" stroke-width="2.5"/>
+  <text x="640" y="156" class="frame-label" fill="#047857">RUNNING</text>
+  <text x="640" y="176" class="state-hint">acquire enabled; reconcile replenishes</text>
+
+  <!-- HEALTHY -->
+  <rect x="670" y="220" width="160" height="80" rx="12" fill="#ffffff" stroke="#047857" stroke-width="2"/>
+  <text x="750" y="253" class="state-name" text-anchor="middle" fill="#047857">HEALTHY</text>
+  <text x="750" y="276" class="state-hint" text-anchor="middle">normal cadence</text>
+
+  <!-- DEGRADED -->
+  <rect x="860" y="380" width="160" height="80" rx="12" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="940" y="413" class="state-name" text-anchor="middle" fill="#92400e">DEGRADED</text>
+  <text x="940" y="436" class="state-hint" text-anchor="middle">exponential backoff</text>
+
+  <!-- HEALTHY -> DEGRADED -->
+  <path d="M 830 300 Q 900 340 890 378" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a4-arrow-red)"/>
+  <text x="885" y="336" class="edge-label-red">consecutive failures ≥ degraded_threshold</text>
+
+  <!-- DEGRADED -> HEALTHY -->
+  <path d="M 870 380 Q 800 340 795 302" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a4-arrow-green)"/>
+  <text x="720" y="366" class="edge-label-green" text-anchor="middle">one success</text>
+
+  <!-- initial dot inside RUNNING -->
+  <circle cx="670" cy="182" r="6" fill="#0f172a"/>
+  <path d="M 675 186 L 720 218" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+
+  <!-- note about acquire allowed in degraded -->
+  <text x="840" y="490" class="caption" text-anchor="middle">acquire is still allowed while DEGRADED</text>
+
+  <!-- STARTING -> RUNNING -->
+  <path d="M 560 240 L 618 240" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+  <text x="589" y="228" class="edge-label" text-anchor="middle">init complete</text>
+
+  <!-- STARTING -> STOPPED (start failure) -->
+  <path d="M 470 280 Q 470 500 470 560" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a4-arrow-red)"/>
+  <text x="490" y="450" class="edge-label-red">start failed</text>
+
+  <!-- DRAINING -->
+  <rect x="380" y="540" width="180" height="80" rx="14" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="470" y="575" class="state-name" text-anchor="middle" fill="#92400e">DRAINING</text>
+  <text x="470" y="598" class="state-hint" text-anchor="middle">wait for in-flight warmups</text>
+
+  <!-- RUNNING -> DRAINING -->
+  <path d="M 780 490 Q 780 580 562 580" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+  <text x="672" y="568" class="edge-label" text-anchor="middle">shutdown(graceful=true)</text>
+
+  <!-- STOPPED -->
+  <rect x="140" y="540" width="180" height="80" rx="14" fill="#f1f5f9" stroke="#334155" stroke-width="2"/>
+  <text x="230" y="575" class="state-name" text-anchor="middle">STOPPED</text>
+  <text x="230" y="598" class="state-hint" text-anchor="middle">terminal</text>
+
+  <!-- DRAINING -> STOPPED -->
+  <path d="M 378 580 L 322 580" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+  <text x="350" y="568" class="edge-label" text-anchor="middle">done or timeout</text>
+
+  <!-- RUNNING -> STOPPED (force) -->
+  <path d="M 620 400 Q 400 400 320 540" stroke="#b91c1c" stroke-width="2" fill="none" marker-end="url(#a4-arrow-red)" stroke-dasharray="6,4"/>
+  <text x="410" y="410" class="edge-label-red">shutdown(graceful=false)</text>
+
+  <!-- final dot -->
+  <circle cx="230" cy="670" r="9" fill="none" stroke="#0f172a" stroke-width="2"/>
+  <circle cx="230" cy="670" r="4" fill="#0f172a"/>
+  <path d="M 230 620 L 230 660" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a4-arrow)"/>
+
+  <text x="700" y="700" class="caption" text-anchor="middle">SandboxPoolManager.destroy(poolName) applies an extra DESTROYING → DESTROYED tombstone protocol to prevent other nodes from silently recreating the same pool name.</text>
+</svg>

--- a/docs/public/images/client-pool-topology.svg
+++ b/docs/public/images/client-pool-topology.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="720" viewBox="0 0 1400 720" role="img" aria-labelledby="title desc">
+  <title id="title">Single-Node vs Distributed Deployment</title>
+  <desc id="desc">Side-by-side comparison of the two deployment topologies. On the left with the in-memory pool state store, each process owns its own idle buffer and pools do not share warmups. On the right with a Redis-backed store, multiple pods share one logical pool: exactly one pod holds the primary lock at any time and drives reconcile, while all pods can acquire from the shared idle buffer.</desc>
+  <defs>
+    <marker id="a5-arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e3a5f"/>
+    </marker>
+    <marker id="a5-arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 26px; font-weight: 700; fill: #1e40af; }
+      .panel-title { font-size: 18px; font-weight: 700; }
+      .box-title { font-size: 14px; font-weight: 700; fill: #0f172a; }
+      .box-text { font-size: 12px; fill: #334155; }
+      .edge-label { font-size: 11px; fill: #475569; }
+      .warn { font-size: 12px; fill: #b91c1c; font-weight: 700; }
+      .ok { font-size: 12px; fill: #047857; font-weight: 700; }
+      .caption { font-size: 12px; fill: #475569; font-style: italic; }
+      .badge-leader { font-size: 11px; font-weight: 700; fill: #ffffff; }
+      .badge-follower { font-size: 11px; font-weight: 700; fill: #ffffff; }
+    </style>
+  </defs>
+
+  <text x="700" y="38" class="title" text-anchor="middle">Single-node vs Distributed Deployment</text>
+
+  <!-- LEFT: Single-node -->
+  <g>
+    <rect x="30" y="80" width="620" height="580" fill="#fef2f2" stroke="#b91c1c" stroke-width="2" rx="10"/>
+    <text x="340" y="112" class="panel-title" fill="#b91c1c" text-anchor="middle">Single-node · InMemoryPoolStateStore</text>
+    <text x="340" y="134" class="caption" text-anchor="middle">Buffer lives in process memory; not shared across processes</text>
+
+    <!-- Process 1 -->
+    <rect x="60" y="170" width="260" height="220" fill="#ffffff" stroke="#334155" stroke-width="1.5" rx="8"/>
+    <text x="190" y="200" class="box-title" text-anchor="middle">Process 1</text>
+    <rect x="90" y="220" width="200" height="60" fill="#eff6ff" stroke="#1e3a5f" stroke-width="1.2" rx="5"/>
+    <text x="190" y="240" class="box-text" text-anchor="middle">SandboxPool</text>
+    <text x="190" y="258" class="box-text" text-anchor="middle" font-style="italic">owner_id=p1</text>
+    <rect x="90" y="300" width="200" height="70" fill="#fff7ed" stroke="#c2410c" stroke-width="1.2" rx="5"/>
+    <text x="190" y="322" class="box-text" text-anchor="middle" font-weight="700">in-process idle buffer</text>
+    <text x="190" y="342" class="box-text" text-anchor="middle">[id_a, id_b]</text>
+    <text x="190" y="360" class="box-text" text-anchor="middle" font-style="italic">max_idle=2</text>
+
+    <!-- Process 2 -->
+    <rect x="360" y="170" width="260" height="220" fill="#ffffff" stroke="#334155" stroke-width="1.5" rx="8"/>
+    <text x="490" y="200" class="box-title" text-anchor="middle">Process 2</text>
+    <rect x="390" y="220" width="200" height="60" fill="#eff6ff" stroke="#1e3a5f" stroke-width="1.2" rx="5"/>
+    <text x="490" y="240" class="box-text" text-anchor="middle">SandboxPool</text>
+    <text x="490" y="258" class="box-text" text-anchor="middle" font-style="italic">owner_id=p2</text>
+    <rect x="390" y="300" width="200" height="70" fill="#fff7ed" stroke="#c2410c" stroke-width="1.2" rx="5"/>
+    <text x="490" y="322" class="box-text" text-anchor="middle" font-weight="700">in-process idle buffer</text>
+    <text x="490" y="342" class="box-text" text-anchor="middle">[id_c, id_d]</text>
+    <text x="490" y="360" class="box-text" text-anchor="middle" font-style="italic">max_idle=2</text>
+
+    <!-- Barrier / no sharing -->
+    <line x1="340" y1="180" x2="340" y2="385" stroke="#b91c1c" stroke-width="1.5" stroke-dasharray="6,4"/>
+    <text x="340" y="405" class="warn" text-anchor="middle">unaware of each other</text>
+
+    <!-- Warnings -->
+    <rect x="60" y="430" width="560" height="200" fill="#ffffff" stroke="#b91c1c" stroke-width="1.5" rx="8"/>
+    <text x="340" y="458" class="box-title" fill="#b91c1c" text-anchor="middle">Common pitfalls</text>
+    <text x="80" y="486" class="box-text">· gunicorn / uvicorn workers: one pool per worker, each with its own max_idle</text>
+    <text x="80" y="508" class="box-text">· Kubernetes replicas: one pool per Pod, actual sandbox count = replicas × max_idle</text>
+    <text x="80" y="530" class="box-text">· Celery workers: tasks land on different workers, no shared warm buffer</text>
+    <text x="80" y="558" class="warn">→ suitable only for dev, tests, and single-instance workers</text>
+    <text x="80" y="586" class="box-text">· Need a truly cross-process / cross-Pod pool?</text>
+    <text x="80" y="608" class="ok">→ switch to the Redis-backed store (see right)</text>
+  </g>
+
+  <!-- RIGHT: Distributed -->
+  <g>
+    <rect x="710" y="80" width="660" height="580" fill="#ecfdf5" stroke="#047857" stroke-width="2" rx="10"/>
+    <text x="1040" y="112" class="panel-title" fill="#047857" text-anchor="middle">Distributed · RedisPoolStateStore</text>
+    <text x="1040" y="134" class="caption" text-anchor="middle">All nodes share one idle buffer and one primary lock</text>
+
+    <!-- Pod A (leader) -->
+    <rect x="740" y="170" width="180" height="140" fill="#ffffff" stroke="#334155" stroke-width="1.5" rx="8"/>
+    <text x="830" y="198" class="box-title" text-anchor="middle">Pod A</text>
+    <rect x="765" y="218" width="130" height="24" fill="#047857" rx="4"/>
+    <text x="830" y="235" class="badge-leader" text-anchor="middle">LEADER</text>
+    <text x="830" y="264" class="box-text" text-anchor="middle">owner_id=a-uuid</text>
+    <text x="830" y="286" class="box-text" text-anchor="middle">acquire + reconcile</text>
+
+    <!-- Pod B -->
+    <rect x="950" y="170" width="180" height="140" fill="#ffffff" stroke="#334155" stroke-width="1.5" rx="8"/>
+    <text x="1040" y="198" class="box-title" text-anchor="middle">Pod B</text>
+    <rect x="975" y="218" width="130" height="24" fill="#6b7280" rx="4"/>
+    <text x="1040" y="235" class="badge-follower" text-anchor="middle">FOLLOWER</text>
+    <text x="1040" y="264" class="box-text" text-anchor="middle">owner_id=b-uuid</text>
+    <text x="1040" y="286" class="box-text" text-anchor="middle">acquire only</text>
+
+    <!-- Pod C -->
+    <rect x="1160" y="170" width="180" height="140" fill="#ffffff" stroke="#334155" stroke-width="1.5" rx="8"/>
+    <text x="1250" y="198" class="box-title" text-anchor="middle">Pod C</text>
+    <rect x="1185" y="218" width="130" height="24" fill="#6b7280" rx="4"/>
+    <text x="1250" y="235" class="badge-follower" text-anchor="middle">FOLLOWER</text>
+    <text x="1250" y="264" class="box-text" text-anchor="middle">owner_id=c-uuid</text>
+    <text x="1250" y="286" class="box-text" text-anchor="middle">acquire only</text>
+
+    <!-- Redis -->
+    <rect x="810" y="380" width="460" height="150" fill="#fff7ed" stroke="#c2410c" stroke-width="2" rx="10"/>
+    <text x="1040" y="410" class="box-title" fill="#c2410c" text-anchor="middle">Redis</text>
+    <text x="1040" y="432" class="box-text" text-anchor="middle" font-style="italic">key_prefix = opensandbox:pool:prod</text>
+    <text x="1040" y="452" class="box-text" text-anchor="middle" font-style="italic">pool_name  = demo-pool</text>
+    <line x1="820" y1="464" x2="1260" y2="464" stroke="#c2410c" stroke-width="1" stroke-dasharray="4,4"/>
+    <text x="1040" y="486" class="box-text" text-anchor="middle" font-weight="700">shared idle buffer: [id_a, id_b, id_c, id_d, ...]</text>
+    <text x="1040" y="508" class="box-text" text-anchor="middle" font-weight="700">primary lock: holder = a-uuid, TTL 60s</text>
+
+    <!-- Edges Pod A -> Redis (acquire + reconcile) -->
+    <path d="M 830 310 L 950 378" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#a5-arrow-purple)" stroke-dasharray="6,4"/>
+    <text x="820" y="360" class="edge-label" fill="#047857" text-anchor="end">acquire + lock + replenish</text>
+
+    <!-- Pod B -> Redis (acquire only) -->
+    <path d="M 1040 310 L 1040 378" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a5-arrow-blue)" stroke-dasharray="6,4"/>
+    <text x="1075" y="345" class="edge-label" text-anchor="start">acquire</text>
+
+    <!-- Pod C -> Redis -->
+    <path d="M 1250 310 L 1130 378" stroke="#1e3a5f" stroke-width="2" fill="none" marker-end="url(#a5-arrow-blue)" stroke-dasharray="6,4"/>
+    <text x="1250" y="360" class="edge-label" text-anchor="start">acquire</text>
+
+    <!-- Notes -->
+    <rect x="740" y="555" width="600" height="90" fill="#ffffff" stroke="#047857" stroke-width="1.5" rx="8"/>
+    <text x="760" y="580" class="box-text">· All nodes share the same pool_name + key_prefix + creation_spec</text>
+    <text x="760" y="600" class="box-text">· Each process needs a unique owner_id (identifies the lock holder, not the pool)</text>
+    <text x="760" y="620" class="box-text">· Only the leader replenishes; if it dies, another node takes over after primary_lock_ttl</text>
+    <text x="760" y="640" class="ok">→ the only correct choice for production (multi-process / multi-Pod)</text>
+  </g>
+</svg>

--- a/docs/public/images/client-pool-warmup-sequence.svg
+++ b/docs/public/images/client-pool-warmup-sequence.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" role="img" aria-labelledby="title desc">
+  <title id="title">Warmup Reconcile Sequence</title>
+  <desc id="desc">Sequence diagram of the warmup reconcile loop on the leader node. A timer ticks every reconcile_interval, the loop tries to acquire the primary lock, and only if it succeeds does it count idle sandboxes and dispatch warmup workers to create new ones and push their IDs into the shared idle buffer. Non-leader ticks return immediately.</desc>
+  <defs>
+    <marker id="a2-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e3a5f"/>
+    </marker>
+    <marker id="a2-arrow-ret" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+    <style>
+      text { font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .title { font-size: 26px; font-weight: 700; fill: #1e40af; }
+      .actor { font-size: 14px; font-weight: 700; fill: #0f172a; }
+      .msg { font-size: 12px; fill: #1e3a5f; }
+      .ret { font-size: 12px; fill: #6d28d9; font-style: italic; }
+      .note { font-size: 12px; fill: #92400e; }
+      .caption { font-size: 12px; fill: #475569; font-style: italic; }
+      .phase { font-size: 13px; font-weight: 700; fill: #c2410c; }
+      .lifeline { stroke: #94a3b8; stroke-dasharray: 4,4; }
+      .actor-box { fill: #eff6ff; stroke: #1e3a5f; stroke-width: 1.5; rx: 6; }
+    </style>
+  </defs>
+
+  <text x="700" y="38" class="title" text-anchor="middle">Warmup Reconcile Sequence (Leader node)</text>
+
+  <!-- Actor headers -->
+  <g>
+    <rect x="60" y="70" width="160" height="42" class="actor-box"/>
+    <text x="140" y="97" class="actor" text-anchor="middle">Timer</text>
+
+    <rect x="320" y="70" width="180" height="42" class="actor-box"/>
+    <text x="410" y="97" class="actor" text-anchor="middle">Reconcile Loop</text>
+
+    <rect x="600" y="70" width="180" height="42" class="actor-box"/>
+    <text x="690" y="97" class="actor" text-anchor="middle">PoolStateStore</text>
+
+    <rect x="880" y="70" width="180" height="42" class="actor-box"/>
+    <text x="970" y="97" class="actor" text-anchor="middle">Warmup Worker</text>
+
+    <rect x="1160" y="70" width="180" height="42" class="actor-box"/>
+    <text x="1250" y="97" class="actor" text-anchor="middle">Lifecycle API</text>
+  </g>
+
+  <!-- Lifelines -->
+  <line x1="140" y1="112" x2="140" y2="830" class="lifeline"/>
+  <line x1="410" y1="112" x2="410" y2="830" class="lifeline"/>
+  <line x1="690" y1="112" x2="690" y2="830" class="lifeline"/>
+  <line x1="970" y1="112" x2="970" y2="830" class="lifeline"/>
+  <line x1="1250" y1="112" x2="1250" y2="830" class="lifeline"/>
+
+  <!-- 1. tick -->
+  <path d="M 140 160 L 408 160" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="274" y="152" class="msg" text-anchor="middle">1. tick (every reconcile_interval)</text>
+
+  <!-- 2. acquireLock -->
+  <path d="M 410 200 L 688 200" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="549" y="192" class="msg" text-anchor="middle">2. acquireLock(owner_id, ttl=primary_lock_ttl)</text>
+
+  <!-- alt frame: lock not acquired -->
+  <rect x="380" y="220" width="720" height="70" fill="#fef3c7" stroke="#92400e" stroke-width="1" rx="4" opacity="0.35"/>
+  <text x="395" y="240" class="phase">alt  lock not acquired (skip this tick)</text>
+  <path d="M 688 260 L 412 260" stroke="#6d28d9" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow-ret)" stroke-dasharray="5,3"/>
+  <text x="550" y="252" class="ret" text-anchor="middle">false</text>
+  <text x="410" y="282" class="note">→ Reconcile Loop returns immediately and waits for the next tick</text>
+
+  <!-- else frame: lock acquired -->
+  <rect x="380" y="310" width="960" height="470" fill="#ecfdf5" stroke="#047857" stroke-width="1" rx="4" opacity="0.25"/>
+  <text x="395" y="330" class="phase">else  lock acquired → leader replenishes</text>
+
+  <!-- 3. count / reap -->
+  <path d="M 410 360 L 688 360" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="549" y="352" class="msg" text-anchor="middle">3. count idle &amp; reap expired entries</text>
+
+  <!-- return N -->
+  <path d="M 688 400 L 412 400" stroke="#6d28d9" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow-ret)" stroke-dasharray="5,3"/>
+  <text x="550" y="392" class="ret" text-anchor="middle">idle_count = N</text>
+
+  <!-- gap comment -->
+  <text x="410" y="430" class="note">// gap = max_idle − N; dispatch gap create tasks (max parallelism = warmup_concurrency)</text>
+
+  <!-- loop frame -->
+  <rect x="440" y="450" width="890" height="290" fill="#faf5ff" stroke="#6d28d9" stroke-width="1" rx="4" opacity="0.35"/>
+  <text x="455" y="470" class="phase" fill="#6d28d9">loop  gap times</text>
+
+  <!-- 4. dispatch -->
+  <path d="M 410 500 L 968 500" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="689" y="492" class="msg" text-anchor="middle">4. dispatch create task</text>
+
+  <!-- 5. create -->
+  <path d="M 970 540 L 1248 540" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="1109" y="532" class="msg" text-anchor="middle">5. create(creation_spec)</text>
+
+  <!-- 5r. sandbox_id -->
+  <path d="M 1250 580 L 972 580" stroke="#6d28d9" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow-ret)" stroke-dasharray="5,3"/>
+  <text x="1110" y="572" class="ret" text-anchor="middle">sandbox_id</text>
+
+  <!-- 6. wait ready -->
+  <path d="M 970 620 L 1248 620" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="1109" y="612" class="msg" text-anchor="middle">6. wait ready (≤ warmup_ready_timeout)</text>
+
+  <!-- 7. optional health check + preparer -->
+  <text x="990" y="655" class="note">opt: warmup_health_check</text>
+  <text x="990" y="675" class="note">opt: warmup_sandbox_preparer</text>
+
+  <!-- 8. push -->
+  <path d="M 970 715 L 692 715" stroke="#1e3a5f" stroke-width="1.8" fill="none" marker-end="url(#a2-arrow)"/>
+  <text x="830" y="707" class="msg" text-anchor="middle">7. push(sandbox_id, expiry = now + idle_timeout)</text>
+
+  <!-- footer notes -->
+  <text x="60" y="800" class="caption">After degraded_threshold consecutive failures the pool enters DEGRADED and applies exponential backoff (acquire still works).</text>
+  <text x="60" y="820" class="caption">primary_lock_ttl must exceed warmup_ready_timeout + preparer time, or you risk "lock expired → two leaders replenishing at once".</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds a new cross-SDK guide at `docs/guides/client-pool.md` that documents the experimental client-side sandbox pool available in the Python, Kotlin/Java, and Go SDKs.

## Why a new guide

Client-pool coverage today is split across three per-SDK reference pages (`docs/sdks/python.md`, `docs/sdks/kotlin.md`, `docs/sdks/go.md`). The concept, semantics, and deployment model are cross-language, so this guide follows the repository docs rule of putting cross-cutting long-form content under `docs/` while leaving per-language surface in `docs/sdks/`.

## Contents

- **What the pool actually pools** — sandbox IDs on the server, not HTTP connections and not SDK client objects
- **Warmup vs acquire paths** — leader-only reconcile with a small warmup worker pool; acquire runs on every node
- **AcquirePolicy** — `FAIL_FAST` vs `DIRECT_CREATE` (the two policies currently on `main`; the retry variants on the feature branch aren't included)
- **Configuration** — canonical parameter table with defaults, matching current SDK source of truth
- **State stores** — `InMemoryPoolStateStore` vs Redis-backed store, with the distributed-deployment invariants
- **Minimal usage** — one runnable example each for Python sync, Python asyncio, Kotlin/Java, and Go
- **Diagnostics** — `snapshot`, `snapshot_idle_entries`, `resize`, `release_all_idle`, and `SandboxPoolManager.destroy`

## Diagrams

Five hand-drawn SVGs under `docs/public/images/client-pool-*.svg`, matching the visual style of the existing `architecture-overview.svg` (monospace font, same palette, `<title>`/`<desc>` for accessibility):

| File | Illustrates |
|---|---|
| `client-pool-architecture.svg` | Application nodes ↔ SandboxPool ↔ shared PoolStateStore ↔ Lifecycle API |
| `client-pool-warmup-sequence.svg` | Leader-only reconcile tick: lock → count → dispatch → create → ready → push |
| `client-pool-acquire-decision.svg` | pop → TTL check → connect/health/renew → success, with FAIL_FAST / DIRECT_CREATE branches |
| `client-pool-lifecycle.svg` | `NOT_STARTED → STARTING → RUNNING → DRAINING → STOPPED` with the `HEALTHY ↔ DEGRADED` substates |
| `client-pool-topology.svg` | Single-node in-memory pool vs multi-Pod Redis-backed pool |

## Files changed

- **New**: `docs/guides/client-pool.md`
- **New**: 5 SVGs under `docs/public/images/`
- **Edit**: `docs/.vitepress/config.mts` — register the new page in the guides sidebar

## Verification

- `xmllint --noout` passes on all 5 SVGs
- Non-ASCII scan (`[\u4e00-\u9fff]`) confirms all diagram text is English
- `pnpm docs:build` completes with zero errors
- Verified locally with `pnpm docs:dev` on http://127.0.0.1:5173/guides/client-pool

## Notes

- Guide reflects `main` behavior. It intentionally does **not** document the `RETRY_NEXT_IDLE` / `RETRY_NEXT_IDLE_THEN_CREATE` policies or `max_acquire_retries`, since those live on an unmerged feature branch. When that branch lands, the AcquirePolicy section and configuration table can be extended in a follow-up.
- No SDK code, spec, or public API changes.