### PR TITLE
chore(sdks): bump release versions

### DIFF
--- a/docs/guides/sdk-telemetry.md
+++ b/docs/guides/sdk-telemetry.md
@@ -43,7 +43,7 @@ After create succeeds or fails, the SDK fire-and-forget posts to `POST /v1/metri
 ```
 
 - `sandboxId` / `image` may be omitted when create fails early.
-- SDK language and version come from the HTTP `User-Agent` header (for example `OpenSandbox-Python-SDK/0.1.14`), not from body fields.
+- SDK language and version come from the HTTP `User-Agent` header (for example `OpenSandbox-Python-SDK/0.1.15`), not from body fields.
 
 The server accepts the event with `204` and, when `[otel]` is enabled, records an OTEL histogram. See [server configuration](https://github.com/opensandbox-group/OpenSandbox/blob/main/server/configuration.md#otel).
 

--- a/sdks/Directory.Build.props
+++ b/sdks/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Shared C# SDK packaging metadata -->
-    <OpenSandboxPackageVersion>0.1.4</OpenSandboxPackageVersion>
+    <OpenSandboxPackageVersion>0.1.5</OpenSandboxPackageVersion>
     <OpenSandboxCodeInterpreterPackageVersion>0.1.1</OpenSandboxCodeInterpreterPackageVersion>
     <OpenSandboxDependencyVersionRange>[$(OpenSandboxPackageVersion),0.2.0)</OpenSandboxDependencyVersionRange>
   </PropertyGroup>

--- a/sdks/code-interpreter/python/pyproject.toml
+++ b/sdks/code-interpreter/python/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.4.2,<3.0",
-    "opensandbox>=0.1.10,<0.2.0",
+    "opensandbox>=0.1.15,<0.2.0",
 ]
 
 [project.urls]

--- a/sdks/code-interpreter/python/uv.lock
+++ b/sdks/code-interpreter/python/uv.lock
@@ -260,6 +260,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=21.3.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "pydantic", specifier = ">=2.4.2,<3.0" },
+    { name = "pyjwt", marker = "extra == 'pool-redis'", specifier = ">=2.13.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0" },
     { name = "redis", marker = "extra == 'pool-redis'", specifier = ">=5.0,<6.0" },
 ]

--- a/sdks/package.json
+++ b/sdks/package.json
@@ -15,11 +15,12 @@
       "minimatch@^5.0.0": "5.1.8",
       "rollup@^4.0.0": "4.60.2",
       "picomatch@^4.0.0": "4.0.4",
-      "brace-expansion@^1.0.0": "1.1.13",
-      "brace-expansion@^2.0.0": "2.0.3",
+      "brace-expansion@^1.0.0": "1.1.16",
+      "brace-expansion@^2.0.0": "2.1.2",
+      "brace-expansion@^5.0.0": "5.0.7",
       "flatted@^3.0.0": "3.4.2",
-      "fast-uri@^3.0.0": "3.1.2",
-      "js-yaml@^4.0.0": "4.2.0",
+      "fast-uri@^3.0.0": "3.1.4",
+      "js-yaml@^4.0.0": "4.3.0",
       "undici": "7.28.0"
     }
   },

--- a/sdks/pnpm-lock.yaml
+++ b/sdks/pnpm-lock.yaml
@@ -8,11 +8,12 @@ overrides:
   minimatch@^5.0.0: 5.1.8
   rollup@^4.0.0: 4.60.2
   picomatch@^4.0.0: 4.0.4
-  brace-expansion@^1.0.0: 1.1.13
-  brace-expansion@^2.0.0: 2.0.3
+  brace-expansion@^1.0.0: 1.1.16
+  brace-expansion@^2.0.0: 2.1.2
+  brace-expansion@^5.0.0: 5.0.7
   flatted@^3.0.0: 3.4.2
-  fast-uri@^3.0.0: 3.1.2
-  js-yaml@^4.0.0: 4.2.0
+  fast-uri@^3.0.0: 3.1.4
+  js-yaml@^4.0.0: 4.3.0
   undici: 7.28.0
 
 importers:
@@ -365,79 +366,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -572,14 +560,14 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   bundle-require@5.1.0:
@@ -711,8 +699,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -808,8 +796,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1236,7 +1224,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -1279,7 +1267,7 @@ snapshots:
   '@redocly/ajv@8.17.1':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1292,7 +1280,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 5.1.8
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -1498,16 +1486,16 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1666,7 +1654,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1741,7 +1729,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -1780,15 +1768,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimatch@5.1.8:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   mlly@1.8.0:
     dependencies:

--- a/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Core/Constants.cs
@@ -66,7 +66,7 @@ public static class Constants
     /// <summary>
     /// Default user agent string for SDK HTTP requests.
     /// </summary>
-    public const string DefaultUserAgent = "OpenSandbox-CSharp-SDK/0.1.4";
+    public const string DefaultUserAgent = "OpenSandbox-CSharp-SDK/0.1.5";
 
     /// <summary>
     /// Environment variable name for the OpenSandbox domain.

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ConstantsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ConstantsTests.cs
@@ -94,6 +94,6 @@ public class ConstantsTests
     [Fact]
     public void DefaultUserAgent_ShouldMatchPackageVersion()
     {
-        Constants.DefaultUserAgent.Should().Be("OpenSandbox-CSharp-SDK/0.1.4");
+        Constants.DefaultUserAgent.Should().Be("OpenSandbox-CSharp-SDK/0.1.5");
     }
 }

--- a/sdks/sandbox/go/constants.go
+++ b/sdks/sandbox/go/constants.go
@@ -39,7 +39,7 @@ const (
 	DefaultCodeInterpreterTimeoutSeconds = 900
 
 	// Version is the SDK version reported in the User-Agent header.
-	Version = "1.0.4"
+	Version = "1.0.5"
 
 	// APIVersion is the lifecycle API version prefix.
 	APIVersion = "v1"

--- a/sdks/sandbox/go/constants_test.go
+++ b/sdks/sandbox/go/constants_test.go
@@ -20,7 +20,7 @@ import "testing"
 // reported in the User-Agent header and must be bumped together with the
 // released module tag. Update this expectation when releasing.
 func TestVersion_MatchesReleasedTag(t *testing.T) {
-	const want = "1.0.4"
+	const want = "1.0.5"
 	if Version != want {
 		t.Fatalf("Version = %q, want %q; bump this together with the release tag", Version, want)
 	}

--- a/sdks/sandbox/javascript/package.json
+++ b/sdks/sandbox/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alibaba-group/opensandbox",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OpenSandbox TypeScript/JavaScript SDK (sandbox lifecycle + execd APIs)",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -37,7 +37,7 @@ export interface paths {
          *     export is disabled (noop recording).
          *
          *     SDK language and version are taken from the HTTP `User-Agent` header
-         *     (for example `OpenSandbox-Python-SDK/0.1.14`), not from the JSON body.
+         *     (for example `OpenSandbox-Python-SDK/0.1.15`), not from the JSON body.
          */
         post: operations["reportMetricsEvent"];
         delete?: never;

--- a/sdks/sandbox/javascript/src/core/constants.ts
+++ b/sdks/sandbox/javascript/src/core/constants.ts
@@ -27,7 +27,7 @@ export const DEFAULT_READY_TIMEOUT_SECONDS = 30;
 export const DEFAULT_HEALTH_CHECK_POLLING_INTERVAL_MILLIS = 200;
 
 export const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
-export const DEFAULT_USER_AGENT = "OpenSandbox-JS-SDK/0.1.10";
+export const DEFAULT_USER_AGENT = "OpenSandbox-JS-SDK/0.1.11";
 
 // Custom header carrying the SDK host's own IP. A non-standard name is used on
 // purpose: standard forwarded headers (X-Forwarded-For, etc.) are rewritten or

--- a/sdks/sandbox/javascript/tests/connection.test.mjs
+++ b/sdks/sandbox/javascript/tests/connection.test.mjs
@@ -40,7 +40,7 @@ test("ConnectionConfig default userAgent matches package version", () => {
     domain: "https://api.opensandbox.test",
   });
 
-  assert.equal(connectionConfig.userAgent, "OpenSandbox-JS-SDK/0.1.10");
+  assert.equal(connectionConfig.userAgent, "OpenSandbox-JS-SDK/0.1.11");
 });
 
 test("ConnectionConfig.disableMetrics is preserved by withTransportIfMissing", () => {

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.16
+project.version=1.0.17
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -88,7 +88,7 @@ class ConnectionConfig private constructor(
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
         internal const val ENV_DISABLE_METRICS = "OPENSANDBOX_DISABLE_METRICS"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.16"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.17"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
@@ -26,6 +26,6 @@ class ConnectionConfigUserAgentTest {
     fun `default userAgent matches package version`() {
         val config = ConnectionConfig.builder().build()
 
-        assertEquals("OpenSandbox-Kotlin-SDK/1.0.16", config.userAgent)
+        assertEquals("OpenSandbox-Kotlin-SDK/1.0.17", config.userAgent)
     }
 }

--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -68,7 +68,7 @@ source = "vcs"
 root = "../../.."
 tag_regex = "^python/sandbox/v(?P<version>\\d+\\.\\d+\\.\\d+(?:[\\.\\w\\+\\-]*)?)$"
 git_describe_command = 'git describe --dirty --tags --long --match "python/sandbox/v*"'
-fallback_version = "0.1.14"
+fallback_version = "0.1.15"
 
 [tool.hatch.build]
 include = [

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/api/metrics/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/api/metrics/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Contains endpoint functions for accessing the API"""

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/api/metrics/report_metrics_event.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/api/metrics/report_metrics_event.py
@@ -1,0 +1,246 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from http import HTTPStatus
+from typing import Any, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.metrics_event import MetricsEvent
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: MetricsEvent,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/metrics/events",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | ErrorResponse | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 500:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetricsEvent,
+) -> Response[Any | ErrorResponse]:
+    """Report an SDK metrics event
+
+     Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+
+    SDKs SHOULD fire-and-forget this call after `create` + readiness complete
+    (or after a failed creation attempt). Failures to report MUST NOT affect
+    sandbox usability. The server accepts events even when OpenTelemetry
+    export is disabled (noop recording).
+
+    SDK language and version are taken from the HTTP `User-Agent` header
+    (for example `OpenSandbox-Python-SDK/0.1.14`), not from the JSON body.
+
+    Args:
+        body (MetricsEvent): SDK-reported metrics event. Phase 1 covers sandbox creation latency
+            from
+            the start of create until readiness succeeds or creation fails.
+
+            SDK language and package version are identified via the request
+            `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetricsEvent,
+) -> Any | ErrorResponse | None:
+    """Report an SDK metrics event
+
+     Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+
+    SDKs SHOULD fire-and-forget this call after `create` + readiness complete
+    (or after a failed creation attempt). Failures to report MUST NOT affect
+    sandbox usability. The server accepts events even when OpenTelemetry
+    export is disabled (noop recording).
+
+    SDK language and version are taken from the HTTP `User-Agent` header
+    (for example `OpenSandbox-Python-SDK/0.1.14`), not from the JSON body.
+
+    Args:
+        body (MetricsEvent): SDK-reported metrics event. Phase 1 covers sandbox creation latency
+            from
+            the start of create until readiness succeeds or creation fails.
+
+            SDK language and package version are identified via the request
+            `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetricsEvent,
+) -> Response[Any | ErrorResponse]:
+    """Report an SDK metrics event
+
+     Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+
+    SDKs SHOULD fire-and-forget this call after `create` + readiness complete
+    (or after a failed creation attempt). Failures to report MUST NOT affect
+    sandbox usability. The server accepts events even when OpenTelemetry
+    export is disabled (noop recording).
+
+    SDK language and version are taken from the HTTP `User-Agent` header
+    (for example `OpenSandbox-Python-SDK/0.1.14`), not from the JSON body.
+
+    Args:
+        body (MetricsEvent): SDK-reported metrics event. Phase 1 covers sandbox creation latency
+            from
+            the start of create until readiness succeeds or creation fails.
+
+            SDK language and package version are identified via the request
+            `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetricsEvent,
+) -> Any | ErrorResponse | None:
+    """Report an SDK metrics event
+
+     Accepts best-effort telemetry from SDKs (Phase 1: sandbox creation latency).
+
+    SDKs SHOULD fire-and-forget this call after `create` + readiness complete
+    (or after a failed creation attempt). Failures to report MUST NOT affect
+    sandbox usability. The server accepts events even when OpenTelemetry
+    export is disabled (noop recording).
+
+    SDK language and version are taken from the HTTP `User-Agent` header
+    (for example `OpenSandbox-Python-SDK/0.1.14`), not from the JSON body.
+
+    Args:
+        body (MetricsEvent): SDK-reported metrics event. Phase 1 covers sandbox creation latency
+            from
+            the start of create until readiness succeeds or creation fails.
+
+            SDK language and package version are identified via the request
+            `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
@@ -33,6 +33,8 @@ from .image_spec import ImageSpec
 from .image_spec_auth import ImageSpecAuth
 from .list_sandboxes_response import ListSandboxesResponse
 from .list_snapshots_response import ListSnapshotsResponse
+from .metrics_event import MetricsEvent
+from .metrics_event_event_type import MetricsEventEventType
 from .network_policy import NetworkPolicy
 from .network_policy_default_action import NetworkPolicyDefaultAction
 from .network_rule import NetworkRule
@@ -74,6 +76,8 @@ __all__ = (
     "ImageSpecAuth",
     "ListSandboxesResponse",
     "ListSnapshotsResponse",
+    "MetricsEvent",
+    "MetricsEventEventType",
     "NetworkPolicy",
     "NetworkPolicyDefaultAction",
     "NetworkRule",

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/metrics_event.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/metrics_event.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.metrics_event_event_type import MetricsEventEventType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MetricsEvent")
+
+
+@_attrs_define
+class MetricsEvent:
+    """SDK-reported metrics event. Phase 1 covers sandbox creation latency from
+    the start of create until readiness succeeds or creation fails.
+
+    SDK language and package version are identified via the request
+    `User-Agent` header (for example `OpenSandbox-Go-SDK/0.1.0`), not body fields.
+
+        Attributes:
+            event_type (MetricsEventEventType): Metric event type
+            create_duration_ms (int): Wall-clock duration in milliseconds from create start to ready or failure
+            success (bool): Whether create + readiness completed successfully
+            sandbox_id (str | Unset): Sandbox identifier when available (may be omitted if create failed before an ID was
+                assigned)
+            image (str | Unset): Container image URI or snapshot startup source label
+    """
+
+    event_type: MetricsEventEventType
+    create_duration_ms: int
+    success: bool
+    sandbox_id: str | Unset = UNSET
+    image: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        event_type = self.event_type.value
+
+        create_duration_ms = self.create_duration_ms
+
+        success = self.success
+
+        sandbox_id = self.sandbox_id
+
+        image = self.image
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "eventType": event_type,
+                "createDurationMs": create_duration_ms,
+                "success": success,
+            }
+        )
+        if sandbox_id is not UNSET:
+            field_dict["sandboxId"] = sandbox_id
+        if image is not UNSET:
+            field_dict["image"] = image
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        event_type = MetricsEventEventType(d.pop("eventType"))
+
+        create_duration_ms = d.pop("createDurationMs")
+
+        success = d.pop("success")
+
+        sandbox_id = d.pop("sandboxId", UNSET)
+
+        image = d.pop("image", UNSET)
+
+        metrics_event = cls(
+            event_type=event_type,
+            create_duration_ms=create_duration_ms,
+            success=success,
+            sandbox_id=sandbox_id,
+            image=image,
+        )
+
+        metrics_event.additional_properties = d
+        return metrics_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/metrics_event_event_type.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/metrics_event_event_type.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class MetricsEventEventType(str, Enum):
+    SANDBOX_CREATE = "sandbox.create"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/config/connection.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection.py
@@ -65,7 +65,7 @@ class ConnectionConfig(BaseModel):
         default=False, description="Enable debug logging for HTTP requests"
     )
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.14", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.15", description="User agent string"
     )
     headers: dict[str, str] = Field(
         default_factory=dict, description="User defined headers"

--- a/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
+++ b/sdks/sandbox/python/src/opensandbox/config/connection_sync.py
@@ -53,7 +53,7 @@ class ConnectionConfigSync(BaseModel):
     )
     debug: bool = Field(default=False, description="Enable debug logging for HTTP requests")
     user_agent: str = Field(
-        default="OpenSandbox-Python-SDK/0.1.14", description="User agent string"
+        default="OpenSandbox-Python-SDK/0.1.15", description="User agent string"
     )
     headers: dict[str, str] = Field(default_factory=dict, description="User defined headers")
 

--- a/sdks/sandbox/python/tests/test_connection_config.py
+++ b/sdks/sandbox/python/tests/test_connection_config.py
@@ -22,8 +22,8 @@ from opensandbox.config import ConnectionConfig, ConnectionConfigSync
 # Regression: the default User-Agent version is hand-maintained and must be
 # bumped together with the package version. Update this expectation when releasing.
 def test_default_user_agent_matches_package_version() -> None:
-    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.14"
-    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.14"
+    assert ConnectionConfig().user_agent == "OpenSandbox-Python-SDK/0.1.15"
+    assert ConnectionConfigSync().user_agent == "OpenSandbox-Python-SDK/0.1.15"
 
 
 def test_protocol_validation() -> None:

--- a/tests/javascript/package.json
+++ b/tests/javascript/package.json
@@ -8,13 +8,14 @@
     "overrides": {
       "rollup": "4.60.2",
       "picomatch@^4.0.0": "4.0.4",
-      "brace-expansion@^1.0.0": "1.1.13",
-      "brace-expansion@^2.0.0": "2.0.3",
+      "brace-expansion@^1.0.0": "1.1.16",
+      "brace-expansion@^2.0.0": "2.1.2",
+      "brace-expansion@^5.0.0": "5.0.7",
       "flatted@^3.0.0": "3.4.2",
       "esbuild": "0.25.2",
-      "postcss": "8.5.10",
+      "postcss": "8.5.12",
       "vite": "6.4.3",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": "5.2.1"
     }
   },
   "scripts": {

--- a/tests/javascript/pnpm-lock.yaml
+++ b/tests/javascript/pnpm-lock.yaml
@@ -7,13 +7,14 @@ settings:
 overrides:
   rollup: 4.60.2
   picomatch@^4.0.0: 4.0.4
-  brace-expansion@^1.0.0: 1.1.13
-  brace-expansion@^2.0.0: 2.0.3
+  brace-expansion@^1.0.0: 1.1.16
+  brace-expansion@^2.0.0: 2.1.2
+  brace-expansion@^5.0.0: 5.0.7
   flatted@^3.0.0: 3.4.2
   esbuild: 0.25.2
-  postcss: 8.5.10
+  postcss: 8.5.12
   vite: 6.4.3
-  js-yaml: '>=4.2.0'
+  js-yaml: 5.2.1
 
 importers:
 
@@ -291,79 +292,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -535,11 +523,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   callsites@3.1.0:
@@ -725,8 +713,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -811,8 +799,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1110,7 +1098,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.0
+      js-yaml: 5.2.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -1389,12 +1377,12 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1591,7 +1579,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-yaml@5.2.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -1622,11 +1610,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   ms@2.1.3: {}
 
@@ -1667,7 +1655,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -1775,7 +1763,7 @@ snapshots:
       esbuild: 0.25.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       rollup: 4.60.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- bump non-MCP SDK release versions and matching User-Agent strings
- align code-interpreter sandbox dependency ranges with the new sandbox SDK version
- refresh lifecycle telemetry User-Agent examples in spec, docs, and generated SDK comments

## Validation
- uv run ruff check tests/test_connection_config.py src/opensandbox/config/connection.py src/opensandbox/config/connection_sync.py src/opensandbox/api/lifecycle/api/metrics/report_metrics_event.py
- pnpm --filter @alibaba-group/opensandbox run lint
- go test ./...
- dotnet test sdks/sandbox/csharp/tests/OpenSandbox.Tests/OpenSandbox.Tests.csproj --filter ConstantsTests
- ./gradlew --no-configuration-cache :sandbox:test --tests '*ConnectionConfigUserAgentTest'