### PR TITLE
feat(isolated-session): add fail-closed workload lifecycle gate

### DIFF
--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -161,6 +161,23 @@ jobs:
           sudo cp builddir/bwrap /usr/local/bin/bwrap
           bwrap --version
 
+      - name: Build native session workload gate
+        run: |
+          sudo install -d /usr/local/libexec
+          sudo cc -O2 -Wall -Wextra -Werror \
+            components/execd/native/session-gate.c \
+            -o /usr/local/libexec/opensandbox-session-gate
+          test -x /usr/local/bin/bwrap
+          test -x /usr/local/libexec/opensandbox-session-gate
+
+      - name: Run workload lifecycle integration test
+        working-directory: components/execd
+        run: |
+          sudo -E env "PATH=$PATH" go test \
+            -v -count=1 -timeout=2m \
+            -run '^TestBwrapLifecycleEndToEnd$' \
+            ./pkg/isolation
+
       - name: Run bwrap integration tests
         working-directory: components/execd
         run: sudo -E env "PATH=$PATH" go test -tags="linux,bwrap" -v -count=1 -timeout=5m ./pkg/runtime/bwrap_test/

--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -177,7 +177,8 @@ jobs:
       - name: Run workload lifecycle integration test
         working-directory: components/execd
         run: |
-          sudo -E env "PATH=$PATH" go test \
+          # Execd must authenticate a non-root workload without CAP_SYS_PTRACE.
+          sudo -E setpriv --bounding-set=-sys_ptrace env "PATH=$PATH" go test \
             -v -count=1 -timeout=2m \
             -run '^TestBwrapLifecycleEndToEnd$' \
             ./pkg/isolation

--- a/.github/workflows/execd-test.yml
+++ b/.github/workflows/execd-test.yml
@@ -163,12 +163,16 @@ jobs:
 
       - name: Build native session workload gate
         run: |
-          sudo install -d /usr/local/libexec
+          sudo install -d /usr/local/libexec /opt/opensandbox
           sudo cc -O2 -Wall -Wextra -Werror \
             components/execd/native/session-gate.c \
             -o /usr/local/libexec/opensandbox-session-gate
+          sudo install -m 0555 \
+            /usr/local/libexec/opensandbox-session-gate \
+            /opt/opensandbox/opensandbox-session-gate
           test -x /usr/local/bin/bwrap
           test -x /usr/local/libexec/opensandbox-session-gate
+          test -x /opt/opensandbox/opensandbox-session-gate
 
       - name: Run workload lifecycle integration test
         working-directory: components/execd

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -97,6 +97,7 @@ FROM alpine:latest
 
 COPY --from=bwrap-builder /build/bwrap/bwrap /usr/local/bin/bwrap
 COPY --from=bwrap-builder /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
+COPY --from=bwrap-builder /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate
 COPY --from=builder /build/execd .
 COPY --from=builder /build/execd.exe ./execd.exe
 COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -76,6 +76,9 @@ RUN CGO_ENABLED=0 GOOS=windows go build ${GOFLAGS} -trimpath -buildvcs=false \
 # Build static bubblewrap with musl.
 FROM alpine:latest AS bwrap-builder
 RUN apk add --no-cache git musl-dev meson ninja gcc libcap-dev libcap-static pkgconfig bash
+COPY components/execd/native/session-gate.c /build/session-gate.c
+RUN gcc -Os -static -s -Wall -Wextra -Werror \
+    -o /build/opensandbox-session-gate /build/session-gate.c
 RUN git clone --depth 1 --branch v0.11.2 \
     https://github.com/containers/bubblewrap /build/bwrap
 WORKDIR /build/bwrap
@@ -93,6 +96,7 @@ RUN rm /usr/lib/libcap.so /usr/lib/libcap.so.2 && \
 FROM alpine:latest
 
 COPY --from=bwrap-builder /build/bwrap/bwrap /usr/local/bin/bwrap
+COPY --from=bwrap-builder /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
 COPY --from=builder /build/execd .
 COPY --from=builder /build/execd.exe ./execd.exe
 COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor

--- a/components/execd/native/session-gate.c
+++ b/components/execd/native/session-gate.c
@@ -42,46 +42,67 @@
 static const char waiting_frame[] = "OPENSANDBOX_SESSION_WAITING_V1";
 static const char ready_frame[] = "OPENSANDBOX_SESSION_READY_V1";
 
-static void fail_closed(int control_fd)
+static int parse_fd(const char *value)
+{
+    char *end = NULL;
+    long parsed;
+
+    errno = 0;
+    parsed = strtol(value, &end, 10);
+    if (errno != 0 || end == value || *end != '\0' ||
+        parsed < 3 || parsed > INT_MAX)
+        return -1;
+    return (int)parsed;
+}
+
+static void fail_closed(int control_fd, int exec_fd)
 {
     if (control_fd >= 0)
         (void)close(control_fd);
+    if (exec_fd >= 0 && exec_fd != control_fd)
+        (void)close(exec_fd);
     _exit(GATE_FAILURE);
 }
 
 int main(int argc, char **argv)
 {
-    char *end = NULL;
-    long parsed_fd;
     int control_fd;
+    int exec_fd;
     int socket_type = 0;
     socklen_t socket_type_len = sizeof(socket_type);
     char incoming[sizeof(ready_frame)];
     ssize_t received;
     ssize_t sent;
 
-    if (argc < 4 || strcmp(argv[2], "--") != 0)
-        fail_closed(-1);
+    if (argc < 5 || strcmp(argv[3], "--") != 0)
+        fail_closed(-1, -1);
 
-    errno = 0;
-    parsed_fd = strtol(argv[1], &end, 10);
-    if (errno != 0 || end == argv[1] || *end != '\0' ||
-        parsed_fd < 3 || parsed_fd > INT_MAX)
-        fail_closed(-1);
-    control_fd = (int)parsed_fd;
+    control_fd = parse_fd(argv[1]);
+    exec_fd = parse_fd(argv[2]);
+    if (control_fd < 0 || exec_fd < 0 || control_fd == exec_fd)
+        fail_closed(control_fd, exec_fd);
 
     if (fcntl(control_fd, F_GETFD) < 0)
-        fail_closed(control_fd);
+        fail_closed(control_fd, exec_fd);
+    if (fcntl(exec_fd, F_GETFD) < 0)
+        fail_closed(control_fd, exec_fd);
+    /*
+     * bubblewrap starts this helper through /proc/self/fd/<exec_fd>. Once
+     * main is running the executable is already mapped, so close that
+     * descriptor before the workload handshake to avoid leaking it onward.
+     */
+    if (close(exec_fd) != 0)
+        fail_closed(control_fd, -1);
     if (getsockopt(control_fd, SOL_SOCKET, SO_TYPE,
                    &socket_type, &socket_type_len) < 0 ||
         socket_type != SOCK_SEQPACKET)
-        fail_closed(control_fd);
+        fail_closed(control_fd, -1);
 
     (void)signal(SIGPIPE, SIG_IGN);
     sent = send(control_fd, waiting_frame, sizeof(waiting_frame) - 1,
                 MSG_NOSIGNAL);
     if (sent != (ssize_t)(sizeof(waiting_frame) - 1))
-        fail_closed(control_fd);
+        fail_closed(control_fd, -1);
 
     /*
      * The buffer has room for one byte beyond the expected payload. This
@@ -90,11 +111,11 @@ int main(int argc, char **argv)
     received = recv(control_fd, incoming, sizeof(incoming), 0);
     if (received != (ssize_t)(sizeof(ready_frame) - 1) ||
         memcmp(incoming, ready_frame, sizeof(ready_frame) - 1) != 0)
-        fail_closed(control_fd);
+        fail_closed(control_fd, -1);
 
     if (close(control_fd) != 0)
         _exit(GATE_FAILURE);
 
-    execvp(argv[3], &argv[3]);
+    execvp(argv[4], &argv[4]);
     _exit(EXEC_FAILURE);
 }

--- a/components/execd/native/session-gate.c
+++ b/components/execd/native/session-gate.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * opensandbox-session-gate is the last fail-closed barrier before a session
+ * workload executes. bubblewrap's --block-fd treats EOF as success, so it
+ * cannot be the authorization boundary by itself.
+ *
+ * The helper announces that it is blocked over an inherited SOCK_SEQPACKET
+ * socket. execd authenticates the sender with SCM_CREDENTIALS, validates its
+ * host PID and network namespace, and then sends the exact READY frame.
+ * EOF, a short/long frame, an invalid descriptor, or any socket error exits
+ * without ever executing the workload.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define GATE_FAILURE 125
+#define EXEC_FAILURE 126
+
+static const char waiting_frame[] = "OPENSANDBOX_SESSION_WAITING_V1";
+static const char ready_frame[] = "OPENSANDBOX_SESSION_READY_V1";
+
+static void fail_closed(int control_fd)
+{
+    if (control_fd >= 0)
+        (void)close(control_fd);
+    _exit(GATE_FAILURE);
+}
+
+int main(int argc, char **argv)
+{
+    char *end = NULL;
+    long parsed_fd;
+    int control_fd;
+    int socket_type = 0;
+    socklen_t socket_type_len = sizeof(socket_type);
+    char incoming[sizeof(ready_frame)];
+    ssize_t received;
+    ssize_t sent;
+
+    if (argc < 4 || strcmp(argv[2], "--") != 0)
+        fail_closed(-1);
+
+    errno = 0;
+    parsed_fd = strtol(argv[1], &end, 10);
+    if (errno != 0 || end == argv[1] || *end != '\0' ||
+        parsed_fd < 3 || parsed_fd > INT_MAX)
+        fail_closed(-1);
+    control_fd = (int)parsed_fd;
+
+    if (fcntl(control_fd, F_GETFD) < 0)
+        fail_closed(control_fd);
+    if (getsockopt(control_fd, SOL_SOCKET, SO_TYPE,
+                   &socket_type, &socket_type_len) < 0 ||
+        socket_type != SOCK_SEQPACKET)
+        fail_closed(control_fd);
+
+    (void)signal(SIGPIPE, SIG_IGN);
+    sent = send(control_fd, waiting_frame, sizeof(waiting_frame) - 1,
+                MSG_NOSIGNAL);
+    if (sent != (ssize_t)(sizeof(waiting_frame) - 1))
+        fail_closed(control_fd);
+
+    /*
+     * The buffer has room for one byte beyond the expected payload. This
+     * makes overlong seqpacket messages observably different from READY.
+     */
+    received = recv(control_fd, incoming, sizeof(incoming), 0);
+    if (received != (ssize_t)(sizeof(ready_frame) - 1) ||
+        memcmp(incoming, ready_frame, sizeof(ready_frame) - 1) != 0)
+        fail_closed(control_fd);
+
+    if (close(control_fd) != 0)
+        _exit(GATE_FAILURE);
+
+    execvp(argv[3], &argv[3]);
+    _exit(EXEC_FAILURE);
+}

--- a/components/execd/native/session-gate.c
+++ b/components/execd/native/session-gate.c
@@ -29,7 +29,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -98,7 +97,6 @@ int main(int argc, char **argv)
         socket_type != SOCK_SEQPACKET)
         fail_closed(control_fd, -1);
 
-    (void)signal(SIGPIPE, SIG_IGN);
     sent = send(control_fd, waiting_frame, sizeof(waiting_frame) - 1,
                 MSG_NOSIGNAL);
     if (sent != (ssize_t)(sizeof(waiting_frame) - 1))

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -138,8 +138,23 @@ func buildArgvWithLifecycle(
 		)
 	}
 
-	// 12. Separator + identity switch.
+	// 12. Separator + fail-closed gate + identity switch.
 	argv = append(argv, "--")
+
+	// In setpriv mode the trusted gate must run before credentials are dropped.
+	// Execd authenticates and inspects the blocked gate through /proc; moving
+	// setpriv after the gate keeps those checks available without granting
+	// CAP_SYS_PTRACE. Once READY arrives, the gate execs setpriv and the caller's
+	// command in the same PID and namespaces.
+	if lifecycle != nil {
+		argv = append(
+			argv,
+			"/proc/self/fd/"+lifecycle.gateExecFD,
+			lifecycle.controlFD,
+			lifecycle.gateExecFD,
+			"--",
+		)
+	}
 
 	// In userns mode, uid/gid are set via --uid/--gid in segment 1.
 	if !useUserns {
@@ -161,15 +176,6 @@ func buildArgvWithLifecycle(
 			}
 			argv = append(argv, setprivArgv...)
 		}
-	}
-	if lifecycle != nil {
-		argv = append(
-			argv,
-			"/proc/self/fd/"+lifecycle.gateExecFD,
-			lifecycle.controlFD,
-			lifecycle.gateExecFD,
-			"--",
-		)
 	}
 
 	return argv, nil
@@ -383,8 +389,8 @@ func matchEnvPattern(name, pattern string) bool {
 // Wrap rewrites cmd to execute under bwrap.
 func wrapWithArgv(cmd *exec.Cmd, bwrapPath string, argv []string) {
 	// Prepend bwrap argv before the original command.
-	// argv already ends with ["--", "setpriv", ...] and the original
-	// cmd.Args[0] is the user command after setpriv.
+	// argv already contains the bwrap separator and any lifecycle gate or
+	// identity-switch prefix. The original cmd.Args[0] follows that prefix.
 	userArgs := cmd.Args
 	cmd.Args = make([]string, 0, len(argv)+len(userArgs))
 	cmd.Args = append(cmd.Args, bwrapPath)

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -26,8 +26,27 @@ import (
 	"strings"
 )
 
-// buildArgv constructs the bwrap command line from wrap options.
+type bwrapLifecycleArgv struct {
+	gateFD    string
+	controlFD string
+	blockFD   string
+	statusFD  string
+}
+
+// buildArgv constructs the legacy bwrap command line from wrap options.
 func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
+	return buildArgvWithLifecycle(opts, seccompFd, nil)
+}
+
+// buildArgvWithLifecycle constructs the bwrap command line and, when lifecycle
+// is non-nil, installs the native fail-closed workload gate. The gate mount is
+// deliberately added after /run is replaced by tmpfs and before caller-
+// controlled mounts are applied.
+func buildArgvWithLifecycle(
+	opts WrapOptions,
+	seccompFd string,
+	lifecycle *bwrapLifecycleArgv,
+) ([]string, error) {
 	if err := validateWrapOptions(opts); err != nil {
 		return nil, err
 	}
@@ -74,6 +93,13 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 
 	// 4–6. Virtual filesystems.
 	argv = append(argv, "--tmpfs", "/run", "--dev", "/dev", "--proc", "/proc")
+	if lifecycle != nil {
+		argv = append(
+			argv,
+			"--dir", sessionGateSandboxDir,
+			"--ro-bind-fd", lifecycle.gateFD, sessionGateSandboxPath,
+		)
+	}
 
 	// 7. Workspace.
 	wsArgv, err := bwrapWorkspaceSegment(opts)
@@ -120,6 +146,13 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 	// setsid(2) returns EPERM for a group leader — it would fail every
 	// session start. Process-group isolation from Setpgid is sufficient.
 	argv = append(argv, "--die-with-parent")
+	if lifecycle != nil {
+		argv = append(
+			argv,
+			"--block-fd", lifecycle.blockFD,
+			"--json-status-fd", lifecycle.statusFD,
+		)
+	}
 
 	// 12. Separator + identity switch.
 	argv = append(argv, "--")
@@ -144,6 +177,14 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 			}
 			argv = append(argv, setprivArgv...)
 		}
+	}
+	if lifecycle != nil {
+		argv = append(
+			argv,
+			sessionGateSandboxPath,
+			lifecycle.controlFD,
+			"--",
+		)
 	}
 
 	return argv, nil

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -27,10 +27,10 @@ import (
 )
 
 type bwrapLifecycleArgv struct {
-	gateFD    string
-	controlFD string
-	blockFD   string
-	statusFD  string
+	gateExecFD string
+	controlFD  string
+	blockFD    string
+	statusFD   string
 }
 
 // buildArgv constructs the legacy bwrap command line from wrap options.
@@ -39,9 +39,8 @@ func buildArgv(opts WrapOptions, seccompFd string) ([]string, error) {
 }
 
 // buildArgvWithLifecycle constructs the bwrap command line and, when lifecycle
-// is non-nil, installs the native fail-closed workload gate. The gate mount is
-// deliberately added after /run is replaced by tmpfs and before caller-
-// controlled mounts are applied.
+// is non-nil, executes the native fail-closed workload gate directly through
+// its inherited descriptor.
 func buildArgvWithLifecycle(
 	opts WrapOptions,
 	seccompFd string,
@@ -91,14 +90,12 @@ func buildArgvWithLifecycle(
 		argv = append(argv, bwrapTmpSegment(opts.Profile)...)
 	}
 
-	// 4–6. Virtual filesystems.
-	argv = append(argv, "--tmpfs", "/run", "--dev", "/dev", "--proc", "/proc")
-	if lifecycle != nil {
-		argv = append(
-			argv,
-			"--dir", sessionGateSandboxDir,
-			"--ro-bind-fd", lifecycle.gateFD, sessionGateSandboxPath,
-		)
+	// 4–6. Virtual filesystems. Lifecycle mode installs procfs after all
+	// caller-controlled mounts so /proc/self/fd remains the trusted execution
+	// path for the native gate descriptor.
+	argv = append(argv, "--tmpfs", "/run", "--dev", "/dev")
+	if lifecycle == nil {
+		argv = append(argv, "--proc", "/proc")
 	}
 
 	// 7. Workspace.
@@ -130,6 +127,18 @@ func buildArgvWithLifecycle(
 			flag = "--ro-bind"
 		}
 		argv = append(argv, flag, b.Source, dest)
+	}
+
+	// Restore trusted procfs after every caller-controlled mount, then execute
+	// the verified gate through its inherited descriptor. Static mount aliases
+	// therefore cannot replace the gate between validation and execution.
+	//
+	// The isolated-session MVP treats processes sharing the parent sandbox
+	// mount namespace as one trusted owner. Defending against that owner
+	// concurrently replacing the proc mount ancestor still requires a future
+	// execveat-based launcher.
+	if lifecycle != nil {
+		argv = append(argv, "--proc", "/proc")
 	}
 
 	// 9. Environment.
@@ -181,8 +190,9 @@ func buildArgvWithLifecycle(
 	if lifecycle != nil {
 		argv = append(
 			argv,
-			sessionGateSandboxPath,
+			"/proc/self/fd/"+lifecycle.gateExecFD,
 			lifecycle.controlFD,
+			lifecycle.gateExecFD,
 			"--",
 		)
 	}

--- a/components/execd/pkg/isolation/bwrap.go
+++ b/components/execd/pkg/isolation/bwrap.go
@@ -55,32 +55,7 @@ func buildArgvWithLifecycle(
 	var argv []string
 
 	// 1. Namespace flags.
-	if useUserns {
-		argv = append(argv, "--unshare-user")
-		// --disable-userns is unsupported by the setuid build of bwrap;
-		// only add it for the non-setuid binary.
-		if !bwrapIsSetuid {
-			argv = append(argv, "--disable-userns")
-		}
-	}
-	argv = append(argv, "--unshare-pid", "--unshare-uts", "--hostname", "sandbox", "--unshare-ipc", "--unshare-cgroup")
-	if !opts.ShareNet {
-		argv = append(argv, "--unshare-net")
-	}
-	if useUserns {
-		uid := uint32(os.Getuid())
-		gid := uint32(os.Getgid())
-		if opts.Uid != nil {
-			uid = *opts.Uid
-		}
-		if opts.Gid != nil {
-			gid = *opts.Gid
-		}
-		argv = append(argv,
-			"--uid", strconv.FormatUint(uint64(uid), 10),
-			"--gid", strconv.FormatUint(uint64(gid), 10),
-		)
-	}
+	argv = append(argv, bwrapNamespaceSegment(opts, useUserns)...)
 
 	// 2. Root filesystem (read-only).
 	argv = append(argv, "--ro-bind", "/", "/")
@@ -198,6 +173,37 @@ func buildArgvWithLifecycle(
 	}
 
 	return argv, nil
+}
+
+func bwrapNamespaceSegment(opts WrapOptions, useUserns bool) []string {
+	var argv []string
+	if useUserns {
+		argv = append(argv, "--unshare-user")
+		// --disable-userns is unsupported by the setuid build of bwrap;
+		// only add it for the non-setuid binary.
+		if !bwrapIsSetuid {
+			argv = append(argv, "--disable-userns")
+		}
+	}
+	argv = append(argv, "--unshare-pid", "--unshare-uts", "--hostname", "sandbox", "--unshare-ipc", "--unshare-cgroup")
+	if !opts.ShareNet {
+		argv = append(argv, "--unshare-net")
+	}
+	if useUserns {
+		uid := uint32(os.Getuid())
+		gid := uint32(os.Getgid())
+		if opts.Uid != nil {
+			uid = *opts.Uid
+		}
+		if opts.Gid != nil {
+			gid = *opts.Gid
+		}
+		argv = append(argv,
+			"--uid", strconv.FormatUint(uint64(uid), 10),
+			"--gid", strconv.FormatUint(uint64(gid), 10),
+		)
+	}
+	return argv
 }
 
 // validateWrapOptions checks for invalid or conflicting options.

--- a/components/execd/pkg/isolation/bwrap_linux.go
+++ b/components/execd/pkg/isolation/bwrap_linux.go
@@ -176,9 +176,6 @@ func (b *bwrapImpl) WrapWithLifecycle(
 	if err := validateWrapOptions(opts); err != nil {
 		return nil, fmt.Errorf("bwrap: %w", err)
 	}
-	if err := validateLifecycleMountSafety(opts); err != nil {
-		return nil, fmt.Errorf("bwrap: %w", err)
-	}
 
 	firstAddedFile := len(cmd.ExtraFiles)
 	cleanupExtraFiles := true
@@ -197,7 +194,7 @@ func (b *bwrapImpl) WrapWithLifecycle(
 	if err != nil {
 		return nil, fmt.Errorf("bwrap: %w", err)
 	}
-	gateFD := appendExtraFile(cmd, gateFile)
+	gateExecFD := appendExtraFile(cmd, gateFile)
 
 	statusReader, statusWriter, err := os.Pipe()
 	if err != nil {
@@ -240,10 +237,10 @@ func (b *bwrapImpl) WrapWithLifecycle(
 		opts,
 		seccompFD,
 		&bwrapLifecycleArgv{
-			gateFD:    gateFD,
-			controlFD: controlFD,
-			blockFD:   setupFD,
-			statusFD:  statusFD,
+			gateExecFD: gateExecFD,
+			controlFD:  controlFD,
+			blockFD:    setupFD,
+			statusFD:   statusFD,
 		},
 	)
 	if err != nil {
@@ -257,6 +254,7 @@ func (b *bwrapImpl) WrapWithLifecycle(
 		controlParent,
 		controlChildFD,
 		controlSocketInode,
+		!opts.ShareNet,
 	)
 	cleanupExtraFiles = false
 	closeControlParent = false

--- a/components/execd/pkg/isolation/bwrap_linux.go
+++ b/components/execd/pkg/isolation/bwrap_linux.go
@@ -143,28 +143,154 @@ func (b *bwrapImpl) Wrap(cmd *exec.Cmd, opts WrapOptions) error {
 		return fmt.Errorf("bwrap: binary not found")
 	}
 
-	// Wire up seccomp BPF via memfd, if available.
-	var seccompFd string
-	if len(seccompBPF) > 0 {
-		fd, err := createMemfdWithData(seccompBPF)
-		if err != nil {
-			return fmt.Errorf("bwrap: seccomp memfd: %w", err)
-		}
-		// ExtraFiles are assigned fds starting at 3 in the child process.
-		seccompFd = strconv.Itoa(3 + len(cmd.ExtraFiles))
-		cmd.ExtraFiles = append(cmd.ExtraFiles, os.NewFile(uintptr(fd), "seccomp"))
+	firstAddedFile := len(cmd.ExtraFiles)
+	seccompFd, err := appendSeccompFile(cmd)
+	if err != nil {
+		return err
 	}
 
 	argv, err := buildArgv(opts, seccompFd)
 	if err != nil {
-		for _, f := range cmd.ExtraFiles {
-			f.Close()
-		}
+		closeExtraFilesFrom(cmd, firstAddedFile)
 		return fmt.Errorf("bwrap: %w", err)
 	}
 
 	wrapWithArgv(cmd, bwrapPath, argv)
 	return nil
+}
+
+// WrapWithLifecycle installs the native fail-closed workload gate and exposes
+// bubblewrap's host-visible child/network identity. The returned lifecycle
+// must be aborted and closed if cmd.Start is not called. Once cmd.Start
+// returns, the caller must close the parent copies in cmd.ExtraFiles.
+func (b *bwrapImpl) WrapWithLifecycle(
+	cmd *exec.Cmd,
+	opts WrapOptions,
+) (WorkloadLifecycle, error) {
+	if bwrapPath == "" {
+		bwrapPath = findBwrap()
+	}
+	if bwrapPath == "" {
+		return nil, fmt.Errorf("bwrap: binary not found")
+	}
+	if err := validateWrapOptions(opts); err != nil {
+		return nil, fmt.Errorf("bwrap: %w", err)
+	}
+	if err := validateLifecycleMountSafety(opts); err != nil {
+		return nil, fmt.Errorf("bwrap: %w", err)
+	}
+
+	firstAddedFile := len(cmd.ExtraFiles)
+	cleanupExtraFiles := true
+	defer func() {
+		if cleanupExtraFiles {
+			closeExtraFilesFrom(cmd, firstAddedFile)
+		}
+	}()
+
+	seccompFD, err := appendSeccompFile(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	gateFile, err := openSessionGate()
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: %w", err)
+	}
+	gateFD := appendExtraFile(cmd, gateFile)
+
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: create status pipe: %w", err)
+	}
+	parentFiles := []*os.File{statusReader}
+	defer func() {
+		if cleanupExtraFiles {
+			for _, file := range parentFiles {
+				_ = file.Close()
+			}
+		}
+	}()
+	statusFD := appendExtraFile(cmd, statusWriter)
+
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: create setup gate: %w", err)
+	}
+	parentFiles = append(parentFiles, setupWriter)
+	setupFD := appendExtraFile(cmd, setupReader)
+
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: %w", err)
+	}
+	closeControlParent := true
+	defer func() {
+		if closeControlParent {
+			_ = controlParent.Close()
+		}
+	}()
+	controlFD := appendExtraFile(cmd, controlChild)
+	controlChildFD, err := strconv.Atoi(controlFD)
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: parse native workload gate descriptor: %w", err)
+	}
+
+	argv, err := buildArgvWithLifecycle(
+		opts,
+		seccompFD,
+		&bwrapLifecycleArgv{
+			gateFD:    gateFD,
+			controlFD: controlFD,
+			blockFD:   setupFD,
+			statusFD:  statusFD,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("bwrap: %w", err)
+	}
+	wrapWithArgv(cmd, bwrapPath, argv)
+
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		controlChildFD,
+		controlSocketInode,
+	)
+	cleanupExtraFiles = false
+	closeControlParent = false
+	return lifecycle, nil
+}
+
+func appendSeccompFile(cmd *exec.Cmd) (string, error) {
+	if len(seccompBPF) == 0 {
+		return "", nil
+	}
+	fd, err := createMemfdWithData(seccompBPF)
+	if err != nil {
+		return "", fmt.Errorf("bwrap: seccomp memfd: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), "seccomp")
+	if file == nil {
+		_ = unix.Close(fd)
+		return "", fmt.Errorf("bwrap: seccomp memfd: invalid descriptor")
+	}
+	return appendExtraFile(cmd, file), nil
+}
+
+func appendExtraFile(cmd *exec.Cmd, file *os.File) string {
+	// ExtraFiles are assigned descriptors starting at 3 in the child.
+	childFD := strconv.Itoa(3 + len(cmd.ExtraFiles))
+	cmd.ExtraFiles = append(cmd.ExtraFiles, file)
+	return childFD
+}
+
+func closeExtraFilesFrom(cmd *exec.Cmd, first int) {
+	for _, file := range cmd.ExtraFiles[first:] {
+		_ = file.Close()
+	}
+	cmd.ExtraFiles = cmd.ExtraFiles[:first]
 }
 
 // createMemfdWithData creates an anonymous memfd, writes data to it, and
@@ -189,3 +315,4 @@ func createMemfdWithData(data []byte) (int, error) {
 
 // Ensure bwrapImpl satisfies Isolator.
 var _ Isolator = (*bwrapImpl)(nil)
+var _ LifecycleIsolator = (*bwrapImpl)(nil)

--- a/components/execd/pkg/isolation/bwrap_stub.go
+++ b/components/execd/pkg/isolation/bwrap_stub.go
@@ -48,5 +48,12 @@ func (b *bwrapStub) Capabilities() Capabilities { return Capabilities{Available:
 func (b *bwrapStub) Wrap(_ *exec.Cmd, _ WrapOptions) error {
 	return fmt.Errorf("bwrap: unavailable on non-Linux platform")
 }
+func (b *bwrapStub) WrapWithLifecycle(
+	_ *exec.Cmd,
+	_ WrapOptions,
+) (WorkloadLifecycle, error) {
+	return nil, fmt.Errorf("bwrap: lifecycle unavailable on non-Linux platform")
+}
 
 var _ Isolator = (*bwrapStub)(nil)
+var _ LifecycleIsolator = (*bwrapStub)(nil)

--- a/components/execd/pkg/isolation/isolator.go
+++ b/components/execd/pkg/isolation/isolator.go
@@ -15,7 +15,10 @@
 // Package isolation provides per-execution namespace isolation via bubblewrap.
 package isolation
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 // Profile presets default isolation settings.
 type Profile string
@@ -149,4 +152,64 @@ type Isolator interface {
 	Available() bool
 	Capabilities() Capabilities
 	Wrap(cmd *exec.Cmd, opts WrapOptions) error
+}
+
+// WorkloadIdentity is the host-visible identity of a workload that is
+// completely constructed but still blocked behind its fail-closed ready gate.
+//
+// PID is the process that will exec the caller's command after MarkReady.
+// SandboxPID is bubblewrap's host-visible child PID (the namespace init when
+// PID namespaces are enabled). NetNamespaceID is the inode reported by
+// /proc/PID/ns/net. ProcessStartTimeTicks disambiguates PID reuse.
+//
+// These values identify the workload; they do not pin a namespace or create a
+// cgroup. Callers that require those facilities must install them before
+// MarkReady and fail closed if they cannot.
+type WorkloadIdentity struct {
+	PID                   int
+	SandboxPID            int
+	NetNamespaceID        uint64
+	ProcessStartTimeTicks uint64
+}
+
+// WorkloadLifecycle controls the startup gate and consumes bubblewrap's
+// complete JSON status stream. A workload cannot execute the caller's command
+// until MarkReady succeeds. Abort and Close are idempotent.
+type WorkloadLifecycle interface {
+	// WaitForIdentity waits until both bubblewrap and the native workload gate
+	// have been authenticated and returns the host-visible workload identity.
+	// Context cancellation aborts startup; it never releases the workload.
+	WaitForIdentity(ctx context.Context) (WorkloadIdentity, error)
+
+	// MarkReady releases the native workload gate. It is valid only after a
+	// successful WaitForIdentity call.
+	MarkReady() error
+
+	// Abort permanently denies startup and closes all gate channels. Closing a
+	// gate is deliberately not treated as readiness.
+	Abort()
+
+	// DrainDone closes after the JSON status stream reaches a validated EOF or
+	// encounters an error. The stream continues to be drained after MarkReady.
+	// Once a workload has been released, callers must monitor DrainDone and
+	// terminate that workload if DrainError is non-nil: its lifecycle identity
+	// and exit accounting can no longer be trusted.
+	DrainDone() <-chan struct{}
+	DrainError() error
+	ExitCode() (int, bool)
+
+	// Close releases lifecycle descriptors and waits for the status-drain
+	// goroutine. It does not release or terminate the workload, so callers must
+	// stop a running command before Close.
+	Close() error
+}
+
+// LifecycleIsolator is required for secure isolated sessions. The legacy Wrap
+// method remains for ordinary callers, while WrapWithLifecycle adds the
+// fail-closed startup protocol. After WrapWithLifecycle returns successfully,
+// the caller owns every file in cmd.ExtraFiles and must close those parent
+// copies immediately after cmd.Start returns, whether Start succeeds or fails.
+type LifecycleIsolator interface {
+	Isolator
+	WrapWithLifecycle(cmd *exec.Cmd, opts WrapOptions) (WorkloadLifecycle, error)
 }

--- a/components/execd/pkg/isolation/lifecycle_linux.go
+++ b/components/execd/pkg/isolation/lifecycle_linux.go
@@ -471,12 +471,12 @@ func (l *bwrapLifecycle) MarkReady() error {
 			len(sessionGateReadyFrame),
 		)
 	}
-	closeErr := l.control.Close()
+	// A complete SOCK_SEQPACKET write is the irreversible release point.
+	// Cleanup failures cannot make an already-released workload fail closed,
+	// so they must not turn a successful release into a MarkReady error.
+	_ = l.control.Close()
 	l.control = nil
 	l.state = lifecycleWorkloadReady
-	if closeErr != nil {
-		return fmt.Errorf("close native workload gate: %w", closeErr)
-	}
 	return nil
 }
 

--- a/components/execd/pkg/isolation/lifecycle_linux.go
+++ b/components/execd/pkg/isolation/lifecycle_linux.go
@@ -1,0 +1,840 @@
+//go:build linux
+
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package isolation
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sessionGateHostPath    = "/usr/local/libexec/opensandbox-session-gate"
+	sessionGateSandboxDir  = "/run/opensandbox-session"
+	sessionGateSandboxPath = sessionGateSandboxDir + "/gate"
+
+	sessionGateWaitingFrame = "OPENSANDBOX_SESSION_WAITING_V1"
+	sessionGateReadyFrame   = "OPENSANDBOX_SESSION_READY_V1"
+
+	maxBwrapStatusDocumentBytes = 64 * 1024
+	maxBwrapStatusDocuments     = 1024
+
+	controlReadPollInterval = 100 * time.Millisecond
+	controlWriteTimeout     = time.Second
+)
+
+var (
+	errWorkloadLifecycleAborted = errors.New("workload lifecycle aborted")
+	errWorkloadAlreadyReady     = errors.New("workload is already ready")
+)
+
+type lifecycleState uint8
+
+const (
+	lifecycleWaitingForBwrap lifecycleState = iota
+	lifecycleWaitingForGate
+	lifecycleIdentityReady
+	lifecycleWorkloadReady
+	lifecycleAborted
+)
+
+type bwrapSandboxStatus struct {
+	pid            int
+	netNamespaceID uint64
+	err            error
+}
+
+type bwrapLifecycle struct {
+	statusReader *os.File
+
+	mu                 sync.Mutex
+	state              lifecycleState
+	setup              *os.File
+	control            *net.UnixConn
+	controlChildFD     int
+	controlSocketInode uint64
+	identity           WorkloadIdentity
+
+	sandboxStatus chan bwrapSandboxStatus
+	drainDone     chan struct{}
+	drainErr      error
+	exitCode      int
+	hasExitCode   bool
+	closeOnce     sync.Once
+}
+
+func newBwrapLifecycle(
+	statusReader *os.File,
+	setupWriter *os.File,
+	control *net.UnixConn,
+	controlChildFD int,
+	controlSocketInode uint64,
+) *bwrapLifecycle {
+	lifecycle := &bwrapLifecycle{
+		statusReader:       statusReader,
+		state:              lifecycleWaitingForBwrap,
+		setup:              setupWriter,
+		control:            control,
+		controlChildFD:     controlChildFD,
+		controlSocketInode: controlSocketInode,
+		sandboxStatus:      make(chan bwrapSandboxStatus, 1),
+		drainDone:          make(chan struct{}),
+	}
+	go lifecycle.drainStatus()
+	return lifecycle
+}
+
+func (l *bwrapLifecycle) WaitForIdentity(ctx context.Context) (
+	identity WorkloadIdentity,
+	err error,
+) {
+	l.mu.Lock()
+	switch l.state {
+	case lifecycleIdentityReady, lifecycleWorkloadReady:
+		identity = l.identity
+		l.mu.Unlock()
+		return identity, nil
+	case lifecycleAborted:
+		l.mu.Unlock()
+		return WorkloadIdentity{}, errWorkloadLifecycleAborted
+	case lifecycleWaitingForGate:
+		l.mu.Unlock()
+		return WorkloadIdentity{}, errors.New("workload identity wait already in progress")
+	case lifecycleWaitingForBwrap:
+		l.state = lifecycleWaitingForGate
+	}
+	l.mu.Unlock()
+
+	defer func() {
+		if err != nil {
+			l.Abort()
+		}
+	}()
+
+	var status bwrapSandboxStatus
+	select {
+	case status = <-l.sandboxStatus:
+		if status.err != nil {
+			return WorkloadIdentity{}, status.err
+		}
+	case <-ctx.Done():
+		return WorkloadIdentity{}, fmt.Errorf("wait for bwrap status: %w", ctx.Err())
+	}
+
+	if err := validateSandboxStatus(status); err != nil {
+		return WorkloadIdentity{}, err
+	}
+	if err := l.releaseBwrapSetupGate(); err != nil {
+		return WorkloadIdentity{}, err
+	}
+
+	workloadPID, err := l.waitForNativeGate(ctx)
+	if err != nil {
+		return WorkloadIdentity{}, err
+	}
+	identity, err = validateWorkloadIdentity(
+		workloadPID,
+		status,
+		l.controlChildFD,
+		l.controlSocketInode,
+	)
+	if err != nil {
+		return WorkloadIdentity{}, err
+	}
+
+	l.mu.Lock()
+	if l.state == lifecycleAborted {
+		l.mu.Unlock()
+		return WorkloadIdentity{}, errWorkloadLifecycleAborted
+	}
+	l.identity = identity
+	l.state = lifecycleIdentityReady
+	l.mu.Unlock()
+	return identity, nil
+}
+
+func (l *bwrapLifecycle) releaseBwrapSetupGate() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.state == lifecycleAborted {
+		return errWorkloadLifecycleAborted
+	}
+	if l.setup == nil {
+		return errors.New("bwrap setup gate is unavailable")
+	}
+	n, err := l.setup.Write([]byte{1})
+	closeErr := l.setup.Close()
+	l.setup = nil
+	if err != nil {
+		return fmt.Errorf("release bwrap setup gate: %w", err)
+	}
+	if n != 1 {
+		return fmt.Errorf("release bwrap setup gate: short write: got %d, want 1", n)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close bwrap setup gate: %w", closeErr)
+	}
+	return nil
+}
+
+func (l *bwrapLifecycle) waitForNativeGate(ctx context.Context) (int, error) {
+	payload := make([]byte, len(sessionGateWaitingFrame)+1)
+	oob := make([]byte, unix.CmsgSpace(unix.SizeofUcred))
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, fmt.Errorf("wait for native workload gate: %w", err)
+		}
+
+		l.mu.Lock()
+		if l.state == lifecycleAborted || l.control == nil {
+			l.mu.Unlock()
+			return 0, errWorkloadLifecycleAborted
+		}
+		control := l.control
+		l.mu.Unlock()
+
+		deadline := time.Now().Add(controlReadPollInterval)
+		if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+			deadline = contextDeadline
+		}
+		if err := control.SetReadDeadline(deadline); err != nil {
+			return 0, fmt.Errorf("set native workload gate deadline: %w", err)
+		}
+
+		n, oobn, flags, _, err := control.ReadMsgUnix(payload, oob)
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				continue
+			}
+			return 0, fmt.Errorf("read native workload gate: %w", err)
+		}
+		if flags&(unix.MSG_TRUNC|unix.MSG_CTRUNC) != 0 {
+			return 0, errors.New("native workload gate frame or credentials were truncated")
+		}
+		if string(payload[:n]) != sessionGateWaitingFrame {
+			return 0, errors.New("native workload gate sent an invalid waiting frame")
+		}
+
+		credentials, err := parseSingleUnixCredentials(oob[:oobn])
+		if err != nil {
+			return 0, err
+		}
+		if credentials.Pid <= 0 {
+			return 0, fmt.Errorf("native workload gate sent invalid pid %d", credentials.Pid)
+		}
+		return int(credentials.Pid), nil
+	}
+}
+
+func parseSingleUnixCredentials(oob []byte) (*unix.Ucred, error) {
+	messages, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, fmt.Errorf("parse native workload gate credentials: %w", err)
+	}
+	var credentials *unix.Ucred
+	for _, message := range messages {
+		if message.Header.Level != unix.SOL_SOCKET ||
+			message.Header.Type != unix.SCM_CREDENTIALS {
+			return nil, fmt.Errorf(
+				"native workload gate sent unexpected control message level=%d type=%d",
+				message.Header.Level,
+				message.Header.Type,
+			)
+		}
+		if credentials != nil {
+			return nil, errors.New("native workload gate sent duplicate credentials")
+		}
+		credentials, err = unix.ParseUnixCredentials(&message)
+		if err != nil {
+			return nil, fmt.Errorf("parse native workload gate credentials: %w", err)
+		}
+	}
+	if credentials == nil {
+		return nil, errors.New("native workload gate did not send credentials")
+	}
+	return credentials, nil
+}
+
+func validateSandboxStatus(status bwrapSandboxStatus) error {
+	if status.pid <= 0 {
+		return fmt.Errorf("bwrap status reported invalid child-pid %d", status.pid)
+	}
+	if status.netNamespaceID == 0 {
+		return errors.New("bwrap status did not report a network namespace")
+	}
+	actualNamespaceID, err := readNetNamespaceID(status.pid)
+	if err != nil {
+		return fmt.Errorf("read bwrap child network namespace: %w", err)
+	}
+	if actualNamespaceID != status.netNamespaceID {
+		return fmt.Errorf(
+			"bwrap child network namespace mismatch: status=%d proc=%d",
+			status.netNamespaceID,
+			actualNamespaceID,
+		)
+	}
+	return nil
+}
+
+func validateWorkloadIdentity(
+	workloadPID int,
+	status bwrapSandboxStatus,
+	controlFD int,
+	controlSocketInode uint64,
+) (WorkloadIdentity, error) {
+	ppid, startTime, err := readProcessIdentity(workloadPID)
+	if err != nil {
+		return WorkloadIdentity{}, fmt.Errorf("read workload process identity: %w", err)
+	}
+	if ppid != status.pid {
+		return WorkloadIdentity{}, fmt.Errorf(
+			"workload parent mismatch: got %d, want bwrap child %d",
+			ppid,
+			status.pid,
+		)
+	}
+	netNamespaceID, err := readNetNamespaceID(workloadPID)
+	if err != nil {
+		return WorkloadIdentity{}, fmt.Errorf("read workload network namespace: %w", err)
+	}
+	if netNamespaceID != status.netNamespaceID {
+		return WorkloadIdentity{}, fmt.Errorf(
+			"workload network namespace mismatch: status=%d proc=%d",
+			status.netNamespaceID,
+			netNamespaceID,
+		)
+	}
+	if controlFD < 3 || controlSocketInode == 0 {
+		return WorkloadIdentity{}, errors.New("native workload gate socket identity is unavailable")
+	}
+	actualSocketInode, err := readControlSocketInode(workloadPID, controlFD)
+	if err != nil {
+		return WorkloadIdentity{}, fmt.Errorf("read workload control socket identity: %w", err)
+	}
+	if actualSocketInode != controlSocketInode {
+		return WorkloadIdentity{}, fmt.Errorf(
+			"workload control socket mismatch: got %d, want %d",
+			actualSocketInode,
+			controlSocketInode,
+		)
+	}
+	return WorkloadIdentity{
+		PID:                   workloadPID,
+		SandboxPID:            status.pid,
+		NetNamespaceID:        netNamespaceID,
+		ProcessStartTimeTicks: startTime,
+	}, nil
+}
+
+func readControlSocketInode(pid, fd int) (uint64, error) {
+	target, err := os.Readlink(
+		filepath.Join("/proc", strconv.Itoa(pid), "fd", strconv.Itoa(fd)),
+	)
+	if err != nil {
+		return 0, err
+	}
+	const prefix = "socket:["
+	if !strings.HasPrefix(target, prefix) || !strings.HasSuffix(target, "]") {
+		return 0, fmt.Errorf("unexpected control descriptor link %q", target)
+	}
+	inode, err := strconv.ParseUint(target[len(prefix):len(target)-1], 10, 64)
+	if err != nil || inode == 0 {
+		return 0, fmt.Errorf("unexpected control descriptor link %q", target)
+	}
+	return inode, nil
+}
+
+func readProcessIdentity(pid int) (ppid int, startTime uint64, err error) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0, 0, err
+	}
+	// comm is parenthesized and may contain spaces or ')' characters. The last
+	// ')' is followed by field 3 (state).
+	closeParen := bytes.LastIndexByte(data, ')')
+	if closeParen < 0 || closeParen+1 >= len(data) {
+		return 0, 0, errors.New("malformed /proc stat: missing comm terminator")
+	}
+	fields := strings.Fields(string(data[closeParen+1:]))
+	// fields[0] is field 3 (state), fields[1] is ppid, and fields[19] is
+	// starttime (field 22).
+	if len(fields) <= 19 {
+		return 0, 0, fmt.Errorf("malformed /proc stat: got %d trailing fields", len(fields))
+	}
+	parsedPPID, err := strconv.ParseInt(fields[1], 10, 32)
+	if err != nil || parsedPPID <= 0 {
+		return 0, 0, fmt.Errorf("malformed /proc stat ppid %q", fields[1])
+	}
+	parsedStartTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil || parsedStartTime == 0 {
+		return 0, 0, fmt.Errorf("malformed /proc stat starttime %q", fields[19])
+	}
+	return int(parsedPPID), parsedStartTime, nil
+}
+
+func readNetNamespaceID(pid int) (uint64, error) {
+	target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "ns", "net"))
+	if err != nil {
+		return 0, err
+	}
+	const prefix = "net:["
+	if !strings.HasPrefix(target, prefix) || !strings.HasSuffix(target, "]") {
+		return 0, fmt.Errorf("unexpected network namespace link %q", target)
+	}
+	id, err := strconv.ParseUint(target[len(prefix):len(target)-1], 10, 64)
+	if err != nil || id == 0 {
+		return 0, fmt.Errorf("unexpected network namespace link %q", target)
+	}
+	return id, nil
+}
+
+func (l *bwrapLifecycle) MarkReady() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	switch l.state {
+	case lifecycleWorkloadReady:
+		return errWorkloadAlreadyReady
+	case lifecycleAborted:
+		return errWorkloadLifecycleAborted
+	case lifecycleIdentityReady:
+		// Continue below.
+	default:
+		return errors.New("workload identity is not ready")
+	}
+	if l.control == nil {
+		l.state = lifecycleAborted
+		return errors.New("native workload gate is unavailable")
+	}
+	if err := l.control.SetWriteDeadline(time.Now().Add(controlWriteTimeout)); err != nil {
+		l.abortLocked()
+		return fmt.Errorf("set native workload gate write deadline: %w", err)
+	}
+	n, err := l.control.Write([]byte(sessionGateReadyFrame))
+	if err != nil {
+		l.abortLocked()
+		return fmt.Errorf("release native workload gate: %w", err)
+	}
+	if n != len(sessionGateReadyFrame) {
+		l.abortLocked()
+		return fmt.Errorf(
+			"release native workload gate: short write: got %d, want %d",
+			n,
+			len(sessionGateReadyFrame),
+		)
+	}
+	closeErr := l.control.Close()
+	l.control = nil
+	l.state = lifecycleWorkloadReady
+	if closeErr != nil {
+		return fmt.Errorf("close native workload gate: %w", closeErr)
+	}
+	return nil
+}
+
+func (l *bwrapLifecycle) Abort() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.abortLocked()
+}
+
+func (l *bwrapLifecycle) abortLocked() {
+	if l.state == lifecycleAborted {
+		return
+	}
+	l.state = lifecycleAborted
+	if l.control != nil {
+		_ = l.control.Close()
+		l.control = nil
+	}
+	// Close the native gate first. EOF on bubblewrap's block-fd is treated as
+	// success by bubblewrap; if setup is then released, the native helper sees
+	// a closed control socket and exits instead of executing the workload.
+	if l.setup != nil {
+		_ = l.setup.Close()
+		l.setup = nil
+	}
+	if l.statusReader != nil {
+		_ = l.statusReader.Close()
+	}
+}
+
+func (l *bwrapLifecycle) DrainDone() <-chan struct{} {
+	return l.drainDone
+}
+
+func (l *bwrapLifecycle) DrainError() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.drainErr
+}
+
+func (l *bwrapLifecycle) ExitCode() (int, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.exitCode, l.hasExitCode
+}
+
+func (l *bwrapLifecycle) Close() error {
+	l.closeOnce.Do(func() {
+		l.Abort()
+		<-l.drainDone
+	})
+	err := l.DrainError()
+	if errors.Is(err, errWorkloadLifecycleAborted) {
+		// Closing an otherwise healthy lifecycle intentionally interrupts the
+		// status reader after denying the native gate. That interruption is
+		// expected teardown, not a cleanup failure.
+		return nil
+	}
+	return err
+}
+
+func (l *bwrapLifecycle) drainStatus() {
+	defer close(l.drainDone)
+	defer l.statusReader.Close()
+
+	scanner := bufio.NewScanner(l.statusReader)
+	scanner.Buffer(make([]byte, 4096), maxBwrapStatusDocumentBytes)
+
+	var (
+		documentCount int
+		sawChild      bool
+		sawExit       bool
+	)
+	for scanner.Scan() {
+		documentCount++
+		if documentCount > maxBwrapStatusDocuments {
+			l.finishStatusDrain(
+				fmt.Errorf("bwrap status exceeded %d documents", maxBwrapStatusDocuments),
+				sawChild,
+			)
+			return
+		}
+
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(scanner.Bytes(), &object); err != nil {
+			l.finishStatusDrain(fmt.Errorf("decode bwrap status document: %w", err), sawChild)
+			return
+		}
+		if object == nil {
+			l.finishStatusDrain(errors.New("bwrap status document is not an object"), sawChild)
+			return
+		}
+
+		childRaw, hasChild := object["child-pid"]
+		if hasChild {
+			if sawChild {
+				l.finishStatusDrain(errors.New("bwrap status repeated child-pid"), true)
+				return
+			}
+			childPID, err := parseStatusUint(childRaw, "child-pid", 1<<31-1, false)
+			if err != nil {
+				l.finishStatusDrain(err, false)
+				return
+			}
+			netRaw, ok := object["net-namespace"]
+			if !ok {
+				l.finishStatusDrain(
+					errors.New("bwrap child status omitted net-namespace"),
+					false,
+				)
+				return
+			}
+			netNamespaceID, err := parseStatusUint(
+				netRaw,
+				"net-namespace",
+				^uint64(0),
+				false,
+			)
+			if err != nil {
+				l.finishStatusDrain(err, false)
+				return
+			}
+			sawChild = true
+			l.sandboxStatus <- bwrapSandboxStatus{
+				pid:            int(childPID),
+				netNamespaceID: netNamespaceID,
+			}
+		}
+
+		exitRaw, hasExit := object["exit-code"]
+		if hasExit {
+			if !sawChild {
+				l.finishStatusDrain(errors.New("bwrap status reported exit-code before child-pid"), false)
+				return
+			}
+			if sawExit {
+				l.finishStatusDrain(errors.New("bwrap status repeated exit-code"), sawChild)
+				return
+			}
+			exitCode, err := parseStatusUint(exitRaw, "exit-code", 255, true)
+			if err != nil {
+				l.finishStatusDrain(err, sawChild)
+				return
+			}
+			sawExit = true
+			l.mu.Lock()
+			l.exitCode = int(exitCode)
+			l.hasExitCode = true
+			l.mu.Unlock()
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		if l.isAborted() {
+			err = errWorkloadLifecycleAborted
+		} else {
+			err = fmt.Errorf("read bwrap status: %w", err)
+		}
+		l.finishStatusDrain(err, sawChild)
+		return
+	}
+	if !sawChild {
+		l.finishStatusDrain(
+			errors.New("bwrap status reached EOF before child-pid"),
+			false,
+		)
+		return
+	}
+	if !sawExit {
+		l.finishStatusDrain(
+			errors.New("bwrap status reached EOF before exit-code"),
+			true,
+		)
+		return
+	}
+	l.finishStatusDrain(nil, true)
+}
+
+func (l *bwrapLifecycle) finishStatusDrain(err error, sawChild bool) {
+	l.mu.Lock()
+	if l.drainErr == nil {
+		l.drainErr = err
+	}
+	if err != nil {
+		l.abortLocked()
+	}
+	l.mu.Unlock()
+	if !sawChild {
+		select {
+		case l.sandboxStatus <- bwrapSandboxStatus{err: err}:
+		default:
+		}
+	}
+}
+
+func (l *bwrapLifecycle) isAborted() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.state == lifecycleAborted
+}
+
+func parseStatusUint(
+	raw json.RawMessage,
+	name string,
+	maximum uint64,
+	allowZero bool,
+) (uint64, error) {
+	if len(raw) == 0 {
+		return 0, fmt.Errorf("bwrap status %s is not an unsigned integer", name)
+	}
+	for _, character := range raw {
+		if character < '0' || character > '9' {
+			return 0, fmt.Errorf("bwrap status %s is not an unsigned integer", name)
+		}
+	}
+	value, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bwrap status %s is not an unsigned integer: %w", name, err)
+	}
+	if (!allowZero && value == 0) || value > maximum {
+		return 0, fmt.Errorf("bwrap status %s value %d is out of range", name, value)
+	}
+	return value, nil
+}
+
+// validateLifecycleMountSafety prevents caller-controlled mounts from
+// replacing the native gate after it has been installed.
+func validateLifecycleMountSafety(opts WrapOptions) error {
+	check := func(kind, destination string) error {
+		if mountCoversPath(destination, sessionGateSandboxPath) {
+			return fmt.Errorf(
+				"isolation: %s mount %q covers reserved lifecycle gate %q",
+				kind,
+				destination,
+				sessionGateSandboxPath,
+			)
+		}
+		return nil
+	}
+	if err := check("workspace", opts.Workspace.Path); err != nil {
+		return err
+	}
+	for _, destination := range opts.ExtraWritable {
+		if err := check("extra writable", destination); err != nil {
+			return err
+		}
+	}
+	for _, bind := range opts.Binds {
+		destination := bind.Dest
+		if destination == "" {
+			destination = bind.Source
+		}
+		if err := check("bind", destination); err != nil {
+			return err
+		}
+	}
+	if opts.UpperDir != "" {
+		upperRoot := filepath.Dir(filepath.Dir(opts.UpperDir))
+		if err := check("upper root", upperRoot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mountCoversPath(destination, target string) bool {
+	destination = filepath.Clean(destination)
+	target = filepath.Clean(target)
+	if destination == target || destination == string(filepath.Separator) {
+		return true
+	}
+	return strings.HasPrefix(target, destination+string(filepath.Separator))
+}
+
+func openSessionGate() (*os.File, error) {
+	fd, err := unix.Open(
+		sessionGateHostPath,
+		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open native workload gate: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), "opensandbox-session-gate")
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, errors.New("open native workload gate: invalid descriptor")
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("stat native workload gate: %w", err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		file.Close()
+		return nil, errors.New("native workload gate is not a regular file")
+	}
+	if stat.Mode&0o111 == 0 {
+		file.Close()
+		return nil, errors.New("native workload gate is not executable")
+	}
+	if stat.Mode&0o022 != 0 {
+		file.Close()
+		return nil, errors.New("native workload gate is group- or world-writable")
+	}
+	if stat.Uid != 0 && stat.Uid != uint32(os.Geteuid()) {
+		file.Close()
+		return nil, fmt.Errorf(
+			"native workload gate has untrusted owner uid %d",
+			stat.Uid,
+		)
+	}
+	return file, nil
+}
+
+func newGateSocketpair() (*net.UnixConn, *os.File, uint64, error) {
+	fds, err := unix.Socketpair(
+		unix.AF_UNIX,
+		unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("create native workload gate socket: %w", err)
+	}
+	closeFDs := true
+	defer func() {
+		if closeFDs {
+			_ = unix.Close(fds[0])
+			_ = unix.Close(fds[1])
+		}
+	}()
+	if err := unix.SetsockoptInt(
+		fds[0],
+		unix.SOL_SOCKET,
+		unix.SO_PASSCRED,
+		1,
+	); err != nil {
+		return nil, nil, 0, fmt.Errorf("enable native workload gate credentials: %w", err)
+	}
+	var childStat unix.Stat_t
+	if err := unix.Fstat(fds[1], &childStat); err != nil {
+		return nil, nil, 0, fmt.Errorf("stat native workload gate socket: %w", err)
+	}
+	if childStat.Ino == 0 {
+		return nil, nil, 0, errors.New("native workload gate socket has no inode")
+	}
+
+	parentFile := os.NewFile(uintptr(fds[0]), "session-gate-parent")
+	childFile := os.NewFile(uintptr(fds[1]), "session-gate-child")
+	if parentFile == nil || childFile == nil {
+		if parentFile != nil {
+			_ = parentFile.Close()
+			fds[0] = -1
+		}
+		if childFile != nil {
+			_ = childFile.Close()
+			fds[1] = -1
+		}
+		return nil, nil, 0, errors.New("create native workload gate files")
+	}
+	rawConnection, err := net.FileConn(parentFile)
+	_ = parentFile.Close()
+	fds[0] = -1
+	if err != nil {
+		_ = childFile.Close()
+		fds[1] = -1
+		return nil, nil, 0, fmt.Errorf("adopt native workload gate socket: %w", err)
+	}
+	parentConnection, ok := rawConnection.(*net.UnixConn)
+	if !ok {
+		_ = rawConnection.Close()
+		_ = childFile.Close()
+		fds[1] = -1
+		return nil, nil, 0, errors.New("native workload gate is not a Unix socket")
+	}
+	closeFDs = false
+	return parentConnection, childFile, childStat.Ino, nil
+}
+
+var _ WorkloadLifecycle = (*bwrapLifecycle)(nil)

--- a/components/execd/pkg/isolation/lifecycle_linux.go
+++ b/components/execd/pkg/isolation/lifecycle_linux.go
@@ -570,61 +570,22 @@ func (l *bwrapLifecycle) drainStatus() {
 			return
 		}
 
-		childRaw, hasChild := object["child-pid"]
+		childStatus, hasChild, err := l.parseChildStatus(object, sawChild)
+		if err != nil {
+			l.finishStatusDrain(err, sawChild)
+			return
+		}
 		if hasChild {
-			if sawChild {
-				l.finishStatusDrain(errors.New("bwrap status repeated child-pid"), true)
-				return
-			}
-			childPID, err := parseStatusUint(childRaw, "child-pid", 1<<31-1, false)
-			if err != nil {
-				l.finishStatusDrain(err, false)
-				return
-			}
-			var netNamespaceID uint64
-			netRaw, ok := object["net-namespace"]
-			if !ok {
-				if l.requireNetNamespace {
-					l.finishStatusDrain(
-						errors.New("bwrap child status omitted net-namespace"),
-						false,
-					)
-					return
-				}
-			} else {
-				netNamespaceID, err = parseStatusUint(
-					netRaw,
-					"net-namespace",
-					^uint64(0),
-					false,
-				)
-				if err != nil {
-					l.finishStatusDrain(err, false)
-					return
-				}
-			}
 			sawChild = true
-			l.sandboxStatus <- bwrapSandboxStatus{
-				pid:            int(childPID),
-				netNamespaceID: netNamespaceID,
-			}
+			l.sandboxStatus <- childStatus
 		}
 
-		exitRaw, hasExit := object["exit-code"]
+		exitCode, hasExit, err := parseExitStatus(object, sawChild, sawExit)
+		if err != nil {
+			l.finishStatusDrain(err, sawChild)
+			return
+		}
 		if hasExit {
-			if !sawChild {
-				l.finishStatusDrain(errors.New("bwrap status reported exit-code before child-pid"), false)
-				return
-			}
-			if sawExit {
-				l.finishStatusDrain(errors.New("bwrap status repeated exit-code"), sawChild)
-				return
-			}
-			exitCode, err := parseStatusUint(exitRaw, "exit-code", 255, true)
-			if err != nil {
-				l.finishStatusDrain(err, sawChild)
-				return
-			}
 			sawExit = true
 			l.mu.Lock()
 			l.exitCode = int(exitCode)
@@ -657,6 +618,69 @@ func (l *bwrapLifecycle) drainStatus() {
 		return
 	}
 	l.finishStatusDrain(nil, true)
+}
+
+func (l *bwrapLifecycle) parseChildStatus(
+	object map[string]json.RawMessage,
+	sawChild bool,
+) (bwrapSandboxStatus, bool, error) {
+	childRaw, hasChild := object["child-pid"]
+	if !hasChild {
+		return bwrapSandboxStatus{}, false, nil
+	}
+	if sawChild {
+		return bwrapSandboxStatus{}, false, errors.New("bwrap status repeated child-pid")
+	}
+	childPID, err := parseStatusUint(childRaw, "child-pid", 1<<31-1, false)
+	if err != nil {
+		return bwrapSandboxStatus{}, false, err
+	}
+
+	var netNamespaceID uint64
+	netRaw, hasNetNamespace := object["net-namespace"]
+	if !hasNetNamespace {
+		if l.requireNetNamespace {
+			return bwrapSandboxStatus{}, false, errors.New(
+				"bwrap child status omitted net-namespace",
+			)
+		}
+	} else {
+		netNamespaceID, err = parseStatusUint(
+			netRaw,
+			"net-namespace",
+			^uint64(0),
+			false,
+		)
+		if err != nil {
+			return bwrapSandboxStatus{}, false, err
+		}
+	}
+	return bwrapSandboxStatus{
+		pid:            int(childPID),
+		netNamespaceID: netNamespaceID,
+	}, true, nil
+}
+
+func parseExitStatus(
+	object map[string]json.RawMessage,
+	sawChild bool,
+	sawExit bool,
+) (uint64, bool, error) {
+	exitRaw, hasExit := object["exit-code"]
+	if !hasExit {
+		return 0, false, nil
+	}
+	if !sawChild {
+		return 0, false, errors.New("bwrap status reported exit-code before child-pid")
+	}
+	if sawExit {
+		return 0, false, errors.New("bwrap status repeated exit-code")
+	}
+	exitCode, err := parseStatusUint(exitRaw, "exit-code", 255, true)
+	if err != nil {
+		return 0, false, err
+	}
+	return exitCode, true, nil
 }
 
 func (l *bwrapLifecycle) finishStatusDrain(err error, sawChild bool) {

--- a/components/execd/pkg/isolation/lifecycle_linux.go
+++ b/components/execd/pkg/isolation/lifecycle_linux.go
@@ -35,9 +35,7 @@ import (
 )
 
 const (
-	sessionGateHostPath    = "/usr/local/libexec/opensandbox-session-gate"
-	sessionGateSandboxDir  = "/run/opensandbox-session"
-	sessionGateSandboxPath = sessionGateSandboxDir + "/gate"
+	sessionGateRuntimeHostPath = "/opt/opensandbox/opensandbox-session-gate"
 
 	sessionGateWaitingFrame = "OPENSANDBOX_SESSION_WAITING_V1"
 	sessionGateReadyFrame   = "OPENSANDBOX_SESSION_READY_V1"
@@ -73,13 +71,14 @@ type bwrapSandboxStatus struct {
 type bwrapLifecycle struct {
 	statusReader *os.File
 
-	mu                 sync.Mutex
-	state              lifecycleState
-	setup              *os.File
-	control            *net.UnixConn
-	controlChildFD     int
-	controlSocketInode uint64
-	identity           WorkloadIdentity
+	mu                  sync.Mutex
+	state               lifecycleState
+	requireNetNamespace bool
+	setup               *os.File
+	control             *net.UnixConn
+	controlChildFD      int
+	controlSocketInode  uint64
+	identity            WorkloadIdentity
 
 	sandboxStatus chan bwrapSandboxStatus
 	drainDone     chan struct{}
@@ -95,16 +94,18 @@ func newBwrapLifecycle(
 	control *net.UnixConn,
 	controlChildFD int,
 	controlSocketInode uint64,
+	requireNetNamespace bool,
 ) *bwrapLifecycle {
 	lifecycle := &bwrapLifecycle{
-		statusReader:       statusReader,
-		state:              lifecycleWaitingForBwrap,
-		setup:              setupWriter,
-		control:            control,
-		controlChildFD:     controlChildFD,
-		controlSocketInode: controlSocketInode,
-		sandboxStatus:      make(chan bwrapSandboxStatus, 1),
-		drainDone:          make(chan struct{}),
+		statusReader:        statusReader,
+		state:               lifecycleWaitingForBwrap,
+		requireNetNamespace: requireNetNamespace,
+		setup:               setupWriter,
+		control:             control,
+		controlChildFD:      controlChildFD,
+		controlSocketInode:  controlSocketInode,
+		sandboxStatus:       make(chan bwrapSandboxStatus, 1),
+		drainDone:           make(chan struct{}),
 	}
 	go lifecycle.drainStatus()
 	return lifecycle
@@ -147,7 +148,8 @@ func (l *bwrapLifecycle) WaitForIdentity(ctx context.Context) (
 		return WorkloadIdentity{}, fmt.Errorf("wait for bwrap status: %w", ctx.Err())
 	}
 
-	if err := validateSandboxStatus(status); err != nil {
+	status, err = validateSandboxStatus(status, l.requireNetNamespace)
+	if err != nil {
 		return WorkloadIdentity{}, err
 	}
 	if err := l.releaseBwrapSetupGate(); err != nil {
@@ -283,25 +285,43 @@ func parseSingleUnixCredentials(oob []byte) (*unix.Ucred, error) {
 	return credentials, nil
 }
 
-func validateSandboxStatus(status bwrapSandboxStatus) error {
+func validateSandboxStatus(
+	status bwrapSandboxStatus,
+	requireNetNamespace bool,
+) (bwrapSandboxStatus, error) {
 	if status.pid <= 0 {
-		return fmt.Errorf("bwrap status reported invalid child-pid %d", status.pid)
-	}
-	if status.netNamespaceID == 0 {
-		return errors.New("bwrap status did not report a network namespace")
+		return bwrapSandboxStatus{}, fmt.Errorf(
+			"bwrap status reported invalid child-pid %d",
+			status.pid,
+		)
 	}
 	actualNamespaceID, err := readNetNamespaceID(status.pid)
 	if err != nil {
-		return fmt.Errorf("read bwrap child network namespace: %w", err)
+		return bwrapSandboxStatus{}, fmt.Errorf(
+			"read bwrap child network namespace: %w",
+			err,
+		)
+	}
+	if status.netNamespaceID == 0 {
+		if requireNetNamespace {
+			return bwrapSandboxStatus{}, errors.New(
+				"bwrap status did not report the requested private network namespace",
+			)
+		}
+		// Bubblewrap only reports namespace IDs that it created. In share-net
+		// mode the child is still blocked by --block-fd, so its PID cannot be
+		// reused while we derive the inherited namespace from /proc.
+		status.netNamespaceID = actualNamespaceID
+		return status, nil
 	}
 	if actualNamespaceID != status.netNamespaceID {
-		return fmt.Errorf(
+		return bwrapSandboxStatus{}, fmt.Errorf(
 			"bwrap child network namespace mismatch: status=%d proc=%d",
 			status.netNamespaceID,
 			actualNamespaceID,
 		)
 	}
-	return nil
+	return status, nil
 }
 
 func validateWorkloadIdentity(
@@ -561,23 +581,27 @@ func (l *bwrapLifecycle) drainStatus() {
 				l.finishStatusDrain(err, false)
 				return
 			}
+			var netNamespaceID uint64
 			netRaw, ok := object["net-namespace"]
 			if !ok {
-				l.finishStatusDrain(
-					errors.New("bwrap child status omitted net-namespace"),
+				if l.requireNetNamespace {
+					l.finishStatusDrain(
+						errors.New("bwrap child status omitted net-namespace"),
+						false,
+					)
+					return
+				}
+			} else {
+				netNamespaceID, err = parseStatusUint(
+					netRaw,
+					"net-namespace",
+					^uint64(0),
 					false,
 				)
-				return
-			}
-			netNamespaceID, err := parseStatusUint(
-				netRaw,
-				"net-namespace",
-				^uint64(0),
-				false,
-			)
-			if err != nil {
-				l.finishStatusDrain(err, false)
-				return
+				if err != nil {
+					l.finishStatusDrain(err, false)
+					return
+				}
 			}
 			sawChild = true
 			l.sandboxStatus <- bwrapSandboxStatus{
@@ -682,63 +706,18 @@ func parseStatusUint(
 	return value, nil
 }
 
-// validateLifecycleMountSafety prevents caller-controlled mounts from
-// replacing the native gate after it has been installed.
-func validateLifecycleMountSafety(opts WrapOptions) error {
-	check := func(kind, destination string) error {
-		if mountCoversPath(destination, sessionGateSandboxPath) {
-			return fmt.Errorf(
-				"isolation: %s mount %q covers reserved lifecycle gate %q",
-				kind,
-				destination,
-				sessionGateSandboxPath,
-			)
-		}
-		return nil
-	}
-	if err := check("workspace", opts.Workspace.Path); err != nil {
-		return err
-	}
-	for _, destination := range opts.ExtraWritable {
-		if err := check("extra writable", destination); err != nil {
-			return err
-		}
-	}
-	for _, bind := range opts.Binds {
-		destination := bind.Dest
-		if destination == "" {
-			destination = bind.Source
-		}
-		if err := check("bind", destination); err != nil {
-			return err
-		}
-	}
-	if opts.UpperDir != "" {
-		upperRoot := filepath.Dir(filepath.Dir(opts.UpperDir))
-		if err := check("upper root", upperRoot); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func mountCoversPath(destination, target string) bool {
-	destination = filepath.Clean(destination)
-	target = filepath.Clean(target)
-	if destination == target || destination == string(filepath.Separator) {
-		return true
-	}
-	return strings.HasPrefix(target, destination+string(filepath.Separator))
-}
-
 func openSessionGate() (*os.File, error) {
+	return openSessionGatePath(sessionGateRuntimeHostPath)
+}
+
+func openSessionGatePath(path string) (*os.File, error) {
 	fd, err := unix.Open(
-		sessionGateHostPath,
+		path,
 		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
 		0,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("open native workload gate: %w", err)
+		return nil, fmt.Errorf("open native workload gate %q: %w", path, err)
 	}
 	file := os.NewFile(uintptr(fd), "opensandbox-session-gate")
 	if file == nil {

--- a/components/execd/pkg/isolation/lifecycle_linux_test.go
+++ b/components/execd/pkg/isolation/lifecycle_linux_test.go
@@ -725,7 +725,9 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 	tests := []struct {
 		name       string
 		reply      *string
+		script     string
 		wantExit   int
+		wantSignal syscall.Signal
 		wantMarker bool
 	}{
 		{name: "control eof", wantExit: 125},
@@ -735,6 +737,12 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 			reply:      stringPointer(sessionGateReadyFrame),
 			wantExit:   0,
 			wantMarker: true,
+		},
+		{
+			name:       "exact ready preserves default sigpipe",
+			reply:      stringPointer(sessionGateReadyFrame),
+			script:     "kill -s PIPE $$; exit 42",
+			wantSignal: syscall.SIGPIPE,
 		},
 		{
 			name:     "ready with trailing byte",
@@ -756,6 +764,10 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 				t.Fatal(err)
 			}
 			marker := filepath.Join(t.TempDir(), "executed")
+			script := "printf executed > " + marker
+			if test.script != "" {
+				script = test.script
+			}
 			command := exec.Command(
 				binary,
 				"3",
@@ -763,7 +775,7 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 				"--",
 				"/bin/sh",
 				"-c",
-				"printf executed > "+marker,
+				script,
 			)
 			command.ExtraFiles = []*os.File{controlChild, gateExecutable}
 			if err := command.Start(); err != nil {
@@ -807,16 +819,31 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 				t.Fatal(err)
 			}
 			waitErr := command.Wait()
-			exitCode := 0
-			if waitErr != nil {
+			if test.wantSignal != 0 {
 				var exitErr *exec.ExitError
 				if !errors.As(waitErr, &exitErr) {
-					t.Fatal(waitErr)
+					t.Fatalf("workload was not terminated by %s: %v", test.wantSignal, waitErr)
 				}
-				exitCode = exitErr.ExitCode()
-			}
-			if exitCode != test.wantExit {
-				t.Fatalf("exit code = %d, want %d", exitCode, test.wantExit)
+				waitStatus, ok := exitErr.Sys().(syscall.WaitStatus)
+				if !ok || !waitStatus.Signaled() || waitStatus.Signal() != test.wantSignal {
+					t.Fatalf(
+						"workload status = %v, want signal %s",
+						waitStatus,
+						test.wantSignal,
+					)
+				}
+			} else {
+				exitCode := 0
+				if waitErr != nil {
+					var exitErr *exec.ExitError
+					if !errors.As(waitErr, &exitErr) {
+						t.Fatal(waitErr)
+					}
+					exitCode = exitErr.ExitCode()
+				}
+				if exitCode != test.wantExit {
+					t.Fatalf("exit code = %d, want %d", exitCode, test.wantExit)
+				}
 			}
 			_, markerErr := os.Stat(marker)
 			if test.wantMarker && markerErr != nil {

--- a/components/execd/pkg/isolation/lifecycle_linux_test.go
+++ b/components/execd/pkg/isolation/lifecycle_linux_test.go
@@ -17,6 +17,7 @@
 package isolation
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -857,11 +858,16 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 }
 
 func TestLifecycleArgvExecutesGateDescriptorAfterRestoringProc(t *testing.T) {
+	uid := uint32(65534)
+	gid := uint32(65534)
 	opts := WrapOptions{
 		Profile:       ProfileStrict,
 		Workspace:     WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
 		UpperDir:      "/var/lib/opensandbox/upper/session/upper",
 		ExtraWritable: []string{"/data"},
+		UidMode:       UidModeSetpriv,
+		Uid:           &uid,
+		Gid:           &gid,
 		Binds: []BindMount{{
 			Source:   "/source",
 			Dest:     "/mounted",
@@ -894,6 +900,17 @@ func TestLifecycleArgvExecutesGateDescriptorAfterRestoringProc(t *testing.T) {
 	}
 	if strings.Contains(joined, "--ro-bind-fd") {
 		t.Fatalf("lifecycle gate must execute by descriptor, not mount path: %v", argv)
+	}
+	gateIndex := indexArgvSequence(argv, "/proc/self/fd/4", "7", "4", "--")
+	setprivIndex := indexArgvSequence(
+		argv,
+		"setpriv",
+		"--reuid=65534",
+		"--regid=65534",
+		"--clear-groups",
+	)
+	if gateIndex < 0 || setprivIndex < 0 || gateIndex >= setprivIndex {
+		t.Fatalf("lifecycle gate must run before setpriv: %v", argv)
 	}
 	procIndex := indexArgvSequence(argv, "--proc", "/proc")
 	if procIndex < 0 {
@@ -933,11 +950,14 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 	}
 	_ = gate.Close()
 
+	unprivilegedID := uint32(65534)
 	tests := []struct {
 		name       string
 		markReady  bool
 		shareNet   bool
 		gateAlias  bool
+		uid        *uint32
+		gid        *uint32
 		wantMarker bool
 	}{
 		{
@@ -950,6 +970,13 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 			markReady:  true,
 			shareNet:   true,
 			wantMarker: true,
+		},
+		{
+			name:      "non-root setpriv ready executes workload",
+			markReady: true,
+			shareNet:  true,
+			uid:       &unprivilegedID,
+			gid:       &unprivilegedID,
 		},
 		{
 			name:       "caller symlink alias cannot replace gate",
@@ -993,11 +1020,22 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 					ReadOnly: true,
 				}}
 			}
+			script := "printf executed > " + marker + "; exit 7"
+			if test.uid != nil {
+				script = fmt.Sprintf(
+					"test \"$(id -u)\" = %d; printf %%s \"$(id -u)\"; exit 7",
+					*test.uid,
+				)
+			}
 			command := exec.Command(
 				"/bin/sh",
 				"-c",
-				"printf executed > "+marker+"; exit 7",
+				script,
 			)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			command.Stdout = &stdout
+			command.Stderr = &stderr
 			command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			implementation := &bwrapImpl{
 				probe: ProbeResult{Available: true},
@@ -1011,6 +1049,9 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 						Mode: WorkspaceRW,
 					},
 					ShareNet:       test.shareNet,
+					UidMode:        UidModeSetpriv,
+					Uid:            test.uid,
+					Gid:            test.gid,
 					Binds:          binds,
 					EnvPassthrough: EnvSpec{Mode: EnvModeDeny},
 				},
@@ -1060,7 +1101,8 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 					// an acceptable fail-closed outcome.
 					return
 				}
-				t.Fatal(err)
+				waitErr := command.Wait()
+				t.Fatalf("%v (wait: %v, stderr: %q)", err, waitErr, stderr.String())
 			}
 			if identity.PID <= 0 || identity.SandboxPID <= 0 ||
 				identity.NetNamespaceID == 0 ||
@@ -1078,7 +1120,7 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 			} else {
 				lifecycle.Abort()
 			}
-			_ = command.Wait()
+			waitErr := command.Wait()
 			select {
 			case <-lifecycle.DrainDone():
 			case <-time.After(5 * time.Second):
@@ -1087,10 +1129,20 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 
 			_, markerErr := os.Stat(marker)
 			if test.wantMarker && markerErr != nil {
-				t.Fatalf("ready workload did not execute: %v", markerErr)
+				t.Fatalf(
+					"ready workload did not execute: %v (wait: %v, stderr: %q)",
+					markerErr,
+					waitErr,
+					stderr.String(),
+				)
 			}
 			if !test.wantMarker && !os.IsNotExist(markerErr) {
 				t.Fatalf("denied workload executed: %v", markerErr)
+			}
+			if test.uid != nil {
+				if got, want := stdout.String(), strconv.FormatUint(uint64(*test.uid), 10); got != want {
+					t.Fatalf("workload uid output = %q, want %q", got, want)
+				}
 			}
 			if _, err := os.Stat(fakeGateMarker); !os.IsNotExist(err) {
 				t.Fatalf("caller-controlled gate alias executed: %v", err)

--- a/components/execd/pkg/isolation/lifecycle_linux_test.go
+++ b/components/execd/pkg/isolation/lifecycle_linux_test.go
@@ -1,0 +1,908 @@
+//go:build linux
+
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package isolation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func newStatusTestLifecycle(
+	t *testing.T,
+) (*bwrapLifecycle, *os.File) {
+	t.Helper()
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		statusReader.Close()
+		statusWriter.Close()
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		statusReader.Close()
+		statusWriter.Close()
+		setupReader.Close()
+		setupWriter.Close()
+		t.Fatal(err)
+	}
+	setupReader.Close()
+	controlChildFD := int(controlChild.Fd())
+	controlChild.Close()
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		controlChildFD,
+		controlSocketInode,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+	})
+	return lifecycle, statusWriter
+}
+
+func waitForDrain(t *testing.T, lifecycle *bwrapLifecycle) {
+	t.Helper()
+	select {
+	case <-lifecycle.DrainDone():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for bwrap status drain")
+	}
+}
+
+func TestBwrapStatusDrainAcceptsUnknownObjectsAndCapturesExit(t *testing.T) {
+	lifecycle, writer := newStatusTestLifecycle(t)
+	if _, err := writer.Write([]byte(
+		"{\"future-event\":{\"value\":1}}\n" +
+			"{\"child-pid\":123,\"net-namespace\":456,\"future-member\":true}\n" +
+			"{\"another-future-event\":null}\n" +
+			"{\"exit-code\":0,\"future-member\":\"ok\"}\n",
+	)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	status := <-lifecycle.sandboxStatus
+	if status.err != nil {
+		t.Fatal(status.err)
+	}
+	if status.pid != 123 || status.netNamespaceID != 456 {
+		t.Fatalf("status = %+v", status)
+	}
+	waitForDrain(t, lifecycle)
+	if err := lifecycle.DrainError(); err != nil {
+		t.Fatal(err)
+	}
+	if exitCode, ok := lifecycle.ExitCode(); !ok || exitCode != 0 {
+		t.Fatalf("ExitCode = (%d, %v), want (0, true)", exitCode, ok)
+	}
+}
+
+func TestBwrapStatusDrainRejectsInvalidStreams(t *testing.T) {
+	oversized := strings.Repeat(" ", maxBwrapStatusDocumentBytes+1) + "\n"
+	tooMany := strings.Repeat("{}\n", maxBwrapStatusDocuments+1)
+	tests := []struct {
+		name       string
+		stream     string
+		wantError  string
+		childFirst bool
+	}{
+		{
+			name:      "eof before child",
+			stream:    "{\"future\":true}\n",
+			wantError: "EOF before child-pid",
+		},
+		{
+			name:       "eof before exit",
+			stream:     "{\"child-pid\":1,\"net-namespace\":2}\n",
+			wantError:  "EOF before exit-code",
+			childFirst: true,
+		},
+		{
+			name:      "malformed json",
+			stream:    "{not-json}\n",
+			wantError: "decode bwrap status",
+		},
+		{
+			name:      "non-object",
+			stream:    "null\n",
+			wantError: "not an object",
+		},
+		{
+			name:      "missing namespace",
+			stream:    "{\"child-pid\":1}\n",
+			wantError: "omitted net-namespace",
+		},
+		{
+			name:      "zero pid",
+			stream:    "{\"child-pid\":0,\"net-namespace\":2}\n",
+			wantError: "child-pid value 0 is out of range",
+		},
+		{
+			name:      "fractional pid",
+			stream:    "{\"child-pid\":1.5,\"net-namespace\":2}\n",
+			wantError: "not an unsigned integer",
+		},
+		{
+			name: "duplicate child",
+			stream: "{\"child-pid\":1,\"net-namespace\":2}\n" +
+				"{\"child-pid\":3,\"net-namespace\":4}\n",
+			wantError:  "repeated child-pid",
+			childFirst: true,
+		},
+		{
+			name: "duplicate exit",
+			stream: "{\"child-pid\":1,\"net-namespace\":2}\n" +
+				"{\"exit-code\":0}\n{\"exit-code\":1}\n",
+			wantError:  "repeated exit-code",
+			childFirst: true,
+		},
+		{
+			name:      "oversized document",
+			stream:    oversized,
+			wantError: "token too long",
+		},
+		{
+			name:      "too many documents",
+			stream:    tooMany,
+			wantError: "exceeded 1024 documents",
+		},
+		{
+			name: "exit out of range",
+			stream: "{\"child-pid\":1,\"net-namespace\":2}\n" +
+				"{\"exit-code\":256}\n",
+			wantError:  "exit-code value 256 is out of range",
+			childFirst: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lifecycle, writer := newStatusTestLifecycle(t)
+			writeDone := make(chan struct{})
+			go func() {
+				_, _ = writer.Write([]byte(test.stream))
+				_ = writer.Close()
+				close(writeDone)
+			}()
+			if !test.childFirst {
+				status := <-lifecycle.sandboxStatus
+				if status.err == nil {
+					t.Fatalf("sandbox status unexpectedly succeeded: %+v", status)
+				}
+			}
+			waitForDrain(t, lifecycle)
+			<-writeDone
+			err := lifecycle.DrainError()
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("DrainError = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestLifecycleUsesCredentialsAndProcIdentityBeforeReady(t *testing.T) {
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		int(controlChild.Fd()),
+		controlSocketInode,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	})
+
+	sandboxPID := os.Getppid()
+	netNamespaceID, err := readNetNamespaceID(sandboxPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(
+		statusWriter,
+		"{\"child-pid\":%d,\"net-namespace\":%d}\n",
+		sandboxPID,
+		netNamespaceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	setupReleased := make(chan byte, 1)
+	go func() {
+		var release [1]byte
+		n, _ := setupReader.Read(release[:])
+		if n == 1 {
+			setupReleased <- release[0]
+		}
+	}()
+	waitingSent := make(chan struct{})
+	go func() {
+		<-setupReleased
+		_, _ = controlChild.Write([]byte(sessionGateWaitingFrame))
+		close(waitingSent)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	identity, err := lifecycle.WaitForIdentity(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-waitingSent
+	if identity.PID != os.Getpid() {
+		t.Fatalf("workload PID = %d, want credential PID %d", identity.PID, os.Getpid())
+	}
+	if identity.SandboxPID != sandboxPID {
+		t.Fatalf("sandbox PID = %d, want %d", identity.SandboxPID, sandboxPID)
+	}
+	if identity.NetNamespaceID != netNamespaceID {
+		t.Fatalf("net namespace = %d, want %d", identity.NetNamespaceID, netNamespaceID)
+	}
+	if identity.ProcessStartTimeTicks == 0 {
+		t.Fatal("workload start time was not captured")
+	}
+
+	readyRead := make(chan string, 1)
+	go func() {
+		buffer := make([]byte, len(sessionGateReadyFrame)+1)
+		n, _ := controlChild.Read(buffer)
+		readyRead <- string(buffer[:n])
+	}()
+	if err := lifecycle.MarkReady(); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-readyRead; got != sessionGateReadyFrame {
+		t.Fatalf("ready frame = %q, want %q", got, sessionGateReadyFrame)
+	}
+	if _, err := statusWriter.Write([]byte("{\"exit-code\":0}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := statusWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForDrain(t, lifecycle)
+	if err := lifecycle.DrainError(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLifecycleNamespaceMismatchFailsBeforeNativeReady(t *testing.T) {
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		int(controlChild.Fd()),
+		controlSocketInode,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	})
+
+	sandboxPID := os.Getppid()
+	netNamespaceID, err := readNetNamespaceID(sandboxPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = fmt.Fprintf(
+		statusWriter,
+		"{\"child-pid\":%d,\"net-namespace\":%d}\n",
+		sandboxPID,
+		netNamespaceID+1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = lifecycle.WaitForIdentity(ctx)
+	if err == nil || !strings.Contains(err.Error(), "network namespace mismatch") {
+		t.Fatalf("WaitForIdentity error = %v", err)
+	}
+
+	var setupByte [1]byte
+	if n, readErr := setupReader.Read(setupByte[:]); n != 0 || readErr == nil {
+		t.Fatalf("setup gate = (%d, %v), want EOF without readiness", n, readErr)
+	}
+	var controlByte [1]byte
+	if n, readErr := controlChild.Read(controlByte[:]); n != 0 || readErr == nil {
+		t.Fatalf("control gate = (%d, %v), want EOF without readiness", n, readErr)
+	}
+}
+
+func TestLifecycleStatusFailureAfterIdentityDeniesReadyWithoutDeadlock(t *testing.T) {
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		int(controlChild.Fd()),
+		controlSocketInode,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	})
+
+	sandboxPID := os.Getppid()
+	netNamespaceID, err := readNetNamespaceID(sandboxPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(
+		statusWriter,
+		"{\"child-pid\":%d,\"net-namespace\":%d}\n",
+		sandboxPID,
+		netNamespaceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		var release [1]byte
+		if n, _ := setupReader.Read(release[:]); n == 1 {
+			_, _ = controlChild.Write([]byte(sessionGateWaitingFrame))
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = lifecycle.WaitForIdentity(ctx)
+	cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := statusWriter.Write([]byte("{malformed}\n")); err != nil {
+		t.Fatal(err)
+	}
+	waitForDrain(t, lifecycle)
+	if err := lifecycle.MarkReady(); !errors.Is(err, errWorkloadLifecycleAborted) {
+		t.Fatalf("MarkReady = %v, want lifecycle aborted", err)
+	}
+	var controlByte [1]byte
+	if n, readErr := controlChild.Read(controlByte[:]); n != 0 || readErr == nil {
+		t.Fatalf("native gate = (%d, %v), want EOF without READY", n, readErr)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- lifecycle.Close()
+	}()
+	select {
+	case closeErr := <-closeDone:
+		if closeErr == nil || !strings.Contains(closeErr.Error(), "decode bwrap status") {
+			t.Fatalf("Close error = %v, want status decode failure", closeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close deadlocked after identity-to-ready lifecycle failure")
+	}
+}
+
+func TestLifecycleContextCancellationClosesAllGates(t *testing.T) {
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		int(controlChild.Fd()),
+		controlSocketInode,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = lifecycle.WaitForIdentity(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForIdentity = %v, want context.Canceled", err)
+	}
+	waitForDrain(t, lifecycle)
+}
+
+func TestLifecycleAbortAndCloseAreConcurrentAndDoNotLeakFDs(t *testing.T) {
+	countFDs := func() int {
+		t.Helper()
+		entries, err := os.ReadDir("/proc/self/fd")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(entries)
+	}
+	baseline := countFDs()
+
+	const iterations = 32
+	for iteration := 0; iteration < iterations; iteration++ {
+		statusReader, statusWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		setupReader, setupWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		lifecycle := newBwrapLifecycle(
+			statusReader,
+			setupWriter,
+			controlParent,
+			int(controlChild.Fd()),
+			controlSocketInode,
+		)
+
+		var waitGroup sync.WaitGroup
+		for caller := 0; caller < 8; caller++ {
+			waitGroup.Add(1)
+			go func(caller int) {
+				defer waitGroup.Done()
+				if caller%2 == 0 {
+					lifecycle.Abort()
+				} else {
+					_ = lifecycle.Close()
+				}
+			}(caller)
+		}
+		waitGroup.Wait()
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	}
+
+	if after := countFDs(); after != baseline {
+		t.Fatalf(
+			"lifecycle descriptor count changed after %d iterations: before=%d after=%d",
+			iterations,
+			baseline,
+			after,
+		)
+	}
+}
+
+func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
+	compiler, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("C compiler is unavailable")
+	}
+	source := filepath.Join("..", "..", "native", "session-gate.c")
+	binary := filepath.Join(t.TempDir(), "opensandbox-session-gate")
+	compile := exec.Command(
+		compiler,
+		"-O2",
+		"-Wall",
+		"-Wextra",
+		"-Werror",
+		"-o",
+		binary,
+		source,
+	)
+	if output, err := compile.CombinedOutput(); err != nil {
+		t.Fatalf("compile native gate: %v\n%s", err, output)
+	}
+
+	tests := []struct {
+		name       string
+		reply      *string
+		wantExit   int
+		wantMarker bool
+	}{
+		{name: "control eof", wantExit: 125},
+		{name: "wrong frame", reply: stringPointer("WRONG"), wantExit: 125},
+		{
+			name:       "exact ready",
+			reply:      stringPointer(sessionGateReadyFrame),
+			wantExit:   0,
+			wantMarker: true,
+		},
+		{
+			name:     "ready with trailing byte",
+			reply:    stringPointer(sessionGateReadyFrame + "X"),
+			wantExit: 125,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			controlParent, controlChild, _, err := newGateSocketpair()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer controlParent.Close()
+			marker := filepath.Join(t.TempDir(), "executed")
+			command := exec.Command(
+				binary,
+				"3",
+				"--",
+				"/bin/sh",
+				"-c",
+				"printf executed > "+marker,
+			)
+			command.ExtraFiles = []*os.File{controlChild}
+			if err := command.Start(); err != nil {
+				controlChild.Close()
+				t.Fatal(err)
+			}
+			controlChild.Close()
+
+			payload := make([]byte, len(sessionGateWaitingFrame)+1)
+			oob := make([]byte, 256)
+			n, oobn, flags, _, err := controlParent.ReadMsgUnix(payload, oob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if flags&(unix.MSG_TRUNC|unix.MSG_CTRUNC) != 0 ||
+				string(payload[:n]) != sessionGateWaitingFrame {
+				t.Fatalf("waiting frame = (%q, flags=%d)", payload[:n], flags)
+			}
+			credentials, err := parseSingleUnixCredentials(oob[:oobn])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if int(credentials.Pid) != command.Process.Pid {
+				t.Fatalf(
+					"credential pid = %d, helper pid = %d",
+					credentials.Pid,
+					command.Process.Pid,
+				)
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("workload executed before READY: %v", err)
+			}
+
+			if test.reply == nil {
+				if err := controlParent.Close(); err != nil {
+					t.Fatal(err)
+				}
+			} else if _, err := controlParent.Write([]byte(*test.reply)); err != nil {
+				t.Fatal(err)
+			}
+			waitErr := command.Wait()
+			exitCode := 0
+			if waitErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(waitErr, &exitErr) {
+					t.Fatal(waitErr)
+				}
+				exitCode = exitErr.ExitCode()
+			}
+			if exitCode != test.wantExit {
+				t.Fatalf("exit code = %d, want %d", exitCode, test.wantExit)
+			}
+			_, markerErr := os.Stat(marker)
+			if test.wantMarker && markerErr != nil {
+				t.Fatalf("ready workload did not execute: %v", markerErr)
+			}
+			if !test.wantMarker && !os.IsNotExist(markerErr) {
+				t.Fatalf("denied workload executed: %v", markerErr)
+			}
+		})
+	}
+}
+
+func TestLifecycleMountSafetyRejectsGateReplacement(t *testing.T) {
+	base := WrapOptions{
+		Profile:   ProfileStrict,
+		Workspace: WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*WrapOptions)
+	}{
+		{
+			name: "workspace ancestor",
+			mutate: func(opts *WrapOptions) {
+				opts.Workspace.Path = "/run"
+			},
+		},
+		{
+			name: "extra writable exact",
+			mutate: func(opts *WrapOptions) {
+				opts.ExtraWritable = []string{sessionGateSandboxPath}
+			},
+		},
+		{
+			name: "bind ancestor",
+			mutate: func(opts *WrapOptions) {
+				opts.Binds = []BindMount{{
+					Source: "/tmp/source",
+					Dest:   sessionGateSandboxDir,
+				}}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := base
+			test.mutate(&opts)
+			if err := validateLifecycleMountSafety(opts); err == nil {
+				t.Fatal("unsafe lifecycle mount was accepted")
+			}
+		})
+	}
+	if err := validateLifecycleMountSafety(base); err != nil {
+		t.Fatalf("safe mounts rejected: %v", err)
+	}
+}
+
+func TestLifecycleArgvInstallsGateAfterRunTmpfs(t *testing.T) {
+	opts := WrapOptions{
+		Profile:   ProfileStrict,
+		Workspace: WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
+	}
+	argv, err := buildArgvWithLifecycle(
+		opts,
+		"3",
+		&bwrapLifecycleArgv{
+			gateFD:    "4",
+			statusFD:  "5",
+			blockFD:   "6",
+			controlFD: "7",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(argv, " ")
+	for _, required := range []string{
+		"--ro-bind-fd 4 " + sessionGateSandboxPath,
+		"--block-fd 6",
+		"--json-status-fd 5",
+		sessionGateSandboxPath + " 7 --",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Errorf("argv missing %q: %s", required, joined)
+		}
+	}
+	tmpfsIndex := indexArgvSequence(argv, "--tmpfs", "/run")
+	gateIndex := indexArgvSequence(argv, "--ro-bind-fd", "4", sessionGateSandboxPath)
+	if tmpfsIndex < 0 || gateIndex < 0 || gateIndex < tmpfsIndex {
+		t.Fatalf("gate mount must follow /run tmpfs: %v", argv)
+	}
+}
+
+func TestBwrapLifecycleEndToEnd(t *testing.T) {
+	originalBwrapPath := bwrapPath
+	bwrapPath = findBwrap()
+	t.Cleanup(func() {
+		bwrapPath = originalBwrapPath
+	})
+	if bwrapPath == "" {
+		t.Skip("bubblewrap is unavailable")
+	}
+	gate, err := openSessionGate()
+	if err != nil {
+		t.Skipf("native workload gate is unavailable: %v", err)
+	}
+	_ = gate.Close()
+
+	tests := []struct {
+		name       string
+		markReady  bool
+		wantMarker bool
+	}{
+		{name: "ready executes workload", markReady: true, wantMarker: true},
+		{name: "control eof denies workload", markReady: false, wantMarker: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			marker := filepath.Join(workspace, "executed")
+			command := exec.Command(
+				"/bin/sh",
+				"-c",
+				"printf executed > "+marker+"; exit 7",
+			)
+			command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			implementation := &bwrapImpl{
+				probe: ProbeResult{Available: true},
+			}
+			lifecycleInterface, err := implementation.WrapWithLifecycle(
+				command,
+				WrapOptions{
+					Profile: ProfileStrict,
+					Workspace: WorkspaceSpec{
+						Path: workspace,
+						Mode: WorkspaceRW,
+					},
+					ShareNet:       false,
+					EnvPassthrough: EnvSpec{Mode: EnvModeDeny},
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lifecycle := lifecycleInterface.(*bwrapLifecycle)
+			t.Cleanup(func() {
+				lifecycle.Abort()
+				_ = lifecycle.Close()
+				if command.Process != nil {
+					_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+				}
+			})
+
+			if err := command.Start(); err != nil {
+				for _, file := range command.ExtraFiles {
+					_ = file.Close()
+				}
+				t.Fatal(err)
+			}
+			for _, file := range command.ExtraFiles {
+				_ = file.Close()
+			}
+			command.ExtraFiles = nil
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			identity, err := lifecycle.WaitForIdentity(ctx)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if identity.PID <= 0 || identity.SandboxPID <= 0 ||
+				identity.NetNamespaceID == 0 ||
+				identity.ProcessStartTimeTicks == 0 {
+				t.Fatalf("incomplete workload identity: %+v", identity)
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("workload executed before gate decision: %v", err)
+			}
+
+			if test.markReady {
+				if err := lifecycle.MarkReady(); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				lifecycle.Abort()
+			}
+			_ = command.Wait()
+			select {
+			case <-lifecycle.DrainDone():
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out draining bwrap exit status")
+			}
+
+			_, markerErr := os.Stat(marker)
+			if test.wantMarker && markerErr != nil {
+				t.Fatalf("ready workload did not execute: %v", markerErr)
+			}
+			if !test.wantMarker && !os.IsNotExist(markerErr) {
+				t.Fatalf("denied workload executed: %v", markerErr)
+			}
+			if test.markReady {
+				if drainErr := lifecycle.DrainError(); drainErr != nil {
+					t.Fatalf("valid bwrap lifecycle stream failed: %v", drainErr)
+				}
+				if exitCode, ok := lifecycle.ExitCode(); !ok || exitCode != 7 {
+					t.Fatalf("bwrap ExitCode = (%d, %v), want (7, true)", exitCode, ok)
+				}
+			}
+		})
+	}
+}
+
+func indexArgvSequence(argv []string, sequence ...string) int {
+	for i := 0; i+len(sequence) <= len(argv); i++ {
+		matched := true
+		for j := range sequence {
+			if argv[i+j] != sequence[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return i
+		}
+	}
+	return -1
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func TestReadProcessIdentityRejectsMissingPID(t *testing.T) {
+	_, _, err := readProcessIdentity(1<<31 - 1)
+	if err == nil {
+		t.Fatal("missing pid was accepted")
+	}
+}
+
+func TestParseStatusUintRejectsSignedAndStringValues(t *testing.T) {
+	for _, value := range []string{"-1", `"1"`, "1e2"} {
+		t.Run(strconv.Quote(value), func(t *testing.T) {
+			if _, err := parseStatusUint([]byte(value), "value", 1000, false); err == nil {
+				t.Fatalf("value %s was accepted", value)
+			}
+		})
+	}
+}

--- a/components/execd/pkg/isolation/lifecycle_linux_test.go
+++ b/components/execd/pkg/isolation/lifecycle_linux_test.go
@@ -64,6 +64,7 @@ func newStatusTestLifecycle(
 		controlParent,
 		controlChildFD,
 		controlSocketInode,
+		true,
 	)
 	t.Cleanup(func() {
 		_ = lifecycle.Close()
@@ -233,6 +234,7 @@ func TestLifecycleUsesCredentialsAndProcIdentityBeforeReady(t *testing.T) {
 		controlParent,
 		int(controlChild.Fd()),
 		controlSocketInode,
+		true,
 	)
 	t.Cleanup(func() {
 		_ = lifecycle.Close()
@@ -314,6 +316,95 @@ func TestLifecycleUsesCredentialsAndProcIdentityBeforeReady(t *testing.T) {
 	}
 }
 
+func TestLifecycleDerivesSharedNetworkIdentityWhenStatusOmitsNamespace(t *testing.T) {
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupReader, setupWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlParent, controlChild, controlSocketInode, err := newGateSocketpair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := newBwrapLifecycle(
+		statusReader,
+		setupWriter,
+		controlParent,
+		int(controlChild.Fd()),
+		controlSocketInode,
+		false,
+	)
+	t.Cleanup(func() {
+		_ = lifecycle.Close()
+		_ = statusWriter.Close()
+		_ = setupReader.Close()
+		_ = controlChild.Close()
+	})
+
+	sandboxPID := os.Getppid()
+	expectedNamespaceID, err := readNetNamespaceID(sandboxPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(
+		statusWriter,
+		"{\"child-pid\":%d}\n",
+		sandboxPID,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	setupReleased := make(chan struct{})
+	go func() {
+		var release [1]byte
+		if n, _ := setupReader.Read(release[:]); n == 1 {
+			close(setupReleased)
+			_, _ = controlChild.Write([]byte(sessionGateWaitingFrame))
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	identity, err := lifecycle.WaitForIdentity(ctx)
+	cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-setupReleased
+	if identity.NetNamespaceID != expectedNamespaceID {
+		t.Fatalf(
+			"shared network namespace = %d, want %d",
+			identity.NetNamespaceID,
+			expectedNamespaceID,
+		)
+	}
+
+	readyRead := make(chan string, 1)
+	go func() {
+		buffer := make([]byte, len(sessionGateReadyFrame)+1)
+		n, _ := controlChild.Read(buffer)
+		readyRead <- string(buffer[:n])
+	}()
+	if err := lifecycle.MarkReady(); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-readyRead; got != sessionGateReadyFrame {
+		t.Fatalf("ready frame = %q, want %q", got, sessionGateReadyFrame)
+	}
+	if _, err := statusWriter.Write([]byte("{\"exit-code\":0}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := statusWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForDrain(t, lifecycle)
+	if err := lifecycle.DrainError(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLifecycleNamespaceMismatchFailsBeforeNativeReady(t *testing.T) {
 	statusReader, statusWriter, err := os.Pipe()
 	if err != nil {
@@ -333,6 +424,7 @@ func TestLifecycleNamespaceMismatchFailsBeforeNativeReady(t *testing.T) {
 		controlParent,
 		int(controlChild.Fd()),
 		controlSocketInode,
+		true,
 	)
 	t.Cleanup(func() {
 		_ = lifecycle.Close()
@@ -392,6 +484,7 @@ func TestLifecycleStatusFailureAfterIdentityDeniesReadyWithoutDeadlock(t *testin
 		controlParent,
 		int(controlChild.Fd()),
 		controlSocketInode,
+		true,
 	)
 	t.Cleanup(func() {
 		_ = lifecycle.Close()
@@ -471,6 +564,7 @@ func TestLifecycleContextCancellationClosesAllGates(t *testing.T) {
 		controlParent,
 		int(controlChild.Fd()),
 		controlSocketInode,
+		true,
 	)
 	t.Cleanup(func() {
 		_ = lifecycle.Close()
@@ -519,6 +613,7 @@ func TestLifecycleAbortAndCloseAreConcurrentAndDoNotLeakFDs(t *testing.T) {
 			controlParent,
 			int(controlChild.Fd()),
 			controlSocketInode,
+			true,
 		)
 
 		var waitGroup sync.WaitGroup
@@ -547,6 +642,62 @@ func TestLifecycleAbortAndCloseAreConcurrentAndDoNotLeakFDs(t *testing.T) {
 			baseline,
 			after,
 		)
+	}
+}
+
+func TestOpenSessionGateAcceptsManagedRuntimePath(t *testing.T) {
+	root := t.TempDir()
+	managed := filepath.Join(root, "managed-gate")
+	if err := os.WriteFile(managed, []byte("managed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := openSessionGatePath(managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	buffer := make([]byte, 16)
+	n, err := file.Read(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buffer[:n]); got != "managed" {
+		t.Fatalf("opened gate contents = %q, want managed path", got)
+	}
+}
+
+func TestOpenSessionGateRejectsMissingManagedRuntimePath(t *testing.T) {
+	root := t.TempDir()
+	managed := filepath.Join(root, "missing-managed-gate")
+
+	file, err := openSessionGatePath(managed)
+	if file != nil {
+		file.Close()
+		t.Fatal("missing managed gate unexpectedly opened")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing managed gate error = %v", err)
+	}
+}
+
+func TestOpenSessionGateRejectsUnsafeManagedRuntimePath(t *testing.T) {
+	root := t.TempDir()
+	managed := filepath.Join(root, "managed-gate")
+	if err := os.WriteFile(managed, []byte("unsafe"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(managed, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := openSessionGatePath(managed)
+	if file != nil {
+		file.Close()
+		t.Fatal("unsafe managed gate unexpectedly opened")
+	}
+	if err == nil || !strings.Contains(err.Error(), "group- or world-writable") {
+		t.Fatalf("open unsafe managed gate error = %v", err)
 	}
 }
 
@@ -599,21 +750,29 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer controlParent.Close()
+			gateExecutable, err := os.Open(binary)
+			if err != nil {
+				controlChild.Close()
+				t.Fatal(err)
+			}
 			marker := filepath.Join(t.TempDir(), "executed")
 			command := exec.Command(
 				binary,
 				"3",
+				"4",
 				"--",
 				"/bin/sh",
 				"-c",
 				"printf executed > "+marker,
 			)
-			command.ExtraFiles = []*os.File{controlChild}
+			command.ExtraFiles = []*os.File{controlChild, gateExecutable}
 			if err := command.Start(); err != nil {
 				controlChild.Close()
+				gateExecutable.Close()
 				t.Fatal(err)
 			}
 			controlChild.Close()
+			gateExecutable.Close()
 
 			payload := make([]byte, len(sessionGateWaitingFrame)+1)
 			oob := make([]byte, 256)
@@ -670,64 +829,26 @@ func TestSessionGateHelperFailsClosedAndExecutesOnlyAfterReady(t *testing.T) {
 	}
 }
 
-func TestLifecycleMountSafetyRejectsGateReplacement(t *testing.T) {
-	base := WrapOptions{
-		Profile:   ProfileStrict,
-		Workspace: WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
-	}
-	tests := []struct {
-		name   string
-		mutate func(*WrapOptions)
-	}{
-		{
-			name: "workspace ancestor",
-			mutate: func(opts *WrapOptions) {
-				opts.Workspace.Path = "/run"
-			},
-		},
-		{
-			name: "extra writable exact",
-			mutate: func(opts *WrapOptions) {
-				opts.ExtraWritable = []string{sessionGateSandboxPath}
-			},
-		},
-		{
-			name: "bind ancestor",
-			mutate: func(opts *WrapOptions) {
-				opts.Binds = []BindMount{{
-					Source: "/tmp/source",
-					Dest:   sessionGateSandboxDir,
-				}}
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			opts := base
-			test.mutate(&opts)
-			if err := validateLifecycleMountSafety(opts); err == nil {
-				t.Fatal("unsafe lifecycle mount was accepted")
-			}
-		})
-	}
-	if err := validateLifecycleMountSafety(base); err != nil {
-		t.Fatalf("safe mounts rejected: %v", err)
-	}
-}
-
-func TestLifecycleArgvInstallsGateAfterRunTmpfs(t *testing.T) {
+func TestLifecycleArgvExecutesGateDescriptorAfterRestoringProc(t *testing.T) {
 	opts := WrapOptions{
-		Profile:   ProfileStrict,
-		Workspace: WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
+		Profile:       ProfileStrict,
+		Workspace:     WorkspaceSpec{Path: "/workspace", Mode: WorkspaceRW},
+		UpperDir:      "/var/lib/opensandbox/upper/session/upper",
+		ExtraWritable: []string{"/data"},
+		Binds: []BindMount{{
+			Source:   "/source",
+			Dest:     "/mounted",
+			ReadOnly: true,
+		}},
 	}
 	argv, err := buildArgvWithLifecycle(
 		opts,
 		"3",
 		&bwrapLifecycleArgv{
-			gateFD:    "4",
-			statusFD:  "5",
-			blockFD:   "6",
-			controlFD: "7",
+			gateExecFD: "4",
+			statusFD:   "5",
+			blockFD:    "6",
+			controlFD:  "7",
 		},
 	)
 	if err != nil {
@@ -735,27 +856,46 @@ func TestLifecycleArgvInstallsGateAfterRunTmpfs(t *testing.T) {
 	}
 	joined := strings.Join(argv, " ")
 	for _, required := range []string{
-		"--ro-bind-fd 4 " + sessionGateSandboxPath,
+		"--proc /proc",
 		"--block-fd 6",
 		"--json-status-fd 5",
-		sessionGateSandboxPath + " 7 --",
+		"/proc/self/fd/4 7 4 --",
 	} {
 		if !strings.Contains(joined, required) {
 			t.Errorf("argv missing %q: %s", required, joined)
 		}
 	}
-	tmpfsIndex := indexArgvSequence(argv, "--tmpfs", "/run")
-	gateIndex := indexArgvSequence(argv, "--ro-bind-fd", "4", sessionGateSandboxPath)
-	if tmpfsIndex < 0 || gateIndex < 0 || gateIndex < tmpfsIndex {
-		t.Fatalf("gate mount must follow /run tmpfs: %v", argv)
+	if strings.Contains(joined, "--ro-bind-fd") {
+		t.Fatalf("lifecycle gate must execute by descriptor, not mount path: %v", argv)
+	}
+	procIndex := indexArgvSequence(argv, "--proc", "/proc")
+	if procIndex < 0 {
+		t.Fatalf("trusted proc mount missing: %v", argv)
+	}
+	for name, sequence := range map[string][]string{
+		"workspace":      {"--bind", "/workspace", "/workspace"},
+		"upper root":     {"--tmpfs", "/var/lib/opensandbox/upper"},
+		"extra writable": {"--bind", "/data", "/data"},
+		"explicit bind":  {"--ro-bind", "/source", "/mounted"},
+	} {
+		index := indexArgvSequence(argv, sequence...)
+		if index < 0 {
+			t.Fatalf("%s mount missing: %v", name, argv)
+		}
+		if procIndex < index {
+			t.Fatalf("trusted proc mount must follow %s mount: %v", name, argv)
+		}
 	}
 }
 
 func TestBwrapLifecycleEndToEnd(t *testing.T) {
 	originalBwrapPath := bwrapPath
 	bwrapPath = findBwrap()
+	originalSeccompBPF := seccompBPF
+	seccompBPF = nil
 	t.Cleanup(func() {
 		bwrapPath = originalBwrapPath
+		seccompBPF = originalSeccompBPF
 	})
 	if bwrapPath == "" {
 		t.Skip("bubblewrap is unavailable")
@@ -769,15 +909,63 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 	tests := []struct {
 		name       string
 		markReady  bool
+		shareNet   bool
+		gateAlias  bool
 		wantMarker bool
 	}{
-		{name: "ready executes workload", markReady: true, wantMarker: true},
-		{name: "control eof denies workload", markReady: false, wantMarker: false},
+		{
+			name:       "private network ready executes workload",
+			markReady:  true,
+			wantMarker: true,
+		},
+		{
+			name:       "shared network ready executes workload",
+			markReady:  true,
+			shareNet:   true,
+			wantMarker: true,
+		},
+		{
+			name:       "caller symlink alias cannot replace gate",
+			markReady:  true,
+			gateAlias:  true,
+			wantMarker: true,
+		},
+		{
+			name:       "control eof denies workload",
+			markReady:  false,
+			wantMarker: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			workspace := t.TempDir()
 			marker := filepath.Join(workspace, "executed")
+			fakeGateMarker := filepath.Join(workspace, "fake-gate-executed")
+			var binds []BindMount
+			if test.gateAlias {
+				fakeProc := filepath.Join(workspace, "fake-proc")
+				fakeFDDir := filepath.Join(fakeProc, "self", "fd")
+				if err := os.MkdirAll(fakeFDDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				fakeGate := filepath.Join(fakeFDDir, "3")
+				fakeGateScript := fmt.Sprintf(
+					"#!/bin/sh\nprintf fake > %q\nexit 125\n",
+					fakeGateMarker,
+				)
+				if err := os.WriteFile(fakeGate, []byte(fakeGateScript), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				procAlias := filepath.Join(workspace, "proc-alias")
+				if err := os.Symlink("/proc", procAlias); err != nil {
+					t.Fatal(err)
+				}
+				binds = []BindMount{{
+					Source:   fakeProc,
+					Dest:     procAlias,
+					ReadOnly: true,
+				}}
+			}
 			command := exec.Command(
 				"/bin/sh",
 				"-c",
@@ -795,7 +983,8 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 						Path: workspace,
 						Mode: WorkspaceRW,
 					},
-					ShareNet:       false,
+					ShareNet:       test.shareNet,
+					Binds:          binds,
 					EnvPassthrough: EnvSpec{Mode: EnvModeDeny},
 				},
 			)
@@ -826,6 +1015,24 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 			identity, err := lifecycle.WaitForIdentity(ctx)
 			cancel()
 			if err != nil {
+				if test.gateAlias {
+					_ = command.Wait()
+					if _, markerErr := os.Stat(fakeGateMarker); !os.IsNotExist(markerErr) {
+						t.Fatalf(
+							"caller-controlled proc alias executed fake gate: %v",
+							markerErr,
+						)
+					}
+					if _, markerErr := os.Stat(marker); !os.IsNotExist(markerErr) {
+						t.Fatalf(
+							"caller-controlled proc alias executed workload: %v",
+							markerErr,
+						)
+					}
+					// Rejecting an aliased proc mount before the gate starts is
+					// an acceptable fail-closed outcome.
+					return
+				}
 				t.Fatal(err)
 			}
 			if identity.PID <= 0 || identity.SandboxPID <= 0 ||
@@ -857,6 +1064,9 @@ func TestBwrapLifecycleEndToEnd(t *testing.T) {
 			}
 			if !test.wantMarker && !os.IsNotExist(markerErr) {
 				t.Fatalf("denied workload executed: %v", markerErr)
+			}
+			if _, err := os.Stat(fakeGateMarker); !os.IsNotExist(err) {
+				t.Fatalf("caller-controlled gate alias executed: %v", err)
 			}
 			if test.markReady {
 				if drainErr := lifecycle.DrainError(); drainErr != nil {

--- a/components/execd/pkg/runtime/bash_session.go
+++ b/components/execd/pkg/runtime/bash_session.go
@@ -207,7 +207,7 @@ func (s *bashSession) run(ctx context.Context, request *ExecuteCodeRequest) erro
 
 	shell := getShell()
 	args := make([]string, 0, 3)
-	if shell == "bash" {
+	if shell == bashShell {
 		args = append(args, "--noprofile", "--norc")
 	}
 	args = append(args, scriptPath)

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -37,6 +37,8 @@ import (
 	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
 )
 
+const bashShell = "bash"
+
 var forwardSignals = []os.Signal{
 	syscall.SIGINT,
 	syscall.SIGTERM,
@@ -50,8 +52,8 @@ var forwardSignals = []os.Signal{
 // getShell returns the preferred shell, falling back to sh if bash is not available.
 // This is needed for Alpine-based Docker images that only have sh by default.
 func getShell() string {
-	if _, err := exec.LookPath("bash"); err == nil {
-		return "bash"
+	if _, err := exec.LookPath(bashShell); err == nil {
+		return bashShell
 	}
 	return "sh"
 }

--- a/components/execd/pkg/runtime/isolated_session.go
+++ b/components/execd/pkg/runtime/isolated_session.go
@@ -76,7 +76,7 @@ func newIsolatedSession(id string, opts *IsolatedSessionOptions, iso isolation.I
 func (s *isolatedSession) start() error {
 	shell := getShell()
 	var args []string
-	if shell == "bash" {
+	if shell == bashShell {
 		args = append(args, "--noprofile", "--norc")
 	}
 	cmd := exec.Command(shell, args...)

--- a/components/execd/pkg/runtime/pty_session.go
+++ b/components/execd/pkg/runtime/pty_session.go
@@ -224,7 +224,7 @@ func (s *ptySession) ReplayBuffer() *replayBuffer {
 func buildPTYCommand(command string) *exec.Cmd {
 	shell := getShell()
 	var args []string
-	if shell == "bash" {
+	if shell == bashShell {
 		args = append(args, "--norc", "--noprofile")
 	}
 	if command != "" {

--- a/components/execd/tests/smoke_bwrap.sh
+++ b/components/execd/tests/smoke_bwrap.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Smoke test: build execd image, extract execd+bwrap, verify bwrap works.
+# Smoke test: build execd image, extract execd+bwrap+the native workload gate,
+# and verify the packaged isolation artifacts work.
 #
 # Prerequisites: docker
 #
@@ -57,16 +58,18 @@ echo ">> Image built."
 # Step 2: Extract binaries from image
 # -------------------------------------------------------------------
 echo ""
-echo ">> Step 2: Extracting execd and bwrap from image..."
+echo ">> Step 2: Extracting execd, bwrap, and workload gate from image..."
 mkdir -p "${SMOKE_DIR}"
 docker run --rm \
   --entrypoint "" \
   -v "${SMOKE_DIR}:/out" \
   "${IMAGE}" \
-  sh -c 'cp /execd /usr/local/bin/bwrap /out/ && chmod +x /out/execd /out/bwrap'
+  sh -c 'cp /execd /usr/local/bin/bwrap /out/ && \
+    cp /usr/local/libexec/opensandbox-session-gate /out/session-gate && \
+    chmod +x /out/execd /out/bwrap /out/session-gate'
 
 echo ">> Extracted:"
-ls -lh "${SMOKE_DIR}/execd" "${SMOKE_DIR}/bwrap"
+ls -lh "${SMOKE_DIR}/execd" "${SMOKE_DIR}/bwrap" "${SMOKE_DIR}/session-gate"
 
 # -------------------------------------------------------------------
 # Step 3: Verify bwrap is static
@@ -170,6 +173,7 @@ echo "========================================="
 echo " Smoke Test PASSED"
 echo "========================================="
 echo "  bwrap: static binary, namespace works"
+echo "  gate: native fail-closed workload gate packaged"
 echo "  execd: starts, serves /ping"
 echo "  image: ${IMAGE}"
 echo ""

--- a/components/execd/tests/smoke_bwrap.sh
+++ b/components/execd/tests/smoke_bwrap.sh
@@ -65,11 +65,18 @@ docker run --rm \
   -v "${SMOKE_DIR}:/out" \
   "${IMAGE}" \
   sh -c 'cp /execd /usr/local/bin/bwrap /out/ && \
-    cp /usr/local/libexec/opensandbox-session-gate /out/session-gate && \
-    chmod +x /out/execd /out/bwrap /out/session-gate'
+    cp /usr/local/libexec/opensandbox-session-gate /out/session-gate-source && \
+    cp /opt/opensandbox/opensandbox-session-gate /out/session-gate-runtime && \
+    chmod +x /out/execd /out/bwrap \
+      /out/session-gate-source /out/session-gate-runtime'
 
 echo ">> Extracted:"
-ls -lh "${SMOKE_DIR}/execd" "${SMOKE_DIR}/bwrap" "${SMOKE_DIR}/session-gate"
+ls -lh \
+  "${SMOKE_DIR}/execd" \
+  "${SMOKE_DIR}/bwrap" \
+  "${SMOKE_DIR}/session-gate-source" \
+  "${SMOKE_DIR}/session-gate-runtime"
+cmp "${SMOKE_DIR}/session-gate-source" "${SMOKE_DIR}/session-gate-runtime"
 
 # -------------------------------------------------------------------
 # Step 3: Verify bwrap is static

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -152,6 +152,7 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         self._execd_archive_cache: Dict[str, bytes] = {}
         self._bootstrap_script_cache: Dict[str, bytes] = {}
         self._bwrap_archive_cache: Dict[str, bytes] = {}
+        self._session_gate_archive_cache: Dict[str, bytes] = {}
         self._windows_profile_cache: Dict[str, bytes] = {}
         self._daemon_platform: Optional[PlatformSpec] = None
         self._metadata_store = DockerMetadataStore()

--- a/server/opensandbox_server/services/docker/runtime.py
+++ b/server/opensandbox_server/services/docker/runtime.py
@@ -29,7 +29,7 @@ import time
 from typing import Optional
 from uuid import uuid4
 
-from docker.errors import DockerException
+from docker.errors import DockerException, NotFound as DockerNotFound
 from fastapi import HTTPException, status
 
 from opensandbox_server.api.schema import PlatformSpec
@@ -42,6 +42,8 @@ OPENSANDBOX_DIR = "/opt/opensandbox"
 # even when the server runs on Windows.
 EXECED_INSTALL_PATH = posixpath.join(OPENSANDBOX_DIR, "execd")
 BOOTSTRAP_PATH = posixpath.join(OPENSANDBOX_DIR, "bootstrap.sh")
+SESSION_GATE_SOURCE_PATH = "/usr/local/libexec/opensandbox-session-gate"
+SESSION_GATE_INSTALL_PATH = posixpath.join(OPENSANDBOX_DIR, "opensandbox-session-gate")
 DEFAULT_EXECD_ENVS_PATH = posixpath.join(OPENSANDBOX_DIR, ".env")
 
 
@@ -125,6 +127,24 @@ class DockerRuntimeMixin:
                             self._bwrap_archive_cache[cache_key] = b"".join(bwrap_stream)
                     except DockerException:
                         logger.warning("bwrap not found in execd image — isolation will be unavailable, upgrade execd image to v1.1.0+")
+                # Cache the native workload gate independently so older execd
+                # images remain usable for legacy, non-lifecycle isolation.
+                if cache_key not in self._session_gate_archive_cache:
+                    try:
+                        with self._docker_operation(
+                            "execd cache read session gate", "execd-cache"
+                        ):
+                            gate_stream, _ = container.get_archive(
+                                SESSION_GATE_SOURCE_PATH
+                            )
+                            self._session_gate_archive_cache[cache_key] = b"".join(
+                                gate_stream
+                            )
+                    except DockerNotFound:
+                        logger.warning(
+                            "session workload gate not found in execd image — "
+                            "gated isolated-session lifecycle will be unavailable"
+                        )
             except DockerException as exc:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -262,6 +282,43 @@ class DockerRuntimeMixin:
                 exc,
             )
 
+    def _copy_session_gate_to_container(
+        self,
+        container,
+        sandbox_id: str,
+        platform: Optional[PlatformSpec] = None,
+    ) -> None:
+        """Copy the native workload gate into its managed runtime path.
+
+        Older execd images do not contain this helper, so distribution remains
+        best-effort for backward compatibility. WrapWithLifecycle still opens
+        the managed path fail-closed before starting a workload.
+        """
+        cache_key = self._normalize_platform_key(platform)
+        archive = self._session_gate_archive_cache.get(cache_key)
+        if archive is None:
+            logger.warning(
+                "session workload gate archive not cached for %s — "
+                "gated isolated-session lifecycle will be unavailable",
+                cache_key,
+            )
+            return
+
+        try:
+            with self._docker_operation("copy session gate to sandbox", sandbox_id):
+                container.put_archive(path=OPENSANDBOX_DIR, data=archive)
+        except DockerException as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "code": SandboxErrorCodes.EXECD_DISTRIBUTION_FAILED,
+                    "message": (
+                        "Failed to copy session workload gate into sandbox "
+                        f"at {SESSION_GATE_INSTALL_PATH}: {str(exc)}"
+                    ),
+                },
+            ) from exc
+
     def _prepare_sandbox_runtime(
         self,
         container,
@@ -272,3 +329,4 @@ class DockerRuntimeMixin:
         self._copy_execd_to_container(container, sandbox_id, platform)
         self._install_bootstrap_script(container, sandbox_id, platform)
         self._copy_bwrap_to_container(container, sandbox_id, platform)
+        self._copy_session_gate_to_container(container, sandbox_id, platform)

--- a/server/opensandbox_server/services/k8s/provider_common.py
+++ b/server/opensandbox_server/services/k8s/provider_common.py
@@ -125,7 +125,11 @@ def _build_execd_init_container(
         "chmod +x /opt/opensandbox/execd && "
         "chmod +x /opt/opensandbox/bootstrap.sh && "
         "(cp /usr/local/bin/bwrap /opt/opensandbox/bwrap && "
-        "chmod +x /opt/opensandbox/bwrap || true)"
+        "chmod +x /opt/opensandbox/bwrap || true) && "
+        "(test ! -e /usr/local/libexec/opensandbox-session-gate || "
+        "(cp /usr/local/libexec/opensandbox-session-gate "
+        "/opt/opensandbox/opensandbox-session-gate && "
+        "chmod 0555 /opt/opensandbox/opensandbox-session-gate))"
     )
     security_context = None
     if disable_ipv6_for_egress:

--- a/server/tests/k8s/test_agent_sandbox_provider.py
+++ b/server/tests/k8s/test_agent_sandbox_provider.py
@@ -711,6 +711,11 @@ class TestAgentSandboxProviderExecdInit:
         init_containers = body["spec"]["podTemplate"]["spec"]["initContainers"]
         assert len(init_containers) == 1
         assert "resources" not in init_containers[0]
+        init_script = init_containers[0]["args"][0]
+        assert (
+            "cp /usr/local/libexec/opensandbox-session-gate "
+            "/opt/opensandbox/opensandbox-session-gate"
+        ) in init_script
 
     def test_init_container_has_resources_when_configured(self, mock_k8s_client):
         provider = AgentSandboxProvider(

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -411,7 +411,17 @@ spec:
         assert init_container["name"] == "execd-installer"
         assert init_container["image"] == "execd:test"
         assert init_container["command"] == ["/bin/sh", "-c"]
-        assert "bootstrap.sh" in init_container["args"][0]
+        init_script = init_container["args"][0]
+        assert "bootstrap.sh" in init_script
+        assert (
+            "cp /usr/local/libexec/opensandbox-session-gate "
+            "/opt/opensandbox/opensandbox-session-gate"
+        ) in init_script
+        assert (
+            "test ! -e /usr/local/libexec/opensandbox-session-gate || "
+            "(cp /usr/local/libexec/opensandbox-session-gate"
+        ) in init_script
+        assert "chmod 0555 /opt/opensandbox/opensandbox-session-gate" in init_script
         assert init_container["volumeMounts"][0]["name"] == "opensandbox-bin"
         # No resources configured: resources field should be absent
         assert "resources" not in init_container

--- a/server/tests/test_docker_runtime_bootstrap.py
+++ b/server/tests/test_docker_runtime_bootstrap.py
@@ -17,8 +17,14 @@ import pathlib
 import tarfile
 from unittest.mock import MagicMock, patch
 
+from docker.errors import DockerException
+from fastapi import HTTPException
+import pytest
+
 from opensandbox_server.config import AppConfig, IngressConfig, RuntimeConfig, ServerConfig
+from opensandbox_server.services.constants import SandboxErrorCodes
 from opensandbox_server.services.docker import DockerSandboxService
+from opensandbox_server.services.docker.runtime import OPENSANDBOX_DIR
 
 
 def _app_config() -> AppConfig:
@@ -93,3 +99,66 @@ def test_install_bootstrap_script_uses_full_bootstrap_sh(mock_docker):
     assert 'EXECD="${EXECD:=/opt/opensandbox/execd}"' in script or "EXECD=" in script
     assert 'if [ -z "${EXECD_ENVS:-}" ]; then' in script
     assert 'export EXECD_ENVS' in script
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_copy_session_gate_installs_cached_archive_in_managed_directory(mock_docker):
+    mock_docker.from_env.return_value = MagicMock()
+    service = DockerSandboxService(config=_app_config())
+    cache_key = service._normalize_platform_key(None)
+    service._session_gate_archive_cache[cache_key] = b"session-gate-archive"
+    mock_container = MagicMock()
+
+    with patch.object(service, "_docker_operation"):
+        service._copy_session_gate_to_container(mock_container, "test-sandbox")
+
+    mock_container.put_archive.assert_called_once_with(
+        path=OPENSANDBOX_DIR,
+        data=b"session-gate-archive",
+    )
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_copy_session_gate_is_backward_compatible_when_archive_is_missing(mock_docker):
+    mock_docker.from_env.return_value = MagicMock()
+    service = DockerSandboxService(config=_app_config())
+    mock_container = MagicMock()
+
+    service._copy_session_gate_to_container(mock_container, "test-sandbox")
+
+    mock_container.put_archive.assert_not_called()
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_copy_session_gate_rejects_distribution_failure(mock_docker):
+    mock_docker.from_env.return_value = MagicMock()
+    service = DockerSandboxService(config=_app_config())
+    cache_key = service._normalize_platform_key(None)
+    service._session_gate_archive_cache[cache_key] = b"session-gate-archive"
+    mock_container = MagicMock()
+    mock_container.put_archive.side_effect = DockerException("copy failed")
+
+    with patch.object(service, "_docker_operation"):
+        with pytest.raises(HTTPException) as exc_info:
+            service._copy_session_gate_to_container(mock_container, "test-sandbox")
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail["code"] == SandboxErrorCodes.EXECD_DISTRIBUTION_FAILED
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_prepare_sandbox_runtime_distributes_session_gate(mock_docker):
+    mock_docker.from_env.return_value = MagicMock()
+    service = DockerSandboxService(config=_app_config())
+    mock_container = MagicMock()
+
+    with patch.object(service, "_copy_execd_to_container"), patch.object(
+        service,
+        "_install_bootstrap_script",
+    ), patch.object(service, "_copy_bwrap_to_container"), patch.object(
+        service,
+        "_copy_session_gate_to_container",
+    ) as copy_gate:
+        service._prepare_sandbox_runtime(mock_container, "test-sandbox")
+
+    copy_gate.assert_called_once_with(mock_container, "test-sandbox", None)

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -53,6 +53,7 @@ from opensandbox_server.services.constants import (
 )
 from opensandbox_server.services.docker import DockerSandboxService
 from opensandbox_server.services.docker.metadata import DockerMetadataStore
+from opensandbox_server.services.docker.runtime import SESSION_GATE_SOURCE_PATH
 from opensandbox_server.services.helpers import (
     parse_gpu_request,
     parse_memory_limit,
@@ -580,6 +581,83 @@ def test_fetch_execd_archive_caches_by_platform_key(mock_docker):
     assert amd64_second == b"amd64"
     assert arm64_data == b"arm64"
     assert mock_client.containers.create.call_count == 2
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_fetch_execd_archive_caches_session_gate_by_platform_key(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+    mock_client.info.return_value = {"OSType": "linux", "Architecture": "amd64"}
+    container = MagicMock()
+
+    def get_archive(path):
+        return ([f"archive:{path}".encode()], {})
+
+    container.get_archive.side_effect = get_archive
+    mock_client.containers.create.return_value = container
+    service = DockerSandboxService(config=_app_config())
+
+    with patch.object(service, "_ensure_image_available"), patch.object(
+        service, "_docker_operation"
+    ):
+        service._fetch_execd_archive()
+
+    assert service._session_gate_archive_cache["default"] == (
+        f"archive:{SESSION_GATE_SOURCE_PATH}".encode()
+    )
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_fetch_execd_archive_allows_older_image_without_session_gate(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+    mock_client.info.return_value = {"OSType": "linux", "Architecture": "amd64"}
+    container = MagicMock()
+
+    def get_archive(path):
+        if path == SESSION_GATE_SOURCE_PATH:
+            raise DockerNotFound("session gate missing")
+        return ([f"archive:{path}".encode()], {})
+
+    container.get_archive.side_effect = get_archive
+    mock_client.containers.create.return_value = container
+    service = DockerSandboxService(config=_app_config())
+
+    with patch.object(service, "_ensure_image_available"), patch.object(
+        service, "_docker_operation"
+    ):
+        assert service._fetch_execd_archive() == b"archive:/execd"
+
+    assert "default" not in service._session_gate_archive_cache
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_fetch_execd_archive_rejects_session_gate_read_failure(mock_docker):
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+    mock_client.info.return_value = {"OSType": "linux", "Architecture": "amd64"}
+    container = MagicMock()
+
+    def get_archive(path):
+        if path == SESSION_GATE_SOURCE_PATH:
+            raise DockerException("session gate read failed")
+        return ([f"archive:{path}".encode()], {})
+
+    container.get_archive.side_effect = get_archive
+    mock_client.containers.create.return_value = container
+    service = DockerSandboxService(config=_app_config())
+
+    with patch.object(service, "_ensure_image_available"), patch.object(
+        service, "_docker_operation"
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            service._fetch_execd_archive()
+
+    assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert exc_info.value.detail["code"] == SandboxErrorCodes.EXECD_DISTRIBUTION_FAILED
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
 def test_fetch_execd_archive_maps_platform_typeerror_to_invalid_parameter(mock_docker):


### PR DESCRIPTION
# Summary

- Add a native fail-closed workload gate for Bubblewrap-based isolated sessions so the target command cannot execute until execd explicitly marks the authenticated workload ready.
- Execute the verified gate through an inherited file descriptor after restoring a trusted `/proc`; validate peer credentials, the real workload PID, the effective network namespace, and the complete Bubblewrap JSON status stream before releasing the workload.
- Preserve private-network fail-closed semantics while deriving the effective namespace from the blocked workload PID for Bubblewrap's shared-network mode, where no newly-created namespace is reported.
- Package the gate in the execd image and distribute it to the managed `/opt/opensandbox` runtime path for both Docker and Kubernetes. Missing helpers in older images keep legacy isolation available, while read/copy failures fail with `EXECD_DISTRIBUTION_FAILED`.
- Centralize the existing Bash shell literal because selecting the execd workflow exposed a pre-existing package-wide `goconst` violation on the current `main` branch.
- This is the first isolated-session implementation phase. It adds only the workload lifecycle primitive; capability admission and session networking are deliberately left disabled for later PRs.
- The native helper, inherited-FD lifecycle protocol, server distribution, image packaging, and integration coverage land together because their protocol and installation path must remain synchronized.

Within the isolated-session MVP, processes sharing the parent sandbox mount namespace belong to the same trusted owner. The inherited-descriptor gate and final trusted proc mount prevent static caller-controlled mount aliases from replacing the helper; protecting against a trusted owner concurrently replacing an ancestor mount would require a future `execveat` launcher.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [x] Integration tests
- [x] e2e / manual verification

- `go vet ./...`
- `golangci-lint v1.64.8 run -v ./...`
- Linux amd64 and Windows amd64 `go build ./...`
- Lifecycle race suite in a privileged, network-disabled Linux container
- `TestBwrapLifecycleEndToEnd` in the same container: private/shared network READY, caller mount-alias protection, and control-EOF fail-closed paths
- Targeted Docker/Kubernetes server tests and Ruff checks
- Real execd Docker image build; source and managed-runtime gate artifacts had identical SHA-256 digests and execd was executable inside the Linux container
- `git diff --check`

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

The existing `Isolator.Wrap` path remains unchanged. The lifecycle interface is additive, includes a non-Linux stub, and does not change any public API, SDK, specification, or user-facing configuration.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed: this is an internal execd lifecycle primitive)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
