### PR TITLE
fix(egress): upgrade mitmproxy to 11.0.2

### DIFF
--- a/components/egress/Dockerfile
+++ b/components/egress/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
 RUN useradd -r -u 10042 -d /var/lib/mitmproxy -s /usr/sbin/nologin mitmproxy \
     && mkdir -p /var/lib/mitmproxy/.mitmproxy \
     && chown -R mitmproxy:mitmproxy /var/lib/mitmproxy \
-    && pip3 install --no-cache-dir --break-system-packages 'mitmproxy>=10,<11' \
+    && pip3 install --no-cache-dir --break-system-packages 'mitmproxy==11.0.2' \
     && (command -v mitmdump && mitmdump --version) \
     && mkdir -p /var/egress/mitmscripts
 


### PR DESCRIPTION
## Summary

Upgrade the egress image from `mitmproxy>=10,<11` to `mitmproxy==11.0.2`.

Mitmproxy 11 includes the upstream HTTP/2 flow-control fix from [mitmproxy/mitmproxy#7317](https://github.com/mitmproxy/mitmproxy/pull/7317), which increases stream and connection receive windows and avoids severe throughput throttling for large HTTP/2 responses.

## Performance

Exact 216 MiB HTTP/2 response through the transparent egress proxy:

| Path | Duration | Throughput |
|---|---:|---:|
| mitmproxy 10.4.2 | 353s | 0.61 MiB/s |
| Direct TLS | 8.1s | 26.67 MiB/s |
| mitmproxy 11.0.2 | 8.8s | 24.43 MiB/s |

Mitmproxy 11.0.2 restores throughput close to the direct path without patching private mitmproxy classes.

## Validation

- Built the amd64 egress image successfully with mitmproxy 11.0.2 on Debian Bookworm/Python 3.11
- Built the linux/arm64 egress image successfully; all native dependencies used prebuilt aarch64 wheels with no source compilation
- Arm64 image digest: `sha256:fe242dc5bb00672dc9283a858e627941838f39d0d63cbecdd2078c62f757bcdf`
- Confirmed transparent interception starts successfully in an OpenSandbox workload
- `python3 -m unittest components.egress.tests.test_mitmscripts_system` (34 tests)

Closes #1395.