### PR TITLE
docs: remove broken Star History section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,3 @@ and how roadmap items are managed.
 - Issues: Submit bugs, feature requests, or design discussions through GitHub Issues
 - Discord: Join the [OpenSandbox Discord community](https://discord.gg/g7FuPs8YeD)
 - DingTalk: Join the [OpenSandbox technical discussion group](https://qr.dingtalk.com/action/joingroup?code=v1,k1,A4Bgl5q1I1eNU/r33D18YFNrMY108aFF38V+r19RJOM=&_dt_no_comment=1&origin=11)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=opensandbox-group/OpenSandbox&type=date&legend=top-left)](https://www.star-history.com/#opensandbox-group/OpenSandbox&type=date&legend=top-left)


### PR DESCRIPTION
## Summary

- Remove the Star History section from README.md since GitHub's API restriction on the Stargazers endpoint causes the embedded SVG to no longer render for public visitors.

Closes #1362

## Test plan

- [ ] Verify README renders correctly without the Star History section