### PR TITLE
fix(egress): renew active DNS IP leases

### DIFF
--- a/components/egress/nft.go
+++ b/components/egress/nft.go
@@ -58,6 +58,7 @@ func setupNft(ctx context.Context, nftMgr nftApplier, initialPolicy *policy.Netw
 			log.Warnf("[dns] add resolved IPs to nft failed for domain %q: %v", domain, err)
 		}
 	})
+	nftMgr.StartConnectionRefresh(ctx)
 }
 
 func parseNftOptions() nftables.Options {

--- a/components/egress/pkg/nftables/connection_tracker.go
+++ b/components/egress/pkg/nftables/connection_tracker.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"sort"
+	"time"
+
+	"github.com/alibaba/opensandbox/egress/pkg/log"
+	"github.com/alibaba/opensandbox/egress/pkg/telemetry"
+	"github.com/alibaba/opensandbox/internal/safego"
+)
+
+type connectionTracker struct {
+	dynamicIPs        map[netip.Addr]time.Time
+	previousActiveIPs map[netip.Addr]struct{}
+	listConnections   func(context.Context) ([]tcpConnection, error)
+	now               func() time.Time
+}
+
+type refreshPlan struct {
+	addresses []netip.Addr
+	active    map[netip.Addr]struct{}
+	at        time.Time
+}
+
+func newConnectionTracker() *connectionTracker {
+	return &connectionTracker{
+		dynamicIPs:        make(map[netip.Addr]time.Time),
+		previousActiveIPs: make(map[netip.Addr]struct{}),
+		listConnections:   listTCPConnections,
+		now:               time.Now,
+	}
+}
+
+func (t *connectionTracker) setDynamicIPs(ips []ResolvedIP) {
+	now := t.now()
+	for _, ip := range ips {
+		addr := ip.Addr.Unmap()
+		if addr.IsValid() {
+			t.dynamicIPs[addr] = now.Add(clampTTL(ip.TTL))
+		}
+	}
+}
+
+func (t *connectionTracker) start(ctx context.Context, interval time.Duration, manager *Manager) {
+	safego.Go(func() {
+		t.run(ctx, interval, manager)
+	})
+}
+
+func (t *connectionTracker) run(ctx context.Context, interval time.Duration, manager *Manager) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			connections, err := t.listConnections(ctx)
+			if err != nil {
+				t.clearPreviousActiveIPs(manager)
+				log.Warnf("nftables: list active TCP connections failed: %v", err)
+				continue
+			}
+			refreshCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			err = t.refreshActiveConnections(refreshCtx, connections, manager)
+			cancel()
+			if err != nil {
+				log.Warnf("nftables: refresh active DNS IPs failed: %v", err)
+			}
+		}
+	}
+}
+
+func (t *connectionTracker) refreshActiveConnections(ctx context.Context, connections []tcpConnection, manager *Manager) error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	plan := t.refreshCandidates(connections)
+	if len(plan.addresses) > 0 {
+		script := buildRefreshResolvedIPsScript(tableName, plan.addresses)
+		if _, err := manager.run(ctx, script); err != nil {
+			return err
+		}
+		telemetry.RecordNftablesUpdate()
+	}
+	t.recordRefresh(plan)
+	return nil
+}
+
+func (t *connectionTracker) clearPreviousActiveIPs(manager *Manager) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	t.previousActiveIPs = make(map[netip.Addr]struct{})
+}
+
+func (t *connectionTracker) refreshCandidates(connections []tcpConnection) refreshPlan {
+	active := activeRemoteIPs(connections)
+	now := t.now()
+	for addr, expiresAt := range t.dynamicIPs {
+		if !expiresAt.After(now) {
+			if _, isActive := active[addr]; isActive {
+				continue
+			}
+			if _, wasActive := t.previousActiveIPs[addr]; wasActive {
+				continue
+			}
+			delete(t.dynamicIPs, addr)
+			delete(t.previousActiveIPs, addr)
+		}
+	}
+
+	current := make(map[netip.Addr]struct{})
+	refresh := make(map[netip.Addr]struct{})
+	for addr := range active {
+		if _, ok := t.dynamicIPs[addr]; ok {
+			current[addr] = struct{}{}
+			refresh[addr] = struct{}{}
+		}
+	}
+	// A final refresh when activity ends makes the existing timeout the
+	// reconnect grace period instead of extending every DNS answer globally.
+	for addr := range t.previousActiveIPs {
+		if _, stillActive := current[addr]; !stillActive {
+			if _, known := t.dynamicIPs[addr]; known {
+				refresh[addr] = struct{}{}
+			}
+		}
+	}
+
+	addresses := make([]netip.Addr, 0, len(refresh))
+	for addr := range refresh {
+		addresses = append(addresses, addr)
+	}
+	sort.Slice(addresses, func(i, j int) bool { return addresses[i].Compare(addresses[j]) < 0 })
+	return refreshPlan{addresses: addresses, active: current, at: now}
+}
+
+func (t *connectionTracker) recordRefresh(plan refreshPlan) {
+	for _, addr := range plan.addresses {
+		t.dynamicIPs[addr] = plan.at.Add(time.Duration(dynSetTimeoutS) * time.Second)
+	}
+	t.previousActiveIPs = plan.active
+}
+
+func (t *connectionTracker) clearPreviousActiveIPsLocked() {
+	t.previousActiveIPs = make(map[netip.Addr]struct{})
+}
+
+func (t *connectionTracker) clear() {
+	t.dynamicIPs = make(map[netip.Addr]time.Time)
+	t.clearPreviousActiveIPsLocked()
+}
+
+func activeRemoteIPs(connections []tcpConnection) map[netip.Addr]struct{} {
+	active := make(map[netip.Addr]struct{})
+	for _, connection := range connections {
+		if !activeTCPState(connection.state) || !connection.remote.IsValid() {
+			continue
+		}
+		active[connection.remote.Unmap()] = struct{}{}
+	}
+	return active
+}
+
+func activeTCPState(state string) bool {
+	switch state {
+	case "ESTABLISHED", "SYN_SENT", "SYN_RECV", "FIN_WAIT1", "FIN_WAIT2", "CLOSE_WAIT", "CLOSING", "LAST_ACK":
+		return true
+	default:
+		return false
+	}
+}

--- a/components/egress/pkg/nftables/connection_tracker_test.go
+++ b/components/egress/pkg/nftables/connection_tracker_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionTrackerSetDynamicIPs(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	tracker := newConnectionTracker()
+	tracker.now = func() time.Time { return now }
+	tracker.setDynamicIPs([]ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: 10 * time.Second},
+		{Addr: netip.MustParseAddr("::ffff:192.0.2.1"), TTL: 120 * time.Second},
+	})
+
+	require.Equal(t, map[netip.Addr]time.Time{
+		netip.MustParseAddr("1.1.1.1"):   now.Add(70 * time.Second),
+		netip.MustParseAddr("192.0.2.1"): now.Add(180 * time.Second),
+	}, tracker.dynamicIPs)
+}
+
+func TestConnectionTrackerRefreshCandidates(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	tracker := newConnectionTracker()
+	tracker.now = func() time.Time { return now }
+	tracker.setDynamicIPs([]ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute},
+		{Addr: netip.MustParseAddr("2001:db8::1"), TTL: time.Minute},
+	})
+
+	refresh := tracker.refreshCandidates([]tcpConnection{
+		{remote: netip.MustParseAddr("2001:db8::1"), state: "ESTABLISHED"},
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "SYN_SENT"},
+		{remote: netip.MustParseAddr("2.2.2.2"), state: "ESTABLISHED"},
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "TIME_WAIT"},
+	})
+
+	require.Equal(t, []netip.Addr{
+		netip.MustParseAddr("1.1.1.1"),
+		netip.MustParseAddr("2001:db8::1"),
+	}, refresh.addresses)
+	require.Equal(t, map[netip.Addr]struct{}{
+		netip.MustParseAddr("1.1.1.1"):     {},
+		netip.MustParseAddr("2001:db8::1"): {},
+	}, refresh.active)
+}
+
+func TestConnectionTrackerFinalRefreshAfterClose(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	addr := netip.MustParseAddr("1.1.1.1")
+	tracker := newConnectionTracker()
+	tracker.now = func() time.Time { return now }
+	tracker.setDynamicIPs([]ResolvedIP{{Addr: addr, TTL: time.Minute}})
+	tracker.recordRefresh(tracker.refreshCandidates([]tcpConnection{{remote: addr, state: "ESTABLISHED"}}))
+
+	refresh := tracker.refreshCandidates(nil)
+	require.Equal(t, []netip.Addr{addr}, refresh.addresses)
+	tracker.recordRefresh(refresh)
+	require.Empty(t, tracker.refreshCandidates(nil).addresses)
+	require.Equal(t, now.Add(6*time.Minute), tracker.dynamicIPs[addr])
+}
+
+func TestConnectionTrackerForgetsExpiredInactiveIP(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	tracker := newConnectionTracker()
+	tracker.now = func() time.Time { return now }
+	tracker.setDynamicIPs([]ResolvedIP{{Addr: netip.MustParseAddr("1.1.1.1"), TTL: 10 * time.Second}})
+	now = now.Add(71 * time.Second)
+
+	require.Empty(t, tracker.refreshCandidates(nil).addresses)
+	require.Empty(t, tracker.dynamicIPs)
+}
+
+func TestConnectionTrackerClear(t *testing.T) {
+	tracker := newConnectionTracker()
+	tracker.setDynamicIPs([]ResolvedIP{{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute}})
+	tracker.previousActiveIPs[netip.MustParseAddr("1.1.1.1")] = struct{}{}
+
+	tracker.clear()
+	require.Empty(t, tracker.dynamicIPs)
+	require.Empty(t, tracker.previousActiveIPs)
+}

--- a/components/egress/pkg/nftables/connections_linux.go
+++ b/components/egress/pkg/nftables/connections_linux.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package nftables
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/netip"
+	"os"
+	"strings"
+)
+
+type tcpConnection struct {
+	remote netip.Addr
+	state  string
+}
+
+var tcpStates = map[string]string{
+	"01": "ESTABLISHED",
+	"02": "SYN_SENT",
+	"03": "SYN_RECV",
+	"04": "FIN_WAIT1",
+	"05": "FIN_WAIT2",
+	"08": "CLOSE_WAIT",
+	"09": "LAST_ACK",
+	"0B": "CLOSING",
+}
+
+func listTCPConnections(ctx context.Context) ([]tcpConnection, error) {
+	var connections []tcpConnection
+	for _, file := range []struct {
+		path string
+		ipv6 bool
+	}{
+		{path: "/proc/net/tcp"},
+		{path: "/proc/net/tcp6", ipv6: true},
+	} {
+		parsed, err := readTCPConnections(ctx, file.path, file.ipv6)
+		if err != nil {
+			if file.ipv6 && os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		connections = append(connections, parsed...)
+	}
+	return connections, nil
+}
+
+func readTCPConnections(ctx context.Context, path string, ipv6 bool) ([]tcpConnection, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var connections []tcpConnection
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() { // header
+	}
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		state, ok := tcpStates[strings.ToUpper(fields[3])]
+		if !ok {
+			continue
+		}
+		remote, err := decodeProcAddress(fields[2], ipv6)
+		if err != nil || remote.IsUnspecified() {
+			continue
+		}
+		connections = append(connections, tcpConnection{remote: remote, state: state})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return connections, nil
+}
+
+func decodeProcAddress(value string, ipv6 bool) (netip.Addr, error) {
+	hexIP, _, ok := strings.Cut(value, ":")
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid proc address %q", value)
+	}
+	bytes, err := hex.DecodeString(hexIP)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if ipv6 {
+		if len(bytes) != 16 {
+			return netip.Addr{}, fmt.Errorf("invalid IPv6 address %q", hexIP)
+		}
+		for i := 0; i < len(bytes); i += 4 {
+			reverseBytes(bytes[i : i+4])
+		}
+	} else {
+		if len(bytes) != 4 {
+			return netip.Addr{}, fmt.Errorf("invalid IPv4 address %q", hexIP)
+		}
+		reverseBytes(bytes)
+	}
+	addr, ok := netip.AddrFromSlice(bytes)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid IP address %q", hexIP)
+	}
+	return addr.Unmap(), nil
+}
+
+func reverseBytes(bytes []byte) {
+	for i, j := 0, len(bytes)-1; i < j; i, j = i+1, j-1 {
+		bytes[i], bytes[j] = bytes[j], bytes[i]
+	}
+}

--- a/components/egress/pkg/nftables/connections_linux_test.go
+++ b/components/egress/pkg/nftables/connections_linux_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadTCPConnections(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tcp")
+	contents := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n" +
+		"   0: 0100007F:1234 01010101:01BB 01 00000000:00000000 00:00000000 00000000  1000 0 1\n" +
+		"   1: 0100007F:1235 02020202:01BB 06 00000000:00000000 00:00000000 00000000  1000 0 2\n"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	connections, err := readTCPConnections(context.Background(), path, false)
+	require.NoError(t, err)
+	require.Equal(t, []tcpConnection{{remote: mustAddr("1.1.1.1"), state: "ESTABLISHED"}}, connections)
+}
+
+func TestDecodeProcAddressIPv6(t *testing.T) {
+	addr, err := decodeProcAddress("B80D0120000000000000000001000000:01BB", true)
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8::1", addr.String())
+}
+
+func mustAddr(value string) netip.Addr {
+	return netip.MustParseAddr(value)
+}

--- a/components/egress/pkg/nftables/connections_other.go
+++ b/components/egress/pkg/nftables/connections_other.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+)
+
+type tcpConnection struct {
+	remote netip.Addr
+	state  string
+}
+
+func listTCPConnections(context.Context) ([]tcpConnection, error) {
+	return nil, nil
+}

--- a/components/egress/pkg/nftables/dynamic.go
+++ b/components/egress/pkg/nftables/dynamic.go
@@ -41,13 +41,46 @@ type ResolvedIP struct {
 // buildAddResolvedIPsScript returns a nft script fragment that
 // adds resolved IPs to dyn_allow_v4/v6 with timeout.
 func buildAddResolvedIPsScript(table string, ips []ResolvedIP) string {
-	var v4, v6 []string
+	elements := make([]ResolvedIP, 0, len(ips))
 	for _, r := range ips {
-		sec := clampTTL(r.TTL)
-		if r.Addr.Is4() {
-			v4 = append(v4, fmt.Sprintf("%s timeout %ds", r.Addr.String(), sec))
-		} else if r.Addr.Is6() {
-			v6 = append(v6, fmt.Sprintf("%s timeout %ds", r.Addr.String(), sec))
+		elements = append(elements, ResolvedIP{
+			Addr: r.Addr,
+			TTL:  clampTTL(r.TTL),
+		})
+	}
+	return buildResolvedIPElementsScript(table, elements)
+}
+
+func clampTTL(d time.Duration) time.Duration {
+	sec := int(d.Seconds()) + nftTTLSlackSec
+	sec = min(max(sec, minTTLSec), maxTTLSec)
+	return time.Duration(sec) * time.Second
+}
+
+// buildRefreshResolvedIPsScript renders active connection refreshes with the
+// full set timeout rather than the DNS TTL. Activity proves the address is
+// still in use, and the final refresh after the connection closes makes this
+// same bounded timeout the reconnect grace period.
+func buildRefreshResolvedIPsScript(table string, ips []netip.Addr) string {
+	elements := make([]ResolvedIP, 0, len(ips))
+	for _, addr := range ips {
+		elements = append(elements, ResolvedIP{
+			Addr: addr,
+			TTL:  dynSetTimeoutS * time.Second,
+		})
+	}
+	return buildResolvedIPElementsScript(table, elements)
+}
+
+func buildResolvedIPElementsScript(table string, elements []ResolvedIP) string {
+	var v4, v6 []string
+	for _, element := range elements {
+		addr := element.Addr.Unmap()
+		value := fmt.Sprintf("%s timeout %ds", addr, int(element.TTL/time.Second))
+		if addr.Is4() {
+			v4 = append(v4, value)
+		} else if addr.Is6() {
+			v6 = append(v6, value)
 		}
 	}
 	var b strings.Builder
@@ -58,15 +91,4 @@ func buildAddResolvedIPsScript(table string, ips []ResolvedIP) string {
 		fmt.Fprintf(&b, "add element inet %s %s { %s }\n", table, dynAllowV6Set, strings.Join(v6, ", "))
 	}
 	return b.String()
-}
-
-func clampTTL(d time.Duration) int {
-	sec := int(d.Seconds()) + nftTTLSlackSec
-	if sec < minTTLSec {
-		return minTTLSec
-	}
-	if sec > maxTTLSec {
-		return maxTTLSec
-	}
-	return sec
 }

--- a/components/egress/pkg/nftables/manager.go
+++ b/components/egress/pkg/nftables/manager.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	"github.com/alibaba/opensandbox/egress/pkg/log"
@@ -28,14 +29,15 @@ import (
 )
 
 const (
-	tableName     = "opensandbox"
-	chainName     = "egress"
-	allowV4Set    = "allow_v4"
-	allowV6Set    = "allow_v6"
-	denyV4Set     = "deny_v4"
-	denyV6Set     = "deny_v6"
-	dohBlockV4Set = "doh_block_v4"
-	dohBlockV6Set = "doh_block_v6"
+	tableName                        = "opensandbox"
+	chainName                        = "egress"
+	allowV4Set                       = "allow_v4"
+	allowV6Set                       = "allow_v6"
+	denyV4Set                        = "deny_v4"
+	denyV6Set                        = "deny_v6"
+	dohBlockV4Set                    = "doh_block_v4"
+	dohBlockV6Set                    = "doh_block_v6"
+	defaultConnectionRefreshInterval = 30 * time.Second
 )
 
 type runner func(ctx context.Context, script string) ([]byte, error)
@@ -45,28 +47,45 @@ type Options struct {
 	BlockDoH443    bool
 	DoHBlocklistV4 []string
 	DoHBlocklistV6 []string
+	// ConnectionRefreshInterval controls how often active TCP connections renew
+	// DNS-derived nft leases. Shorter intervals reduce the maximum temporary
+	// reconnect gap, but increase /proc scans and nft updates. The 30-second
+	// default is half the minimum 60-second DNS lease.
+	ConnectionRefreshInterval time.Duration
 }
 
 type Manager struct {
-	run  runner
-	opts Options
-	mu   sync.Mutex
+	run     runner
+	opts    Options
+	mu      sync.Mutex
+	tracker *connectionTracker
 }
 
 func NewManager() *Manager {
-	return &Manager{run: defaultRunner, opts: Options{BlockDoT: true}}
+	return newManager(defaultRunner, Options{BlockDoT: true})
 }
 
 func NewManagerWithRunner(r runner) *Manager {
-	return &Manager{run: r, opts: Options{BlockDoT: true}}
+	return newManager(r, Options{BlockDoT: true})
 }
 
 func NewManagerWithRunnerAndOptions(r runner, opts Options) *Manager {
-	return &Manager{run: r, opts: opts}
+	return newManager(r, opts)
 }
 
 func NewManagerWithOptions(opts Options) *Manager {
-	return &Manager{run: defaultRunner, opts: opts}
+	return newManager(defaultRunner, opts)
+}
+
+func newManager(r runner, opts Options) *Manager {
+	if opts.ConnectionRefreshInterval <= 0 {
+		opts.ConnectionRefreshInterval = defaultConnectionRefreshInterval
+	}
+	return &Manager{
+		run:     r,
+		opts:    opts,
+		tracker: newConnectionTracker(),
+	}
 }
 
 func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy) error {
@@ -87,6 +106,7 @@ func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy) erro
 			fallback := removeDeleteTableLine(script)
 			if fallback != script {
 				if _, retryErr := m.run(ctx, fallback); retryErr == nil {
+					m.tracker.clear()
 					telemetry.SetNftablesRuleCount(telemetry.NftRuleCountFromPolicy(p))
 					telemetry.RecordNftablesUpdate()
 					return nil
@@ -95,6 +115,7 @@ func (m *Manager) ApplyStatic(ctx context.Context, p *policy.NetworkPolicy) erro
 		}
 		return err
 	}
+	m.tracker.clear()
 	telemetry.SetNftablesRuleCount(telemetry.NftRuleCountFromPolicy(p))
 	telemetry.RecordNftablesUpdate()
 	log.Infof("nftables: static policy applied successfully")
@@ -115,9 +136,29 @@ func (m *Manager) AddResolvedIPs(ctx context.Context, ips []ResolvedIP) error {
 	log.Debugf("nftables: adding %d resolved IP(s) to dynamic allow sets with script statement %s", len(ips), script)
 	_, err := m.run(ctx, script)
 	if err == nil {
+		m.tracker.setDynamicIPs(ips)
 		telemetry.RecordNftablesUpdate()
 	}
 	return err
+}
+
+// StartConnectionRefresh keeps DNS-learned IPs authorized while a TCP
+// connection to them is active. The normal set timeout remains as the grace
+// period after the connection closes.
+//
+// Renewal is intentionally best-effort:
+//   - an active connection first observed after its entry expires is restored
+//     on the next poll, so reconnects may fail for up to one refresh interval;
+//   - a connection that starts and closes entirely between polls cannot be
+//     observed and requires a later DNS lookup to restore its expired entry;
+//   - delayed polls or nft failures can extend the temporary reconnect gap;
+//   - only TCP is tracked here; UDP and QUIC rely on DNS-driven entry refresh.
+//
+// Existing connections survive these gaps through conntrack. A successful
+// observation renews the entry for the full timeout, and the final observation
+// after close provides the same bounded grace period for reconnects.
+func (m *Manager) StartConnectionRefresh(ctx context.Context) {
+	m.tracker.start(ctx, m.opts.ConnectionRefreshInterval, m)
 }
 
 // RemoveEnforcement drops inet opensandbox; missing table is not an error.
@@ -133,6 +174,7 @@ func (m *Manager) RemoveEnforcement(ctx context.Context) error {
 		}
 		return err
 	}
+	m.tracker.clear()
 	log.Infof("nftables: removed table inet %s", tableName)
 	return nil
 }

--- a/components/egress/pkg/nftables/manager_test.go
+++ b/components/egress/pkg/nftables/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -227,4 +228,219 @@ func TestApplyStatic_NormalizesOverlappingAllow(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.ApplyStatic(context.Background(), p))
 	expectContains(t, rendered, "add element inet opensandbox allow_v4 { 100.64.0.0/10 }")
+}
+
+func TestRefreshActiveConnections_RenewsKnownActiveIP(t *testing.T) {
+	var scripts []string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		scripts = append(scripts, script)
+		return nil, nil
+	})
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute},
+	}))
+
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), []tcpConnection{
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "ESTABLISHED"},
+		{remote: netip.MustParseAddr("2.2.2.2"), state: "ESTABLISHED"},
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "TIME_WAIT"},
+	}, m))
+
+	require.Len(t, scripts, 2)
+	require.Equal(t, "add element inet opensandbox dyn_allow_v4 { 1.1.1.1 timeout 360s }\n", scripts[1])
+}
+
+func TestRefreshActiveConnections_RenewsOnceAfterConnectionCloses(t *testing.T) {
+	var scripts []string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		scripts = append(scripts, script)
+		return nil, nil
+	})
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("2001:db8::1"), TTL: time.Minute},
+	}))
+	active := []tcpConnection{
+		{remote: netip.MustParseAddr("2001:db8::1"), state: "ESTABLISHED"},
+	}
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), active, m))
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), nil, m))
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), nil, m))
+
+	require.Len(t, scripts, 3)
+	require.Equal(t, "add element inet opensandbox dyn_allow_v6 { 2001:db8::1 timeout 360s }\n", scripts[1])
+	require.Equal(t, scripts[1], scripts[2])
+}
+
+func TestApplyStatic_ClearsTrackedDynamicIPs(t *testing.T) {
+	var scripts []string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		scripts = append(scripts, script)
+		return nil, nil
+	})
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute},
+	}))
+	require.NoError(t, m.ApplyStatic(context.Background(), policy.DefaultDenyPolicy()))
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), []tcpConnection{
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "ESTABLISHED"},
+	}, m))
+
+	require.Len(t, scripts, 2)
+}
+
+func TestAddResolvedIPs_DoesNotTrackFailedInsert(t *testing.T) {
+	m := NewManagerWithRunner(func(_ context.Context, _ string) ([]byte, error) {
+		return nil, fmt.Errorf("nft failed")
+	})
+	require.Error(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute},
+	}))
+
+	m.run = func(_ context.Context, _ string) ([]byte, error) {
+		require.FailNow(t, "failed insert must not become refresh eligible")
+		return nil, nil
+	}
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), []tcpConnection{
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "ESTABLISHED"},
+	}, m))
+}
+
+func TestRefreshActiveConnections_ForgetsExpiredInactiveIP(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	m := NewManagerWithRunner(func(_ context.Context, _ string) ([]byte, error) {
+		return nil, nil
+	})
+	m.tracker.now = func() time.Time { return now }
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: 10 * time.Second},
+	}))
+	now = now.Add(71 * time.Second)
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), nil, m))
+
+	require.Empty(t, m.tracker.dynamicIPs)
+}
+
+func TestRefreshActiveConnections_RenewsExpiredActiveIP(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	var scripts []string
+	m := NewManagerWithRunner(func(_ context.Context, script string) ([]byte, error) {
+		scripts = append(scripts, script)
+		return nil, nil
+	})
+	m.tracker.now = func() time.Time { return now }
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: 10 * time.Second},
+	}))
+	now = now.Add(71 * time.Second)
+	require.NoError(t, m.tracker.refreshActiveConnections(context.Background(), []tcpConnection{
+		{remote: netip.MustParseAddr("1.1.1.1"), state: "ESTABLISHED"},
+	}, m))
+
+	require.Len(t, scripts, 2)
+	require.Equal(t, now.Add(6*time.Minute), m.tracker.dynamicIPs[netip.MustParseAddr("1.1.1.1")])
+}
+
+func TestStartConnectionRefresh_StopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	called := make(chan struct{}, 1)
+	m := NewManagerWithRunnerAndOptions(func(_ context.Context, _ string) ([]byte, error) {
+		return nil, nil
+	}, Options{ConnectionRefreshInterval: time.Millisecond})
+	m.tracker.listConnections = func(context.Context) ([]tcpConnection, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return nil, nil
+	}
+	m.StartConnectionRefresh(ctx)
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		require.FailNow(t, "refresh worker did not run")
+	}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+	for len(called) > 0 {
+		<-called
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Empty(t, called)
+}
+
+func TestStartConnectionRefresh_PollErrorClearsPriorActivity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var scripts []string
+	var polls int
+	done := make(chan struct{})
+	m := NewManagerWithRunnerAndOptions(func(_ context.Context, script string) ([]byte, error) {
+		scripts = append(scripts, script)
+		return nil, nil
+	}, Options{ConnectionRefreshInterval: time.Millisecond})
+	m.tracker.listConnections = func(context.Context) ([]tcpConnection, error) {
+		polls++
+		switch polls {
+		case 1:
+			return []tcpConnection{{remote: netip.MustParseAddr("1.1.1.1"), state: "ESTABLISHED"}}, nil
+		case 2:
+			return nil, fmt.Errorf("proc unavailable")
+		default:
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+			return nil, nil
+		}
+	}
+	require.NoError(t, m.AddResolvedIPs(context.Background(), []ResolvedIP{
+		{Addr: netip.MustParseAddr("1.1.1.1"), TTL: time.Minute},
+	}))
+	m.StartConnectionRefresh(ctx)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow(t, "refresh worker did not complete poll sequence")
+	}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	// Initial insert plus the active renewal. A stale final renewal must not be
+	// emitted after the observation gap.
+	require.Len(t, scripts, 2)
+}
+
+func TestNewManager_DefaultsConnectionRefreshInterval(t *testing.T) {
+	m := NewManagerWithOptions(Options{})
+	require.Equal(t, 30*time.Second, m.opts.ConnectionRefreshInterval)
+}
+
+func TestManagerSerializesConcurrentTrackerUpdates(t *testing.T) {
+	m := NewManagerWithRunner(func(_ context.Context, _ string) ([]byte, error) {
+		return nil, nil
+	})
+	addr := netip.MustParseAddr("1.1.1.1")
+	var wg sync.WaitGroup
+	errs := make(chan error, 60)
+	for range 20 {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			errs <- m.AddResolvedIPs(context.Background(), []ResolvedIP{{Addr: addr, TTL: time.Minute}})
+		}()
+		go func() {
+			defer wg.Done()
+			errs <- m.tracker.refreshActiveConnections(context.Background(), []tcpConnection{{remote: addr, state: "ESTABLISHED"}}, m)
+		}()
+		go func() {
+			defer wg.Done()
+			errs <- m.ApplyStatic(context.Background(), policy.DefaultDenyPolicy())
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }

--- a/components/egress/policy_server.go
+++ b/components/egress/policy_server.go
@@ -50,6 +50,7 @@ type policyUpdater interface {
 type nftApplier interface {
 	ApplyStatic(context.Context, *policy.NetworkPolicy) error
 	AddResolvedIPs(context.Context, []nftables.ResolvedIP) error
+	StartConnectionRefresh(context.Context)
 	RemoveEnforcement(context.Context) error
 }
 

--- a/components/egress/policy_server_test.go
+++ b/components/egress/policy_server_test.go
@@ -65,6 +65,8 @@ func (s *stubNft) AddResolvedIPs(_ context.Context, _ []nftables.ResolvedIP) err
 	return nil
 }
 
+func (s *stubNft) StartConnectionRefresh(context.Context) {}
+
 func (s *stubNft) RemoveEnforcement(_ context.Context) error {
 	return nil
 }

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -39,6 +39,8 @@ The egress control is implemented as a **Sidecar** that shares the network names
     - Uses `nftables` to enforce IP-level allow/deny. Resolved IPs for allowed domains are added to dynamic allow sets with TTL (dynamic DNS).
     - At startup, the sidecar whitelists **127.0.0.1** (redirect target for the proxy) and **nameserver IPs** from `/etc/resolv.conf` so DNS resolution and proxy upstream work (including private DNS). Nameserver count is capped and invalid IPs are filtered.
 
+Dynamic entries initially use the DNS TTL plus a short safety margin, clamped to 60–360 seconds. The sidecar polls active TCP connections every 30 seconds and renews only DNS-authorized remote IPs that are still in use. When activity ends, one final six-minute renewal provides a bounded reconnect window before the entry expires normally. This means an active TCP connection can keep an IP authorized beyond its original DNS TTL; UDP and QUIC entries are not connection-tracked and continue to expire according to DNS-driven TTL updates.
+
 ### Kubernetes Service Access Under `defaultAction: deny`
 
 In Kubernetes deployments that use `defaultAction: deny`, reaching an in-cluster Service usually needs two separate allowances:


### PR DESCRIPTION
## Summary

- poll TCP sockets in the shared network namespace every 30 seconds
- renew only IPs learned from allowed DNS responses while a connection is active
- perform one final renewal when activity ends, using the existing six-minute timeout as bounded reconnect grace
- clear tracked dynamic addresses whenever policy replacement recreates the nftables table

## Problem

In `dns+nft` mode, DNS-derived dynamic nft entries can expire while a long-lived client still retains the resolved address. Conntrack preserves the existing connection, but a later new upstream connection can be dropped if the client does not query DNS again first.

Closes #1398.

## Design

The worker reads `/proc/net/tcp` and `/proc/net/tcp6` directly. This sees both workload sockets and transparent mitmproxy upstream sockets because containers share a network namespace even when they do not share a PID namespace.

Initial DNS insertion and TTL clamping are unchanged. Only a DNS-authorized IP observed on an active TCP connection is renewed to the existing six-minute set timeout. Unknown active IPs are ignored. After activity ends, one final renewal provides reconnect grace and then the entry expires normally.

A 30-second default balances reconnect recovery against `/proc` parsing and nft update overhead. It is configurable through `nftables.Options.ConnectionRefreshInterval`.

## Validation

- `go test -race ./pkg/nftables`
- `go test ./...`
- `go vet ./...`
- Darwin and Windows compile-only checks
- existing mitmproxy addon suite: 34 tests
- amd64 image build succeeded

### Stock six-minute behavior

Without active renewal, the same Java 21 / gRPC Java 1.66 persistent-channel test failed after 370 seconds:

```text
initial_rpc ok duration_ms=574 state=READY
sleeping_seconds=370
reconnect_rpc failed duration_ms=20026 state=READY ... Name resolution delay 0.000000000 seconds
followup_rpc failed duration_ms=20025 state=READY ... Name resolution delay 0.000000000 seconds
```

### With this PR

```text
channel_state=READY
initial_rpc ok duration_ms=807 state=READY
sleeping_seconds=370
reconnect_rpc ok duration_ms=431 state=READY
followup_rpc ok duration_ms=80 state=READY
```

During that idle period, the six-minute lease counted down to about six seconds. The reconnect succeeded and the worker reset it to about 5m43s. No renewal warnings or errors were logged.

An internal image with a 24-hour timeout also passed, but that is a broad workaround and is not the baseline or proposed design.

A full cold remote build completed successfully beyond the six-minute boundary with no gRPC timeout/retry errors.

## Scope

TCP only. UDP and QUIC continue to rely on DNS-driven refresh. Connections that begin and end entirely between polls may be missed; these corner cases are documented on `StartConnectionRefresh`.