### PR TITLE
fix(execd): fall back to sh for PTY sessions

### DIFF
--- a/components/execd/PTY.md
+++ b/components/execd/PTY.md
@@ -1,6 +1,6 @@
 # Interactive PTY sessions
 
-Use this when you need a **long-lived Bash** driven over **WebSocket**: PTY mode behaves like a real terminal (colors, `stty`, resize); **pipe mode** (`pty=0`) splits stdout/stderr without a TTY. **Unix/macOS/Linux only** — not supported on Windows.
+Use this when you need a **long-lived shell** driven over **WebSocket**: PTY mode behaves like a real terminal (colors, `stty`, resize); **pipe mode** (`pty=0`) splits stdout/stderr without a TTY. execd uses Bash when available and falls back to `sh` on minimal images without Bash. **Unix/macOS/Linux only** — not supported on Windows.
 
 ## Typical usage
 
@@ -27,9 +27,9 @@ Use this when you need a **long-lived Bash** driven over **WebSocket**: PTY mode
 
 3. **Traffic** — after a JSON `connected` frame, the server sends **binary** chunks: first byte is the channel (`0x01` stdout, `0x02` stderr in pipe mode only, `0x03` replay with an 8-byte offset header). Send **stdin** as binary: `0x00` + raw bytes. For **resize** / **signals** / **ping**, send **JSON text** frames, e.g. `{"type":"resize","cols":120,"rows":40}`, `{"type":"signal","signal":"SIGINT"}`, `{"type":"ping"}`.
 
-4. **One WebSocket per session** — a second connection gets **409** until the first closes, unless it passes **`?takeover=1`**: the current holder is then closed with WebSocket code **4001** (reason `TAKEN_OVER`) and the new connection takes over the **same** shell. This lets a session move between clients/devices without restarting Bash.
+4. **One WebSocket per session** — a second connection gets **409** until the first closes, unless it passes **`?takeover=1`**: the current holder is then closed with WebSocket code **4001** (reason `TAKEN_OVER`) and the new connection takes over the **same** shell. This lets a session move between clients/devices without restarting the shell.
 
-5. **End** — when Bash exits, you get a JSON `exit` frame with `exit_code` and the socket closes. Use **`DELETE /pty/:id`** to tear down the session from the server side.
+5. **End** — when the shell exits, you get a JSON `exit` frame with `exit_code` and the socket closes. Use **`DELETE /pty/:id`** to tear down the session from the server side.
 
 ## Modes
 
@@ -38,5 +38,6 @@ Use this when you need a **long-lived Bash** driven over **WebSocket**: PTY mode
 
 ## Notes
 
+- Commands running under the `sh` fallback must use syntax supported by the image's `sh` implementation.
 - Output is also buffered for **replay**; reconnect with `since=` to catch up.
 - In PTY streams, **shell echo** may appear before your command’s real output, so avoid matching only on text that also appears in the typed line.

--- a/components/execd/pkg/runtime/pty_session.go
+++ b/components/execd/pkg/runtime/pty_session.go
@@ -64,7 +64,7 @@ func NewPTYSessionID() string {
 	return uuidString()
 }
 
-// ptySession manages a single interactive PTY or pipe-mode bash process.
+// ptySession manages a single interactive PTY or pipe-mode shell process.
 //
 // Lifecycle:
 //  1. Create via newPTYSession.
@@ -75,7 +75,7 @@ func NewPTYSessionID() string {
 type ptySession struct {
 	id      string
 	cwd     string
-	command string // optional custom command; defaults to bash if empty
+	command string // optional custom command interpreted by the selected shell
 
 	mu      sync.Mutex
 	closing bool
@@ -187,7 +187,7 @@ func (s *ptySession) TakeoverWS(timeout time.Duration) bool {
 	}
 }
 
-// IsRunning returns true if the bash process is currently alive.
+// IsRunning returns true if the shell process is currently alive.
 func (s *ptySession) IsRunning() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -219,7 +219,21 @@ func (s *ptySession) ReplayBuffer() *replayBuffer {
 	return s.replay
 }
 
-// StartPTY launches bash via pty.StartWithSize.
+// buildPTYCommand selects Bash when available and otherwise falls back to sh.
+// Bash startup flags must not be passed to sh because they are not portable.
+func buildPTYCommand(command string) *exec.Cmd {
+	shell := getShell()
+	var args []string
+	if shell == "bash" {
+		args = append(args, "--norc", "--noprofile")
+	}
+	if command != "" {
+		args = append(args, "-c", command)
+	}
+	return exec.Command(shell, args...)
+}
+
+// StartPTY launches the preferred shell via pty.StartWithSize.
 // Must be called with the WS lock held.
 func (s *ptySession) StartPTY() error {
 	s.mu.Lock()
@@ -232,11 +246,7 @@ func (s *ptySession) StartPTY() error {
 		return errors.New("pty session is closing")
 	}
 
-	cmdArgs := []string{"--norc", "--noprofile"}
-	if s.command != "" {
-		cmdArgs = append(cmdArgs, "-c", s.command)
-	}
-	cmd := exec.Command("bash", cmdArgs...)
+	cmd := buildPTYCommand(s.command)
 	cmd.Env = os.Environ()
 	if s.cwd != "" {
 		cmd.Dir = s.cwd
@@ -261,7 +271,7 @@ func (s *ptySession) StartPTY() error {
 	return nil
 }
 
-// StartPipe launches bash with plain stdin/stdout/stderr os.Pipes.
+// StartPipe launches the preferred shell with plain stdin/stdout/stderr os.Pipes.
 // Must be called with the WS lock held.
 func (s *ptySession) StartPipe() error {
 	s.mu.Lock()
@@ -293,11 +303,7 @@ func (s *ptySession) StartPipe() error {
 		return fmt.Errorf("stderr pipe: %w", err)
 	}
 
-	cmdArgs := []string{"--norc", "--noprofile"}
-	if s.command != "" {
-		cmdArgs = append(cmdArgs, "-c", s.command)
-	}
-	cmd := exec.Command("bash", cmdArgs...)
+	cmd := buildPTYCommand(s.command)
 	cmd.Env = os.Environ()
 	if s.cwd != "" {
 		cmd.Dir = s.cwd
@@ -429,7 +435,7 @@ func (s *ptySession) waitAndExitPipe(cmd *exec.Cmd, stdinW, stdoutR, stderrR *os
 	close(doneCh)
 }
 
-// WriteStdin writes p to bash stdin (PTY master or pipe write-end).
+// WriteStdin writes p to shell stdin (PTY master or pipe write-end).
 func (s *ptySession) WriteStdin(p []byte) (int, error) {
 	s.mu.Lock()
 	w := s.stdin

--- a/components/execd/pkg/runtime/pty_session_test.go
+++ b/components/execd/pkg/runtime/pty_session_test.go
@@ -20,7 +20,9 @@ package runtime
 import (
 	"bufio"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +45,48 @@ func replayContains(t *testing.T, s *ptySession, substr string, timeout time.Dur
 		time.Sleep(25 * time.Millisecond)
 	}
 	return false
+}
+
+func TestPTYSession_FallsBackToSh(t *testing.T) {
+	shPath, err := exec.LookPath("sh")
+	require.NoError(t, err, "sh is required to test the fallback")
+	shPath, err = filepath.Abs(shPath)
+	require.NoError(t, err)
+
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(shPath, filepath.Join(binDir, "sh")))
+	t.Setenv("PATH", binDir)
+	require.Equal(t, "sh", getShell())
+
+	t.Run("pty", func(t *testing.T) {
+		s := newPTYSession(uuidString(), "", "printf fallback_pty")
+		require.NoError(t, s.StartPTY())
+		t.Cleanup(func() { s.close() })
+
+		require.True(t, replayContains(t, s, "fallback_pty", 5*time.Second),
+			"expected custom command output from sh in PTY mode")
+	})
+
+	t.Run("pipe", func(t *testing.T) {
+		s := newPTYSession(uuidString(), "", "")
+		require.NoError(t, s.StartPipe())
+		t.Cleanup(func() { s.close() })
+
+		stdoutR, _, detach := s.AttachOutput()
+		defer detach()
+		stdoutCh := make(chan string, 1)
+		safego.Go(func() {
+			sc := bufio.NewScanner(stdoutR)
+			for sc.Scan() {
+				stdoutCh <- sc.Text()
+			}
+		})
+
+		_, writeErr := s.WriteStdin([]byte("printf 'fallback_pipe\\n'\nexit\n"))
+		require.NoError(t, writeErr)
+		require.True(t, waitForLine(stdoutCh, "fallback_pipe", 5*time.Second),
+			"expected interactive command output from sh in pipe mode")
+	})
 }
 
 func TestPTYSession_BasicExecution(t *testing.T) {

--- a/components/execd/pkg/web/controller/pty_ws.go
+++ b/components/execd/pkg/web/controller/pty_ws.go
@@ -58,7 +58,7 @@ const (
 //  3. Upgrade HTTP → WebSocket
 //     3b. Takeover (if requested): evict the holder and acquire — only now that the
 //     handshake is accepted, so a failed upgrade never evicts anyone
-//  4. Start bash if not already running
+//  4. Start the shell if not already running
 //     5+6. AtomicAttachOutputWithSnapshot (snapshot + attach under outMu — no loss window)
 //  7. defer: detach → pumpWg.Wait → UnlockWS → ClearEvictHandler (hook live through cleanup)
 //     Register close-only eviction hook (before initial writes, so a stalled replay can
@@ -131,7 +131,7 @@ func PTYSessionWebSocket(ctx *gin.Context) {
 	pipeMode := ctx.Query("pty") == "0"
 	since := queryInt64(ctx.Query("since"), 0)
 
-	// 4. Start bash if not already running.
+	// 4. Start the shell if not already running.
 	if !session.IsRunning() {
 		var startErr error
 		if pipeMode {

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -50,6 +50,10 @@ curl -v http://localhost:44772/ping
   - PTY over WebSocket (`/pty`)
   - Local metrics endpoints (`/metrics`, `/metrics/watch`)
 
+PTY sessions use Bash when it is available and fall back to `sh` on minimal
+images that do not include Bash. Commands submitted to a fallback session must
+use syntax supported by that image's `sh` implementation.
+
 ## Isolated Sessions
 
 Isolated sessions run a bash process inside a per-execution


### PR DESCRIPTION
# Summary
- Reuse execd's existing Bash-to-`sh` shell selection for PTY and pipe-mode sessions.
- Keep Bash's `--norc --noprofile` flags when Bash is present without passing unsupported flags to `sh`.
- Add `sh`-only coverage for custom PTY commands and interactive pipe sessions, and document the fallback and shell-syntax caveat.

Closes #1358.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:

- `cd components/execd && go test ./pkg/runtime ./pkg/web/controller -count=1`
- `cd components/execd && go vet ./pkg/runtime ./pkg/web/controller`
- `cd docs && corepack pnpm docs:build`
- `git diff --check upstream/main...HEAD`

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
