### PR TITLE
fix(egress): purge stale mitmproxy CA on startup

### DIFF
--- a/components/egress/main.go
+++ b/components/egress/main.go
@@ -50,6 +50,11 @@ func main() {
 	ctx = withLogger(ctx)
 	defer log.Logger.Sync()
 
+	// Erase any stale mitmproxy CA left on the shared volume by a previous
+	// egress generation so the agent's bootstrap wait-loop blocks for this
+	// generation's export. See PurgeStaleExportedCA / upstream issue #1370.
+	mitmproxy.PurgeStaleExportedCA()
+
 	otelShutdown, err := telemetry.Init(ctx)
 	if err != nil {
 		log.Warnf("OpenTelemetry metrics disabled (continuing without OTLP): %v", err)

--- a/components/egress/pkg/mitmproxy/cacert_export.go
+++ b/components/egress/pkg/mitmproxy/cacert_export.go
@@ -62,6 +62,40 @@ func waitMitmCACertPath(confDirEnv, home string) (string, error) {
 	return "", fmt.Errorf("mitmproxy CA not found after %v (tried: %v)", waitCACert, cands)
 }
 
+// PurgeStaleExportedCA removes any mitmproxy-ca-cert.pem left on the shared
+// volume by a previous generation of this egress container. mitmproxy's CA
+// lives in the egress container's ephemeral confdir, so an egress container
+// restart rotates the CA while the previous public cert is still on the
+// (pod-scoped) shared volume; without this purge, an agent container starting
+// alongside us would pass its bootstrap readiness check on the stale file
+// and install a CA that no longer matches what mitmproxy will sign with.
+// See upstream issue #1370. Must be called as early as possible in main().
+func PurgeStaleExportedCA() {
+	if !constants.IsTruthy(os.Getenv(constants.EnvMitmproxyTransparent)) {
+		return
+	}
+	purgeStaleExportedCAFrom(constants.OpenSandboxRootDir)
+}
+
+// purgeStaleExportedCAFrom is the testable core of PurgeStaleExportedCA.
+func purgeStaleExportedCAFrom(rootDir string) {
+	path := filepath.Join(rootDir, mitmCACertName)
+	err := os.Remove(path)
+	switch {
+	case err == nil:
+		// warn: on first pod startup this file should not exist; its presence
+		// means the egress container (or process) has restarted, which is
+		// useful signal when diagnosing HTTPS-from-agent problems.
+		log.Warnf("[mitmproxy] removed stale exported CA at %s (previous egress generation left it behind; see upstream issue #1370)", path)
+	case os.IsNotExist(err):
+		// Common on first pod startup.
+	default:
+		// Non-fatal: SyncRootCA will overwrite the file. But on the race
+		// path the agent may still grab the old contents before we do.
+		log.Warnf("[mitmproxy] failed to remove stale exported CA at %s: %v", path, err)
+	}
+}
+
 func SyncRootCA(confDirEnv, home string) error {
 	src, err := waitMitmCACertPath(confDirEnv, home)
 	if err != nil {

--- a/components/egress/pkg/mitmproxy/cacert_export_test.go
+++ b/components/egress/pkg/mitmproxy/cacert_export_test.go
@@ -15,6 +15,7 @@
 package mitmproxy
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,4 +33,42 @@ func TestCandidateCACertPaths(t *testing.T) {
 		filepath.Join("/custom", ".mitmproxy", mitmCACertName),
 		filepath.Join(h, ".mitmproxy", mitmCACertName),
 	}, got)
+}
+
+func TestPurgeStaleExportedCAFrom_RemovesExistingFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, mitmCACertName)
+	require.NoError(t, os.WriteFile(path, []byte("stale-ca"), 0o644))
+
+	purgeStaleExportedCAFrom(root)
+
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "expected file to be removed, got err=%v", err)
+}
+
+func TestPurgeStaleExportedCAFrom_NoFileIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	// No file present; must not panic and must not create anything.
+	purgeStaleExportedCAFrom(root)
+
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestPurgeStaleExportedCAFrom_LeavesUnrelatedFiles(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, mitmCACertName)
+	require.NoError(t, os.WriteFile(stale, []byte("stale-ca"), 0o644))
+
+	// A sibling file that must survive (e.g. the agent's merged bundle).
+	other := filepath.Join(root, "merged-ca-certificates.pem")
+	require.NoError(t, os.WriteFile(other, []byte("merged"), 0o644))
+
+	purgeStaleExportedCAFrom(root)
+
+	_, err := os.Stat(stale)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(other)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Fixes part of #1370.

mitmproxy's CA lives in the egress container's ephemeral confdir (`/var/lib/mitmproxy/.mitmproxy/`). Every time the egress container restarts, a fresh CA is generated with a new fingerprint. The previous generation's public cert, however, may still be on the pod-scoped shared volume at `/opt/opensandbox/mitmproxy-ca-cert.pem` (an `emptyDir` under Kubernetes / a docker named volume, both survive container restarts).

Without any purge, an agent container starting or restarting alongside egress passes its bootstrap readiness check `[ -f "$MITM_CA" ] && [ -s "$MITM_CA" ]` on the stale file *before* egress has had a chance to overwrite it, and installs a CA that no longer matches what mitmproxy will sign with. Subsequent HTTPS from agent then fails with `unable to get local issuer certificate`.

## What this change does

Erase `/opt/opensandbox/mitmproxy-ca-cert.pem` as early as possible in `egress` `main()` — immediately after logger initialization, before any telemetry / policy / dnsproxy / iptables / mitmproxy setup. This forces the agent's bootstrap wait-loop to block until *this* generation's `SyncRootCA` writes the current CA back to the shared volume.

Log level is `warn`: on a healthy first pod startup the file does not exist and nothing is logged; a `removed stale exported CA` warning is real signal that egress just restarted, which is useful when diagnosing HTTPS-from-agent problems.

## Scope

**Fixes**: pod-container co-restart (both containers restarting together within the same pod, with `emptyDir` surviving). This is scenario C in #1370.

**Does NOT fix**: egress-alone container restart (scenario B in #1370). In that case, the agent's bootstrap has long finished and never re-reads the file, so no amount of egress-side purging helps. That case still requires an agent-side reload path (watcher in `execd`), which is intentionally out of scope for this PR.

**Not affected**: whole-pod recreation (scenario A) already goes through a fresh shared volume and works correctly.

## In-place egress process restart (uncommon)

If the egress process is somehow restarted while its container stays up (uncommon under normal K8s / Docker lifecycles, since egress is PID 1), mitmproxy will reuse the CA already in confdir. The purge deletes the shared-volume copy, `SyncRootCA` writes back the same bytes moments later, and any agent bootstrap running concurrently only blocks for the duration of that gap. Functionally a no-op; the `warn` line correctly reports "previous egress generation left it behind".

## Tests

Added unit tests for the pure helper `purgeStaleExportedCAFrom` covering:

- Existing file is removed.
- Absent file is a no-op (first-boot path).
- Unrelated files (e.g. `merged-ca-certificates.pem`) are left untouched.

Local verification:

```
cd components/egress
go build -mod=mod ./...
go vet -mod=mod ./...
go test -mod=mod ./...
```

All pass.

## Files changed

- `components/egress/main.go` — call `mitmproxy.PurgeStaleExportedCA()` after `withLogger`, before telemetry init.
- `components/egress/pkg/mitmproxy/cacert_export.go` — new exported `PurgeStaleExportedCA()` and internal testable `purgeStaleExportedCAFrom`.
- `components/egress/pkg/mitmproxy/cacert_export_test.go` — three focused unit tests.
