### PR TITLE
feat(sdks/kotlin): resilient SDK transport (OSEP-0016)

### DIFF
--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -372,12 +372,14 @@ Default behavior:
   (before any byte is written) are still retried for these methods.
 - Up to `3` retries with decorrelated-jitter exponential backoff, honoring a server
   `Retry-After` header (capped at 60s).
-- **SSE / streaming requests bypass retry** entirely (bodies are not replayable).
+- **SSE / streaming requests bypass the SDK retry policy** because their bodies
+  are not safely replayable. They retain OkHttp's built-in connection recovery.
 
 ::: warning Behavior change
-Retries are on by default. This can increase the number of HTTP attempts and tail
-latency compared to earlier SDK versions. If you rely on fast-fail semantics, opt
-out explicitly with `RetryPolicy.disabled()`.
+SDK-policy retries are on by default. This can increase the number of HTTP attempts
+and tail latency compared to earlier SDK versions. To disable the new SDK-policy
+retries, use `RetryPolicy.disabled()`; non-streaming requests then fall back to
+OkHttp's pre-existing built-in connection recovery.
 :::
 
 ```java
@@ -386,7 +388,7 @@ import com.alibaba.opensandbox.sandbox.transport.StatusCode;
 import java.time.Duration;
 import java.util.Set;
 
-// Fast-fail: never retry.
+// Disable SDK-policy retries and retain OkHttp's built-in connection recovery.
 ConnectionConfig config = ConnectionConfig.builder()
     .apiKey("your-key")
     .domain("api.opensandbox.io")

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -324,6 +324,7 @@ The `ConnectionConfig` class manages API server connection settings.
 | `debug`          | Enable debug logging for HTTP requests     | `false`                      | -                      |
 | `headers`        | Custom HTTP headers                        | Empty                        | -                      |
 | `connectionPool` | Shared OKHttp ConnectionPool               | SDK-created per instance     | -                      |
+| `retryPolicy`    | Automatic retry policy for non-streaming requests (see [Automatic retries](#_2-automatic-retries)) | Enabled (`RetryPolicy()`) | -                 |
 | `useServerProxy` | Use sandbox server as proxy for execd/endpoint requests (e.g. when client cannot reach the sandbox directly) | `false` | -                      |
 | `disableMetrics` | Disable SDK create-latency telemetry (see [SDK Telemetry](/guides/sdk-telemetry)) | `false` | `OPENSANDBOX_DISABLE_METRICS` |
 
@@ -355,7 +356,63 @@ ConnectionConfig sharedConfig = ConnectionConfig.builder()
 `Sandbox.builder()...build()` reports create latency to `POST /v1/metrics/events` by default. Call `ConnectionConfig.builder().disableMetrics(true)` or export `OPENSANDBOX_DISABLE_METRICS=1` to opt out. See [SDK Telemetry](/guides/sdk-telemetry).
 :::
 
-### 2. Sandbox Creation Configuration
+### 2. Automatic retries
+
+The SDK retries transient failures automatically. `ConnectionConfig` installs a
+`RetryInterceptor` (`com.alibaba.opensandbox.sandbox.transport.RetryPolicy`) on the
+SDK's non-streaming HTTP clients.
+
+Default behavior:
+
+- **Enabled by default.** Idempotent methods (`GET/HEAD/PUT/DELETE/OPTIONS`) are
+  retried on `429`, `502`, `503`, and on pre-send transport failures (DNS, TCP
+  connect, TLS handshake).
+- **`POST`/`PATCH` are never retried on a status code by default**, since the
+  request may already have been applied server-side. Pre-send transport failures
+  (before any byte is written) are still retried for these methods.
+- Up to `3` retries with decorrelated-jitter exponential backoff, honoring a server
+  `Retry-After` header (capped at 60s).
+- **SSE / streaming requests bypass retry** entirely (bodies are not replayable).
+
+::: warning Behavior change
+Retries are on by default. This can increase the number of HTTP attempts and tail
+latency compared to earlier SDK versions. If you rely on fast-fail semantics, opt
+out explicitly with `RetryPolicy.disabled()`.
+:::
+
+```java
+import com.alibaba.opensandbox.sandbox.transport.RetryPolicy;
+import com.alibaba.opensandbox.sandbox.transport.StatusCode;
+import java.time.Duration;
+import java.util.Set;
+
+// Fast-fail: never retry.
+ConnectionConfig config = ConnectionConfig.builder()
+    .apiKey("your-key")
+    .domain("api.opensandbox.io")
+    .retryPolicy(RetryPolicy.disabled())
+    .build();
+
+// Custom policy: more retries, an overall wall-clock deadline, and an opt-in to
+// retry POST/PATCH on 503 (only safe if your endpoints are idempotent).
+ConnectionConfig tuned = ConnectionConfig.builder()
+    .apiKey("your-key")
+    .domain("api.opensandbox.io")
+    .retryPolicy(new RetryPolicy(
+        /* maxRetries */ 5,
+        /* initialBackoff */ Duration.ofMillis(500),
+        /* maxBackoff */ Duration.ofSeconds(30),
+        /* backoffMultiplier */ 2.0,
+        /* jitter */ com.alibaba.opensandbox.sandbox.transport.JitterMode.DECORRELATED,
+        /* retryableStatusCodesIdempotent */ RetryPolicy.DEFAULT_IDEMPOTENT_STATUS,
+        /* retryableStatusCodesNonIdempotent */ Set.of(StatusCode.SERVICE_UNAVAILABLE),
+        /* perAttemptTimeout */ null,
+        /* overallDeadline */ Duration.ofSeconds(20),
+        /* onRetry */ null))
+    .build();
+```
+
+### 3. Sandbox Creation Configuration
 
 The `Sandbox.builder()` allows configuring the sandbox environment.
 
@@ -405,7 +462,7 @@ Sandbox sandbox = Sandbox.builder()
     .build();
 ```
 
-### 3. Runtime Egress Policy Updates
+### 4. Runtime Egress Policy Updates
 
 Runtime egress reads and patches go directly to the sandbox egress sidecar.
 The SDK first resolves the sandbox endpoint on port `18080`, then calls the sidecar `/policy` API.
@@ -427,7 +484,7 @@ sandbox.patchEgressRules(
 );
 ```
 
-### 4. Credential Vault
+### 5. Credential Vault
 
 Credential Vault injects outbound credentials from the egress sidecar while
 keeping real secrets out of sandbox environment variables, commands, files, and

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -372,8 +372,9 @@ Default behavior:
   (before any byte is written) are still retried for these methods.
 - Up to `3` retries with decorrelated-jitter exponential backoff, honoring a server
   `Retry-After` header (capped at 60s).
-- **SSE / streaming requests bypass the SDK retry policy** because their bodies
-  are not safely replayable. They retain OkHttp's built-in connection recovery.
+- **SSE / streaming requests bypass all automatic retry** because their bodies
+  are not safely replayable. The SSE client also disables OkHttp's built-in
+  connection recovery to prevent a streaming command POST from being replayed.
 
 ::: warning Behavior change
 SDK-policy retries are on by default. This can increase the number of HTTP attempts

--- a/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapter.kt
+++ b/sdks/sandbox/kotlin/code-interpreter/src/main/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapter.kt
@@ -25,13 +25,10 @@ import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.execd.CodeInterpretingApi
 import com.alibaba.opensandbox.sandbox.api.models.execd.EventNode
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionEventDispatcher
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -142,15 +139,9 @@ class CodesAdapter(
 
             httpClientProvider.sseClient.newCall(httpRequest).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    val message = "Failed to run code. Status code: ${response.code}, Body: $errorBodyString"
-                    throw SandboxApiException(
-                        message = message,
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, responseBody ->
+                        "Failed to run code. Status code: $statusCode, Body: $responseBody"
+                    }
                 }
 
                 response.body?.byteStream()?.bufferedReader(Charsets.UTF_8)?.use { reader ->

--- a/sdks/sandbox/kotlin/code-interpreter/src/test/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/code-interpreter/src/test/kotlin/com/alibaba/opensandbox/codeinterpreter/infrastructure/adapters/service/CodesAdapterTest.kt
@@ -20,6 +20,7 @@ import com.alibaba.opensandbox.codeinterpreter.domain.models.execd.executions.Ru
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxRateLimitException
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ExecutionHandlers
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxEndpoint
 import okhttp3.mockwebserver.MockResponse
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -225,5 +227,27 @@ class CodesAdapterTest {
 
         assertEquals(500, ex.statusCode)
         assertEquals("req-kotlin-code-123", ex.requestId)
+    }
+
+    @Test
+    fun `run should map unstructured rate limit response metadata`() {
+        val responseBody = "slow down"
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("X-Request-ID", "req-kotlin-code-rate-limit")
+                .addHeader("Retry-After", "2")
+                .setBody(responseBody),
+        )
+
+        val request = RunCodeRequest.builder().code("print('slow')").build()
+        val ex = assertThrows(SandboxRateLimitException::class.java) { codesAdapter.run(request) }
+
+        assertEquals(429, ex.statusCode)
+        assertEquals("RATE_LIMIT", ex.error.code)
+        assertEquals("req-kotlin-code-rate-limit", ex.requestId)
+        assertEquals(Duration.ofSeconds(2), ex.retryAfter)
+        assertEquals(responseBody, ex.responseBody)
+        assertTrue(ex.isRetryable)
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -103,10 +103,11 @@ class HttpClientProvider(
         if (config.retryPolicy.wrapsTransport()) {
             addInterceptor(RetryInterceptor(config.retryPolicy))
         }
-        // When the SDK's own retry is disabled, also suppress OkHttp's built-in
-        // retryOnConnectionFailure so fast-fail callers genuinely see a single
-        // attempt (matches the Python transport wrapper).
-        if (!config.retryPolicy.wrapsTransport()) {
+        // When maxRetries is 0 (including disabled() and time-out-only
+        // policies), suppress OkHttp's built-in retryOnConnectionFailure so
+        // the public "no retry" contract is honoured regardless of whether
+        // the interceptor is installed for timeout/deadline/onRetry knobs.
+        if (config.retryPolicy.maxRetries == 0) {
             retryOnConnectionFailure(false)
         }
         return this

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -18,6 +18,7 @@ package com.alibaba.opensandbox.sandbox
 
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.models.execd.SECURE_ACCESS_HEADER
+import com.alibaba.opensandbox.sandbox.transport.RetryInterceptor
 import okhttp3.ConnectionPool
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -55,6 +56,7 @@ class HttpClientProvider(
         lazy {
             baseBuilder
                 .applyStandardTimeouts()
+                .addRetryInterceptor()
                 .addLoggingInterceptor()
                 .build()
         }
@@ -66,6 +68,7 @@ class HttpClientProvider(
         lazy {
             baseBuilder
                 .applyStandardTimeouts()
+                .addRetryInterceptor()
                 .addInterceptor(AuthenticationInterceptor(config.getApiKey())) // Add auth before logging
                 .addLoggingInterceptor()
                 .build()
@@ -74,6 +77,12 @@ class HttpClientProvider(
     val authenticatedClient: OkHttpClient by authenticatedClientLazy
 
     // 3. Explicit lazy definition for SSE client
+    //
+    // The SSE client deliberately does NOT install the retry interceptor: SSE
+    // bootstraps hold the response body open and their request bodies are not
+    // safely replayable for a non-idempotent status opt-in. Fresh-connection
+    // recovery on pre-send failures is still provided by OkHttp's built-in
+    // retryOnConnectionFailure.
     private val sseClientLazy =
         lazy {
             baseBuilder
@@ -89,6 +98,19 @@ class HttpClientProvider(
     val sseClient: OkHttpClient by sseClientLazy
 
     // --- Helper Extensions ---
+
+    private fun OkHttpClient.Builder.addRetryInterceptor(): OkHttpClient.Builder {
+        if (config.retryPolicy.wrapsTransport()) {
+            addInterceptor(RetryInterceptor(config.retryPolicy))
+        }
+        // When the SDK's own retry is disabled, also suppress OkHttp's built-in
+        // retryOnConnectionFailure so fast-fail callers genuinely see a single
+        // attempt (matches the Python transport wrapper).
+        if (!config.retryPolicy.wrapsTransport()) {
+            retryOnConnectionFailure(false)
+        }
+        return this
+    }
 
     private fun OkHttpClient.Builder.applyStandardTimeouts(): OkHttpClient.Builder {
         val timeout = config.requestTimeout.toMillis()

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -102,16 +102,18 @@ class HttpClientProvider(
 
     // --- Helper Extensions ---
 
+    /**
+     * Installs [RetryInterceptor] and disables OkHttp's built-in connection
+     * recovery, so the SDK is the single owner of retry behaviour (matching
+     * the Python transport wrapper single-owner model).
+     *
+     * When the policy does not require the interceptor (wrapsTransport() is
+     * false), this is a no-op — the caller relies on OkHttp defaults.
+     */
     private fun OkHttpClient.Builder.addRetryInterceptor(): OkHttpClient.Builder {
         if (config.retryPolicy.wrapsTransport()) {
-            addInterceptor(RetryInterceptor(config.retryPolicy))
-        }
-        // When maxRetries is 0 (including disabled() and time-out-only
-        // policies), suppress OkHttp's built-in retryOnConnectionFailure so
-        // the public "no retry" contract is honoured regardless of whether
-        // the interceptor is installed for timeout/deadline/onRetry knobs.
-        if (config.retryPolicy.maxRetries == 0) {
             retryOnConnectionFailure(false)
+            addInterceptor(RetryInterceptor(config.retryPolicy))
         }
         return this
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -78,10 +78,9 @@ class HttpClientProvider(
 
     // 3. Explicit lazy definition for SSE client
     //
-    // The SSE client deliberately does NOT install the retry interceptor: SSE
-    // bootstraps hold the response body open and their request bodies are not
-    // safely replayable for a non-idempotent status opt-in. It retains OkHttp's
-    // built-in connection recovery regardless of RetryPolicy.
+    // The SSE client deliberately disables all automatic retries: streaming
+    // command POSTs are not safely replayable and could start a command twice
+    // if the connection fails after the server accepts the request.
     private val sseClientLazy =
         lazy {
             baseBuilder
@@ -89,6 +88,7 @@ class HttpClientProvider(
                 .readTimeout(0, TimeUnit.MILLISECONDS)
                 .writeTimeout(config.requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
                 .callTimeout(0, TimeUnit.MILLISECONDS)
+                .retryOnConnectionFailure(false)
                 .addInterceptor(ExtraHeadersInterceptor(getSseHeaders()))
                 .addLoggingInterceptor()
                 .build()

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -80,9 +80,7 @@ class HttpClientProvider(
     //
     // The SSE client deliberately does NOT install the retry interceptor: SSE
     // bootstraps hold the response body open and their request bodies are not
-    // safely replayable for a non-idempotent status opt-in. Fresh-connection
-    // recovery on pre-send failures is still provided by OkHttp's built-in
-    // retryOnConnectionFailure.
+    // safely replayable for a non-idempotent status opt-in.
     private val sseClientLazy =
         lazy {
             baseBuilder
@@ -92,6 +90,11 @@ class HttpClientProvider(
                 .callTimeout(0, TimeUnit.MILLISECONDS)
                 .addInterceptor(ExtraHeadersInterceptor(getSseHeaders()))
                 .addLoggingInterceptor()
+                .also { builder ->
+                    if (config.retryPolicy.maxRetries == 0) {
+                        builder.retryOnConnectionFailure(false)
+                    }
+                }
                 .build()
         }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProvider.kt
@@ -80,7 +80,8 @@ class HttpClientProvider(
     //
     // The SSE client deliberately does NOT install the retry interceptor: SSE
     // bootstraps hold the response body open and their request bodies are not
-    // safely replayable for a non-idempotent status opt-in.
+    // safely replayable for a non-idempotent status opt-in. It retains OkHttp's
+    // built-in connection recovery regardless of RetryPolicy.
     private val sseClientLazy =
         lazy {
             baseBuilder
@@ -90,11 +91,6 @@ class HttpClientProvider(
                 .callTimeout(0, TimeUnit.MILLISECONDS)
                 .addInterceptor(ExtraHeadersInterceptor(getSseHeaders()))
                 .addLoggingInterceptor()
-                .also { builder ->
-                    if (config.retryPolicy.maxRetries == 0) {
-                        builder.retryOnConnectionFailure(false)
-                    }
-                }
                 .build()
         }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -16,6 +16,7 @@
 
 package com.alibaba.opensandbox.sandbox.config
 
+import com.alibaba.opensandbox.sandbox.transport.RetryPolicy
 import okhttp3.ConnectionPool
 import java.time.Duration
 
@@ -58,6 +59,12 @@ class ConnectionConfig private constructor(
      * Also honored via the `OPENSANDBOX_DISABLE_METRICS=1` environment variable.
      */
     val disableMetrics: Boolean = false,
+    /**
+     * Retry policy applied to non-streaming requests. Enabled by default; pass
+     * [RetryPolicy.disabled] for fast-fail. SSE / streaming requests always
+     * bypass retry regardless of this value.
+     */
+    val retryPolicy: RetryPolicy = RetryPolicy(),
 ) {
     /**
      * Creates a copy of this ConnectionConfig without copying the connectionPool.
@@ -79,6 +86,7 @@ class ConnectionConfig private constructor(
             endpointCacheSize = this.endpointCacheSize,
             endpointCacheDisabled = this.endpointCacheDisabled,
             disableMetrics = this.disableMetrics,
+            retryPolicy = this.retryPolicy,
         )
 
     companion object {
@@ -178,6 +186,7 @@ class ConnectionConfig private constructor(
         private var endpointCacheSize: Int = 1024
         private var endpointCacheDisabled: Boolean = false
         private var disableMetrics: Boolean = false
+        private var retryPolicy: RetryPolicy = RetryPolicy()
 
         /**
          * Use sandbox server as proxy for process execd requests.
@@ -284,6 +293,18 @@ class ConnectionConfig private constructor(
         }
 
         /**
+         * Set the retry policy applied to non-streaming requests.
+         *
+         * Retries are enabled by default (idempotent methods only). Pass
+         * [RetryPolicy.disabled] for fast-fail semantics. SSE / streaming
+         * requests always bypass retry.
+         */
+        fun retryPolicy(retryPolicy: RetryPolicy): Builder {
+            this.retryPolicy = retryPolicy
+            return this
+        }
+
+        /**
          * Enable or disable HTTP request logging (headers).
          *
          * This is intended for local debugging. Sensitive headers will be redacted.
@@ -358,6 +379,7 @@ class ConnectionConfig private constructor(
                 endpointCacheSize = endpointCacheSize,
                 endpointCacheDisabled = endpointCacheDisabled,
                 disableMetrics = disableMetrics,
+                retryPolicy = retryPolicy,
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -62,8 +62,9 @@ class ConnectionConfig private constructor(
     /**
      * Retry policy applied to non-streaming requests. Enabled by default; pass
      * [RetryPolicy.disabled] to disable SDK-policy retries and fall back to
-     * OkHttp's built-in connection recovery. SSE / streaming requests always
-     * bypass the SDK retry policy regardless of this value.
+     * OkHttp's built-in connection recovery. SSE / streaming requests bypass
+     * the SDK retry policy and disable built-in connection recovery regardless
+     * of this value because they cannot be safely replayed.
      */
     val retryPolicy: RetryPolicy = RetryPolicy(),
 ) {
@@ -298,8 +299,9 @@ class ConnectionConfig private constructor(
          *
          * Retries are enabled by default (idempotent methods only). Pass
          * [RetryPolicy.disabled] to disable SDK-policy retries and fall back to
-         * OkHttp's built-in connection recovery. SSE / streaming requests always
-         * bypass the SDK retry policy.
+         * OkHttp's built-in connection recovery. SSE / streaming requests bypass
+         * the SDK retry policy and disable built-in connection recovery because
+         * they cannot be safely replayed.
          */
         fun retryPolicy(retryPolicy: RetryPolicy): Builder {
             this.retryPolicy = retryPolicy

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -61,8 +61,9 @@ class ConnectionConfig private constructor(
     val disableMetrics: Boolean = false,
     /**
      * Retry policy applied to non-streaming requests. Enabled by default; pass
-     * [RetryPolicy.disabled] for fast-fail. SSE / streaming requests always
-     * bypass retry regardless of this value.
+     * [RetryPolicy.disabled] to disable SDK-policy retries and fall back to
+     * OkHttp's built-in connection recovery. SSE / streaming requests always
+     * bypass the SDK retry policy regardless of this value.
      */
     val retryPolicy: RetryPolicy = RetryPolicy(),
 ) {
@@ -296,8 +297,9 @@ class ConnectionConfig private constructor(
          * Set the retry policy applied to non-streaming requests.
          *
          * Retries are enabled by default (idempotent methods only). Pass
-         * [RetryPolicy.disabled] for fast-fail semantics. SSE / streaming
-         * requests always bypass retry.
+         * [RetryPolicy.disabled] to disable SDK-policy retries and fall back to
+         * OkHttp's built-in connection recovery. SSE / streaming requests always
+         * bypass the SDK retry policy.
          */
         fun retryPolicy(retryPolicy: RetryPolicy): Builder {
             this.retryPolicy = retryPolicy

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
@@ -16,20 +16,27 @@
 
 package com.alibaba.opensandbox.sandbox.domain.exceptions
 
+import java.time.Duration
+
 /**
  * Base exception class for all sandbox-related errors.
  *
  * Inherits from [RuntimeException] (Unchecked Exception) to avoid forcing
  * Java callers to implement verbose try-catch blocks while still allowing
  * specific error handling when needed.
+ *
+ * [isRetryable] reflects whether the SDK actually decided to retry this failure:
+ * budget exhaustion, deadline expiry, and caller cancellation all force it to
+ * `false` even for transient causes.
  */
 open class SandboxException(
     message: String? = null,
     cause: Throwable? = null,
     val error: SandboxError,
     val requestId: String? = null,
+    open val isRetryable: Boolean = false,
 ) : RuntimeException(message, cause) {
-    // Keep the old constructor signature for binary compatibility with already-compiled clients.
+    // Keep the old constructor signature for binary compatibility.
     constructor(
         message: String?,
         cause: Throwable?,
@@ -49,34 +56,138 @@ open class SandboxException(
 }
 
 /**
- * Thrown when the Sandbox API returns an error response (e.g., HTTP 4xx or 5xx) or meet unexpected error when calling api.
+ * Thrown when the Sandbox API returns an error response (e.g., HTTP 4xx or 5xx)
+ * or meets an unexpected error when calling the API.
+ *
+ * [responseBody] carries the raw response body from the server so callers can
+ * inspect payloads the SDK could not parse into a structured [SandboxError].
  */
-class SandboxApiException(
+open class SandboxApiException(
     message: String? = null,
     cause: Throwable? = null,
     val statusCode: Int? = null,
     error: SandboxError = SandboxError(SandboxError.UNEXPECTED_RESPONSE),
     requestId: String? = null,
-) : SandboxException(message, cause, error, requestId) {
-    // Keep the old constructor signature for binary compatibility with already-compiled clients.
+    val responseBody: String? = null,
+    isRetryable: Boolean = false,
+) : SandboxException(
+        message = message,
+        cause = cause,
+        error = error,
+        requestId = requestId,
+    ) {
+    @Suppress("LeakingThis")
+    override val isRetryable: Boolean = isRetryable
+
+    // Keep the old constructor signature for binary compatibility.
+    @Suppress("unused", "LongLine")
     constructor(
         message: String?,
         cause: Throwable?,
         statusCode: Int?,
         error: SandboxError,
-    ) : this(message = message, cause = cause, statusCode = statusCode, error = error, requestId = null)
+    ) : this(
+        message = message,
+        cause = cause,
+        statusCode = statusCode,
+        error = error,
+        requestId = null,
+        responseBody = null,
+        isRetryable = false,
+    )
+
+    // Keep the five-arg signature for binary compatibility.
+    @Suppress("unused", "LongLine")
+    constructor(
+        message: String?,
+        cause: Throwable?,
+        statusCode: Int?,
+        error: SandboxError,
+        requestId: String?,
+    ) : this(
+        message = message,
+        cause = cause,
+        statusCode = statusCode,
+        error = error,
+        requestId = requestId,
+        responseBody = null,
+        isRetryable = false,
+    )
 }
+
+/**
+ * Thrown when the API returns HTTP 429 (Too Many Requests).
+ *
+ * [retryAfter] carries the server-supplied `Retry-After` header value as a
+ * [Duration] when present, so fast-fail callers can still act on it.
+ */
+class SandboxRateLimitException
+    @JvmOverloads
+    constructor(
+        message: String? = null,
+        cause: Throwable? = null,
+        statusCode: Int? = 429,
+        error: SandboxError = SandboxError(SandboxError.RATE_LIMIT, message),
+        requestId: String? = null,
+        val retryAfter: Duration? = null,
+        responseBody: String? = null,
+        isRetryable: Boolean = false,
+    ) : SandboxApiException(
+            message = message,
+            cause = cause,
+            statusCode = statusCode,
+            error = error,
+            requestId = requestId,
+            responseBody = responseBody,
+            isRetryable = isRetryable,
+        )
 
 /**
  * Thrown when an unexpected internal error occurs within the SDK
  */
-class SandboxInternalException(
+open class SandboxInternalException(
     message: String? = null,
     cause: Throwable? = null,
 ) : SandboxException(
         message = message,
         cause = cause,
         error = SandboxError(SandboxError.INTERNAL_UNKNOWN_ERROR),
+    ) {
+    @Suppress("LeakingThis")
+    open override val isRetryable: Boolean = false
+}
+
+/**
+ * Thrown when a per-attempt timeout or overall retry deadline fires.
+ *
+ * Distinct from [SandboxReadyTimeoutException], which is the health-poll timeout
+ * during sandbox startup.
+ */
+class SandboxTimeoutException(
+    message: String? = null,
+    cause: Throwable? = null,
+    isRetryable: Boolean = false,
+) : SandboxException(
+        message = message,
+        cause = cause,
+        error = SandboxError(SandboxError.TIMEOUT, message),
+        requestId = null,
+        isRetryable = isRetryable,
+    )
+
+/**
+ * Transport-layer failure: DNS, TCP connect, TLS, or connection reset.
+ */
+class SandboxConnectionException(
+    message: String? = null,
+    cause: Throwable? = null,
+    isRetryable: Boolean = false,
+) : SandboxException(
+        message = message,
+        cause = cause,
+        error = SandboxError(SandboxError.CONNECTION, message),
+        requestId = null,
+        isRetryable = isRetryable,
     )
 
 /**
@@ -216,6 +327,15 @@ data class SandboxError(
         const val UNHEALTHY = "UNHEALTHY"
         const val INVALID_ARGUMENT = "INVALID_ARGUMENT"
         const val UNEXPECTED_RESPONSE = "UNEXPECTED_RESPONSE"
+
+        /** A per-attempt timeout or overall retry deadline fired. */
+        const val TIMEOUT = "TIMEOUT"
+
+        /** Transport-layer failure: DNS, TCP connect, TLS, or connection reset. */
+        const val CONNECTION = "CONNECTION"
+
+        /** The API returned HTTP 429 (Too Many Requests). */
+        const val RATE_LIMIT = "RATE_LIMIT"
 
         /** A snapshot reached the `Failed` state while waiting for it to become ready. */
         const val SNAPSHOT_FAILED = "SNAPSHOT_FAILED"

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -21,15 +21,27 @@ import com.alibaba.opensandbox.sandbox.api.infrastructure.ClientException
 import com.alibaba.opensandbox.sandbox.api.infrastructure.ServerError
 import com.alibaba.opensandbox.sandbox.api.infrastructure.ServerException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxConnectionException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxInternalException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxRateLimitException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxTimeoutException
+import com.alibaba.opensandbox.sandbox.transport.RetryDeadlineExceededException
+import com.alibaba.opensandbox.sandbox.transport.RetryPolicy
+import com.alibaba.opensandbox.sandbox.transport.parseRetryAfter
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientError as DiagnosticClientError
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientException as DiagnosticClientException
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ServerError as DiagnosticServerError
@@ -61,6 +73,42 @@ fun Exception.toSandboxException(): SandboxException {
         is ExecdClientException, is ExecdServerException,
         is DiagnosticClientException, is DiagnosticServerException,
         -> this.toApiException()
+        // The retry interceptor exhausted the overall deadline before the next
+        // attempt: surface as a timeout, never retryable.
+        is RetryDeadlineExceededException ->
+            SandboxTimeoutException(
+                message = "Request timed out: ${this.message}",
+                cause = this,
+                isRetryable = false,
+            )
+        // Read timeouts: the request was sent but did not finish in time.
+        is SocketTimeoutException ->
+            if (this.message?.lowercase()?.contains("connect") == true) {
+                SandboxConnectionException(
+                    message = "Network connectivity error: ${this.message}",
+                    cause = this,
+                    isRetryable = false,
+                )
+            } else {
+                SandboxTimeoutException(
+                    message = "Request timed out: ${this.message}",
+                    cause = this,
+                    isRetryable = false,
+                )
+            }
+        // Pre-send connectivity failures: DNS, TCP connect, TLS handshake.
+        is ConnectException, is UnknownHostException, is NoRouteToHostException, is SSLException ->
+            SandboxConnectionException(
+                message = "Network connectivity error: ${this.message}",
+                cause = this,
+                isRetryable = false,
+            )
+        is InterruptedIOException ->
+            SandboxTimeoutException(
+                message = "Request timed out: ${this.message}",
+                cause = this,
+                isRetryable = false,
+            )
         is IOException ->
             SandboxInternalException(
                 message = "Network connectivity error: ${this.message}",
@@ -96,16 +144,18 @@ private fun Exception.toApiException(): SandboxApiException {
             else -> 0 to null
         }
 
-    val requestId =
+    val headers: Map<String, List<String>>? =
         when (rawResponse) {
-            is ClientError<*> -> rawResponse.headers.extractRequestId()
-            is ServerError<*> -> rawResponse.headers.extractRequestId()
-            is ExecdClientError<*> -> rawResponse.headers.extractRequestId()
-            is ExecdServerError<*> -> rawResponse.headers.extractRequestId()
-            is DiagnosticClientError<*> -> rawResponse.headers.extractRequestId()
-            is DiagnosticServerError<*> -> rawResponse.headers.extractRequestId()
+            is ClientError<*> -> rawResponse.headers
+            is ServerError<*> -> rawResponse.headers
+            is ExecdClientError<*> -> rawResponse.headers
+            is ExecdServerError<*> -> rawResponse.headers
+            is DiagnosticClientError<*> -> rawResponse.headers
+            is DiagnosticServerError<*> -> rawResponse.headers
             else -> null
         }
+
+    val requestId = headers?.extractRequestId()
 
     val errorBody =
         when (rawResponse) {
@@ -125,12 +175,35 @@ private fun Exception.toApiException(): SandboxApiException {
             SandboxError(UNEXPECTED_RESPONSE)
         }
 
+    val responseBody = errorBody as? String
+    // Status-code-based transient indicator. Matches the Python SDK behavior:
+    // flags {429,502,503} as retryable regardless of HTTP method or budget state.
+    // In practice, the retry interceptor has already exhausted retries before the
+    // exception surfaces here, so the boundary value is almost always false.
+    // The flag is a transient-status signal, not a "we retried this" signal.
+    val isRetryable = statusCode in RetryPolicy.DEFAULT_IDEMPOTENT_STATUS
+
+    if (statusCode == 429) {
+        return SandboxRateLimitException(
+            message = this.message,
+            statusCode = statusCode,
+            cause = this,
+            error = sandboxError,
+            requestId = requestId,
+            retryAfter = headers?.extractRetryAfter(),
+            responseBody = responseBody,
+            isRetryable = isRetryable,
+        )
+    }
+
     return SandboxApiException(
         message = this.message,
         statusCode = statusCode,
         cause = this,
         error = sandboxError,
         requestId = requestId,
+        responseBody = responseBody,
+        isRetryable = isRetryable,
     )
 }
 
@@ -138,6 +211,14 @@ private fun Map<String, List<String>>.extractRequestId(): String? {
     return entries.firstOrNull { (key, _) ->
         key.equals("X-Request-ID", ignoreCase = true)
     }?.value?.firstOrNull()?.takeIf { it.isNotBlank() }
+}
+
+private fun Map<String, List<String>>.extractRetryAfter(): java.time.Duration? {
+    val raw =
+        entries.firstOrNull { (key, _) ->
+            key.equals("Retry-After", ignoreCase = true)
+        }?.value?.firstOrNull()
+    return parseRetryAfter(raw)
 }
 
 fun parseSandboxError(body: Any?): SandboxError? {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -81,13 +81,21 @@ fun Exception.toSandboxException(): SandboxException {
                 cause = this,
                 isRetryable = false,
             )
+        // Pre-send connectivity failures: DNS, TCP connect, TLS handshake.
+        is ConnectException, is UnknownHostException, is NoRouteToHostException, is SSLException ->
+            SandboxConnectionException(
+                message = "Network connectivity error: ${this.message}",
+                cause = this,
+                isRetryable = true,
+            )
+
         // Read timeouts: the request was sent but did not finish in time.
         is SocketTimeoutException ->
             if (this.message?.lowercase()?.contains("connect") == true) {
                 SandboxConnectionException(
                     message = "Network connectivity error: ${this.message}",
                     cause = this,
-                    isRetryable = false,
+                    isRetryable = true,
                 )
             } else {
                 SandboxTimeoutException(
@@ -96,13 +104,6 @@ fun Exception.toSandboxException(): SandboxException {
                     isRetryable = false,
                 )
             }
-        // Pre-send connectivity failures: DNS, TCP connect, TLS handshake.
-        is ConnectException, is UnknownHostException, is NoRouteToHostException, is SSLException ->
-            SandboxConnectionException(
-                message = "Network connectivity error: ${this.message}",
-                cause = this,
-                isRetryable = false,
-            )
         is InterruptedIOException ->
             SandboxTimeoutException(
                 message = "Request timed out: ${this.message}",

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -35,17 +35,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
+import okhttp3.Response
 import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.time.Duration
 import javax.net.ssl.SSLException
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientError as DiagnosticClientError
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ClientException as DiagnosticClientException
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ServerError as DiagnosticServerError
 import com.alibaba.opensandbox.sandbox.api.diagnostic.infrastructure.ServerException as DiagnosticServerException
+import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ApiResponse as ExecdApiResponse
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ClientError as ExecdClientError
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ClientException as ExecdClientException
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ServerError as ExecdServerError
@@ -65,6 +68,84 @@ import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ServerException 
  * normal control-flow case such as polling for a not-yet-created file.
  */
 fun Throwable.isFileNotFound(): Boolean = this is SandboxApiException && error.code == SandboxError.FILE_NOT_FOUND
+
+private fun buildSandboxApiException(
+    message: String?,
+    statusCode: Int,
+    cause: Throwable? = null,
+    errorBody: Any? = null,
+    requestId: String? = null,
+    retryAfter: Duration? = null,
+): SandboxApiException {
+    val sandboxError =
+        parseSandboxError(errorBody) ?: if (errorBody is String) {
+            SandboxError(UNEXPECTED_RESPONSE, errorBody)
+        } else {
+            SandboxError(UNEXPECTED_RESPONSE)
+        }
+    val responseBody = errorBody as? String
+    val isRetryable = statusCode in RetryPolicy.DEFAULT_IDEMPOTENT_STATUS
+
+    if (statusCode == 429) {
+        return SandboxRateLimitException(
+            message = message,
+            statusCode = statusCode,
+            cause = cause,
+            error = sandboxError,
+            requestId = requestId,
+            retryAfter = retryAfter,
+            responseBody = responseBody,
+            isRetryable = isRetryable,
+        )
+    }
+
+    return SandboxApiException(
+        message = message,
+        statusCode = statusCode,
+        cause = cause,
+        error = sandboxError,
+        requestId = requestId,
+        responseBody = responseBody,
+        isRetryable = isRetryable,
+    )
+}
+
+/**
+ * Build the public API exception surface for handwritten OkHttp adapter paths.
+ *
+ * The generated clients flow through [toSandboxException]; direct OkHttp calls
+ * must expose the same raw body, request metadata, rate-limit subtype, and
+ * retryability signal.
+ */
+internal fun Response.toSandboxApiException(
+    responseBody: String? = body?.string(),
+    message: (statusCode: Int, responseBody: String?) -> String,
+): SandboxApiException =
+    buildSandboxApiException(
+        message = message(code, responseBody),
+        statusCode = code,
+        errorBody = responseBody,
+        requestId = header("X-Request-ID"),
+        retryAfter = parseRetryAfter(header("Retry-After")),
+    )
+
+/** Build the same error surface from an execd generated-client HTTP response. */
+internal fun ExecdApiResponse<*>.toSandboxApiException(message: (statusCode: Int, responseBody: String?) -> String): SandboxApiException {
+    val errorBody: Any? =
+        when (this) {
+            is ExecdClientError<*> -> body
+            is ExecdServerError<*> -> body
+            else -> null
+        }
+    val responseBody = errorBody as? String
+    return buildSandboxApiException(
+        message = message(statusCode, responseBody),
+        statusCode = statusCode,
+        errorBody = errorBody,
+        requestId = headers.extractRequestId(),
+        retryAfter = headers.extractRetryAfter(),
+    )
+}
 
 fun Exception.toSandboxException(): SandboxException {
     return when (this) {
@@ -169,42 +250,13 @@ private fun Exception.toApiException(): SandboxApiException {
             else -> null
         }
 
-    val sandboxError =
-        parseSandboxError(errorBody) ?: if (errorBody is String) {
-            SandboxError(UNEXPECTED_RESPONSE, errorBody)
-        } else {
-            SandboxError(UNEXPECTED_RESPONSE)
-        }
-
-    val responseBody = errorBody as? String
-    // Status-code-based transient indicator. Matches the Python SDK behavior:
-    // flags {429,502,503} as retryable regardless of HTTP method or budget state.
-    // In practice, the retry interceptor has already exhausted retries before the
-    // exception surfaces here, so the boundary value is almost always false.
-    // The flag is a transient-status signal, not a "we retried this" signal.
-    val isRetryable = statusCode in RetryPolicy.DEFAULT_IDEMPOTENT_STATUS
-
-    if (statusCode == 429) {
-        return SandboxRateLimitException(
-            message = this.message,
-            statusCode = statusCode,
-            cause = this,
-            error = sandboxError,
-            requestId = requestId,
-            retryAfter = headers?.extractRetryAfter(),
-            responseBody = responseBody,
-            isRetryable = isRetryable,
-        )
-    }
-
-    return SandboxApiException(
+    return buildSandboxApiException(
         message = this.message,
         statusCode = statusCode,
         cause = this,
-        error = sandboxError,
+        errorBody = errorBody,
         requestId = requestId,
-        responseBody = responseBody,
-        isRetryable = isRetryable,
+        retryAfter = headers?.extractRetryAfter(),
     )
 }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/ExceptionConverter.kt
@@ -78,10 +78,10 @@ private fun buildSandboxApiException(
     retryAfter: Duration? = null,
 ): SandboxApiException {
     val sandboxError =
-        parseSandboxError(errorBody) ?: if (errorBody is String) {
-            SandboxError(UNEXPECTED_RESPONSE, errorBody)
-        } else {
-            SandboxError(UNEXPECTED_RESPONSE)
+        parseSandboxError(errorBody) ?: when {
+            statusCode == 429 -> SandboxError(SandboxError.RATE_LIMIT, message)
+            errorBody is String -> SandboxError(UNEXPECTED_RESPONSE, errorBody)
+            else -> SandboxError(UNEXPECTED_RESPONSE)
         }
     val responseBody = errorBody as? String
     val isRetryable = statusCode in RetryPolicy.DEFAULT_IDEMPOTENT_STATUS
@@ -117,7 +117,7 @@ private fun buildSandboxApiException(
  * must expose the same raw body, request metadata, rate-limit subtype, and
  * retryability signal.
  */
-internal fun Response.toSandboxApiException(
+fun Response.toSandboxApiException(
     responseBody: String? = body?.string(),
     message: (statusCode: Int, responseBody: String?) -> String,
 ): SandboxApiException =

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapter.kt
@@ -26,9 +26,6 @@ import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.ServerException
 import com.alibaba.opensandbox.sandbox.api.execd.infrastructure.Success
 import com.alibaba.opensandbox.sandbox.api.models.execd.EventNode
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandLogs
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.CommandStatus
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
@@ -41,8 +38,8 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.Executi
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionConverter.toCommandStatus
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionEventDispatcher
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.jsonParser
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toCommandTimeoutMillis
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -282,14 +279,7 @@ internal class CommandsAdapter(
             return
         }
 
-        val errorBodyString = response.body?.string()
-        val sandboxError = parseSandboxError(errorBodyString)
-        throw SandboxApiException(
-            message = failureMessage(response.code, errorBodyString),
-            statusCode = response.code,
-            error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-            requestId = response.header("X-Request-ID"),
-        )
+        throw response.toSandboxApiException(message = failureMessage)
     }
 
     private fun decodeEventLine(line: String): EventNode? {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/EgressAdapter.kt
@@ -18,9 +18,6 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.egress.PolicyApi
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Credential
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.CredentialAuth
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.CredentialAuthMetadata
@@ -46,7 +43,7 @@ import com.alibaba.opensandbox.sandbox.domain.services.Egress
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter.toApiEgressNetworkRule
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter.toDomainEgressNetworkPolicy
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.jsonParser
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -264,12 +261,9 @@ internal class EgressAdapter(
             if (response.isSuccessful) {
                 return if (response.code == 204 || responseBody.isBlank()) null else responseBody
             }
-            throw SandboxApiException(
-                message = "$operation failed. Status code: ${response.code}, Body: $responseBody",
-                statusCode = response.code,
-                error = parseSandboxError(responseBody) ?: SandboxError(UNEXPECTED_RESPONSE, responseBody.takeIf { it.isNotBlank() }),
-                requestId = response.header("X-Request-ID"),
-            )
+            throw response.toSandboxApiException(responseBody) { statusCode, body ->
+                "$operation failed. Status code: $statusCode, Body: $body"
+            }
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/FilesystemAdapter.kt
@@ -19,9 +19,6 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.execd.FilesystemApi
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceEntry
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceResult
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.EntryInfo
@@ -37,7 +34,7 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.Filesys
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.FilesystemConverter.toEntryInfo
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.FilesystemConverter.toEntryInfoMap
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.isFileNotFound
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -97,15 +94,9 @@ internal class FilesystemAdapter(
             val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    val message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString"
-                    throw SandboxApiException(
-                        message = message,
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 }
 
                 val charset = getCharsetFromEncoding(encoding)
@@ -127,15 +118,9 @@ internal class FilesystemAdapter(
             val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    val message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString"
-                    throw SandboxApiException(
-                        message = message,
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 }
                 return response.body?.bytes() ?: ByteArray(0)
             }
@@ -157,15 +142,9 @@ internal class FilesystemAdapter(
 
             if (!response.isSuccessful) {
                 try {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    val message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString"
-                    throw SandboxApiException(
-                        message = message,
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 } catch (e: Exception) {
                     response.close()
                     throw e
@@ -240,15 +219,9 @@ internal class FilesystemAdapter(
 
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    val message = "Failed to write files. Status code: ${response.code}, Body: $errorBodyString"
-                    throw SandboxApiException(
-                        message = message,
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to write files. Status code: $statusCode, Body: $body"
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedFilesystemAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedFilesystemAdapter.kt
@@ -19,9 +19,6 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.execd.IsolatedExecutionApi
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceEntry
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.ContentReplaceResult
 import com.alibaba.opensandbox.sandbox.domain.models.execd.filesystem.EntryInfo
@@ -37,7 +34,7 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.Filesys
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.FilesystemConverter.toEntryInfo
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.FilesystemConverter.toEntryInfoMap
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.isFileNotFound
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -103,14 +100,9 @@ internal class IsolatedFilesystemAdapter(
             val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    throw SandboxApiException(
-                        message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString",
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 }
                 val charset = getCharsetFromEncoding(encoding)
                 return response.body?.source()?.readString(charset) ?: ""
@@ -131,14 +123,9 @@ internal class IsolatedFilesystemAdapter(
             val request = buildDownloadRequest(path, range, offset, limit)
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    throw SandboxApiException(
-                        message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString",
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 }
                 return response.body?.bytes() ?: ByteArray(0)
             }
@@ -159,14 +146,9 @@ internal class IsolatedFilesystemAdapter(
             val response = httpClientProvider.httpClient.newCall(request).execute()
             if (!response.isSuccessful) {
                 try {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    throw SandboxApiException(
-                        message = "Failed to read file. Status code: ${response.code}, Body: $errorBodyString",
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to read file. Status code: $statusCode, Body: $body"
+                    }
                 } catch (e: Exception) {
                     response.close()
                     throw e
@@ -235,14 +217,9 @@ internal class IsolatedFilesystemAdapter(
 
             httpClientProvider.httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    val errorBodyString = response.body?.string()
-                    val sandboxError = parseSandboxError(errorBodyString)
-                    throw SandboxApiException(
-                        message = "Failed to write files. Status code: ${response.code}, Body: $errorBodyString",
-                        statusCode = response.code,
-                        error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-                        requestId = response.header("X-Request-ID"),
-                    )
+                    throw response.toSandboxApiException { statusCode, body ->
+                        "Failed to write files. Status code: $statusCode, Body: $body"
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -324,11 +301,9 @@ internal class IsolatedFilesystemAdapter(
             val replaceMap = entries.toApiReplaceFileContentMap()
             val response = api.isolatedReplaceContentWithHttpInfo(sessionUuid, replaceMap, verbose = false)
             if (response.statusCode !in 200..299) {
-                throw SandboxApiException(
-                    message = "Replace contents failed. Status: ${response.statusCode}",
-                    statusCode = response.statusCode,
-                    error = SandboxError(UNEXPECTED_RESPONSE),
-                )
+                throw response.toSandboxApiException { statusCode, body ->
+                    "Replace contents failed. Status: $statusCode, Body: $body"
+                }
             }
         } catch (e: Exception) {
             logger.error("Failed to replace contents", e)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/IsolatedSessionsAdapter.kt
@@ -18,9 +18,6 @@ package com.alibaba.opensandbox.sandbox.infrastructure.adapters.service
 
 import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.models.execd.EventNode
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.Execution
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.BindMount
 import com.alibaba.opensandbox.sandbox.domain.models.execd.isolated.CreateIsolatedSessionRequest
@@ -37,7 +34,7 @@ import com.alibaba.opensandbox.sandbox.domain.services.IsolationService
 import com.alibaba.opensandbox.sandbox.domain.services.IsolationSession
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.ExecutionEventDispatcher
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.jsonParser
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -443,14 +440,9 @@ internal class IsolatedSessionsAdapter(
         operation: String,
     ) {
         if (response.isSuccessful) return
-        val errorBody = response.body?.string()
-        val sandboxError = parseSandboxError(errorBody)
-        throw SandboxApiException(
-            message = "$operation failed. Status: ${response.code}, Body: $errorBody",
-            statusCode = response.code,
-            error = sandboxError ?: SandboxError(UNEXPECTED_RESPONSE),
-            requestId = response.header("X-Request-ID"),
-        )
+        throw response.toSandboxApiException { statusCode, body ->
+            "$operation failed. Status: $statusCode, Body: $body"
+        }
     }
 
     private fun decodeEventLine(line: String): EventNode? {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
@@ -20,9 +20,6 @@ import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.SandboxesApi
 import com.alibaba.opensandbox.sandbox.api.SnapshotsApi
 import com.alibaba.opensandbox.sandbox.api.infrastructure.Serializer
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError
-import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxError.Companion.UNEXPECTED_RESPONSE
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.CredentialProxyConfig
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos
@@ -47,7 +44,7 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.Sandbox
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter.toSandboxInfo
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter.toSandboxRenewResponse
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter.toSnapshotInfo
-import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.parseSandboxError
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxApiException
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -223,12 +220,9 @@ internal class SandboxesAdapter(
             if (response.isSuccessful) {
                 return Serializer.kotlinxSerializationJson.decodeFromString<ApiSandbox>(responseBody)
             }
-            throw SandboxApiException(
-                message = "Failed to patch sandbox metadata. Status code: ${response.code}, Body: $responseBody",
-                statusCode = response.code,
-                error = parseSandboxError(responseBody) ?: SandboxError(UNEXPECTED_RESPONSE),
-                requestId = response.header("X-Request-ID"),
-            )
+            throw response.toSandboxApiException(responseBody) { statusCode, body ->
+                "Failed to patch sandbox metadata. Status code: $statusCode, Body: $body"
+            }
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryDecision.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryDecision.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Random
+
+/** Classifier-friendly view of one request/response cycle. No OkHttp dependency. */
+internal data class Outcome(
+    val isTransportError: Boolean,
+    val statusCode: Int? = null,
+    val isPreSend: Boolean = false,
+    val isOpaqueTransport: Boolean = false,
+    // Read/write timeout and unexpected-EOF are useful for observability but
+    // treated identically by shouldRetry.
+    val cause: RetryCause = RetryCause.STATUS_OTHER,
+)
+
+/**
+ * Decide whether to retry.
+ *
+ * Checks budget/deadline/cancellation first, then the transport-vs-status branch.
+ * Pre-send transport failures retry on any method; post-send and opaque transport
+ * failures retry on idempotent methods only.
+ *
+ * [bodyReplayable] guards non-idempotent uploads: when the request body cannot be
+ * re-sent (one-shot [okhttp3.RequestBody]), re-dispatching would send a truncated
+ * body. A status-code retry always consumes the body first, so it is suppressed for
+ * non-replayable bodies. A pre-send failure writes no bytes on the *first* attempt,
+ * so it may still be retried once; beyond that, the stream may be partially consumed
+ * and pre-send retries are also suppressed.
+ */
+internal fun shouldRetry(
+    method: String,
+    outcome: Outcome,
+    retriesUsed: Int,
+    policy: RetryPolicy,
+    elapsed: Duration,
+    cancelled: Boolean = false,
+    bodyReplayable: Boolean = true,
+): Boolean {
+    if (retriesUsed >= policy.maxRetries) return false
+    if (policy.overallDeadline != null && elapsed >= policy.overallDeadline) return false
+    if (cancelled) return false
+
+    val idempotent = isIdempotentMethod(method)
+
+    if (outcome.isTransportError) {
+        if (outcome.isPreSend) {
+            // First attempt wrote no bytes, so a non-replayable body is still
+            // intact and safe to resend once. After that, assume the stream may
+            // be partially consumed and stop.
+            if (!bodyReplayable && retriesUsed >= 1) return false
+            return true
+        }
+        return idempotent
+    }
+
+    val statusCode = outcome.statusCode ?: return false
+    // A status-code retry means the body was already sent (and consumed); never
+    // replay a non-replayable body.
+    if (!bodyReplayable) return false
+    return statusCode in policy.retryableStatusesFor(method)
+}
+
+/**
+ * Backoff sleep for retry [retryIndex] (0-based). [previousSleep] is used only by
+ * decorrelated jitter.
+ */
+internal fun computeBackoff(
+    retryIndex: Int,
+    policy: RetryPolicy,
+    previousSleep: Duration,
+    rng: Random,
+): Duration {
+    val maxS = policy.maxBackoff.toNanos() / 1e9
+    val baseS = policy.initialBackoff.toNanos() / 1e9
+    val m = policy.backoffMultiplier
+
+    val expS = if (baseS > 0) minOf(maxS, baseS * Math.pow(m, retryIndex.toDouble())) else 0.0
+
+    val sleepS: Double =
+        when (policy.jitter) {
+            JitterMode.NONE -> expS
+            JitterMode.FULL -> if (expS > 0) rng.nextDouble() * expS else 0.0
+            JitterMode.DECORRELATED -> {
+                val prevS = previousSleep.toNanos() / 1e9
+                if (retryIndex == 0 || prevS <= 0) {
+                    // Clamp the first delay to maxBackoff too so a low maxBackoff
+                    // is respected on the very first retry, matching other modes.
+                    minOf(baseS, maxS)
+                } else {
+                    val upper = minOf(maxS, prevS * m)
+                    val lower = baseS
+                    if (upper < lower) upper else lower + rng.nextDouble() * (upper - lower)
+                }
+            }
+        }
+
+    return Duration.ofNanos((maxOf(0.0, sleepS) * 1e9).toLong())
+}
+
+/**
+ * Fixed operational ceiling for server-supplied `Retry-After` waits. Not
+ * configurable: ignoring a server's back-pressure signal is never a safe default,
+ * and the 60s guard is only there to defend against a pathological header.
+ */
+internal val RETRY_AFTER_CAP: Duration = Duration.ofSeconds(60)
+
+// Overflow guard for numeric Retry-After values, independent of the operational cap.
+private const val MAX_RETRY_AFTER_SECONDS: Long = 100L * 365 * 24 * 3600 // ~100 years
+
+/**
+ * Parse a `Retry-After` header (delta-seconds or HTTP-date). Past dates and negative
+ * deltas normalize to zero; unparseable returns `null`.
+ */
+internal fun parseRetryAfter(
+    headerValue: String?,
+    now: ZonedDateTime? = null,
+): Duration? {
+    if (headerValue == null) return null
+    val raw = headerValue.trim()
+    if (raw.isEmpty()) return null
+
+    // delta-seconds (integer)
+    val seconds = raw.toLongOrNull()
+    if (seconds != null) {
+        if (seconds < 0) return Duration.ZERO
+        return Duration.ofSeconds(minOf(seconds, MAX_RETRY_AFTER_SECONDS))
+    }
+
+    // HTTP-date (RFC 1123)
+    val parsed =
+        try {
+            ZonedDateTime.parse(raw, DateTimeFormatter.RFC_1123_DATE_TIME)
+        } catch (_: DateTimeParseException) {
+            return null
+        }
+    val reference = now ?: ZonedDateTime.now(parsed.zone)
+    val delta = Duration.between(reference, parsed)
+    return if (delta.isNegative) Duration.ZERO else delta
+}
+
+/** Cap [retryAfter] at the fixed 60-second ceiling. */
+internal fun applyRetryAfterCap(retryAfter: Duration?): Duration? {
+    if (retryAfter == null) return null
+    return if (retryAfter > RETRY_AFTER_CAP) RETRY_AFTER_CAP else retryAfter
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
@@ -201,12 +201,11 @@ class RetryInterceptor
                 retriesUsed += 1
                 previousSleep = sleepFor
                 sleeper(sleepFor)
-                // If a thread interruption woke the sleeper, propagate:
-                // Thread.interrupted() clears the flag and returns true iff we
-                // were interrupted. The next loop iteration's isCanceled()
-                // check handles OkHttp cancellations; this covers JVM-level
-                // thread interruption.
-                if (Thread.interrupted()) {
+                // If a thread interruption woke the sleeper, propagate it without
+                // clearing the flag so callers can continue to observe cancellation.
+                // The next loop iteration's isCanceled() check handles OkHttp
+                // cancellations; this covers JVM-level thread interruption.
+                if (Thread.currentThread().isInterrupted) {
                     lastException?.let { throw it }
                     throw IOException("call interrupted during backoff")
                 }
@@ -280,11 +279,15 @@ class RetryInterceptor
             if (e is SSLHandshakeException) {
                 return Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
             }
-            // Generic mid-stream SSL failures (e.g. TLS alerts, protocol errors
-            // after bytes were already written) are not retryable: they indicate
-            // a permanent connection-level issue, not a transient one.
+            // Generic SSL failures do not reveal whether request bytes were sent.
+            // Treat them as opaque transport failures so only idempotent methods
+            // are eligible for retry.
             if (e is SSLException) {
-                return Outcome(isTransportError = false)
+                return Outcome(
+                    isTransportError = true,
+                    isOpaqueTransport = true,
+                    cause = RetryCause.OPAQUE_TRANSPORT,
+                )
             }
             // Generic InterruptedIOException that is not a socket timeout: treat as
             // a post-send read timeout for observability.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
@@ -110,6 +110,12 @@ class RetryInterceptor
                         response = effectiveChain.proceed(request)
                         outcomeForResponse(response.code)
                     } catch (e: InterruptedIOException) {
+                        // A caller interrupt is cancellation, not a retryable
+                        // timeout. Preserve the flag and surface the original
+                        // exception before the retry decision can schedule work.
+                        if (Thread.currentThread().isInterrupted) {
+                            throw e
+                        }
                         exception = e
                         classifyIoException(e)
                     } catch (e: IOException) {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.time.Duration
+import java.util.Random
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+
+/**
+ * OkHttp application interceptor enforcing a [RetryPolicy].
+ *
+ * Installed on the SDK's non-streaming clients only. SSE clients are deliberately
+ * excluded because they hold the response body open and their request bodies are
+ * not safely replayable for a non-idempotent status opt-in.
+ *
+ * OkHttp `RequestBody` is re-readable by default (`isOneShot() == false`), so
+ * replay is safe. Streaming bodies with unknown content length
+ * (`contentLength() == -1`, e.g.  InputStream wrappers from the filesystem
+ * adapters) are treated as non-replayable to avoid truncation.
+ */
+class RetryInterceptor
+    @JvmOverloads
+    constructor(
+        private val policy: RetryPolicy,
+        private val rng: Random = Random(),
+        private val sleeper: (Duration) -> Unit = ::defaultSleeper,
+    ) : Interceptor {
+        private val logger = LoggerFactory.getLogger(RetryInterceptor::class.java)
+
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request()
+            val method = request.method.uppercase()
+            // OkHttp RequestBody is re-readable by default (isOneShot() ==
+            // false), but the SDK wraps InputStream uploads in anonymous
+            // RequestBody subclasses that do not override isOneShot() even
+            // though their stream can only be consumed once.
+            // contentLength() == -1 signals an unknown-length streaming body
+            // — treat it as non-replayable for status-code retries.
+            val bodyReplayable =
+                request.body?.isOneShot() != true &&
+                    request.body?.contentLength() != -1L
+
+            val start = System.nanoTime()
+            var previousSleep: Duration = Duration.ZERO
+            var retriesUsed = 0
+            var lastException: IOException? = null
+
+            while (true) {
+                // Surface caller cancellation immediately — do not retry.
+                if (chain.call().isCanceled()) {
+                    lastException?.let { throw it }
+                    throw IOException("call cancelled")
+                }
+                val elapsedBefore = Duration.ofNanos(System.nanoTime() - start)
+                // Bail out before dispatching if the wall-clock budget is already
+                // gone; surface a timeout mapped to SandboxTimeoutException.
+                policy.overallDeadline?.let { deadline ->
+                    val remaining = deadline.minus(elapsedBefore)
+                    if (remaining <= Duration.ZERO) {
+                        throw RetryDeadlineExceededException(
+                            "retry overallDeadline exceeded before next attempt",
+                            lastException,
+                        )
+                    }
+                }
+
+                // Clamp per-attempt timeouts: apply perAttemptTimeout and remaining
+                // overallDeadline, whichever is tighter. OkHttp chain.with*Timeout
+                // returns a new Chain with the timeout lowered (not raised), so
+                // default values from the caller's OkHttpClient are preserved when
+                // these knobs are unset.
+                var effectiveChain = chain
+                val perAttemptMs = computePerAttemptTimeoutMs(elapsedBefore)
+                if (perAttemptMs != null) {
+                    val ms = perAttemptMs.toInt().coerceAtLeast(1)
+                    effectiveChain = effectiveChain.withConnectTimeout(ms, TimeUnit.MILLISECONDS)
+                    effectiveChain = effectiveChain.withReadTimeout(ms, TimeUnit.MILLISECONDS)
+                    effectiveChain = effectiveChain.withWriteTimeout(ms, TimeUnit.MILLISECONDS)
+                }
+
+                var response: Response? = null
+                var exception: IOException? = null
+                val outcome: Outcome =
+                    try {
+                        response = effectiveChain.proceed(request)
+                        outcomeForResponse(response.code)
+                    } catch (e: InterruptedIOException) {
+                        exception = e
+                        classifyIoException(e)
+                    } catch (e: IOException) {
+                        exception = e
+                        classifyIoException(e)
+                    }
+
+                val elapsedAfter = Duration.ofNanos(System.nanoTime() - start)
+                val cancelled = chain.call().isCanceled()
+                val retry =
+                    shouldRetry(
+                        method = method,
+                        outcome = outcome,
+                        retriesUsed = retriesUsed,
+                        policy = policy,
+                        elapsed = elapsedAfter,
+                        cancelled = cancelled,
+                        bodyReplayable = bodyReplayable,
+                    )
+
+                if (!retry) {
+                    if (exception != null) throw exception
+                    return response!!
+                }
+
+                lastException = exception
+
+                // Compute backoff: honor Retry-After when present.
+                var retryAfter: Duration? = null
+                if (response != null) {
+                    retryAfter = applyRetryAfterCap(parseRetryAfter(response.header("Retry-After")))
+                }
+                var sleepFor =
+                    retryAfter
+                        ?: computeBackoff(retriesUsed, policy, previousSleep, rng)
+
+                // Clamp the sleep to the remaining overall deadline so a long
+                // Retry-After or backoff cannot push us past the caller budget.
+                policy.overallDeadline?.let { deadline ->
+                    val remaining = deadline.minus(elapsedAfter)
+                    if (sleepFor > remaining) {
+                        sleepFor = if (remaining.isNegative) Duration.ZERO else remaining
+                    }
+                }
+
+                // Do not sleep when the call has been cancelled: this avoids a
+                // pointless wait when the caller already requested termination.
+                if (chain.call().isCanceled()) {
+                    lastException?.let { throw it }
+                    throw IOException("call cancelled")
+                }
+
+                val requestId = response?.header("X-Request-ID")
+                val statusCode = response?.code
+                val event =
+                    RetryEvent(
+                        attempt = retriesUsed + 2,
+                        retriesUsed = retriesUsed,
+                        method = method,
+                        url = request.url.toString(),
+                        cause = outcome.cause,
+                        statusCode = statusCode,
+                        backoff = sleepFor,
+                        requestId = requestId,
+                        exception = exception,
+                    )
+                logger.warn(
+                    "retrying {} {}: attempt={} cause={} status={} backoff={}ms request_id={}",
+                    event.method,
+                    event.url,
+                    event.attempt,
+                    event.cause.value,
+                    event.statusCode,
+                    event.backoff.toMillis(),
+                    event.requestId,
+                )
+                policy.onRetry?.let { hook ->
+                    try {
+                        hook(event)
+                    } catch (e: Exception) {
+                        logger.warn("RetryPolicy.onRetry callback raised", e)
+                    }
+                }
+
+                // Release the retried response body so the connection returns to
+                // the pool before the next attempt.
+                response?.close()
+
+                retriesUsed += 1
+                previousSleep = sleepFor
+                sleeper(sleepFor)
+                // If a thread interruption woke the sleeper, propagate:
+                // Thread.interrupted() clears the flag and returns true iff we
+                // were interrupted. The next loop iteration's isCanceled()
+                // check handles OkHttp cancellations; this covers JVM-level
+                // thread interruption.
+                if (Thread.interrupted()) {
+                    lastException?.let { throw it }
+                    throw IOException("call interrupted during backoff")
+                }
+            }
+        }
+
+        private fun outcomeForResponse(code: Int): Outcome =
+            Outcome(
+                isTransportError = false,
+                statusCode = code,
+                cause = RetryCause.forStatus(code),
+            )
+
+        /**
+         * Bound the current attempt by [RetryPolicy.perAttemptTimeout] and the
+         * remaining [RetryPolicy.overallDeadline], whichever is tighter.
+         *
+         * Returns the tightest per-phase timeout in milliseconds for this attempt,
+         * or `null` when neither knob is set and default OkHttp timeouts should be
+         * used.
+         */
+        private fun computePerAttemptTimeoutMs(elapsed: Duration): Long? {
+            val limit: Duration? =
+                when {
+                    policy.perAttemptTimeout != null && policy.overallDeadline != null -> {
+                        val remaining = policy.overallDeadline!! - elapsed
+                        if (remaining <= Duration.ZERO) {
+                            Duration.ZERO
+                        } else {
+                            minOf(
+                                policy.perAttemptTimeout!!,
+                                remaining,
+                            )
+                        }
+                    }
+                    policy.perAttemptTimeout != null -> policy.perAttemptTimeout
+                    policy.overallDeadline != null -> maxOf(policy.overallDeadline!! - elapsed, Duration.ZERO)
+                    else -> null
+                }
+            return limit?.let {
+                val ms = it.toMillis()
+                if (ms <= 0) null else ms
+            }
+        }
+
+        /**
+         * Classify an OkHttp-thrown [IOException].
+         *
+         * - Connect failures (DNS, TCP connect, TLS): pre-send, safe on any method.
+         * - Read timeouts: post-send, idempotent only.
+         * - Other IO errors: opaque, idempotent only.
+         */
+        private fun classifyIoException(e: IOException): Outcome {
+            // Connect timeout: OkHttp raises SocketTimeoutException whose message
+            // contains "connect". Distinguish from read timeout heuristically.
+            if (e is SocketTimeoutException) {
+                val msg = e.message?.lowercase().orEmpty()
+                return if (msg.contains("connect")) {
+                    Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
+                } else {
+                    Outcome(isTransportError = true, cause = RetryCause.READ_TIMEOUT)
+                }
+            }
+            if (e is ConnectException ||
+                e is UnknownHostException ||
+                e is NoRouteToHostException
+            ) {
+                return Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
+            }
+            // SSLHandshakeException is pre-send (handshake never completed).
+            // Other SSLExceptions (e.g. mid-stream protocol errors) are opaque.
+            if (e is SSLHandshakeException) {
+                return Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
+            }
+            if (e is SSLException) {
+                return Outcome(isTransportError = true, isOpaqueTransport = true, cause = RetryCause.OPAQUE_TRANSPORT)
+            }
+            // Generic InterruptedIOException that is not a socket timeout: treat as
+            // a post-send read timeout for observability.
+            if (e is InterruptedIOException) {
+                return Outcome(isTransportError = true, cause = RetryCause.READ_TIMEOUT)
+            }
+            // Any other IOException (e.g. connection reset mid-stream, unexpected
+            // EOF): opaque, retry on idempotent methods only.
+            return Outcome(
+                isTransportError = true,
+                isOpaqueTransport = true,
+                cause = RetryCause.OPAQUE_TRANSPORT,
+            )
+        }
+    }
+
+// Injectable-for-tests default sleeper; real code blocks the calling thread.
+// Uses Thread.sleep() (interruptible) so cancellation during backoff is surfaced
+// via InterruptedException → isCanceled() check on the next loop iteration.
+private fun defaultSleeper(duration: Duration) {
+    val millis = duration.toMillis()
+    if (millis > 0) {
+        try {
+            Thread.sleep(millis)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}
+
+/**
+ * Raised by [RetryInterceptor] when the overall retry deadline is exceeded before
+ * the next attempt. Mapped to `SandboxTimeoutException` by the exception converter.
+ */
+class RetryDeadlineExceededException(
+    message: String,
+    cause: Throwable? = null,
+) : IOException(message, cause)

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptor.kt
@@ -277,12 +277,14 @@ class RetryInterceptor
                 return Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
             }
             // SSLHandshakeException is pre-send (handshake never completed).
-            // Other SSLExceptions (e.g. mid-stream protocol errors) are opaque.
             if (e is SSLHandshakeException) {
                 return Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
             }
+            // Generic mid-stream SSL failures (e.g. TLS alerts, protocol errors
+            // after bytes were already written) are not retryable: they indicate
+            // a permanent connection-level issue, not a transient one.
             if (e is SSLException) {
-                return Outcome(isTransportError = true, isOpaqueTransport = true, cause = RetryCause.OPAQUE_TRANSPORT)
+                return Outcome(isTransportError = false)
             }
             // Generic InterruptedIOException that is not a socket timeout: treat as
             // a post-send read timeout for observability.

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
@@ -84,7 +84,8 @@ data class RetryEvent(
 /**
  * Retry configuration for non-streaming requests.
  *
- * Defaults retry idempotent methods only. Use [disabled] for fast-fail. Extend
+ * Defaults retry idempotent methods only. Use [disabled] to disable SDK-policy
+ * retries and fall back to OkHttp's built-in connection recovery. Extend
  * [retryableStatusCodesNonIdempotent] to opt `POST`/`PATCH` in on specific status
  * codes; the SDK never does this on the caller's behalf.
  *
@@ -94,7 +95,7 @@ data class RetryEvent(
 class RetryPolicy
     @JvmOverloads
     constructor(
-        /** Retries after the initial attempt. `0` disables retry. */
+        /** Retries after the initial attempt. `0` disables SDK-policy retries. */
         val maxRetries: Int = DEFAULT_MAX_RETRIES,
         val initialBackoff: Duration = Duration.ofMillis(500),
         val maxBackoff: Duration = Duration.ofSeconds(30),
@@ -160,7 +161,7 @@ class RetryPolicy
                     StatusCode.SERVICE_UNAVAILABLE,
                 )
 
-            /** Never retry. Also suppresses fresh-connection recovery. */
+            /** Disable SDK-policy retries and fall back to OkHttp's built-in connection recovery. */
             @JvmStatic
             fun disabled(): RetryPolicy = RetryPolicy(maxRetries = 0)
         }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import java.time.Duration
+
+/** RFC 9110 §9.2.2 idempotent methods. */
+private val IDEMPOTENT_METHODS: Set<String> = setOf("GET", "HEAD", "PUT", "DELETE", "OPTIONS")
+
+internal fun isIdempotentMethod(method: String): Boolean = method.uppercase() in IDEMPOTENT_METHODS
+
+/** Backoff jitter algorithm. */
+enum class JitterMode {
+    NONE,
+    FULL,
+    DECORRELATED,
+}
+
+/** Failure classification carried on [RetryEvent]. */
+enum class RetryCause(val value: String) {
+    PRE_SEND("pre_send"),
+    OPAQUE_TRANSPORT("opaque_transport"),
+    READ_TIMEOUT("read_timeout"),
+    WRITE_TIMEOUT("write_timeout"),
+    UNEXPECTED_EOF("unexpected_eof"),
+    STATUS_408("status_408"),
+    STATUS_425("status_425"),
+    STATUS_429("status_429"),
+    STATUS_500("status_500"),
+    STATUS_502("status_502"),
+    STATUS_503("status_503"),
+    STATUS_504("status_504"),
+    STATUS_OTHER("status_other"),
+    ;
+
+    companion object {
+        fun forStatus(statusCode: Int): RetryCause =
+            when (statusCode) {
+                408 -> STATUS_408
+                425 -> STATUS_425
+                429 -> STATUS_429
+                500 -> STATUS_500
+                502 -> STATUS_502
+                503 -> STATUS_503
+                504 -> STATUS_504
+                else -> STATUS_OTHER
+            }
+    }
+}
+
+/**
+ * Payload passed to [RetryPolicy.onRetry] before each backoff sleep.
+ *
+ * @property attempt 1-based index of the upcoming attempt (retry #1 is `attempt=2`).
+ * @property retriesUsed retries consumed so far, i.e. `attempt - 1`.
+ * @property requestId `X-Request-ID` header from the last response, if present.
+ */
+data class RetryEvent(
+    val attempt: Int,
+    val retriesUsed: Int,
+    val method: String,
+    val url: String,
+    val cause: RetryCause,
+    val statusCode: Int?,
+    val backoff: Duration,
+    val requestId: String?,
+    val exception: Throwable?,
+)
+
+/**
+ * Retry configuration for non-streaming requests.
+ *
+ * Defaults retry idempotent methods only. Use [disabled] for fast-fail. Extend
+ * [retryableStatusCodesNonIdempotent] to opt `POST`/`PATCH` in on specific status
+ * codes; the SDK never does this on the caller's behalf.
+ *
+ * This is a value type; adding fields in future is backward-compatible as long as
+ * new fields default to current behavior.
+ */
+class RetryPolicy
+    @JvmOverloads
+    constructor(
+        /** Retries after the initial attempt. `0` disables retry. */
+        val maxRetries: Int = DEFAULT_MAX_RETRIES,
+        val initialBackoff: Duration = Duration.ofMillis(500),
+        val maxBackoff: Duration = Duration.ofSeconds(30),
+        val backoffMultiplier: Double = 2.0,
+        val jitter: JitterMode = JitterMode.DECORRELATED,
+        /** Statuses that trigger retry for `GET/HEAD/PUT/DELETE/OPTIONS`. */
+        val retryableStatusCodesIdempotent: Set<Int> = DEFAULT_IDEMPOTENT_STATUS,
+        /** Statuses that trigger retry for `POST/PATCH`. Empty by default. */
+        val retryableStatusCodesNonIdempotent: Set<Int> = emptySet(),
+        val perAttemptTimeout: Duration? = null,
+        /** Wall-clock cap across all attempts of one logical request. */
+        val overallDeadline: Duration? = null,
+        /** Non-blocking hook fired synchronously before each backoff sleep. */
+        val onRetry: ((RetryEvent) -> Unit)? = null,
+    ) {
+        init {
+            require(maxRetries >= 0) { "maxRetries must be >= 0, got $maxRetries" }
+            require(!initialBackoff.isNegative) { "initialBackoff must be >= 0, got $initialBackoff" }
+            require(!maxBackoff.isNegative) { "maxBackoff must be >= 0, got $maxBackoff" }
+            require(backoffMultiplier >= 1.0) { "backoffMultiplier must be >= 1.0, got $backoffMultiplier" }
+            require(perAttemptTimeout == null || (!perAttemptTimeout.isNegative && !perAttemptTimeout.isZero)) {
+                "perAttemptTimeout must be > 0 when set, got $perAttemptTimeout"
+            }
+            require(overallDeadline == null || (!overallDeadline.isNegative && !overallDeadline.isZero)) {
+                "overallDeadline must be > 0 when set, got $overallDeadline"
+            }
+        }
+
+        /**
+         * Whether this policy requires the retry interceptor to be installed.
+         *
+         * Even `maxRetries == 0` needs the interceptor when the caller uses it
+         * purely to enforce [perAttemptTimeout] or [overallDeadline] on a single
+         * attempt, or to observe failures through [onRetry].
+         */
+        fun wrapsTransport(): Boolean =
+            maxRetries > 0 ||
+                perAttemptTimeout != null ||
+                overallDeadline != null ||
+                onRetry != null
+
+        internal fun retryableStatusesFor(method: String): Set<Int> =
+            if (isIdempotentMethod(method)) {
+                retryableStatusCodesIdempotent
+            } else {
+                retryableStatusCodesNonIdempotent
+            }
+
+        companion object {
+            const val DEFAULT_MAX_RETRIES = 3
+
+            /**
+             * Default idempotent retryable set: 429 (Too Many Requests), 502
+             * (Bad Gateway), 503 (Service Unavailable). Narrower than the OSEP
+             * draft's `{408, 425, 429, 500, 502, 503, 504}`, matching the Python
+             * landing.
+             */
+            @JvmField
+            val DEFAULT_IDEMPOTENT_STATUS: Set<Int> =
+                setOf(
+                    StatusCode.TOO_MANY_REQUESTS,
+                    StatusCode.BAD_GATEWAY,
+                    StatusCode.SERVICE_UNAVAILABLE,
+                )
+
+            /** Never retry. Also suppresses fresh-connection recovery. */
+            @JvmStatic
+            fun disabled(): RetryPolicy = RetryPolicy(maxRetries = 0)
+        }
+    }
+
+/**
+ * Well-known HTTP status codes used by [RetryPolicy].
+ *
+ * Provided so callers can compose status sets with named constants instead of
+ * bare integers, matching the Python SDK's use of `HTTPStatus`.
+ */
+object StatusCode {
+    const val REQUEST_TIMEOUT = 408
+    const val TOO_EARLY = 425
+    const val TOO_MANY_REQUESTS = 429
+    const val INTERNAL_SERVER_ERROR = 500
+    const val BAD_GATEWAY = 502
+    const val SERVICE_UNAVAILABLE = 503
+    const val GATEWAY_TIMEOUT = 504
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicy.kt
@@ -17,6 +17,9 @@
 package com.alibaba.opensandbox.sandbox.transport
 
 import java.time.Duration
+import java.util.Collections
+
+private fun immutableStatusSetCopy(statuses: Set<Int>): Set<Int> = Collections.unmodifiableSet(LinkedHashSet(statuses))
 
 /** RFC 9110 §9.2.2 idempotent methods. */
 private val IDEMPOTENT_METHODS: Set<String> = setOf("GET", "HEAD", "PUT", "DELETE", "OPTIONS")
@@ -101,16 +104,22 @@ class RetryPolicy
         val maxBackoff: Duration = Duration.ofSeconds(30),
         val backoffMultiplier: Double = 2.0,
         val jitter: JitterMode = JitterMode.DECORRELATED,
-        /** Statuses that trigger retry for `GET/HEAD/PUT/DELETE/OPTIONS`. */
-        val retryableStatusCodesIdempotent: Set<Int> = DEFAULT_IDEMPOTENT_STATUS,
-        /** Statuses that trigger retry for `POST/PATCH`. Empty by default. */
-        val retryableStatusCodesNonIdempotent: Set<Int> = emptySet(),
+        retryableStatusCodesIdempotent: Set<Int> = DEFAULT_IDEMPOTENT_STATUS,
+        retryableStatusCodesNonIdempotent: Set<Int> = emptySet(),
         val perAttemptTimeout: Duration? = null,
         /** Wall-clock cap across all attempts of one logical request. */
         val overallDeadline: Duration? = null,
         /** Non-blocking hook fired synchronously before each backoff sleep. */
         val onRetry: ((RetryEvent) -> Unit)? = null,
     ) {
+        /** Statuses that trigger retry for `GET/HEAD/PUT/DELETE/OPTIONS`. */
+        val retryableStatusCodesIdempotent: Set<Int> =
+            immutableStatusSetCopy(retryableStatusCodesIdempotent)
+
+        /** Statuses that trigger retry for `POST/PATCH`. Empty by default. */
+        val retryableStatusCodesNonIdempotent: Set<Int> =
+            immutableStatusSetCopy(retryableStatusCodesNonIdempotent)
+
         init {
             require(maxRetries >= 0) { "maxRetries must be >= 0, got $maxRetries" }
             require(!initialBackoff.isNegative) { "initialBackoff must be >= 0, got $initialBackoff" }
@@ -155,10 +164,12 @@ class RetryPolicy
              */
             @JvmField
             val DEFAULT_IDEMPOTENT_STATUS: Set<Int> =
-                setOf(
-                    StatusCode.TOO_MANY_REQUESTS,
-                    StatusCode.BAD_GATEWAY,
-                    StatusCode.SERVICE_UNAVAILABLE,
+                immutableStatusSetCopy(
+                    setOf(
+                        StatusCode.TOO_MANY_REQUESTS,
+                        StatusCode.BAD_GATEWAY,
+                        StatusCode.SERVICE_UNAVAILABLE,
+                    ),
                 )
 
             /** Disable SDK-policy retries and fall back to OkHttp's built-in connection recovery. */

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProviderTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/HttpClientProviderTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox
+
+import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import com.alibaba.opensandbox.sandbox.transport.RetryInterceptor
+import com.alibaba.opensandbox.sandbox.transport.RetryPolicy
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class HttpClientProviderTest {
+    @Test
+    fun `SSE client disables all automatic retries for every retry policy`() {
+        val policies =
+            listOf(
+                RetryPolicy(),
+                RetryPolicy.disabled(),
+                RetryPolicy(maxRetries = 0, overallDeadline = Duration.ofSeconds(5)),
+            )
+
+        policies.forEach { policy ->
+            HttpClientProvider(
+                ConnectionConfig.builder()
+                    .retryPolicy(policy)
+                    .build(),
+            ).use { provider ->
+                assertFalse(provider.sseClient.retryOnConnectionFailure)
+                assertFalse(provider.sseClient.interceptors.any { it is RetryInterceptor })
+            }
+        }
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
@@ -20,6 +20,7 @@ import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.InvalidArgumentException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxApiException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.SandboxRateLimitException
 import com.alibaba.opensandbox.sandbox.domain.models.execd.SECURE_ACCESS_HEADER
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.ExecutionHandlers
 import com.alibaba.opensandbox.sandbox.domain.models.execd.executions.RunCommandRequest
@@ -279,11 +280,12 @@ class CommandsAdapterTest {
 
     @Test
     fun `run should expose request id on api exception`() {
+        val responseBody = """{"code":"INTERNAL_ERROR","message":"boom"}"""
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(500)
                 .addHeader("X-Request-ID", "req-kotlin-123")
-                .setBody("""{"code":"INTERNAL_ERROR","message":"boom"}"""),
+                .setBody(responseBody),
         )
 
         val request = RunCommandRequest.builder().command("echo Hello").build()
@@ -291,6 +293,28 @@ class CommandsAdapterTest {
 
         assertEquals(500, ex.statusCode)
         assertEquals("req-kotlin-123", ex.requestId)
+        assertEquals(responseBody, ex.responseBody)
+    }
+
+    @Test
+    fun `run should map rate limit response metadata`() {
+        val responseBody = """{"code":"RATE_LIMIT","message":"slow down"}"""
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("X-Request-ID", "req-rate-limit")
+                .addHeader("Retry-After", "2")
+                .setBody(responseBody),
+        )
+
+        val request = RunCommandRequest.builder().command("echo Hello").build()
+        val ex = assertThrows(SandboxRateLimitException::class.java) { commandsAdapter.run(request) }
+
+        assertEquals(429, ex.statusCode)
+        assertEquals("req-rate-limit", ex.requestId)
+        assertEquals(Duration.ofSeconds(2), ex.retryAfter)
+        assertEquals(responseBody, ex.responseBody)
+        assertTrue(ex.isRetryable)
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/CommandsAdapterTest.kt
@@ -297,8 +297,8 @@ class CommandsAdapterTest {
     }
 
     @Test
-    fun `run should map rate limit response metadata`() {
-        val responseBody = """{"code":"RATE_LIMIT","message":"slow down"}"""
+    fun `run should map unstructured rate limit response metadata`() {
+        val responseBody = "slow down"
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(429)
@@ -311,6 +311,7 @@ class CommandsAdapterTest {
         val ex = assertThrows(SandboxRateLimitException::class.java) { commandsAdapter.run(request) }
 
         assertEquals(429, ex.statusCode)
+        assertEquals("RATE_LIMIT", ex.error.code)
         assertEquals("req-rate-limit", ex.requestId)
         assertEquals(Duration.ofSeconds(2), ex.retryAfter)
         assertEquals(responseBody, ex.responseBody)

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryDecisionTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryDecisionTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.Random
+
+class RetryDecisionTest {
+    private val defaultPolicy = RetryPolicy()
+
+    private fun statusOutcome(code: Int) = Outcome(isTransportError = false, statusCode = code, cause = RetryCause.forStatus(code))
+
+    private val preSend =
+        Outcome(isTransportError = true, isPreSend = true, cause = RetryCause.PRE_SEND)
+    private val readTimeout =
+        Outcome(isTransportError = true, cause = RetryCause.READ_TIMEOUT)
+
+    @Test
+    fun `idempotent retries on transient status`() {
+        for (code in listOf(429, 502, 503)) {
+            assertTrue(
+                shouldRetry("GET", statusOutcome(code), 0, defaultPolicy, Duration.ZERO),
+                "GET should retry on $code",
+            )
+        }
+    }
+
+    @Test
+    fun `POST does not retry on any status under default policy`() {
+        for (code in listOf(429, 500, 502, 503, 504)) {
+            assertFalse(
+                shouldRetry("POST", statusOutcome(code), 0, defaultPolicy, Duration.ZERO),
+                "POST should not retry on $code",
+            )
+        }
+    }
+
+    @Test
+    fun `4xx not in set is never retried`() {
+        for (code in listOf(400, 401, 404, 409)) {
+            assertFalse(shouldRetry("GET", statusOutcome(code), 0, defaultPolicy, Duration.ZERO))
+            assertFalse(shouldRetry("POST", statusOutcome(code), 0, defaultPolicy, Duration.ZERO))
+        }
+    }
+
+    @Test
+    fun `pre-send retries on any method`() {
+        assertTrue(shouldRetry("GET", preSend, 0, defaultPolicy, Duration.ZERO))
+        assertTrue(shouldRetry("POST", preSend, 0, defaultPolicy, Duration.ZERO))
+    }
+
+    @Test
+    fun `read timeout retries idempotent only`() {
+        assertTrue(shouldRetry("GET", readTimeout, 0, defaultPolicy, Duration.ZERO))
+        assertFalse(shouldRetry("POST", readTimeout, 0, defaultPolicy, Duration.ZERO))
+    }
+
+    @Test
+    fun `budget exhaustion stops retry`() {
+        assertFalse(shouldRetry("GET", statusOutcome(503), 3, defaultPolicy, Duration.ZERO))
+    }
+
+    @Test
+    fun `overall deadline stops retry`() {
+        val policy = RetryPolicy(overallDeadline = Duration.ofSeconds(10))
+        assertFalse(
+            shouldRetry("GET", statusOutcome(503), 0, policy, Duration.ofSeconds(11)),
+        )
+    }
+
+    @Test
+    fun `cancellation stops retry`() {
+        assertFalse(
+            shouldRetry("GET", statusOutcome(503), 0, defaultPolicy, Duration.ZERO, cancelled = true),
+        )
+    }
+
+    @Test
+    fun `POST opt-in enables status retry`() {
+        val policy = RetryPolicy(retryableStatusCodesNonIdempotent = setOf(429, 502))
+        assertTrue(shouldRetry("POST", statusOutcome(429), 0, policy, Duration.ZERO))
+        assertTrue(shouldRetry("POST", statusOutcome(502), 0, policy, Duration.ZERO))
+        assertFalse(shouldRetry("POST", statusOutcome(503), 0, policy, Duration.ZERO))
+        // Opt-in does not lift post-send read timeouts for non-idempotent methods.
+        assertFalse(shouldRetry("POST", readTimeout, 0, policy, Duration.ZERO))
+    }
+
+    @Test
+    fun `non-replayable body suppresses status retry and second pre-send`() {
+        assertFalse(
+            shouldRetry("GET", statusOutcome(503), 0, defaultPolicy, Duration.ZERO, bodyReplayable = false),
+        )
+        // First pre-send is still allowed (no bytes written yet).
+        assertTrue(
+            shouldRetry("POST", preSend, 0, defaultPolicy, Duration.ZERO, bodyReplayable = false),
+        )
+        // Beyond the first attempt, suppressed.
+        assertFalse(
+            shouldRetry("POST", preSend, 1, defaultPolicy, Duration.ZERO, bodyReplayable = false),
+        )
+    }
+
+    @Test
+    fun `parse retry-after delta seconds`() {
+        assertEquals(Duration.ofSeconds(2), parseRetryAfter("2"))
+        assertEquals(Duration.ZERO, parseRetryAfter("-5"))
+        assertNull(parseRetryAfter(null))
+        assertNull(parseRetryAfter(""))
+        assertNull(parseRetryAfter("not-a-number-or-date"))
+    }
+
+    @Test
+    fun `parse retry-after http date`() {
+        val now = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val future = "Thu, 01 Jan 2026 00:00:30 GMT"
+        assertEquals(Duration.ofSeconds(30), parseRetryAfter(future, now))
+        val past = "Wed, 01 Jan 2020 00:00:00 GMT"
+        assertEquals(Duration.ZERO, parseRetryAfter(past, now))
+    }
+
+    @Test
+    fun `retry-after cap clamps to 60s`() {
+        assertEquals(Duration.ofSeconds(60), applyRetryAfterCap(Duration.ofSeconds(3600)))
+        assertEquals(Duration.ofSeconds(5), applyRetryAfterCap(Duration.ofSeconds(5)))
+        assertNull(applyRetryAfterCap(null))
+    }
+
+    @Test
+    fun `compute backoff none jitter is deterministic exponential`() {
+        val policy =
+            RetryPolicy(
+                jitter = JitterMode.NONE,
+                initialBackoff = Duration.ofMillis(100),
+                maxBackoff = Duration.ofSeconds(30),
+            )
+        val rng = Random(0)
+        assertEquals(100, computeBackoff(0, policy, Duration.ZERO, rng).toMillis())
+        assertEquals(200, computeBackoff(1, policy, Duration.ZERO, rng).toMillis())
+        assertEquals(400, computeBackoff(2, policy, Duration.ZERO, rng).toMillis())
+    }
+
+    @Test
+    fun `compute backoff respects max backoff on first decorrelated retry`() {
+        val policy =
+            RetryPolicy(
+                jitter = JitterMode.DECORRELATED,
+                initialBackoff = Duration.ofSeconds(10),
+                maxBackoff = Duration.ofSeconds(1),
+            )
+        val delay = computeBackoff(0, policy, Duration.ZERO, Random(0))
+        assertTrue(delay <= Duration.ofSeconds(1))
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
@@ -23,6 +23,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -31,6 +32,8 @@ import java.io.IOException
 import java.time.Duration
 import java.util.Random
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.SSLException
 
 class RetryInterceptorTest {
     private lateinit var server: MockWebServer
@@ -182,6 +185,83 @@ class RetryInterceptorTest {
         assertThrows(IOException::class.java) { c.newCall(req).execute() }
         // initial + 3 retries => 3 onRetry events
         assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `GET retries opaque SSL failure`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+        val attempts = AtomicInteger()
+        val c =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .addInterceptor(RetryInterceptor(RetryPolicy(), rng = Random(0), sleeper = {}))
+                .addInterceptor { chain ->
+                    if (attempts.incrementAndGet() == 1) {
+                        throw SSLException("mid-stream TLS failure")
+                    }
+                    chain.proceed(chain.request())
+                }
+                .build()
+
+        assertEquals(200, get(c))
+        assertEquals(2, attempts.get())
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `POST does not retry opaque SSL failure`() {
+        val attempts = AtomicInteger()
+        val c =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .addInterceptor(RetryInterceptor(RetryPolicy(), rng = Random(0), sleeper = {}))
+                .addInterceptor { chain ->
+                    attempts.incrementAndGet()
+                    throw SSLException("mid-stream TLS failure")
+                }
+                .build()
+
+        val req =
+            Request.Builder()
+                .url(server.url("/"))
+                .post("x".toRequestBody())
+                .build()
+        assertThrows(SSLException::class.java) { c.newCall(req).execute() }
+        assertEquals(1, attempts.get())
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `backoff interruption preserves thread interrupt flag`() {
+        val original = IOException("connection reset")
+        val attempts = AtomicInteger()
+        val c =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .addInterceptor(
+                    RetryInterceptor(
+                        RetryPolicy(maxRetries = 1),
+                        rng = Random(0),
+                        sleeper = { Thread.currentThread().interrupt() },
+                    ),
+                )
+                .addInterceptor {
+                    attempts.incrementAndGet()
+                    throw original
+                }
+                .build()
+
+        // Avoid inheriting a stale interrupt from another test, then clean it up
+        // after asserting so this test does not affect the JUnit worker thread.
+        Thread.interrupted()
+        try {
+            val thrown = assertThrows(IOException::class.java) { get(c) }
+            assertSame(original, thrown)
+            assertTrue(Thread.currentThread().isInterrupted)
+            assertEquals(1, attempts.get())
+        } finally {
+            Thread.interrupted()
+        }
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Duration
+import java.util.Random
+import java.util.concurrent.TimeUnit
+
+class RetryInterceptorTest {
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun client(
+        policy: RetryPolicy,
+        retryOnConnectionFailure: Boolean = false,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .retryOnConnectionFailure(retryOnConnectionFailure)
+            .connectTimeout(2, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.SECONDS)
+            // Deterministic rng + no-op sleeper so tests do not actually wait.
+            .addInterceptor(RetryInterceptor(policy, rng = Random(0), sleeper = {}))
+            .build()
+
+    private fun get(client: OkHttpClient): Int {
+        val req = Request.Builder().url(server.url("/")).get().build()
+        client.newCall(req).execute().use { return it.code }
+    }
+
+    private fun post(
+        client: OkHttpClient,
+        body: String = "x",
+    ): Int {
+        val req =
+            Request.Builder()
+                .url(server.url("/"))
+                .post(body.toRequestBody())
+                .build()
+        client.newCall(req).execute().use { return it.code }
+    }
+
+    @Test
+    fun `GET retries 503 then succeeds`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val code = get(client(RetryPolicy()))
+        assertEquals(200, code)
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `GET exhausts retries and returns last 503`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(503)) }
+
+        val code = get(client(RetryPolicy()))
+        assertEquals(503, code)
+        // initial + 3 retries
+        assertEquals(4, server.requestCount)
+    }
+
+    @Test
+    fun `POST does not retry 503 under default policy`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+
+        val code = post(client(RetryPolicy()))
+        assertEquals(503, code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `POST retries 502 when opted in`() {
+        server.enqueue(MockResponse().setResponseCode(502))
+        server.enqueue(MockResponse().setResponseCode(502))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val policy = RetryPolicy(retryableStatusCodesNonIdempotent = setOf(429, 502))
+        val code = post(client(policy))
+        assertEquals(200, code)
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `4xx is never retried`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+        val code = get(client(RetryPolicy()))
+        assertEquals(404, code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `Retry-After header drives backoff`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "0"))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        var observedBackoff: Duration? = null
+        val policy =
+            RetryPolicy(
+                onRetry = { observedBackoff = it.backoff },
+            )
+        val code = get(client(policy))
+        assertEquals(200, code)
+        assertEquals(2, server.requestCount)
+        assertEquals(Duration.ZERO, observedBackoff)
+    }
+
+    @Test
+    fun `Retry-After is capped at 60s`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "3600"))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        var observedBackoff: Duration? = null
+        val policy = RetryPolicy(onRetry = { observedBackoff = it.backoff })
+        get(client(policy))
+        assertEquals(Duration.ofSeconds(60), observedBackoff)
+    }
+
+    @Test
+    fun `disabled policy is single attempt on 503`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+        // disabled() does not wrap, but if used explicitly it must not retry.
+        val code = get(client(RetryPolicy(maxRetries = 0, onRetry = {})))
+        assertEquals(503, code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `pre-send connect failure retries POST`() {
+        // Point at a port with no listener to force a ConnectException (pre-send).
+        val deadPort = server.port
+        server.shutdown()
+        val req =
+            Request.Builder()
+                .url("http://127.0.0.1:$deadPort/")
+                .post("x".toRequestBody())
+                .build()
+        var attempts = 0
+        val policy = RetryPolicy(initialBackoff = Duration.ofMillis(1), onRetry = { attempts++ })
+        val c =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .connectTimeout(500, TimeUnit.MILLISECONDS)
+                .addInterceptor(RetryInterceptor(policy, rng = Random(0), sleeper = {}))
+                .build()
+        assertThrows(IOException::class.java) { c.newCall(req).execute() }
+        // initial + 3 retries => 3 onRetry events
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `overallDeadline enables wrapsTransport`() {
+        // The interceptor deadline path is tested at the decision level in
+        // RetryDecisionTest. Here we verify the wiring: a deadline-installed
+        // interceptor still passes through normal success/failure responses
+        // without flaky clock dependencies.
+        val policy = RetryPolicy(maxRetries = 1, overallDeadline = Duration.ofSeconds(10))
+        assertTrue(policy.wrapsTransport())
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(200))
+        val client =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .addInterceptor(RetryInterceptor(policy, rng = Random(0), sleeper = {}))
+                .build()
+        val code = get(client)
+        assertEquals(200, code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `onRetry receives request id`() {
+        server.enqueue(MockResponse().setResponseCode(503).setHeader("X-Request-ID", "req-1"))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        var event: RetryEvent? = null
+        val policy = RetryPolicy(onRetry = { event = it })
+        get(client(policy))
+        assertEquals("req-1", event?.requestId)
+        assertEquals(503, event?.statusCode)
+        assertEquals(2, event?.attempt)
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryInterceptorTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.time.Duration
 import java.util.Random
 import java.util.concurrent.TimeUnit
@@ -259,6 +260,40 @@ class RetryInterceptorTest {
             assertSame(original, thrown)
             assertTrue(Thread.currentThread().isInterrupted)
             assertEquals(1, attempts.get())
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `IO interruption is terminal and preserves thread interrupt flag`() {
+        val original = InterruptedIOException("interrupted")
+        val attempts = AtomicInteger()
+        val retries = AtomicInteger()
+        val c =
+            OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .addInterceptor(
+                    RetryInterceptor(
+                        RetryPolicy(onRetry = { retries.incrementAndGet() }),
+                        rng = Random(0),
+                        sleeper = {},
+                    ),
+                )
+                .addInterceptor {
+                    attempts.incrementAndGet()
+                    Thread.currentThread().interrupt()
+                    throw original
+                }
+                .build()
+
+        Thread.interrupted()
+        try {
+            val thrown = assertThrows(InterruptedIOException::class.java) { get(c) }
+            assertSame(original, thrown)
+            assertTrue(Thread.currentThread().isInterrupted)
+            assertEquals(1, attempts.get())
+            assertEquals(0, retries.get())
         } finally {
             Thread.interrupted()
         }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicyTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicyTest.kt
@@ -70,6 +70,32 @@ class RetryPolicyTest {
     }
 
     @Test
+    fun `status sets are defensive immutable copies`() {
+        val idempotentStatuses = mutableSetOf(StatusCode.TOO_MANY_REQUESTS)
+        val nonIdempotentStatuses = mutableSetOf(StatusCode.BAD_GATEWAY)
+        val policy =
+            RetryPolicy(
+                retryableStatusCodesIdempotent = idempotentStatuses,
+                retryableStatusCodesNonIdempotent = nonIdempotentStatuses,
+            )
+
+        idempotentStatuses.add(StatusCode.SERVICE_UNAVAILABLE)
+        nonIdempotentStatuses.add(StatusCode.SERVICE_UNAVAILABLE)
+
+        assertEquals(setOf(StatusCode.TOO_MANY_REQUESTS), policy.retryableStatusCodesIdempotent)
+        assertEquals(setOf(StatusCode.BAD_GATEWAY), policy.retryableStatusCodesNonIdempotent)
+        assertThrows(UnsupportedOperationException::class.java) {
+            (policy.retryableStatusCodesIdempotent as MutableSet<Int>).add(StatusCode.SERVICE_UNAVAILABLE)
+        }
+        assertThrows(UnsupportedOperationException::class.java) {
+            (policy.retryableStatusCodesNonIdempotent as MutableSet<Int>).add(StatusCode.SERVICE_UNAVAILABLE)
+        }
+        assertThrows(UnsupportedOperationException::class.java) {
+            (RetryPolicy.DEFAULT_IDEMPOTENT_STATUS as MutableSet<Int>).add(StatusCode.GATEWAY_TIMEOUT)
+        }
+    }
+
+    @Test
     fun `validation rejects invalid values`() {
         assertThrows(IllegalArgumentException::class.java) { RetryPolicy(maxRetries = -1) }
         assertThrows(IllegalArgumentException::class.java) { RetryPolicy(backoffMultiplier = 0.5) }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicyTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/transport/RetryPolicyTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.transport
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class RetryPolicyTest {
+    @Test
+    fun `default policy retries idempotent methods on the narrow transient set`() {
+        val policy = RetryPolicy()
+        assertEquals(3, policy.maxRetries)
+        assertEquals(
+            setOf(StatusCode.TOO_MANY_REQUESTS, StatusCode.BAD_GATEWAY, StatusCode.SERVICE_UNAVAILABLE),
+            policy.retryableStatusesFor("GET"),
+        )
+        assertTrue(policy.retryableStatusesFor("POST").isEmpty())
+        assertTrue(policy.wrapsTransport())
+    }
+
+    @Test
+    fun `disabled policy does not wrap the transport`() {
+        val policy = RetryPolicy.disabled()
+        assertEquals(0, policy.maxRetries)
+        assertFalse(policy.wrapsTransport())
+    }
+
+    @Test
+    fun `disabled policy still wraps when timeout knobs are set`() {
+        val policy = RetryPolicy(maxRetries = 0, overallDeadline = Duration.ofSeconds(5))
+        assertTrue(policy.wrapsTransport())
+    }
+
+    @Test
+    fun `non-idempotent opt-in surfaces for POST`() {
+        val policy =
+            RetryPolicy(
+                retryableStatusCodesNonIdempotent =
+                    setOf(
+                        StatusCode.TOO_MANY_REQUESTS,
+                        StatusCode.BAD_GATEWAY,
+                    ),
+            )
+        assertEquals(
+            setOf(StatusCode.TOO_MANY_REQUESTS, StatusCode.BAD_GATEWAY),
+            policy.retryableStatusesFor("POST"),
+        )
+        assertEquals(
+            setOf(StatusCode.TOO_MANY_REQUESTS, StatusCode.BAD_GATEWAY),
+            policy.retryableStatusesFor("PATCH"),
+        )
+    }
+
+    @Test
+    fun `validation rejects invalid values`() {
+        assertThrows(IllegalArgumentException::class.java) { RetryPolicy(maxRetries = -1) }
+        assertThrows(IllegalArgumentException::class.java) { RetryPolicy(backoffMultiplier = 0.5) }
+        assertThrows(IllegalArgumentException::class.java) {
+            RetryPolicy(perAttemptTimeout = Duration.ZERO)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            RetryPolicy(overallDeadline = Duration.ofSeconds(-1))
+        }
+    }
+
+    @Test
+    fun `retry cause maps known statuses`() {
+        assertEquals(RetryCause.STATUS_429, RetryCause.forStatus(429))
+        assertEquals(RetryCause.STATUS_502, RetryCause.forStatus(502))
+        assertEquals(RetryCause.STATUS_OTHER, RetryCause.forStatus(418))
+    }
+}


### PR DESCRIPTION
## Summary

Kotlin landing of [OSEP-0016 Resilient SDK Transport](https://github.com/opensandbox-group/OpenSandbox/pull/1368), mirroring the [Python landing](https://github.com/opensandbox-group/OpenSandbox/pull/1372). Client-only; no spec change, no server change, no wire-format change.

## What it adds

**Retry interceptor** (`com.alibaba.opensandbox.sandbox.transport.RetryInterceptor`)
- OkHttp `Interceptor` installed on `httpClient` / `authenticatedClient` only; `sseClient` excluded.
- Defaults retry idempotent methods only; `POST`/`PATCH` status-code retry is opt-in through `retryableStatusCodesNonIdempotent`.
- Default idempotent retryable set: `{429, 502, 503}` — matching the Python landing.
- Decorrelated jitter (default), full jitter, and deterministic exponential.
- `Retry-After` honored with a fixed 60s ceiling.
- Classifies OkHttp exceptions: pre-send (`ConnectException`, TLS, DNS) vs read-timeout vs opaque.

**RetryPolicy** (`com.alibaba.opensandbox.sandbox.transport`)
- New value type with `StatusCode` named constants (Java-friendly `const val Int`).
- `ConnectionConfig.builder().retryPolicy()` builder method.
- `RetryPolicy.disabled()` for fast-fail.

**Exception hierarchy**
- `SandboxException.isRetryable` accessor.
- New subclasses: `SandboxRateLimitException` (carries `retryAfter`), `SandboxTimeoutException`, `SandboxConnectionException`.
- Existing classes and public fields unchanged; kept old constructor signatures for binary compatibility.

**Status code constants** (`StatusCode`)
- Named constants (`TOO_MANY_REQUESTS`, `BAD_GATEWAY`, `SERVICE_UNAVAILABLE`, etc.) so callers compose status sets with readable names instead of bare integers, matching the Python SDK`s use of `HTTPStatus`.

## Transport wrappers

- `RetryInterceptor` implements `okhttp3.Interceptor`.
- `ConnectionConfig` builds an `OkHttpClient` with the interceptor by default; `sseClient` deliberately bypasses it.
- `HttpClientProvider` applies `retryInterceptor` only when `retryPolicy.wrapsTransport()` returns true.

## Behavior change

- `RetryPolicy` is enabled by default. Callers that rely on fast-fail semantics must opt out via `.retryPolicy(RetryPolicy.disabled())`.
- Under the default policy, `POST/PATCH` are never retried on any status code; pre-send transport failures (DNS, TCP connect, TLS handshake) are still retried.

## Tests

- Retry policy defaults, validation, `StatusCode` usage.
- Pure decision function: status matrix, transport branch, budget/deadline/cancellation, opt-in rules, jitter algorithms, `Retry-After` parsing and clamping.
- `RetryInterceptor` integration via MockWebServer: success, 4xx pass-through, budget exhaustion, pre-send retry on `POST`, `Retry-After` cap, `onRetry` callback.
- `ConnectionConfig` wiring: default wraps, `disabled()` skips wrapping.

### Build verification

```bash
cd sdks/sandbox/kotlin
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew spotlessCheck :sandbox:test :code-interpreter:test
# BUILD SUCCESSFUL, 271 tests passed
```

## Docs

- `docs/sdks/kotlin.md`: added `retryPolicy` row to connection config table, and new "Automatic retries" section with code examples.

## Non-goals

Same as OSEP-0016: no server-side change, no SSE stream resume, no circuit breaker.

## Related

- OSEP: [#1368](https://github.com/opensandbox-group/OpenSandbox/pull/1368)
- Python: [#1372](https://github.com/opensandbox-group/OpenSandbox/pull/1372)