### PR TITLE
perf(server): use direct Docker container lookup

### DIFF
--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -245,6 +245,17 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
         """Helper to fetch the Docker container associated with a sandbox ID."""
         label_selector = f"{SANDBOX_ID_LABEL}={sandbox_id}"
         try:
+            try:
+                container = self.docker_client.containers.get(f"sandbox-{sandbox_id}")
+            except DockerNotFound:
+                container = None
+
+            if container is not None:
+                labels = container.attrs.get("Config", {}).get("Labels") or {}
+                if labels.get(SANDBOX_ID_LABEL) == sandbox_id:
+                    return container
+
+            # Preserve lookup for managed containers with a nonstandard name.
             containers = self.docker_client.containers.list(
                 all=True, filters={"label": label_selector}
             )

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -2156,6 +2156,7 @@ def test_delete_sandbox_removes_windows_oem_volume(mock_docker):
 
     mock_client = MagicMock()
     mock_client.containers.list.return_value = [mock_container]
+    mock_client.containers.get.return_value = mock_container
     mock_docker.from_env.return_value = mock_client
     service = DockerSandboxService(config=_app_config())
 
@@ -2179,6 +2180,7 @@ def test_delete_sandbox_skips_oem_volume_cleanup_for_linux(mock_docker):
 
     mock_client = MagicMock()
     mock_client.containers.list.return_value = [mock_container]
+    mock_client.containers.get.return_value = mock_container
     mock_docker.from_env.return_value = mock_client
     service = DockerSandboxService(config=_app_config())
 
@@ -2947,6 +2949,7 @@ class TestDockerVolumeValidation:
 
         mock_client = MagicMock()
         mock_client.containers.list.return_value = [mock_container]
+        mock_client.containers.get.return_value = mock_container
         mock_docker.from_env.return_value = mock_client
         service = DockerSandboxService(config=_app_config())
         service._ossfs_mount_ref_counts[mount_key] = 1
@@ -3023,6 +3026,10 @@ class TestDockerVolumeValidation:
         }
         mock_client = MagicMock()
         mock_client.containers.list.return_value = [container_a, container_b]
+        mock_client.containers.get.side_effect = lambda name: {
+            "sandbox-sandbox-a": container_a,
+            "sandbox-sandbox-b": container_b,
+        }[name]
         mock_docker.from_env.return_value = mock_client
 
         service = DockerSandboxService(config=_app_config())
@@ -3924,22 +3931,133 @@ def test_list_sandboxes_wraps_docker_exception(mock_docker):
 
 
 @patch("opensandbox_server.services.docker.docker_service.docker")
-def test_get_container_by_sandbox_id_maps_notfound_to_404(mock_docker):
-    """Concurrent deletion of a single container must yield 404, not 500.
-
-    docker-py's ``containers.list`` performs a follow-up inspect per matched
-    entry; when the container disappears mid-inspect, docker-py raises
-    ``NotFound``. The service must translate this into SANDBOX_NOT_FOUND (404)
-    to match the semantics callers expect when a sandbox has been removed.
-    """
+def test_get_container_by_sandbox_id_uses_deterministic_name(
+    mock_docker: MagicMock,
+) -> None:
     mock_client = MagicMock()
-    mock_client.containers.list.side_effect = DockerNotFound("no such container")
+    mock_client.containers.list.return_value = []
     mock_docker.from_env.return_value = mock_client
 
     service = DockerSandboxService(config=_app_config())
+    container = MagicMock()
+    container.attrs = {
+        "Config": {"Labels": {SANDBOX_ID_LABEL: "sbx-current"}},
+    }
+    mock_client.containers.get.reset_mock()
+    mock_client.containers.list.reset_mock()
+    mock_client.containers.get.return_value = container
+
+    result = service._get_container_by_sandbox_id("sbx-current")
+
+    assert result is container
+    mock_client.containers.get.assert_called_once_with("sandbox-sbx-current")
+    mock_client.containers.list.assert_not_called()
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_get_container_by_sandbox_id_falls_back_to_label_lookup(
+    mock_docker: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    legacy_container = MagicMock()
+    mock_client.containers.list.reset_mock()
+    mock_client.containers.get.side_effect = DockerNotFound("no deterministic name")
+    mock_client.containers.list.return_value = [legacy_container]
+
+    result = service._get_container_by_sandbox_id("sbx-legacy")
+
+    assert result is legacy_container
+    mock_client.containers.get.assert_called_once_with("sandbox-sbx-legacy")
+    mock_client.containers.list.assert_called_once_with(
+        all=True,
+        filters={"label": f"{SANDBOX_ID_LABEL}=sbx-legacy"},
+    )
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_get_container_by_sandbox_id_falls_back_when_name_has_wrong_label(
+    mock_docker: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    named_container = MagicMock()
+    named_container.attrs = {
+        "Config": {"Labels": {SANDBOX_ID_LABEL: "another-sandbox"}},
+    }
+    labelled_container = MagicMock()
+    mock_client.containers.list.reset_mock()
+    mock_client.containers.get.return_value = named_container
+    mock_client.containers.list.return_value = [labelled_container]
+
+    result = service._get_container_by_sandbox_id("sbx-collision")
+
+    assert result is labelled_container
+    mock_client.containers.list.assert_called_once_with(
+        all=True,
+        filters={"label": f"{SANDBOX_ID_LABEL}=sbx-collision"},
+    )
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_get_container_by_sandbox_id_maps_empty_fallback_to_404(
+    mock_docker: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    mock_client.containers.get.side_effect = DockerNotFound("no deterministic name")
+
+    with pytest.raises(HTTPException) as exc:
+        service._get_container_by_sandbox_id("sbx-missing")
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail["code"] == SandboxErrorCodes.SANDBOX_NOT_FOUND
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_get_container_by_sandbox_id_maps_notfound_to_404(
+    mock_docker: MagicMock,
+) -> None:
+    """Concurrent deletion of a single container must yield 404, not 500."""
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    mock_client.containers.get.side_effect = DockerNotFound("no deterministic name")
+    mock_client.containers.list.side_effect = DockerNotFound("no such container")
 
     with pytest.raises(HTTPException) as exc:
         service._get_container_by_sandbox_id("sbx-vanished")
 
     assert exc.value.status_code == status.HTTP_404_NOT_FOUND
     assert exc.value.detail["code"] == SandboxErrorCodes.SANDBOX_NOT_FOUND
+
+
+@patch("opensandbox_server.services.docker.docker_service.docker")
+def test_get_container_by_sandbox_id_maps_docker_error_to_500(
+    mock_docker: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.containers.list.return_value = []
+    mock_docker.from_env.return_value = mock_client
+
+    service = DockerSandboxService(config=_app_config())
+    mock_client.containers.list.reset_mock()
+    mock_client.containers.get.side_effect = DockerException("daemon unavailable")
+
+    with pytest.raises(HTTPException) as exc:
+        service._get_container_by_sandbox_id("sbx-error")
+
+    assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert exc.value.detail["code"] == SandboxErrorCodes.CONTAINER_QUERY_FAILED
+    mock_client.containers.list.assert_not_called()


### PR DESCRIPTION
# Summary

Improve Docker sandbox lookup performance by using the deterministic
`sandbox-<sandbox_id>` container name as the primary lookup path.

The returned container's `opensandbox.io/id` label is validated before it is
accepted. If the name is missing or belongs to another container, the existing
label-based lookup is used as a compatibility fallback.

Existing error semantics are preserved:

- missing sandbox -> `404 SANDBOX_NOT_FOUND`
- Docker query failure -> `500 CONTAINER_QUERY_FAILED`

# Performance

In the local Docker benchmark that motivated this change, two sequential
sandbox endpoint lookups improved from:

| | Before | After |
|---|---:|---:|
| execd endpoint lookup | 3.040 s | 49 ms |
| egress endpoint lookup | 3.026 s | 7 ms |
| Total | 6.066 s | 56 ms |

This is approximately a **108x speedup** for the measured endpoint-resolution
path, or a **99.1% latency reduction**.

These are local benchmark results from the motivating Docker environment and
should not be interpreted as a universal performance guarantee.

# Testing

- [ ] Not run
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Verification:

```text
uv run pytest tests/test_docker_service.py
132 passed
```

```text
uv run ruff check opensandbox_server/services/docker/docker_service.py tests/test_docker_service.py
All checks passed
```

# Breaking Changes

- [x] None
- [ ] Yes

# Checklist

- [x] Clearly described motivation
- [x] Added/updated tests
- [x] Security impact considered
- [x] Backward compatibility considered
- [x] Documentation not required because no public API or configuration changed
