### PR TITLE
docs(osep): renumber conflicting 0015 and set 0017 to implementing

### DIFF
--- a/docs/community/oseps.md
+++ b/docs/community/oseps.md
@@ -27,6 +27,9 @@ See the [OSEP contributing guide](https://github.com/opensandbox-group/OpenSandb
 | [OSEP-0012](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0012-credential-vault.md) | Credential Vault and Credential Proxy | implemented | 2026-06-23 |
 | [OSEP-0013](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0013-isolated-execution-api.md) | Isolated Execution API | implementing | 2026-06-23 |
 | [OSEP-0014](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0014-multi-tenancy.md) | Multi-Tenancy Support for Kubernetes Runtime | draft | 2026-04-29 |
+| [OSEP-0015](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0015-pod-snapshot.md) | Spec-Driven Pod Snapshot for Pause and Resume | draft | 2026-06-27 |
+| [OSEP-0016](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0016-unified-umbrella-release-governance.md) | Unified Umbrella Release Governance | draft | 2026-07-21 |
+| [OSEP-0017](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0017-resilient-sdk-transport.md) | Resilient SDK Transport | implementing | 2026-07-22 |
 
 ## Status Definitions
 

--- a/oseps/0016-unified-umbrella-release-governance.md
+++ b/oseps/0016-unified-umbrella-release-governance.md
@@ -7,7 +7,7 @@ last-updated: 2026-07-21
 status: draft
 ---
 
-# OSEP-0015: Unified Umbrella Release Governance
+# OSEP-0016: Unified Umbrella Release Governance
 
 <!-- toc -->
 - [Summary](#summary)

--- a/oseps/0017-resilient-sdk-transport.md
+++ b/oseps/0017-resilient-sdk-transport.md
@@ -4,10 +4,10 @@ authors:
   - "@Pangjiping"
 creation-date: 2026-07-22
 last-updated: 2026-07-22
-status: draft
+status: implementing
 ---
 
-# OSEP-0016: Resilient SDK Transport
+# OSEP-0017: Resilient SDK Transport
 
 <!-- toc -->
 - [Summary](#summary)

--- a/oseps/README.md
+++ b/oseps/README.md
@@ -21,3 +21,5 @@ This is the complete list of OpenSandbox Enhancement Proposals:
 | [OSEP-0013](0013-isolated-execution-api.md)                    |      Isolated Execution API                                               | implementing  |  2026-06-23  |
 | [OSEP-0014](0014-multi-tenancy.md)                             |      Multi-Tenancy Support for Kubernetes Runtime                         |     draft     |  2026-05-07  |
 | [OSEP-0015](0015-pod-snapshot.md)                              |      Spec-Driven Pod Snapshot for Pause and Resume                        |     draft     |  2026-06-27  |
+| [OSEP-0016](0016-unified-umbrella-release-governance.md)       |      Unified Umbrella Release Governance                                  |     draft     |  2026-07-21  |
+| [OSEP-0017](0017-resilient-sdk-transport.md)                   |      Resilient SDK Transport                                              | implementing  |  2026-07-22  |


### PR DESCRIPTION
## Summary

Resolves the duplicate `0015` OSEP number and refreshes the OSEP index in both the repo README and the docs site.

## Changes

- Rename \`0015-unified-umbrella-release-governance.md\` → \`0016-unified-umbrella-release-governance.md\`
- Rename \`0016-resilient-sdk-transport.md\` → \`0017-resilient-sdk-transport.md\`
- Update the \`# OSEP-xxxx:\` heading inside each renamed file to match the new number
- Add OSEP-0015 / OSEP-0016 / OSEP-0017 rows to \`oseps/README.md\`
- Add OSEP-0015 / OSEP-0016 / OSEP-0017 rows to \`docs/community/oseps.md\`
- Set OSEP-0017 status from \`draft\` to \`implementing\` (frontmatter + both index tables)

## Numbering rationale

Ordered by \`creation-date\` in each proposal's frontmatter:

| Number | Proposal | creation-date |
|---|---|---|
| OSEP-0015 | Spec-Driven Pod Snapshot for Pause and Resume | 2026-06-27 |
| OSEP-0016 | Unified Umbrella Release Governance | 2026-07-21 |
| OSEP-0017 | Resilient SDK Transport | 2026-07-22 |

## Verification

- \`git status\` clean on the branch
- No cross-OSEP references needed updates (OSEP-0015 internal references belong to the pod-snapshot proposal, which keeps 0015)