### PR TITLE
fix(egress): allow intercepted DNS before loopback deny

### DIFF
--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -198,6 +198,8 @@ func buildRuleset(p *policy.NetworkPolicy, opts Options) (string, error) {
 	fmt.Fprintf(&b, "add rule inet %s %s ct state established,related accept\n", tableName, chainName)
 	fmt.Fprintf(&b, "add rule inet %s %s meta mark %s accept\n", tableName, chainName, constants.MarkHex)
 	fmt.Fprintf(&b, "add rule inet %s %s oifname \"lo\" accept\n", tableName, chainName)
+	fmt.Fprintf(&b, "add rule inet %s %s ip daddr 127.0.0.1 udp dport 15353 accept\n", tableName, chainName)
+	fmt.Fprintf(&b, "add rule inet %s %s ip daddr 127.0.0.1 tcp dport 15353 accept\n", tableName, chainName)
 	if opts.BlockDoT {
 		fmt.Fprintf(&b, "add rule inet %s %s tcp dport 853 drop\n", tableName, chainName)
 		fmt.Fprintf(&b, "add rule inet %s %s udp dport 853 drop\n", tableName, chainName)

--- a/components/egress/pkg/nftables/manager_test.go
+++ b/components/egress/pkg/nftables/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,6 +74,35 @@ func TestApplyStatic_DefaultDenyFallbackRuleUsesPlainDrop(t *testing.T) {
 	expectContains(t, rendered, "add chain inet opensandbox egress { type filter hook output priority 0; policy drop; }")
 	expectContains(t, rendered, "add rule inet opensandbox egress drop")
 	require.NotContains(t, rendered, "counter drop", "counter expression is not supported in the QA pod netns")
+}
+
+func TestApplyStatic_AllowsRedirectedDNSBeforeAlwaysDeny(t *testing.T) {
+	var rendered string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		rendered = script
+		return nil, nil
+	})
+
+	p, err := policy.ParsePolicy(`{"defaultAction":"deny","egress":[]}`)
+	require.NoError(t, err)
+	denyLoopback, err := policy.ParseValidatedEgressRule(policy.ActionDeny, "127.0.0.0/8")
+	require.NoError(t, err)
+	merged := policy.MergeAlwaysOverlay(p, []policy.EgressRule{denyLoopback}, nil)
+	policyWithDNS := merged.WithExtraAllowIPs([]netip.Addr{netip.MustParseAddr("127.0.0.1")})
+
+	require.NoError(t, m.ApplyStatic(context.Background(), policyWithDNS))
+
+	denyRule := "add rule inet opensandbox egress ip daddr @deny_v4 drop"
+	denyRuleIndex := strings.Index(rendered, denyRule)
+	require.NotEqual(t, -1, denyRuleIndex, "expected rendered ruleset to contain %q", denyRule)
+	for _, dnsRule := range []string{
+		"add rule inet opensandbox egress ip daddr 127.0.0.1 udp dport 15353 accept",
+		"add rule inet opensandbox egress ip daddr 127.0.0.1 tcp dport 15353 accept",
+	} {
+		dnsRuleIndex := strings.Index(rendered, dnsRule)
+		require.NotEqual(t, -1, dnsRuleIndex, "expected rendered ruleset to contain %q", dnsRule)
+		require.Less(t, dnsRuleIndex, denyRuleIndex, "expected %q before %q", dnsRule, denyRule)
+	}
 }
 
 func TestApplyStatic_DefaultAllowUsesAcceptPolicy(t *testing.T) {


### PR DESCRIPTION
# Summary

- Allow DNS traffic redirected to the internal proxy at `127.0.0.1:15353` before applying static IPv4 deny sets.
- Cover both UDP and TCP DNS with a regression test that renders an operator-managed `deny.always` overlay containing `127.0.0.0/8`.

In `dns+nft` mode, DNS queries sent to port 53 are redirected to the local proxy at `127.0.0.1:15353`. Under Docker, the nftables output filter can observe the redirected destination without an `oifname "lo"` match. If `deny.always` contains `127.0.0.0/8`, the packet therefore reaches `ip daddr @deny_v4 drop` and the sandbox loses DNS.

The fix adds narrowly scoped UDP and TCP accepts for `127.0.0.1:15353` immediately after the existing loopback accept and before BlockDoT and the deny sets. It does not change contracts, configuration, APIs, or general loopback access.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

Validated with Go 1.25.9:

- `gofmt -l . ../internal`
- `go vet ./...`
- `go build .`
- `go test ./...`
- `tests/smoke-dns.sh`
- `tests/smoke-nft.sh`
- `tests/smoke-dynamic-ip.sh`
- `tests/smoke-dns-upstream-probe.sh`

Runtime reproduction with `deny.always` containing `127.0.0.0/8`:

- `opensandbox/egress:v1.1.4`: redirected UDP and TCP DNS time out.
- This branch: redirected UDP and TCP DNS succeed, and both accepts precede `deny_v4`.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; no user-visible contract or configuration change)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
