### PR TITLE
fix(egress): give the DNS latency histogram buckets that match its unit

### DIFF
--- a/components/egress/docs/opentelemetry.md
+++ b/components/egress/docs/opentelemetry.md
@@ -20,14 +20,25 @@ This page lists the OpenTelemetry metrics currently implemented in egress.
 `egress.dns.query.duration` declares its bucket boundaries explicitly:
 
 ```
-0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10
+0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120
 ```
 
-They span a cache hit (sub-millisecond) to the upstream timeout
-(`OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT`, 5s by default), with 10s as an overflow guard.
 Do not drop them: the instrument records **seconds**, while the SDK default boundaries are
 the spec's millisecond ladder (`0, 5, 10, … 10000`), so every realistic latency would fall
 into the single `le=5` bucket and the quantiles would be meaningless.
+
+The head resolves a cache hit (sub-millisecond) up to one upstream timeout
+(`OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT`, 5s by default). The coarse tail exists because
+the recorded duration covers the **whole resolver chain**: forwarding walks the upstreams
+serially, each with the full timeout, so a query can legitimately take
+`timeout x len(upstreams)` — 15s is three resolvers at the default, and 120s is the cap a
+single exchange can be configured to wait. The chain has no finite worst case
+(`OPENSANDBOX_EGRESS_DNS_UPSTREAM` accepts an unbounded resolver list), so anything past
+120s falls in `+Inf` on purpose: at that point the lookup has failed and `_count` is the
+signal, not a quantile.
+
+Note both successful and failed lookups feed this histogram, so its tail mixes slow
+resolutions with exhausted retry chains.
 
 ## Shared Attributes
 

--- a/components/egress/docs/opentelemetry.md
+++ b/components/egress/docs/opentelemetry.md
@@ -20,7 +20,7 @@ This page lists the OpenTelemetry metrics currently implemented in egress.
 `egress.dns.query.duration` declares its bucket boundaries explicitly:
 
 ```
-0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120
+0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120  300  600
 ```
 
 Do not drop them: the instrument records **seconds**, while the SDK default boundaries are
@@ -32,10 +32,12 @@ The head resolves a cache hit (sub-millisecond) up to one upstream timeout
 the recorded duration covers the **whole resolver chain**: forwarding walks the upstreams
 serially, each with the full timeout, so a query can legitimately take
 `timeout x len(upstreams)` — 15s is three resolvers at the default, and 120s is the cap a
-single exchange can be configured to wait. The chain has no finite worst case
-(`OPENSANDBOX_EGRESS_DNS_UPSTREAM` accepts an unbounded resolver list), so anything past
-120s falls in `+Inf` on purpose: at that point the lookup has failed and `_count` is the
-signal, not a quantile.
+single exchange can be configured to wait. A late **success** lands in the tail too, not only an exhausted failure: a query can
+succeed on the second resolver after the first burned a full timeout. The chain has no finite
+worst case either (`OPENSANDBOX_EGRESS_DNS_UPSTREAM` accepts an unbounded resolver list), so
+past the last boundary quantile resolution is lost by construction and `_count` is what
+remains. A configuration that gets there — several resolvers each waiting close to the 120s
+per-exchange cap — has bigger problems than a percentile.
 
 Note both successful and failed lookups feed this histogram, so its tail mixes slow
 resolutions with exhausted retry chains.

--- a/components/egress/docs/opentelemetry.md
+++ b/components/egress/docs/opentelemetry.md
@@ -17,6 +17,18 @@ This page lists the OpenTelemetry metrics currently implemented in egress.
 | `egress.system.memory.usage_bytes` | Observable Gauge | `By` | System memory used bytes (Linux: gopsutil; non-Linux build: `0`). |
 | `egress.system.cpu.utilization` | Observable Gauge | `1` | CPU busy ratio in `[0,1]` (Linux: gopsutil; non-Linux build: `0`). |
 
+`egress.dns.query.duration` declares its bucket boundaries explicitly:
+
+```
+0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10
+```
+
+They span a cache hit (sub-millisecond) to the upstream timeout
+(`OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT`, 5s by default), with 10s as an overflow guard.
+Do not drop them: the instrument records **seconds**, while the SDK default boundaries are
+the spec's millisecond ladder (`0, 5, 10, … 10000`), so every realistic latency would fall
+into the single `le=5` bucket and the quantiles would be meaningless.
+
 ## Shared Attributes
 
 All egress metrics may include shared attributes:

--- a/components/egress/go.mod
+++ b/components/egress/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/sys v0.45.0
 	k8s.io/apimachinery v0.34.2
@@ -30,7 +31,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/components/egress/pkg/telemetry/metrics.go
+++ b/components/egress/pkg/telemetry/metrics.go
@@ -74,6 +74,14 @@ func registerEgressMetrics() error {
 		"egress.dns.query.duration",
 		metric.WithDescription("DNS forward latency"),
 		metric.WithUnit("s"),
+		// Explicit boundaries: this instrument records seconds, but the SDK default
+		// boundaries are the spec's millisecond ladder (0, 5, 10, ... 10000), so every
+		// realistic DNS latency lands in the same bucket and the quantiles are noise.
+		// The ladder below spans a cache hit (sub-ms) to the upstream timeout
+		// (DefaultDNSUpstreamTimeoutSec = 5s), with 10s as the overflow guard.
+		metric.WithExplicitBucketBoundaries(
+			0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+		),
 	)
 	if err != nil {
 		return err

--- a/components/egress/pkg/telemetry/metrics.go
+++ b/components/egress/pkg/telemetry/metrics.go
@@ -77,10 +77,17 @@ func registerEgressMetrics() error {
 		// Explicit boundaries: this instrument records seconds, but the SDK default
 		// boundaries are the spec's millisecond ladder (0, 5, 10, ... 10000), so every
 		// realistic DNS latency lands in the same bucket and the quantiles are noise.
-		// The ladder below spans a cache hit (sub-ms) to the upstream timeout
-		// (DefaultDNSUpstreamTimeoutSec = 5s), with 10s as the overflow guard.
+		//
+		// The head spans a cache hit (sub-ms) to one upstream timeout
+		// (DefaultDNSUpstreamTimeoutSec = 5s). The coarse tail covers the retry chain:
+		// forward() walks the resolvers serially, each with the full timeout, and the
+		// recorded duration is the whole chain — so a query can legitimately take
+		// timeout x len(upstreams). 15s is three resolvers at the default; 120s is the
+		// cap a single exchange can be configured to wait. Past that a lookup has simply
+		// failed, and _count is the signal, not a quantile.
 		metric.WithExplicitBucketBoundaries(
 			0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+			15, 30, 60, 120,
 		),
 	)
 	if err != nil {

--- a/components/egress/pkg/telemetry/metrics.go
+++ b/components/egress/pkg/telemetry/metrics.go
@@ -82,12 +82,15 @@ func registerEgressMetrics() error {
 		// (DefaultDNSUpstreamTimeoutSec = 5s). The coarse tail covers the retry chain:
 		// forward() walks the resolvers serially, each with the full timeout, and the
 		// recorded duration is the whole chain — so a query can legitimately take
-		// timeout x len(upstreams). 15s is three resolvers at the default; 120s is the
-		// cap a single exchange can be configured to wait. Past that a lookup has simply
-		// failed, and _count is the signal, not a quantile.
+		// timeout x len(upstreams), and a late *success* lands there too, not just an
+		// exhausted failure. 15s is three resolvers at the default; 600s covers the 120s
+		// per-exchange cap across a handful of them. The chain has no finite worst case
+		// (OPENSANDBOX_EGRESS_DNS_UPSTREAM takes an unbounded resolver list), so past the
+		// last boundary quantile resolution is lost by construction and _count is what
+		// remains — a configuration that gets there has bigger problems than a percentile.
 		metric.WithExplicitBucketBoundaries(
 			0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
-			15, 30, 60, 120,
+			15, 30, 60, 120, 300, 600,
 		),
 	)
 	if err != nil {

--- a/components/egress/pkg/telemetry/metrics_test.go
+++ b/components/egress/pkg/telemetry/metrics_test.go
@@ -63,9 +63,10 @@ func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
 
 	require.NoError(t, registerEgressMetrics())
 
-	// Cache hit, LAN upstream, slow upstream, one upstream timeout, and a serial retry
-	// through three resolvers at the default timeout.
-	for _, seconds := range []float64{0.0008, 0.012, 0.4, 5, 15} {
+	// Cache hit, LAN upstream, slow upstream, one upstream timeout, a serial retry through
+	// three resolvers at the default timeout, and a late success after two resolvers each
+	// burning the configurable 120s maximum.
+	for _, seconds := range []float64{0.0008, 0.012, 0.4, 5, 15, 240} {
 		RecordDNSForward(seconds)
 	}
 
@@ -87,8 +88,8 @@ func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
 			populated++
 		}
 	}
-	assert.Equal(t, 5, populated,
-		"the five latencies must land in five different buckets, got counts %v for bounds %v",
+	assert.Equal(t, 6, populated,
+		"the six latencies must land in six different buckets, got counts %v for bounds %v",
 		dp.BucketCounts, dp.Bounds)
 	assert.Zero(t, dp.BucketCounts[len(dp.BucketCounts)-1],
 		"a retry-chain latency fell into +Inf, where it cannot be distinguished or interpolated")

--- a/components/egress/pkg/telemetry/metrics_test.go
+++ b/components/egress/pkg/telemetry/metrics_test.go
@@ -63,8 +63,9 @@ func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
 
 	require.NoError(t, registerEgressMetrics())
 
-	// Cache hit, LAN upstream, slow upstream, and the default upstream timeout.
-	for _, seconds := range []float64{0.0008, 0.012, 0.4, 5} {
+	// Cache hit, LAN upstream, slow upstream, one upstream timeout, and a serial retry
+	// through three resolvers at the default timeout.
+	for _, seconds := range []float64{0.0008, 0.012, 0.4, 5, 15} {
 		RecordDNSForward(seconds)
 	}
 
@@ -75,8 +76,10 @@ func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
 	require.NotEmpty(t, dp.Bounds)
 	assert.Less(t, dp.Bounds[0], 0.01,
 		"boundaries look like the millisecond default, not a seconds ladder")
-	assert.GreaterOrEqual(t, dp.Bounds[len(dp.Bounds)-1], float64(constants.DefaultDNSUpstreamTimeoutSec),
-		"the top boundary should cover an upstream timeout")
+	// forward() retries resolvers serially with the full timeout each and records the
+	// whole chain, so the tail has to reach well past a single timeout.
+	assert.Greater(t, dp.Bounds[len(dp.Bounds)-1], float64(constants.DefaultDNSUpstreamTimeoutSec),
+		"the top boundary must leave room for a serial retry chain, not just one timeout")
 
 	populated := 0
 	for _, count := range dp.BucketCounts {
@@ -84,9 +87,11 @@ func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
 			populated++
 		}
 	}
-	assert.Equal(t, 4, populated,
-		"the four latencies must land in four different buckets, got counts %v for bounds %v",
+	assert.Equal(t, 5, populated,
+		"the five latencies must land in five different buckets, got counts %v for bounds %v",
 		dp.BucketCounts, dp.Bounds)
+	assert.Zero(t, dp.BucketCounts[len(dp.BucketCounts)-1],
+		"a retry-chain latency fell into +Inf, where it cannot be distinguished or interpolated")
 }
 
 func dnsDurationDataPoint(t *testing.T, rm *metricdata.ResourceMetrics) metricdata.HistogramDataPoint[float64] {

--- a/components/egress/pkg/telemetry/metrics_test.go
+++ b/components/egress/pkg/telemetry/metrics_test.go
@@ -15,11 +15,17 @@
 package telemetry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/alibaba/opensandbox/egress/pkg/constants"
 	inttelemetry "github.com/alibaba/opensandbox/internal/telemetry"
 )
 
@@ -44,4 +50,58 @@ func TestAppendMetricAttrsFromKeyValuePairs(t *testing.T) {
 
 	out = inttelemetry.AppendAttrsFromKeyValuePairs(nil, "novalue=,=bad,nokv")
 	assert.Len(t, out, 0)
+}
+
+// The instrument records seconds, so it needs boundaries on a seconds ladder. With the
+// SDK default (the spec's millisecond ladder) every realistic DNS latency collapses into
+// one bucket and the quantiles are meaningless.
+func TestDNSQueryDurationBucketsSpanRealisticLatencies(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	previous := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(previous) })
+
+	require.NoError(t, registerEgressMetrics())
+
+	// Cache hit, LAN upstream, slow upstream, and the default upstream timeout.
+	for _, seconds := range []float64{0.0008, 0.012, 0.4, 5} {
+		RecordDNSForward(seconds)
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	dp := dnsDurationDataPoint(t, &rm)
+	require.NotEmpty(t, dp.Bounds)
+	assert.Less(t, dp.Bounds[0], 0.01,
+		"boundaries look like the millisecond default, not a seconds ladder")
+	assert.GreaterOrEqual(t, dp.Bounds[len(dp.Bounds)-1], float64(constants.DefaultDNSUpstreamTimeoutSec),
+		"the top boundary should cover an upstream timeout")
+
+	populated := 0
+	for _, count := range dp.BucketCounts {
+		if count > 0 {
+			populated++
+		}
+	}
+	assert.Equal(t, 4, populated,
+		"the four latencies must land in four different buckets, got counts %v for bounds %v",
+		dp.BucketCounts, dp.Bounds)
+}
+
+func dnsDurationDataPoint(t *testing.T, rm *metricdata.ResourceMetrics) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "egress.dns.query.duration" {
+				continue
+			}
+			hist, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "unexpected aggregation %T", m.Data)
+			require.Len(t, hist.DataPoints, 1)
+			return hist.DataPoints[0]
+		}
+	}
+	t.Fatal("egress.dns.query.duration not collected")
+	return metricdata.HistogramDataPoint[float64]{}
 }

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -181,6 +181,29 @@ See [Credential Vault](/guides/credential-vault) for full API usage, binding rul
 
 Egress can export **OTLP metrics**; application logs use the **native zap** logger (JSON to stdout by default, configurable via `OPENSANDBOX_LOG_OUTPUT` / `OPENSANDBOX_EGRESS_LOG_LEVEL`). OTLP log export is not used.
 
+#### DNS latency buckets
+
+`egress.dns.query.duration` is recorded in **seconds** and declares its bucket boundaries
+explicitly:
+
+```
+0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120
+```
+
+The head resolves a cache hit up to one upstream timeout
+(`OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT`, 5s by default). The coarse tail is there because
+the recorded duration covers the **whole resolver chain** — forwarding walks the upstreams
+serially with the full timeout each, so a query can legitimately take
+`timeout x len(upstreams)`. Anything past 120s falls in `+Inf` by design: the lookup has
+failed, and `_count` is the signal rather than a quantile.
+
+If you tune these, keep them on a seconds ladder. The SDK default boundaries are the spec's
+millisecond ladder (`0, 5, 10, … 10000`), which would put every realistic DNS latency in the
+single `le=5` bucket and make `histogram_quantile()` return an interpolation rather than a
+measurement.
+
+Full metric inventory and attribute semantics: [egress OpenTelemetry reference](https://github.com/opensandbox-group/OpenSandbox/blob/main/components/egress/docs/opentelemetry.md).
+
 ## Build & Run
 
 ### Build Docker Image

--- a/docs/components/egress.md
+++ b/docs/components/egress.md
@@ -187,15 +187,17 @@ Egress can export **OTLP metrics**; application logs use the **native zap** logg
 explicitly:
 
 ```
-0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120
+0.001  0.0025  0.005  0.01  0.025  0.05  0.1  0.25  0.5  1  2.5  5  10  15  30  60  120  300  600
 ```
 
 The head resolves a cache hit up to one upstream timeout
 (`OPENSANDBOX_EGRESS_DNS_UPSTREAM_TIMEOUT`, 5s by default). The coarse tail is there because
 the recorded duration covers the **whole resolver chain** — forwarding walks the upstreams
 serially with the full timeout each, so a query can legitimately take
-`timeout x len(upstreams)`. Anything past 120s falls in `+Inf` by design: the lookup has
-failed, and `_count` is the signal rather than a quantile.
+`timeout x len(upstreams)`. A late **success** lands in the tail too, not only an
+exhausted failure: a query can succeed on the second resolver after the first burned a full
+timeout. Past the last boundary quantile resolution is lost by construction — the chain has no
+finite worst case, since the resolver list is unbounded — and `_count` is what remains.
 
 If you tune these, keep them on a seconds ladder. The SDK default boundaries are the spec's
 millisecond ladder (`0, 5, 10, … 10000`), which would put every realistic DNS latency in the


### PR DESCRIPTION
Fixes #1404.

## Problem

`egress.dns.query.duration` records **seconds** but declared no bucket boundaries, so it got the SDK default — the spec's **millisecond** ladder (`0, 5, 10, … 10000`). Every realistic DNS latency landed in the single `le=5` bucket, which makes any quantile over it an interpolation inside `(0, 5]` rather than a measurement.

The failure is silent: the metric has data and `_count` moves, so nothing signals that the distribution is empty of information.

## Fix

```go
metric.WithExplicitBucketBoundaries(
    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
    15, 30, 60, 120,
)
```

The head resolves a cache hit (sub-millisecond) up to one upstream timeout (`DefaultDNSUpstreamTimeoutSec`, 5s).

The coarse tail is there because the recorded duration wraps the **whole** `forward()`, which walks the resolvers serially with the full timeout each — so a query can legitimately take `timeout x len(upstreams)`. 15s is three resolvers at the default; 120s is the cap a single exchange can be configured to wait. Thanks @chatgpt-codex-connector for catching that my first ladder stopped at 10s and pushed those into `+Inf`.

I kept the boundaries **fixed** rather than deriving them from the configured timeout and upstream count. Derived boundaries vary per deployment, and histograms with different `le` sets cannot be aggregated in one backend — which is the situation this PR is trying to get out of. There is also no finite worst case to cover: `/etc/resolv.conf` discovery is capped at `ResolvNameserverCap = 10`, but `OPENSANDBOX_EGRESS_DNS_UPSTREAM` accepts an unbounded list, so `120 x N` has no ceiling. Past 120s a lookup has failed, and `_count` is the signal rather than a quantile.

I kept the unit as **seconds** rather than switching the instrument to milliseconds: `WithUnit("s")` is already declared, and OTel semantic conventions use seconds for durations. Worth noting that `execd` and `ingress` record milliseconds, which is exactly why the SDK defaults fit them and not this one — this instrument was the only mismatch, and no component in the repo sets explicit boundaries.

| File | Change |
|---|---|
| `pkg/telemetry/metrics.go` | explicit boundaries + a comment on why they must not be dropped |
| `pkg/telemetry/metrics_test.go` | records four operator-relevant latencies, asserts four distinct buckets |
| `docs/opentelemetry.md` | documents the ladder and the reason |
| `go.mod` | `otel/sdk/metric` promoted from indirect to direct (the test needs `ManualReader`; same version, no new module in `go.sum`) |

## Testing

`go test ./pkg/telemetry/` green, `gofmt` clean.

The test is a real regression guard, not a restatement of the constant. It records five latencies an operator would care about — cache hit, LAN resolver, slow resolver, one timeout, and a three-resolver chain — and asserts they land in five distinct buckets with `+Inf` empty. I checked both failure modes actually fail:

Boundaries removed (the original bug), where the failure output *is* the bug:

```
Error:    Not equal: expected: 5, actual: 1
Messages: got counts [0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
          for bounds [0 5 10 25 50 75 100 250 500 750 1000 2500 5000 7500 10000]
```

Tail capped at 10s (the first version of this PR):

```
Error:    Should be zero, but was 1
Messages: a retry-chain latency fell into +Inf, where it cannot be
          distinguished or interpolated
```

## Scope

Deliberately narrow: only the boundaries. Two related things I noticed while measuring this are **not** in here, and I am happy to open separate issues if they are of interest:

- `egress.system.memory.usage_bytes` / `egress.system.cpu.utilization` come from gopsutil, i.e. `/proc/meminfo` and `/proc/stat`, which inside a container report the **node**. Since the sidecar is per-sandbox, every sandbox on a node publishes the same value tagged with its own `sandbox_id` — N identical series that look per-sandbox. Reading cgroup v2 (`memory.current`, `cpu.stat`) would make them the sidecar's own usage and actually useful.
- No histogram in the repo declares boundaries, so the millisecond-unit ones work only by coincidence with the default. A future unit change would break them the same silent way.
- Successful and failed lookups feed this same histogram, so its tail mixes slow resolutions with exhausted retry chains. An outcome attribute would separate them and make the tail far easier to read — but that changes the metric's public shape and adds a dimension, so it did not belong here.

This branch is independent of #1402 and can be merged on its own.

