### PR TITLE
fix(execd): fall back to sh in bash and isolated sessions

### DIFF
--- a/components/execd/pkg/runtime/bash_session.go
+++ b/components/execd/pkg/runtime/bash_session.go
@@ -223,8 +223,8 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 	cmd.Stderr = cmd.Stdout
 
 	if err := cmd.Start(); err != nil {
-		log.Error("start shell session failed: %v (command: %q)", err, log.SanitizeCommand(request.Code))
-		return fmt.Errorf("start shell: %w", err)
+		log.Error("start %s session failed: %v (command: %q)", shell, err, log.SanitizeCommand(request.Code))
+		return fmt.Errorf("start %s: %w", shell, err)
 	}
 	defer s.untrackCurrentProcess()
 	s.trackCurrentProcess(cmd.Process.Pid)
@@ -410,7 +410,7 @@ func parseExportLine(line string) (string, string, bool) {
 		raw := rest[eq+1:]
 		if unquoted, err := strconv.Unquote(raw); err == nil {
 			value = unquoted
-		} else if strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'") {
+		} else if len(raw) >= 2 && strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'") {
 			// POSIX shells commonly emit single-quoted values and represent an
 			// embedded quote by ending the quote, escaping it, and reopening it.
 			value = strings.ReplaceAll(raw[1:len(raw)-1], `'\''`, `'`)

--- a/components/execd/pkg/runtime/bash_session.go
+++ b/components/execd/pkg/runtime/bash_session.go
@@ -205,7 +205,13 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 		return fmt.Errorf("close script file: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "bash", "--noprofile", "--norc", scriptPath)
+	shell := getShell()
+	args := make([]string, 0, 3)
+	if shell == "bash" {
+		args = append(args, "--noprofile", "--norc")
+	}
+	args = append(args, scriptPath)
+	cmd := exec.CommandContext(ctx, shell, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// Do not pass envSnapshot via cmd.Env to avoid "argument list too long" when session env is large.
 	// Child inherits parent env (nil => default in Go). The script file already has "export K=V" for
@@ -217,8 +223,8 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 	cmd.Stderr = cmd.Stdout
 
 	if err := cmd.Start(); err != nil {
-		log.Error("start bash session failed: %v (command: %q)", err, log.SanitizeCommand(request.Code))
-		return fmt.Errorf("start bash: %w", err)
+		log.Error("start shell session failed: %v (command: %q)", err, log.SanitizeCommand(request.Code))
+		return fmt.Errorf("start shell: %w", err)
 	}
 	defer s.untrackCurrentProcess()
 	s.trackCurrentProcess(cmd.Process.Pid)
@@ -385,21 +391,32 @@ func parseExportDump(lines []string) map[string]string {
 }
 
 func parseExportLine(line string) (string, string, bool) {
-	const prefix = "declare -x "
-	if !strings.HasPrefix(line, prefix) {
+	var rest string
+	switch {
+	case strings.HasPrefix(line, "declare -x "):
+		rest = strings.TrimSpace(strings.TrimPrefix(line, "declare -x "))
+	case strings.HasPrefix(line, "export "):
+		rest = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+	default:
 		return "", "", false
 	}
-	rest := strings.TrimSpace(strings.TrimPrefix(line, prefix))
 	if rest == "" {
 		return "", "", false
 	}
+
 	name, value := rest, ""
 	if eq := strings.Index(rest, "="); eq >= 0 {
 		name = rest[:eq]
 		raw := rest[eq+1:]
 		if unquoted, err := strconv.Unquote(raw); err == nil {
 			value = unquoted
+		} else if strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'") {
+			// POSIX shells commonly emit single-quoted values and represent an
+			// embedded quote by ending the quote, escaping it, and reopening it.
+			value = strings.ReplaceAll(raw[1:len(raw)-1], `'\''`, `'`)
 		} else {
+			// Preserve the previous best-effort behavior for shell-specific
+			// formats such as Bash ANSI-C quoting.
 			value = strings.Trim(raw, `"`)
 		}
 	}

--- a/components/execd/pkg/runtime/bash_session_test.go
+++ b/components/execd/pkg/runtime/bash_session_test.go
@@ -123,6 +123,7 @@ func TestParseExportLine_BashAndShFormats(t *testing.T) {
 		{name: "sh", line: `export FOO='hello world'`, wantName: "FOO", wantValue: "hello world", wantOK: true},
 		{name: "sh escaped quote", line: `export FOO='it'\''s'`, wantName: "FOO", wantValue: "it's", wantOK: true},
 		{name: "empty", line: `export FOO=""`, wantName: "FOO", wantValue: "", wantOK: true},
+		{name: "lone quote", line: `export FOO='`, wantName: "FOO", wantValue: "'", wantOK: true},
 	}
 
 	for _, tt := range tests {

--- a/components/execd/pkg/runtime/bash_session_test.go
+++ b/components/execd/pkg/runtime/bash_session_test.go
@@ -88,6 +88,53 @@ func TestBashSession_NonZeroExitEmitsError(t *testing.T) {
 	}
 }
 
+func TestBashSession_FallsBackToSh(t *testing.T) {
+	useShOnlyPath(t)
+
+	session := newBashSession("")
+	t.Cleanup(func() { _ = session.close() })
+	require.NoError(t, session.start())
+
+	require.NoError(t, session.run(context.Background(), &ExecuteCodeRequest{
+		Code:    "export FALLBACK_VALUE='hello world'",
+		Timeout: 3 * time.Second,
+	}))
+
+	var stdoutLines []string
+	require.NoError(t, session.run(context.Background(), &ExecuteCodeRequest{
+		Code:    `printf '%s\n' "$FALLBACK_VALUE"`,
+		Timeout: 3 * time.Second,
+		Hooks: ExecuteResultHook{
+			OnExecuteStdout: func(line string) { stdoutLines = append(stdoutLines, line) },
+		},
+	}))
+	require.Contains(t, stdoutLines, "hello world")
+}
+
+func TestParseExportLine_BashAndShFormats(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantName  string
+		wantValue string
+		wantOK    bool
+	}{
+		{name: "bash", line: `declare -x FOO="hello world"`, wantName: "FOO", wantValue: "hello world", wantOK: true},
+		{name: "sh", line: `export FOO='hello world'`, wantName: "FOO", wantValue: "hello world", wantOK: true},
+		{name: "sh escaped quote", line: `export FOO='it'\''s'`, wantName: "FOO", wantValue: "it's", wantOK: true},
+		{name: "empty", line: `export FOO=""`, wantName: "FOO", wantValue: "", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotValue, gotOK := parseExportLine(tt.line)
+			require.Equal(t, tt.wantOK, gotOK)
+			require.Equal(t, tt.wantName, gotName)
+			require.Equal(t, tt.wantValue, gotValue)
+		})
+	}
+}
+
 func TestBashSession_envAndExitCode(t *testing.T) {
 	session := newBashSession("")
 	t.Cleanup(func() { _ = session.close() })
@@ -440,7 +487,7 @@ exec /tmp/exec_child.sh
 	require.NoError(t, session.run(context.Background(), request), "expected exec to complete without killing the session")
 	require.True(t, containsLine(stdoutLines, "child says hi"), "expected child output, got %v", stdoutLines)
 
-	// Subsequent run should still work because we restart bash per run.
+	// Subsequent run should still work because we restart the shell per run.
 	request = &ExecuteCodeRequest{
 		Code:    "echo still-alive",
 		Hooks:   hooks,

--- a/components/execd/pkg/runtime/isolated_session.go
+++ b/components/execd/pkg/runtime/isolated_session.go
@@ -145,7 +145,7 @@ func (s *isolatedSession) start() error {
 		for _, f := range cmd.ExtraFiles {
 			f.Close()
 		}
-		return err
+		return fmt.Errorf("start %s: %w", shell, err)
 	}
 
 	for _, f := range cmd.ExtraFiles {

--- a/components/execd/pkg/runtime/isolated_session.go
+++ b/components/execd/pkg/runtime/isolated_session.go
@@ -43,7 +43,7 @@ type IsolatedSessionOptions struct {
 	IdleTimeoutSeconds int
 }
 
-// isolatedSession holds a long-running bash process inside a bwrap namespace.
+// isolatedSession holds a long-running shell process inside a bwrap namespace.
 type isolatedSession struct {
 	id        string
 	mu        sync.RWMutex
@@ -72,9 +72,14 @@ func newIsolatedSession(id string, opts *IsolatedSessionOptions, iso isolation.I
 	}
 }
 
-// start launches bwrap + bash inside a namespace.
+// start launches bwrap and the preferred shell inside a namespace.
 func (s *isolatedSession) start() error {
-	cmd := exec.Command("bash", "--noprofile", "--norc")
+	shell := getShell()
+	var args []string
+	if shell == "bash" {
+		args = append(args, "--noprofile", "--norc")
+	}
+	cmd := exec.Command(shell, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	wrapOpts := isolation.WrapOptions{

--- a/components/execd/pkg/runtime/isolated_session_ctrl.go
+++ b/components/execd/pkg/runtime/isolated_session_ctrl.go
@@ -145,7 +145,7 @@ func (r *IsolatedRunner) Available() bool {
 	return r.isolator.Available()
 }
 
-// CreateIsolatedSession starts a new bwrap + bash session.
+// CreateIsolatedSession starts a new bwrap + shell session.
 func (r *IsolatedRunner) CreateIsolatedSession(opts *IsolatedSessionOptions) (string, error) {
 	if err := r.validateExtraWritable(opts.ExtraWritable); err != nil {
 		return "", err
@@ -328,7 +328,7 @@ type StdoutCallback func(line string)
 
 // RunInIsolatedSession executes code in the session.
 // Runs are serialized per session via s.runMu.
-// envs are exported in the bash session before code runs.
+// envs are exported in the shell session before code runs.
 func (r *IsolatedRunner) RunInIsolatedSession(ctx context.Context, id string, code string, envs map[string]string, onStdout StdoutCallback) error {
 	s := r.lookup(id)
 	if s == nil {
@@ -375,8 +375,8 @@ func (r *IsolatedRunner) RunInIsolatedSession(ctx context.Context, id string, co
 	script += fmt.Sprintf("echo %s $?\n", runMarker)
 
 	// On timeout/cancel, send SIGINT to interrupt the running command
-	// without killing the persistent bash session. Closing stdin would
-	// terminate bash entirely.
+	// without killing the persistent shell session. Closing stdin would
+	// terminate the shell entirely.
 	done := make(chan struct{})
 	defer close(done)
 	go func() {

--- a/components/execd/pkg/runtime/isolated_session_test.go
+++ b/components/execd/pkg/runtime/isolated_session_test.go
@@ -175,6 +175,31 @@ func TestSetprivIdentitySwitchRequired(t *testing.T) {
 	}
 }
 
+func TestIsolatedSession_FallsBackToSh(t *testing.T) {
+	useShOnlyPath(t)
+
+	runner := newTestRunner(t)
+	id, err := runner.CreateIsolatedSession(&IsolatedSessionOptions{
+		WorkspacePath: filepath.Join(t.TempDir(), "workspace"),
+		WorkspaceMode: "rw",
+	})
+	if err != nil {
+		t.Fatalf("CreateIsolatedSession: %v", err)
+	}
+	defer runner.DeleteIsolatedSession(id)
+
+	var lines []string
+	err = runner.RunInIsolatedSession(context.Background(), id, "printf 'fallback_isolated\\n'", nil, func(line string) {
+		lines = append(lines, line)
+	})
+	if err != nil {
+		t.Fatalf("RunInIsolatedSession: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "fallback_isolated" {
+		t.Fatalf("output = %v, want [fallback_isolated]", lines)
+	}
+}
+
 func TestCreateIsolatedSession_HappyPath(t *testing.T) {
 	runner := newTestRunner(t)
 
@@ -647,7 +672,7 @@ func TestRunInIsolatedSession_EnvPersistence(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Run 1: set env var in bash session.
+	// Run 1: set env var in the shell session.
 	err = runner.RunInIsolatedSession(ctx, id, "export MY_VAR=hello_from_session", nil, nil)
 	if err != nil {
 		t.Fatalf("run 1: %v", err)

--- a/components/execd/pkg/runtime/pty_session_test.go
+++ b/components/execd/pkg/runtime/pty_session_test.go
@@ -20,9 +20,7 @@ package runtime
 import (
 	"bufio"
 	"io"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -48,15 +46,7 @@ func replayContains(t *testing.T, s *ptySession, substr string, timeout time.Dur
 }
 
 func TestPTYSession_FallsBackToSh(t *testing.T) {
-	shPath, err := exec.LookPath("sh")
-	require.NoError(t, err, "sh is required to test the fallback")
-	shPath, err = filepath.Abs(shPath)
-	require.NoError(t, err)
-
-	binDir := t.TempDir()
-	require.NoError(t, os.Symlink(shPath, filepath.Join(binDir, "sh")))
-	t.Setenv("PATH", binDir)
-	require.Equal(t, "sh", getShell())
+	useShOnlyPath(t)
 
 	t.Run("pty", func(t *testing.T) {
 		s := newPTYSession(uuidString(), "", "printf fallback_pty")

--- a/components/execd/pkg/runtime/shell_fallback_test.go
+++ b/components/execd/pkg/runtime/shell_fallback_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package runtime
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// useShOnlyPath limits PATH to a directory containing sh but not bash.
+func useShOnlyPath(t *testing.T) {
+	t.Helper()
+
+	shPath, err := exec.LookPath("sh")
+	require.NoError(t, err, "sh is required to test the fallback")
+	shPath, err = filepath.Abs(shPath)
+	require.NoError(t, err)
+
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(shPath, filepath.Join(binDir, "sh")))
+	t.Setenv("PATH", binDir)
+	require.Equal(t, "sh", getShell())
+}

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -50,16 +50,19 @@ curl -v http://localhost:44772/ping
   - PTY over WebSocket (`/pty`)
   - Local metrics endpoints (`/metrics`, `/metrics/watch`)
 
-PTY sessions use Bash when it is available and fall back to `sh` on minimal
-images that do not include Bash. Commands submitted to a fallback session must
-use syntax supported by that image's `sh` implementation.
+Shell-backed sessions use Bash when it is available and fall back to `sh` on
+minimal images that do not include Bash. This applies to PTY sessions, the
+Bash session API (which keeps its existing name for compatibility), and
+isolated sessions. Commands submitted to a fallback session must use syntax
+supported by that image's `sh` implementation.
 
 ## Isolated Sessions
 
-Isolated sessions run a bash process inside a per-execution
+Isolated sessions run a shell inside a per-execution
 [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) namespace,
-created via `POST /v1/isolated/session`. Beyond the workspace, callers can
-expose additional host paths into the namespace.
+created via `POST /v1/isolated/session`. Bash is preferred, with `sh` used as a
+fallback. Beyond the workspace, callers can expose additional host paths into
+the namespace.
 
 ### UID modes and capabilities
 


### PR DESCRIPTION
# Summary
- Prefer Bash but fall back to `sh` when launching the Bash session API and long-running isolated-session shell.
- Pass `--noprofile --norc` only to Bash; script paths remain positional and portable.
- Accept POSIX `export -p` output so environment persistence continues to work when the Bash session API runs under `sh`.
- Add `sh`-only tests for Bash-session state persistence and isolated-session execution, and document the fallback semantics.

Closes #1360.

## Design choices

- **Isolated sessions:** use the fallback. The session protocol itself uses portable shell syntax; commands requiring Bash still require an image with Bash and are documented as subject to the `sh` syntax caveat.
- **Bash session API:** keep the existing API/language name for compatibility while using `sh` only when Bash is unavailable. No public API identifiers change.

# Testing
- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Passed:

- `cd components/execd && go test ./pkg/runtime ./pkg/web/controller -count=1`
- fallback-focused runtime tests with `-count=10`
- `cd components/execd && go vet ./pkg/runtime ./pkg/web/controller`
- `cd docs && corepack pnpm docs:build`
- `git diff --check upstream/main...HEAD`

`go test ./pkg/... -count=1` passed all packages except the unchanged isolation test `TestFilterKnownSyscalls`, which expects the legacy `open` syscall to exist on all architectures; that assertion fails in this arm64 environment. The packages changed by this PR passed.

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
