### PR TITLE
feat(execd): add plumbing for OSEP-0018 execd as sandbox init

### DIFF
--- a/components/execd/bootstrap.sh
+++ b/components/execd/bootstrap.sh
@@ -292,10 +292,7 @@ if [ -n "${EXECD_BOOTSTRAP_PRE_SCRIPT:-}" ]; then
 	fi
 fi
 
-echo "starting OpenSandbox Execd daemon at $EXECD."
-$EXECD &
-
-# Allow chained shell commands (e.g., /test1.sh && /test2.sh)
+# Normalize the user command (shared by both init and non-init paths).
 # Usage:
 #   bootstrap.sh -c "/test1.sh && /test2.sh"
 # Or set BOOTSTRAP_CMD="/test1.sh && /test2.sh"
@@ -319,18 +316,22 @@ if [ -z "$SHELL_BIN" ]; then
 	fi
 fi
 
+# Normalize into positional args so both branches see the same argv shape.
 if [ "$CMD" != "" ]; then
-	"$SHELL_BIN" -c "$CMD" &
-	CMD_PID=$!
+	set -- "$SHELL_BIN" -c "$CMD"
 elif [ $# -eq 0 ]; then
-	"$SHELL_BIN" &
-	CMD_PID=$!
-else
-	"$@" &
-	CMD_PID=$!
+	set -- "$SHELL_BIN"
 fi
 
-trap '_forward_signal TERM "$CMD_PID"' TERM
-
-wait "$CMD_PID" 2>/dev/null
-exit $?
+if is_truthy "${EXECD_INIT:-}"; then
+	echo "starting OpenSandbox Execd as sandbox init (PID 1)."
+	exec "$EXECD" --init -- "$@"
+else
+	echo "starting OpenSandbox Execd daemon at $EXECD."
+	"$EXECD" &
+	"$@" &
+	CMD_PID=$!
+	trap '_forward_signal TERM "$CMD_PID"' TERM
+	wait "$CMD_PID" 2>/dev/null
+	exit $?
+fi

--- a/components/execd/cmd/launcher/main.go
+++ b/components/execd/cmd/launcher/main.go
@@ -1,0 +1,329 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type launcherPolicy struct {
+	KeepCaps  []string `json:"keep_caps"`
+	TargetUID uint32   `json:"target_uid"`
+	TargetGID uint32   `json:"target_gid"`
+	StripEnv  []string `json:"strip_env"`
+}
+
+func main() {
+	var (
+		policyB64  string
+		seccompB64 string
+	)
+	flag.StringVar(&policyB64, "policy", "", "base64-encoded hardening policy JSON")
+	flag.StringVar(&seccompB64, "seccomp", "", "base64-encoded seccomp BPF (or 'none')")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "launcher: no command provided")
+		os.Exit(125)
+	}
+
+	policy, err := decodePolicy(policyB64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: policy: %v\n", err)
+		os.Exit(125)
+	}
+
+	bpf, err := decodeSeccomp(seccompB64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: seccomp: %v\n", err)
+		os.Exit(125)
+	}
+
+	if err := applyHardening(policy, bpf); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: %v\n", err)
+		os.Exit(125)
+	}
+
+	argv0, err := exec.LookPath(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: %s: %v\n", args[0], err)
+		os.Exit(126)
+	}
+
+	if err := syscall.Exec(argv0, args, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: exec %s: %v\n", argv0, err)
+		os.Exit(126)
+	}
+}
+
+func decodePolicy(b64 string) (*launcherPolicy, error) {
+	if b64 == "" {
+		return &launcherPolicy{}, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	p := &launcherPolicy{}
+	if err := json.Unmarshal(raw, p); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	return p, nil
+}
+
+func decodeSeccomp(b64 string) ([]byte, error) {
+	if b64 == "" || b64 == "none" {
+		return nil, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return raw, nil
+}
+
+func applyHardening(p *launcherPolicy, bpf []byte) error {
+	// Step 0: strip credential env vars.
+	for _, key := range p.StripEnv {
+		_ = os.Unsetenv(key)
+	}
+
+	// Step 1: keep capabilities across UID change.
+	if err := unix.Prctl(unix.PR_SET_KEEPCAPS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("PR_SET_KEEPCAPS: %w", err)
+	}
+
+	// Step 2: trim bounding set for caps not in KeepCaps.
+	if err := dropBoundingCaps(p.KeepCaps); err != nil {
+		return fmt.Errorf("trim bounding set: %w", err)
+	}
+
+	// Step 3: no_new_privs.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("PR_SET_NO_NEW_PRIVS: %w", err)
+	}
+
+	// Step 4: drop identity.
+	if err := dropIdentity(p.TargetUID, p.TargetGID); err != nil {
+		return fmt.Errorf("drop identity: %w", err)
+	}
+
+	// Step 5: set ambient capabilities.
+	if err := raiseAmbientCaps(p.KeepCaps); err != nil {
+		return fmt.Errorf("ambient caps: %w", err)
+	}
+
+	// Step 6: seccomp (LAST — never blocks launcher's own setup calls).
+	if len(bpf) > 0 {
+		if err := installSeccomp(bpf); err != nil {
+			return fmt.Errorf("seccomp: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func dropBoundingCaps(keep []string) error {
+	keepSet := make(map[string]struct{}, len(keep))
+	for _, c := range keep {
+		keepSet[c] = struct{}{}
+	}
+	for name, cv := range capNameToValue {
+		if _, ok := keepSet[name]; ok {
+			continue
+		}
+		if err := unix.Prctl(unix.PR_CAPBSET_DROP, uintptr(cv), 0, 0, 0); err != nil {
+			if err == unix.EINVAL {
+				continue // cap not in bounding set
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func dropIdentity(uid, gid uint32) error {
+	if err := syscall.Setgroups(nil); err != nil {
+		return err
+	}
+	if err := syscall.Setgid(int(gid)); err != nil {
+		return err
+	}
+	if err := syscall.Setuid(int(uid)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func raiseAmbientCaps(keep []string) error {
+	for _, name := range keep {
+		cv, ok := capNameToValue[name]
+		if !ok {
+			continue
+		}
+
+		caps := unix.CapUserHeader{
+			Version: unix.LINUX_CAPABILITY_VERSION_3,
+			Pid:     0,
+		}
+		var data capUserV3
+		if err := capgetV3(&caps, &data); err != nil {
+			return fmt.Errorf("capget: %w", err)
+		}
+		setCapBitV3(&data, cv)
+		if err := capsetV3(&caps, &data); err != nil {
+			return fmt.Errorf("capset %s: %w", name, err)
+		}
+
+		if err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_RAISE, uintptr(cv), 0, 0); err != nil {
+			return fmt.Errorf("ambient raise %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func capgetV3(hdr *unix.CapUserHeader, data *capUserV3) error {
+	_, _, e1 := unix.Syscall(unix.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}
+
+func capsetV3(hdr *unix.CapUserHeader, data *capUserV3) error {
+	_, _, e1 := unix.Syscall(unix.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		return e1
+	}
+	atomic.StoreUint32(&hdr.Version, unix.LINUX_CAPABILITY_VERSION_3)
+	return nil
+}
+
+// capUserV3 mirrors the kernel v3 capability layout: an array of two
+// records, each {effective, permitted, inheritable}. Caps 0–31 are in
+// record [0]; caps 32–63 in record [1].
+type capUserV3 [2]struct {
+	Effective   uint32
+	Permitted   uint32
+	Inheritable uint32
+}
+
+func setCapBitV3(v3 *capUserV3, cv uintptr) {
+	idx := 0
+	if cv >= 32 {
+		idx = 1
+		cv -= 32
+	}
+	bit := uint32(1) << cv
+	v3[idx].Effective |= bit
+	v3[idx].Permitted |= bit
+	v3[idx].Inheritable |= bit
+}
+
+func installSeccomp(bpf []byte) error {
+	n := len(bpf) / 8
+	filters := make([]unix.SockFilter, n)
+	for i := range n {
+		off := i * 8
+		filters[i] = unix.SockFilter{
+			Code: uint16(bpf[off]) | uint16(bpf[off+1])<<8,
+			Jt:   bpf[off+2],
+			Jf:   bpf[off+3],
+			K:    uint32(bpf[off+4]) | uint32(bpf[off+5])<<8 | uint32(bpf[off+6])<<16 | uint32(bpf[off+7])<<24,
+		}
+	}
+	prog := unix.SockFprog{
+		Len:    uint16(n),
+		Filter: &filters[0],
+	}
+	return unix.Prctl(
+		unix.PR_SET_SECCOMP,
+		unix.SECCOMP_MODE_FILTER,
+		uintptr(unsafe.Pointer(&prog)),
+		0,
+		0,
+	)
+}
+
+// capNameToValue maps capability string names (as used in the isolation TOML
+// and seccomp_gen.go) to their numeric values. Linux capability values are
+// stable ABI; this table is the authoritative mapping for the subset that
+// operators may want to retain via KeepCaps.
+var capNameToValue = map[string]uintptr{
+	"CAP_CHOWN":              0,
+	"CAP_DAC_OVERRIDE":       1,
+	"CAP_DAC_READ_SEARCH":    2,
+	"CAP_FOWNER":             3,
+	"CAP_FSETID":             4,
+	"CAP_KILL":               5,
+	"CAP_SETGID":             6,
+	"CAP_SETUID":             7,
+	"CAP_SETPCAP":            8,
+	"CAP_LINUX_IMMUTABLE":    9,
+	"CAP_NET_BIND_SERVICE":   10,
+	"CAP_NET_BROADCAST":      11,
+	"CAP_NET_ADMIN":          12,
+	"CAP_NET_RAW":            13,
+	"CAP_IPC_LOCK":           14,
+	"CAP_IPC_OWNER":          15,
+	"CAP_SYS_MODULE":         16,
+	"CAP_SYS_RAWIO":          17,
+	"CAP_SYS_CHROOT":         18,
+	"CAP_SYS_PTRACE":         19,
+	"CAP_SYS_PACCT":          20,
+	"CAP_SYS_ADMIN":          21,
+	"CAP_SYS_BOOT":           22,
+	"CAP_SYS_NICE":           23,
+	"CAP_SYS_RESOURCE":       24,
+	"CAP_SYS_TIME":           25,
+	"CAP_SYS_TTY_CONFIG":     26,
+	"CAP_MKNOD":              27,
+	"CAP_LEASE":              28,
+	"CAP_AUDIT_WRITE":        29,
+	"CAP_AUDIT_CONTROL":      30,
+	"CAP_SETFCAP":            31,
+	"CAP_MAC_OVERRIDE":       32,
+	"CAP_MAC_ADMIN":          33,
+	"CAP_SYSLOG":             34,
+	"CAP_WAKE_ALARM":         35,
+	"CAP_BLOCK_SUSPEND":      36,
+	"CAP_AUDIT_READ":         37,
+	"CAP_PERFMON":            38,
+	"CAP_BPF":                39,
+	"CAP_CHECKPOINT_RESTORE": 40,
+}
+
+// allCaps lists every known capability name for bounding-set drop. Every cap
+// is dropped unless explicitly listed in KeepCaps.
+var allCaps []string
+
+func init() {
+	for name := range capNameToValue {
+		allCaps = append(allCaps, name)
+	}
+}

--- a/components/execd/configs/isolation.example.toml
+++ b/components/execd/configs/isolation.example.toml
@@ -82,3 +82,37 @@ allowed_writable = ["/workspace", "/mnt", "/media", "/data"]
 #   # Other potentially dangerous
 #   "userfaultfd", "kexec_load", "kexec_file_load", "acct",
 # ]
+
+# === Hardening: run all user code through a reduced privilege floor ===
+#
+# When enabled, execd becomes the sandbox init (PID 1) and every user-code
+# process (entrypoint, /command, /code, PTY) is launched through a pre-exec
+# prelude that drops capabilities, sets no_new_privs, and installs the seccomp
+# filter. Landlock FS confinement and eBPF audit are additive and enabled
+# separately below.
+#
+# [hardening]
+# enabled = false
+# keep_capabilities = []   # capabilities retained by the workload (default: drop all)
+
+# === Landlock: filesystem confinement ===
+#
+# Adds filesystem access control on top of [hardening]. Requires Linux >= 5.13.
+# Missing kernel support is non-fatal (fail-open): the layer degrades and the
+# sandbox starts without FS confinement.
+#
+# [landlock]
+# enabled = false
+# extra_readable = []      # additional readable paths beyond the built-in set
+# extra_writable = []      # additional writable paths beyond the built-in set
+
+# === eBPF: syscall audit observation ===
+#
+# Records exec/connect/privilege events to a rotating JSONL audit file.
+# Requires CAP_BPF, a BTF kernel (>=5.8), and the execd-ebpf build variant.
+# Observation only — enforcement stays with seccomp and the egress sidecar.
+#
+# [ebpf]
+# enabled = false
+# observe = ["exec", "connect", "privilege"]
+# audit_file = "/var/log/opensandbox/ebpf-audit.jsonl"

--- a/components/execd/main.go
+++ b/components/execd/main.go
@@ -60,6 +60,11 @@ func main() {
 
 	log.Init(flag.ServerLogLevel)
 
+	// Init hardening launcher (fail-open: degrades gracefully on any error).
+	if err := isolation.InitLauncher(isoCfg); err != nil {
+		log.Warn("hardening: init failed (continuing without hardening): %v", err)
+	}
+
 	ctrl := controller.InitCodeRunner()
 
 	// Always store probe result for capabilities endpoint.
@@ -94,6 +99,12 @@ func main() {
 
 	engine := web.NewRouter(flag.ServerAccessToken)
 	addr := fmt.Sprintf(":%d", flag.ServerPort)
+
+	if flag.InitMode {
+		runtime.RunInit(engine, addr, flag.Args)
+		return
+	}
+
 	listener, err := net.Listen("tcp4", addr)
 	if err != nil {
 		log.Error("failed to listen on %s: %v", addr, err)

--- a/components/execd/pkg/flag/flags.go
+++ b/components/execd/pkg/flag/flags.go
@@ -46,4 +46,9 @@ var (
 	// InitMode makes execd the sandbox init (PID 1) when true.
 	// Set via --init or EXECD_INIT=true env var.
 	InitMode bool
+
+	// Args holds the non-flag command-line arguments captured after flag.Parse().
+	// In init mode these are the user entrypoint command and its arguments (the
+	// portion after -- on the execd command line).
+	Args []string
 )

--- a/components/execd/pkg/flag/flags.go
+++ b/components/execd/pkg/flag/flags.go
@@ -42,4 +42,8 @@ var (
 	// IsolationConfigPath points to the TOML isolation config file.
 	// Empty means use built-in defaults.
 	IsolationConfigPath string
+
+	// InitMode makes execd the sandbox init (PID 1) when true.
+	// Set via --init or EXECD_INIT=true env var.
+	InitMode bool
 )

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -105,6 +105,7 @@ func InitFlags() {
 
 	// Parse flags - these will override environment variables if provided
 	flag.Parse()
+	Args = flag.Args()
 	if JupyterIdlePollInterval <= 0 {
 		stdlog.Printf("Invalid --jupyter-idle-poll-interval=%s; fallback to default %s", JupyterIdlePollInterval, 100*time.Millisecond)
 		JupyterIdlePollInterval = 100 * time.Millisecond

--- a/components/execd/pkg/flag/parser.go
+++ b/components/execd/pkg/flag/parser.go
@@ -95,6 +95,14 @@ func InitFlags() {
 	}
 	flag.StringVar(&IsolationConfigPath, "isolation-config", IsolationConfigPath, "Path to isolation TOML config file (default: built-in defaults)")
 
+	// Init mode: execd as sandbox init (PID 1).
+	// Gated by EXECD_INIT env (set by bootstrap.sh before exec); the flag
+	// exists so execd can also be launched directly with --init.
+	if v := os.Getenv("EXECD_INIT"); v != "" {
+		InitMode = isTruthyEnv(v)
+	}
+	flag.BoolVar(&InitMode, "init", InitMode, "Run as sandbox init (PID 1)")
+
 	// Parse flags - these will override environment variables if provided
 	flag.Parse()
 	if JupyterIdlePollInterval <= 0 {
@@ -105,4 +113,16 @@ func InitFlags() {
 	// Log final values
 	log.Info("Jupyter server host is: %s", JupyterServerHost)
 	log.Info("Jupyter server token is: %s", log.MaskToken(JupyterServerToken))
+}
+
+// isTruthyEnv reports whether v is a truthy value for an env-var boolean
+// (1, true, yes, on — case-insensitive). Used for env vars that gate feature
+// flags before the flag package would normally parse them.
+func isTruthyEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/components/execd/pkg/isolation/config.go
+++ b/components/execd/pkg/isolation/config.go
@@ -110,3 +110,19 @@ func LoadConfig(path string) (Config, error) {
 
 	return cfg, nil
 }
+
+// ValidateSeccompDeny checks that the seccomp deny override does not include
+// the launcher's exec syscall (execve), which would block the launcher's
+// own final transition into the workload. Only execve is reserved; execveat
+// stays valid (the launcher does not use it).
+func ValidateSeccompDeny(override *SeccompOverride) error {
+	if override == nil {
+		return nil
+	}
+	for _, name := range override.Deny {
+		if name == "execve" {
+			return fmt.Errorf("seccomp deny list must not include %q: the launcher uses execve to transition into the workload; use execveat if you need to deny exec variants", name)
+		}
+	}
+	return nil
+}

--- a/components/execd/pkg/isolation/config.go
+++ b/components/execd/pkg/isolation/config.go
@@ -34,13 +34,39 @@ type Config struct {
 	// Seccomp overrides the built-in syscall denylist. When nil (i.e. the
 	// [seccomp] section is absent), the built-in denylist is used. When
 	// present, Deny completely replaces the built-in list — no merging.
-	Seccomp *SeccompOverride `toml:"seccomp"`
+	Seccomp   *SeccompOverride `toml:"seccomp"`
+	Hardening *HardeningConfig `toml:"hardening"`
+	Landlock  *LandlockConfig  `toml:"landlock"`
+	Ebpf      *EbpfConfig      `toml:"ebpf"`
 }
 
 // SeccompOverride specifies a custom syscall denylist that replaces the
 // built-in default when present.
 type SeccompOverride struct {
 	Deny []string `toml:"deny"`
+}
+
+// HardeningConfig controls the pre-exec privilege floor applied to all
+// user-code processes. Gated behind [hardening] enabled.
+type HardeningConfig struct {
+	Enabled          bool     `toml:"enabled"`
+	KeepCapabilities []string `toml:"keep_capabilities"`
+}
+
+// LandlockConfig controls filesystem confinement (Linux >= 5.13).
+// Gated behind [landlock] enabled.
+type LandlockConfig struct {
+	Enabled       bool     `toml:"enabled"`
+	ExtraWritable []string `toml:"extra_writable"`
+	ExtraReadable []string `toml:"extra_readable"`
+}
+
+// EbpfConfig controls exec/connect/privilege audit observation.
+// Gated behind [ebpf] enabled; requires the execd-ebpf build variant.
+type EbpfConfig struct {
+	Enabled   bool     `toml:"enabled"`
+	Observe   []string `toml:"observe"`
+	AuditFile string   `toml:"audit_file"`
 }
 
 // DefaultConfig returns the built-in defaults used when no config file is
@@ -52,6 +78,9 @@ func DefaultConfig() Config {
 		DiffMaxBytes:    4 * 1024 * 1024 * 1024, // 4 GiB
 		AllowedWritable: []string{"/workspace", "/mnt", "/media", "/data"},
 		Seccomp:         nil, // use built-in denylist
+		Hardening:       &HardeningConfig{},
+		Landlock:        &LandlockConfig{},
+		Ebpf:            &EbpfConfig{Observe: []string{"exec", "connect", "privilege"}, AuditFile: "/var/log/opensandbox/ebpf-audit.jsonl"},
 	}
 }
 

--- a/components/execd/pkg/isolation/config_test.go
+++ b/components/execd/pkg/isolation/config_test.go
@@ -30,6 +30,18 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, int64(4*1024*1024*1024), cfg.DiffMaxBytes)
 	assert.Equal(t, []string{"/workspace", "/mnt", "/media", "/data"}, cfg.AllowedWritable)
 	assert.Nil(t, cfg.Seccomp)
+
+	require.NotNil(t, cfg.Hardening)
+	assert.False(t, cfg.Hardening.Enabled)
+	assert.Empty(t, cfg.Hardening.KeepCapabilities)
+
+	require.NotNil(t, cfg.Landlock)
+	assert.False(t, cfg.Landlock.Enabled)
+
+	require.NotNil(t, cfg.Ebpf)
+	assert.False(t, cfg.Ebpf.Enabled)
+	assert.Equal(t, []string{"exec", "connect", "privilege"}, cfg.Ebpf.Observe)
+	assert.Equal(t, "/var/log/opensandbox/ebpf-audit.jsonl", cfg.Ebpf.AuditFile)
 }
 
 func TestLoadConfig_EmptyPath(t *testing.T) {
@@ -131,4 +143,67 @@ func writeTempTOML(t *testing.T, content string) string {
 	path := filepath.Join(t.TempDir(), "isolation.toml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 	return path
+}
+
+func TestLoadConfig_Hardening(t *testing.T) {
+	content := `
+[hardening]
+enabled = true
+keep_capabilities = ["CAP_NET_BIND_SERVICE"]
+`
+	path := writeTempTOML(t, content)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Hardening)
+	assert.True(t, cfg.Hardening.Enabled)
+	assert.Equal(t, []string{"CAP_NET_BIND_SERVICE"}, cfg.Hardening.KeepCapabilities)
+}
+
+func TestLoadConfig_Landlock(t *testing.T) {
+	content := `
+[landlock]
+enabled = true
+extra_readable = ["/opt/app"]
+extra_writable = ["/var/cache"]
+`
+	path := writeTempTOML(t, content)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Landlock)
+	assert.True(t, cfg.Landlock.Enabled)
+	assert.Equal(t, []string{"/opt/app"}, cfg.Landlock.ExtraReadable)
+	assert.Equal(t, []string{"/var/cache"}, cfg.Landlock.ExtraWritable)
+}
+
+func TestLoadConfig_Ebpf(t *testing.T) {
+	content := `
+[ebpf]
+enabled = true
+observe = ["exec", "connect"]
+audit_file = "/var/log/audit.jsonl"
+`
+	path := writeTempTOML(t, content)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Ebpf)
+	assert.True(t, cfg.Ebpf.Enabled)
+	assert.Equal(t, []string{"exec", "connect"}, cfg.Ebpf.Observe)
+	assert.Equal(t, "/var/log/audit.jsonl", cfg.Ebpf.AuditFile)
+}
+
+func TestLoadConfig_HardeningDefaultOff(t *testing.T) {
+	content := `upper_root = "/data/iso"`
+	path := writeTempTOML(t, content)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Hardening)
+	assert.False(t, cfg.Hardening.Enabled, "[hardening] absent → enabled=false")
+	require.NotNil(t, cfg.Landlock)
+	assert.False(t, cfg.Landlock.Enabled)
+	require.NotNil(t, cfg.Ebpf)
+	assert.False(t, cfg.Ebpf.Enabled)
 }

--- a/components/execd/pkg/isolation/config_test.go
+++ b/components/execd/pkg/isolation/config_test.go
@@ -207,3 +207,27 @@ func TestLoadConfig_HardeningDefaultOff(t *testing.T) {
 	require.NotNil(t, cfg.Ebpf)
 	assert.False(t, cfg.Ebpf.Enabled)
 }
+
+func TestValidateSeccompDeny_ExecveRejected(t *testing.T) {
+	override := &SeccompOverride{Deny: []string{"mount", "execve", "ptrace"}}
+	err := ValidateSeccompDeny(override)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execve")
+}
+
+func TestValidateSeccompDeny_ExecveatAllowed(t *testing.T) {
+	override := &SeccompOverride{Deny: []string{"mount", "execveat", "ptrace"}}
+	err := ValidateSeccompDeny(override)
+	assert.NoError(t, err)
+}
+
+func TestValidateSeccompDeny_NilOverride(t *testing.T) {
+	err := ValidateSeccompDeny(nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateSeccompDeny_EmptyDeny(t *testing.T) {
+	override := &SeccompOverride{Deny: []string{}}
+	err := ValidateSeccompDeny(override)
+	assert.NoError(t, err)
+}

--- a/components/execd/pkg/isolation/hardening.go
+++ b/components/execd/pkg/isolation/hardening.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package isolation
+
+// HardeningLayerState describes the current enforcement state of a hardening
+// layer. Every layer is best-effort and fail-open: a layer that cannot be
+// applied reports degraded or unsupported rather than aborting startup.
+type HardeningLayerState string
+
+const (
+	HardeningActive      HardeningLayerState = "active"
+	HardeningDisabled    HardeningLayerState = "disabled"
+	HardeningDegraded    HardeningLayerState = "degraded"
+	HardeningUnsupported HardeningLayerState = "unsupported"
+)
+
+// HardeningLayer reports the enforcement state and diagnostic message for a
+// single hardening layer. Message is populated when state is not active.
+type HardeningLayer struct {
+	State   HardeningLayerState `json:"state"`
+	Message string              `json:"message,omitempty"`
+}
+
+// HardeningProbe reports the result of startup hardening capability probing.
+// Returned on the capabilities endpoint so callers see what is actually
+// enforced. Every layer reports the best-effort state; a missing prerequisite
+// degrades that layer and includes a diagnostic message.
+type HardeningProbe struct {
+	InitMode     string         `json:"init_mode"`     // "pid1" | "subreaper" | "none"
+	SignalShield bool           `json:"signal_shield"` // kernel PID 1 signal shield active
+	CapDrop      HardeningLayer `json:"cap_drop"`
+	Seccomp      HardeningLayer `json:"seccomp"`
+	Landlock     HardeningLayer `json:"landlock"`
+	Ebpf         HardeningLayer `json:"ebpf"`
+}
+
+// NewHardeningProbe returns a probe with every layer disabled (the default
+// state when no hardening is configured or the feature is off).
+func NewHardeningProbe() HardeningProbe {
+	return HardeningProbe{
+		InitMode:     "none",
+		SignalShield: false,
+		CapDrop:      HardeningLayer{State: HardeningDisabled},
+		Seccomp:      HardeningLayer{State: HardeningDisabled},
+		Landlock:     HardeningLayer{State: HardeningDisabled},
+		Ebpf:         HardeningLayer{State: HardeningDisabled},
+	}
+}

--- a/components/execd/pkg/isolation/launcher.go
+++ b/components/execd/pkg/isolation/launcher.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package isolation
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
+)
+
+// ErrHardeningDisabled is returned by LaunchWithHardening when hardening is
+// not enabled. Callers should treat this as a signal to fall back to a plain
+// exec.Command.
+var ErrHardeningDisabled = errors.New("hardening: disabled")
+
+// HardeningPolicy carries the pre-exec hardening parameters applied by the
+// native launcher before every user-code process.
+type HardeningPolicy struct {
+	KeepCaps  []string `json:"keep_caps"`
+	TargetUID uint32   `json:"target_uid"`
+	TargetGID uint32   `json:"target_gid"`
+	StripEnv  []string `json:"strip_env"`
+}
+
+// execdCredentialEnv lists environment variables that carry execd's own
+// credentials and must be stripped from every user-code child.
+var execdCredentialEnv = []string{
+	"EXECD_ACCESS_TOKEN",
+	"JUPYTER_TOKEN",
+	"EXECD_ISOLATION_CONFIG",
+	"EXECD_ENVS",
+	"EXECD_LOG_FILE",
+	"EXECD_API_GRACE_SHUTDOWN",
+}
+
+// LaunchChild launches cmd through the native launcher with the given
+// hardening policy and seccomp filter. The launcher applies credential
+// stripping, cap drop, no_new_privs, identity drop, ambient caps, and
+// seccomp (in that order) before execve-ing the real command.
+//
+// launcherPath is the absolute path to the opensandbox-launcher binary.
+// seccompBPF is the raw BPF bytecode; nil means skip seccomp.
+func LaunchChild(launcherPath string, cmd []string, policy HardeningPolicy, seccompBPF []byte) (*exec.Cmd, error) {
+	if launcherPath == "" {
+		return nil, fmt.Errorf("launcher: path is empty")
+	}
+	if len(cmd) == 0 {
+		return nil, fmt.Errorf("launcher: no command provided")
+	}
+
+	policy.StripEnv = execdCredentialEnv
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("launcher: marshal policy: %w", err)
+	}
+	policyB64 := base64.StdEncoding.EncodeToString(policyJSON)
+
+	seccompB64 := "none"
+	if len(seccompBPF) > 0 {
+		seccompB64 = base64.StdEncoding.EncodeToString(seccompBPF)
+	}
+
+	argv := []string{launcherPath, "--policy", policyB64, "--seccomp", seccompB64, "--"}
+	argv = append(argv, cmd...)
+
+	ecmd := exec.Command(argv[0], argv[1:]...)
+	ecmd.Env = os.Environ()
+	return ecmd, nil
+}
+
+// FindLauncher returns the path to the launcher binary. It first checks the
+// directory of the running execd binary, then falls back to a known install
+// path.
+func FindLauncher() string {
+	execdPath, err := os.Executable()
+	if err == nil {
+		dir := filepath.Dir(execdPath)
+		candidate := filepath.Join(dir, "opensandbox-launcher")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	const installPath = "/opt/opensandbox/opensandbox-launcher"
+	if _, err := os.Stat(installPath); err == nil {
+		return installPath
+	}
+	return ""
+}
+
+// Package-level hardening state, initialised by InitLauncher at startup
+// and read by launch paths at request time.
+var (
+	hardeningEnabled bool
+	globalLauncher   string
+	globalSeccompBPF []byte
+	globalKeepCaps   []string
+	globalTargetUID  uint32
+	globalTargetGID  uint32
+)
+
+// InitLauncher initialises the hardening subsystem. It validates config,
+// generates seccomp BPF, resolves the launcher binary path, and probes
+// capability support. On any failure hardening is marked disabled and the
+// reason is logged — the sandbox continues with hardening off (fail-open).
+func InitLauncher(cfg Config) error {
+	if cfg.Hardening == nil || !cfg.Hardening.Enabled {
+		return nil
+	}
+
+	if err := ValidateSeccompDeny(cfg.Seccomp); err != nil {
+		log.Warn("hardening: seccomp validation failed, hardening disabled: %v", err)
+		return nil
+	}
+
+	lp := FindLauncher()
+	if lp == "" {
+		log.Warn("hardening: launcher binary not found (searched: $PWD, /opt/opensandbox/opensandbox-launcher), hardening disabled")
+		return nil
+	}
+
+	bpf, err := generateSeccompDenyBPF(cfg.Seccomp)
+	if err != nil {
+		log.Warn("hardening: seccomp BPF generation failed, hardening disabled: %v", err)
+		return nil
+	}
+
+	// Probe that execd holds the capabilities the launcher needs.
+	if !probeLauncherCaps() {
+		log.Warn("hardening: execd lacks required capabilities (need CAP_SETPCAP, CAP_SETUID, CAP_SETGID), hardening disabled")
+		return nil
+	}
+
+	uid := uint32(os.Getuid())
+	gid := uint32(os.Getgid())
+
+	hardeningEnabled = true
+	globalLauncher = lp
+	globalSeccompBPF = bpf
+	globalKeepCaps = cfg.Hardening.KeepCapabilities
+	globalTargetUID = uid
+	globalTargetGID = gid
+
+	log.Info("hardening: enabled launcher=%s target_uid=%d target_gid=%d seccomp=%v keep_caps=%v",
+		lp, uid, gid, len(bpf) > 0, globalKeepCaps)
+	return nil
+}
+
+// HardeningEnabled reports whether the hardening prelude is active.
+func HardeningEnabled() bool {
+	return hardeningEnabled
+}
+
+// LaunchWithHardening wraps args with the native launcher to apply the
+// pre-exec hardening prelude. Returns an *exec.Cmd that callers can
+// configure (stdout, stderr, env, dir, SysProcAttr) before calling Start.
+// When hardening is disabled, returns nil so callers fall back to a plain
+// exec.Command.
+func LaunchWithHardening(args []string) (*exec.Cmd, error) {
+	if !hardeningEnabled {
+		return nil, ErrHardeningDisabled
+	}
+	policy := HardeningPolicy{
+		KeepCaps:  globalKeepCaps,
+		TargetUID: globalTargetUID,
+		TargetGID: globalTargetGID,
+	}
+	return LaunchChild(globalLauncher, args, policy, globalSeccompBPF)
+}
+
+// probeLauncherCaps checks that execd holds the capabilities required by the
+// launcher prelude. Returns false (and logs) if any essential cap is missing.
+func probeLauncherCaps() bool {
+	required := map[string]uintptr{
+		"CAP_SETPCAP": 8,
+		"CAP_SETUID":  7,
+		"CAP_SETGID":  6,
+	}
+	for name, cv := range required {
+		if !hasCap(cv) {
+			log.Warn("hardening: missing capability %s (%d)", name, cv)
+			return false
+		}
+	}
+	return true
+}
+
+// hasCap reports whether the given capability (0–31) is in the current
+// process's effective set.
+func hasCap(cv uintptr) bool {
+	if cv >= 32 {
+		return false // not probeable via CapUserData alone
+	}
+	hdr := unix.CapUserHeader{
+		Version: unix.LINUX_CAPABILITY_VERSION_1,
+		Pid:     0,
+	}
+	var data unix.CapUserData
+	if err := unix.Capget(&hdr, &data); err != nil {
+		return false
+	}
+	return data.Effective&(1<<cv) != 0
+}

--- a/components/execd/pkg/isolation/launcher_stub.go
+++ b/components/execd/pkg/isolation/launcher_stub.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package isolation
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// ErrHardeningDisabled is returned by LaunchWithHardening on non-Linux
+// platforms (hardening is Linux-only).
+var ErrHardeningDisabled = errors.New("hardening: disabled")
+
+// InitLauncher is a no-op on non-Linux platforms.
+func InitLauncher(cfg Config) error { return nil }
+
+// HardeningEnabled always returns false on non-Linux.
+func HardeningEnabled() bool { return false }
+
+// LaunchWithHardening returns ErrHardeningDisabled on non-Linux.
+func LaunchWithHardening(args []string) (*exec.Cmd, error) { return nil, ErrHardeningDisabled }

--- a/components/execd/pkg/isolation/launcher_test.go
+++ b/components/execd/pkg/isolation/launcher_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package isolation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaunchChild_CmdEncoding(t *testing.T) {
+	policy := HardeningPolicy{
+		KeepCaps:  nil,
+		TargetUID: 1000,
+		TargetGID: 1000,
+	}
+	cmd, err := LaunchChild("/tmp/fake-launcher", []string{"/bin/echo", "hello"}, policy, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/fake-launcher", cmd.Path)
+
+	// Find the -- separator and verify the command args follow it.
+	args := cmd.Args
+	sepIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, sepIdx, 0)
+	userArgs := args[sepIdx+1:]
+	assert.Equal(t, []string{"/bin/echo", "hello"}, userArgs)
+}
+
+func TestLaunchChild_PolicyEncoded(t *testing.T) {
+	policy := HardeningPolicy{
+		KeepCaps:  []string{"CAP_NET_BIND_SERVICE"},
+		TargetUID: 65534,
+		TargetGID: 65534,
+	}
+	cmd, err := LaunchChild("/tmp/fake-launcher", []string{"/bin/sh"}, policy, []byte{0x00, 0x01})
+	require.NoError(t, err)
+
+	// Policy and seccomp should be base64-encoded in args, not plain text.
+	foundPolicy := false
+	foundSeccomp := false
+	for i, a := range cmd.Args {
+		if a == "--policy" && i+1 < len(cmd.Args) {
+			assert.NotEmpty(t, cmd.Args[i+1])
+			assert.NotContains(t, cmd.Args[i+1], "CAP_NET_BIND_SERVICE") // base64, not plain
+			foundPolicy = true
+		}
+		if a == "--seccomp" && i+1 < len(cmd.Args) {
+			assert.NotEmpty(t, cmd.Args[i+1])
+			assert.NotEqual(t, "none", cmd.Args[i+1])
+			foundSeccomp = true
+		}
+	}
+	assert.True(t, foundPolicy)
+	assert.True(t, foundSeccomp)
+}

--- a/components/execd/pkg/runtime/command.go
+++ b/components/execd/pkg/runtime/command.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/alibaba/opensandbox/internal/safego"
 
+	"github.com/alibaba/opensandbox/execd/pkg/isolation"
 	"github.com/alibaba/opensandbox/execd/pkg/jupyter/execute"
 	"github.com/alibaba/opensandbox/execd/pkg/log"
 	"github.com/alibaba/opensandbox/execd/pkg/util/pathutil"
@@ -122,6 +123,8 @@ func buildCredential(uid, gid *uint32) (*syscall.Credential, error) {
 }
 
 // runCommand executes shell commands and streams their output.
+//
+//nolint:gocognit
 func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest) error {
 	session := c.newContextID()
 
@@ -143,26 +146,36 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	// --noprofile/--norc are no-ops for `bash -c`, so shellCommand is not used here.
 	shell := getShell()
-	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
+
+	cmd, err := maybeHardenedCommand(shell, "-c", request.Code)
+	if err != nil {
+		return err
+	}
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
 		return fmt.Errorf("resolve request cwd %s: %w", request.Cwd, err)
 	}
 
-	// Configure credentials and process group
-	cred, err := buildCredential(request.Uid, request.Gid)
-	if err != nil {
-		return fmt.Errorf("failed to build credential: %w", err)
-	}
+	// Configure credentials and process group.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:    true,
-		Credential: cred,
+		Setpgid: true,
+	}
+	if !isolation.HardeningEnabled() {
+		cred, err := buildCredential(request.Uid, request.Gid)
+		if err != nil {
+			return fmt.Errorf("failed to build credential: %w", err)
+		}
+		cmd.SysProcAttr.Credential = cred
 	}
 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
+	if isolation.HardeningEnabled() {
+		cmd.Env = mergeEnvs(cmd.Env, extraEnv)
+	} else {
+		cmd.Env = mergeEnvs(os.Environ(), extraEnv)
+	}
 	cmd.Dir = cwd
 
 	done := make(chan struct{}, 1)
@@ -177,7 +190,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		c.tailStdPipe(stderrPath, request.Hooks.OnExecuteStderr, done)
 	})
 
-	err = cmd.Start()
+	mp, err := startManagedProcessCmd(cmd)
 	if err != nil {
 		close(done)
 		wg.Wait()
@@ -192,7 +205,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 	}
 
 	kernel := &commandKernel{
-		pid:          cmd.Process.Pid,
+		pid:          mp.Pid(),
 		stdoutPath:   stdoutPath,
 		stderrPath:   stderrPath,
 		startedAt:    startAt,
@@ -207,62 +220,40 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		for {
 			select {
 			case <-done:
-				// cmd.Wait() has returned (or start failed). The pid is
-				// about to be — or already has been — reaped, so we
-				// must not signal it. Execute()'s defer cancel() fires
-				// after every foreground command, including successful
-				// ones, so without this gate the SIGKILL below would
-				// run on a recycled pid/pgid and could kill an
-				// unrelated process group.
 				return
 			case <-ctx.Done():
-				// Re-check `done` to avoid a race with cmd.Wait()
-				// returning concurrently. If cmd.Wait() has just
-				// finished, the leader pid may be reaped and recycled
-				// at any moment; signaling -pid would then target a
-				// foreign process group.
 				select {
 				case <-done:
 					return
 				default:
 				}
-				// Genuine cancellation (timeout, client disconnect,
-				// Interrupt). Kill the whole process group so children
-				// don't outlive the cancelled context.
-				if cmd.Process != nil {
-					_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-				}
+				_ = mp.Signal(syscall.SIGKILL)
 				return
 			case sig := <-signals:
 				if sig == nil {
 					continue
 				}
-				// DO NOT forward syscall.SIGURG to children processes.
 				if sig != syscall.SIGCHLD && sig != syscall.SIGURG {
-					_ = syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
+					_ = mp.Signal(sig.(syscall.Signal))
 				}
 			}
 		}
 	})
 
-	err = cmd.Wait()
+	err = mp.Wait()
 	close(done)
 	wg.Wait()
 	if err != nil {
 		var eName, eValue string
-		var eCode int
 		var traceback []string
 
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			exitCode := exitError.ExitCode()
 			eName = "CommandExecError"
-			eValue = strconv.Itoa(exitCode)
-			eCode = exitCode
+			eValue = strconv.Itoa(mp.ExitCode())
 		} else {
 			eName = "CommandExecError"
 			eValue = err.Error()
-			eCode = 1
 		}
 		traceback = []string{err.Error()}
 
@@ -273,7 +264,7 @@ func (c *Controller) runCommand(ctx context.Context, request *ExecuteCodeRequest
 		})
 
 		log.Error("CommandExecError: error running commands: %v", err)
-		c.markCommandFinished(session, eCode, err.Error())
+		c.markCommandFinished(session, mp.ExitCode(), err.Error())
 		return nil
 	}
 
@@ -304,7 +295,12 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	log.Info("received command: %v", log.SanitizeCommand(request.Code))
 	// --noprofile/--norc are no-ops for `bash -c`, so shellCommand is not used here.
 	shell := getShell()
-	cmd := exec.CommandContext(ctx, shell, "-c", request.Code)
+
+	cmd, err := maybeHardenedCommand(shell, "-c", request.Code)
+	if err != nil {
+		cancel()
+		return err
+	}
 	extraEnv := mergeExtraEnvs(loadExtraEnvFromFile(), request.Envs)
 	cwd, err := pathutil.ExpandPathWithEnv(request.Cwd, extraEnv)
 	if err != nil {
@@ -312,20 +308,25 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 		return fmt.Errorf("resolve cwd: %w", err)
 	}
 	cmd.Dir = cwd
-	// Configure credentials and process group
-	cred, err := buildCredential(request.Uid, request.Gid)
-	if err != nil {
-		cancel()
-		return fmt.Errorf("build credential: %w", err)
-	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:    true,
-		Credential: cred,
+		Setpgid: true,
+	}
+	if !isolation.HardeningEnabled() {
+		cred, err := buildCredential(request.Uid, request.Gid)
+		if err != nil {
+			cancel()
+			return fmt.Errorf("build credential: %w", err)
+		}
+		cmd.SysProcAttr.Credential = cred
 	}
 
 	cmd.Stdout = pipe
 	cmd.Stderr = pipe
-	cmd.Env = mergeEnvs(os.Environ(), extraEnv)
+	if isolation.HardeningEnabled() {
+		cmd.Env = mergeEnvs(cmd.Env, extraEnv)
+	} else {
+		cmd.Env = mergeEnvs(os.Environ(), extraEnv)
+	}
 
 	// use DevNull as stdin so interactive programs exit immediately.
 	devNull, err := os.Open(os.DevNull)
@@ -334,7 +335,7 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 		defer devNull.Close()
 	}
 
-	err = cmd.Start()
+	mp, err := startManagedProcessCmd(cmd)
 	kernel := &commandKernel{
 		pid:          -1,
 		stdoutPath:   stdoutPath,
@@ -357,22 +358,17 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	// can find the session immediately after Execute returns. Previously
 	// this happened inside the goroutine, creating a race where the HTTP
 	// handler could return before the kernel was stored.
-	kernel.pid = cmd.Process.Pid
+	kernel.pid = mp.Pid()
 	c.storeCommandKernel(session, kernel)
 
 	safego.Go(func() {
 		defer pipe.Close()
 
-		err = cmd.Wait()
+		err = mp.Wait()
 		cancel()
 		if err != nil {
 			log.Error("CommandExecError: error running commands: %v", err)
-			exitCode := 1
-			var exitError *exec.ExitError
-			if errors.As(err, &exitError) {
-				exitCode = exitError.ExitCode()
-			}
-			c.markCommandFinished(session, exitCode, err.Error())
+			c.markCommandFinished(session, mp.ExitCode(), err.Error())
 			return
 		}
 		c.markCommandFinished(session, 0, "")
@@ -381,11 +377,24 @@ func (c *Controller) runBackgroundCommand(ctx context.Context, cancel context.Ca
 	// ensure we kill the whole process group if the context is cancelled (e.g., timeout).
 	safego.Go(func() {
 		<-ctx.Done()
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) // best-effort
-		}
+		_ = mp.Signal(syscall.SIGKILL) // best-effort
 	})
 
 	request.Hooks.OnExecuteComplete(time.Since(startAt))
 	return nil
+}
+
+// maybeHardenedCommand returns a command wrapped through the hardening launcher
+// when [hardening] is enabled, or a plain command otherwise. Context
+// cancellation is handled by the caller's signal goroutines; this function
+// does NOT use exec.CommandContext to avoid double-kill on context done.
+func maybeHardenedCommand(name string, args ...string) (*exec.Cmd, error) {
+	hcmd, err := isolation.LaunchWithHardening(append([]string{name}, args...))
+	if err != nil && !errors.Is(err, isolation.ErrHardeningDisabled) {
+		return nil, fmt.Errorf("hardening launch: %w", err)
+	}
+	if hcmd != nil {
+		return hcmd, nil
+	}
+	return exec.Command(name, args...), nil
 }

--- a/components/execd/pkg/runtime/entrypoint.go
+++ b/components/execd/pkg/runtime/entrypoint.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/alibaba/opensandbox/execd/pkg/isolation"
+	"github.com/alibaba/opensandbox/execd/pkg/log"
+)
+
+// entrypointSignals lists the signals that execd forwards to the entrypoint
+// process group when running as the sandbox init (PID 1).
+var entrypointSignals = []os.Signal{
+	syscall.SIGTERM,
+	syscall.SIGHUP,
+	syscall.SIGUSR1,
+	syscall.SIGUSR2,
+	syscall.SIGWINCH,
+}
+
+const (
+	shutdownGracePeriod = 5 * time.Second
+)
+
+// RunInit is the init-mode main loop. It starts the HTTP server in a
+// background goroutine, then launches the user entrypoint as a managed child.
+// It reaps orphans, forwards signals, and exits with the entrypoint's exit
+// code when the entrypoint finishes.
+//
+// The server listens on the given addr. If addr is empty, the server is
+// skipped (useful for smoke tests that just need the init loop).
+//
+// args are the user command and its arguments (after -- on the execd command
+// line). If args is empty, no entrypoint is launched and execd exits 0.
+func RunInit(engine interface{ RunListener(net.Listener) error }, addr string, args []string) {
+	initMode := "subreaper"
+	if os.Getpid() == 1 {
+		initMode = "pid1"
+	}
+	log.Info("execd init: mode=%s pid=%d", initMode, os.Getpid())
+
+	if os.Getpid() != 1 {
+		if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+			log.Warn("execd init: PR_SET_CHILD_SUBREAPER failed (proceeding): %v", err)
+		}
+	}
+
+	StartReaper()
+
+	if addr != "" {
+		listener, err := net.Listen("tcp4", addr)
+		if err != nil {
+			log.Error("execd init: listen on %s: %v", addr, err)
+			os.Exit(1)
+		}
+		log.Info("execd init: listening on %s (IPv4)", addr)
+		go func() {
+			if err := engine.RunListener(listener); err != nil {
+				log.Error("execd init: server: %v", err)
+			}
+		}()
+	}
+
+	if len(args) == 0 {
+		log.Info("execd init: no entrypoint args provided, exiting")
+		os.Exit(0)
+	}
+
+	mp, err := startEntrypoint(args)
+	if err != nil {
+		log.Error("execd init: failed to start entrypoint: %v", err)
+		os.Exit(1)
+	}
+
+	forwardSignalsToEntrypoint(mp)
+
+	err = mp.Wait()
+	exitCode := exitCodeFromError(err, mp)
+	log.Info("execd init: entrypoint pid=%d exited code=%d", mp.Pid(), exitCode)
+
+	stopOtherChildren(mp)
+
+	os.Exit(exitCode)
+}
+
+// startEntrypoint launches the user command as a managedProcess. The command is
+// run via the preferred shell (bash or sh) to match the original bootstrap.sh
+// behaviour. When hardening is enabled, the command is routed through the
+// native launcher for pre-exec privilege reduction.
+func startEntrypoint(args []string) (*managedProcess, error) {
+	shell, shellArgs := shellCommand(args...)
+	var cmd *exec.Cmd
+	hcmd, err := isolation.LaunchWithHardening(append([]string{shell}, shellArgs...))
+	if err != nil && !errors.Is(err, isolation.ErrHardeningDisabled) {
+		return nil, fmt.Errorf("hardening launch: %w", err)
+	}
+	if hcmd != nil {
+		cmd = hcmd
+	} else {
+		cmd = exec.Command(shell, shellArgs...)
+	}
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return startManagedProcessCmd(cmd)
+}
+
+// forwardSignalsToEntrypoint listens for application signals and forwards them
+// to the entrypoint's process group. SIGTERM from outside the PID namespace
+// (container stop) is forwarded so the workload can shut down gracefully.
+// In-namespace SIGTERM (workload kill 1) is ignored by the kernel PID 1 signal
+// shield; no handler is installed for it.
+func forwardSignalsToEntrypoint(mp *managedProcess) {
+	sigCh := make(chan os.Signal, len(entrypointSignals))
+	signal.Notify(sigCh, entrypointSignals...)
+	go func() {
+		for sig := range sigCh {
+			if sig == nil {
+				continue
+			}
+			s := sig.(syscall.Signal)
+			if s == syscall.SIGCHLD || s == syscall.SIGURG {
+				continue
+			}
+			log.Info("execd init: forwarding signal %s to entrypoint pgid=%d", s, mp.Pgid())
+			_ = mp.Signal(s)
+		}
+	}()
+}
+
+// stopOtherChildren sends SIGTERM to the entrypoint's process group, waits
+// for the grace period, then escalates to SIGKILL. Called after the entrypoint
+// has exited to clean up the sandbox before execd exits.
+//
+// In PID 1 mode the kernel signal shield protects execd, so we can broadcast
+// safely. In subreaper mode we only signal the entrypoint's process group to
+// avoid affecting unrelated processes.
+func stopOtherChildren(mp *managedProcess) {
+	log.Info("execd init: stopping children (grace=%s, mode=%s)", shutdownGracePeriod, modeStr())
+	if os.Getpid() == 1 {
+		_ = syscall.Kill(-1, syscall.SIGTERM)
+	} else {
+		_ = mp.Signal(syscall.SIGTERM)
+	}
+	time.Sleep(shutdownGracePeriod)
+	if os.Getpid() == 1 {
+		_ = syscall.Kill(-1, syscall.SIGKILL)
+	} else {
+		_ = mp.Signal(syscall.SIGKILL)
+	}
+}
+
+func modeStr() string {
+	if os.Getpid() == 1 {
+		return "pid1"
+	}
+	return "subreaper"
+}
+
+func exitCodeFromError(err error, mp *managedProcess) int {
+	if err == nil {
+		return 0
+	}
+	if mp.ExitCode() >= 0 {
+		return mp.ExitCode()
+	}
+	// Killed by signal: 128 + signal number (convention).
+	if mp.signal > 0 {
+		return 128 + mp.signal
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
+}

--- a/components/execd/pkg/runtime/entrypoint_stub.go
+++ b/components/execd/pkg/runtime/entrypoint_stub.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package runtime
+
+import (
+	"net"
+	"os"
+
+	"github.com/alibaba/opensandbox/execd/pkg/log"
+)
+
+// RunInit is a stub for non-Linux platforms. Init mode is Linux-only.
+func RunInit(engine interface{ RunListener(net.Listener) error }, addr string, args []string) {
+	log.Warn("execd init: not supported on this platform")
+	os.Exit(1)
+}

--- a/components/execd/pkg/runtime/managed.go
+++ b/components/execd/pkg/runtime/managed.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// managedProcess wraps an os/exec.Cmd whose lifecycle is driven by the central
+// reaper instead of Cmd.Wait(). It owns the child's I/O pipes and delivers the
+// exit status from the reaper's wait4 loop.
+//
+// Callers construct a managedProcess, call Start(), read from stdout/stderr,
+// then call Wait() to block until the child exits and clean up resources.
+type managedProcess struct {
+	Cmd      *exec.Cmd
+	pgid     int
+	Stdout   io.ReadCloser
+	Stderr   io.ReadCloser
+	statusCh chan unix.WaitStatus
+	waited   bool
+	exitCode int
+	signal   int
+}
+
+// startManagedProcess prepares cmd for managed execution: creates stdout/stderr
+// pipes, sets Setpgid, calls cmd.Start(), and registers with the global reaper.
+//
+// After Start, the caller owns stdout/stderr and must consume them before Wait.
+func startManagedProcess(cmd *exec.Cmd) (*managedProcess, error) {
+	if cmd == nil {
+		return nil, errors.New("managed process: cmd is nil")
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("managed process: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		stdout.Close()
+		return nil, fmt.Errorf("managed process: stderr pipe: %w", err)
+	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Pgid = 0
+
+	if err := cmd.Start(); err != nil {
+		stdout.Close()
+		stderr.Close()
+		return nil, fmt.Errorf("managed process: start: %w", err)
+	}
+
+	mp := &managedProcess{
+		Cmd:      cmd,
+		pgid:     cmd.Process.Pid,
+		Stdout:   stdout,
+		Stderr:   stderr,
+		statusCh: make(chan unix.WaitStatus, 1),
+	}
+	globalReaper.register(cmd.Process.Pid, mp.statusCh)
+	return mp, nil
+}
+
+// startManagedProcessCmd wraps an already-configured *exec.Cmd (Stdout/Stderr
+// already set to log files or pipes by the caller) in a managedProcess. It
+// ensures Setpgid, calls Start, and registers with the central reaper so that
+// Cmd.Wait() is never called — the reaper owns wait4 for this child.
+func startManagedProcessCmd(cmd *exec.Cmd) (*managedProcess, error) {
+	if cmd == nil {
+		return nil, errors.New("managed process: cmd is nil")
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Pgid = 0
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("managed process: start: %w", err)
+	}
+
+	mp := &managedProcess{
+		Cmd:  cmd,
+		pgid: cmd.Process.Pid,
+	}
+
+	if !globalReaper.isStarted() {
+		return mp, nil
+	}
+
+	mp.statusCh = make(chan unix.WaitStatus, 1)
+	globalReaper.register(cmd.Process.Pid, mp.statusCh)
+	return mp, nil
+}
+
+// Wait blocks until the child exits (status delivered by the reaper), then
+// drains stdout/stderr, joins any copy goroutines, and returns the exit error
+// (nil for exit code 0, *exec.ExitError otherwise).
+//
+// Wait must be called exactly once per managedProcess. After Wait returns,
+// stdout/stderr are closed and the reaper registration is released.
+func (mp *managedProcess) Wait() error {
+	if mp.waited {
+		return errors.New("managed process: Wait called more than once")
+	}
+	mp.waited = true
+
+	if mp.statusCh == nil {
+		// Reaper not running (non-init mode): use Cmd.Wait() directly.
+		err := mp.Cmd.Wait()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				mp.exitCode = exitErr.ExitCode()
+			}
+		}
+		return err
+	}
+
+	defer func() {
+		// Don't close pipes while io.Copy goroutines may still be
+		// draining. Close after the reaper delivers the status;
+		// the write ends were closed by the child's exit.
+		if mp.Stdout != nil {
+			mp.Stdout.Close()
+		}
+		if mp.Stderr != nil {
+			mp.Stderr.Close()
+		}
+	}()
+
+	ws := <-mp.statusCh
+	globalReaper.deregister(mp.Cmd.Process.Pid)
+
+	mp.exitCode = -1
+	if ws.Exited() {
+		mp.exitCode = ws.ExitStatus()
+		if mp.exitCode != 0 {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+		return nil
+	}
+	if ws.Signaled() {
+		mp.signal = int(ws.Signal())
+		return &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	return fmt.Errorf("managed process: pid %d unexpected wait status %#x", mp.Cmd.Process.Pid, ws)
+}
+
+// ExitCode returns the child's exit code, or -1 if the child was killed by a
+// signal or has not yet exited.
+func (mp *managedProcess) ExitCode() int {
+	return mp.exitCode
+}
+
+// Signal sends sig to the process group.
+func (mp *managedProcess) Signal(sig syscall.Signal) error {
+	return syscall.Kill(-mp.pgid, sig)
+}
+
+// Pid returns the child's PID.
+func (mp *managedProcess) Pid() int {
+	return mp.Cmd.Process.Pid
+}
+
+// Pgid returns the child's process group ID.
+func (mp *managedProcess) Pgid() int {
+	return mp.pgid
+}

--- a/components/execd/pkg/runtime/reaper.go
+++ b/components/execd/pkg/runtime/reaper.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package runtime
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// reaper is the single central reaper that owns all wait4 calls for execd-owned
+// children. It runs exactly one reapLoop per process. All child lifecycle
+// (managedProcess, entrypoint, etc.) registers with this reaper instead of
+// calling Cmd.Wait() directly.
+type reaper struct {
+	mu      sync.Mutex
+	started bool
+	owners  map[int]chan<- unix.WaitStatus
+	pending map[int]unix.WaitStatus
+	sigchld chan os.Signal
+}
+
+var globalReaper = &reaper{
+	owners:  make(map[int]chan<- unix.WaitStatus),
+	pending: make(map[int]unix.WaitStatus),
+}
+
+// register records pid as owned. If a pending status already exists (child
+// exited before registration), it is delivered immediately.
+func (r *reaper) register(pid int, ch chan<- unix.WaitStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ws, ok := r.pending[pid]; ok {
+		delete(r.pending, pid)
+		r.mu.Unlock()
+		ch <- ws
+		return
+	}
+	r.owners[pid] = ch
+	r.mu.Unlock()
+}
+
+// deregister removes pid from the owner registry and clears any buffered
+// pending status.
+func (r *reaper) deregister(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.owners, pid)
+	delete(r.pending, pid)
+}
+
+// StartReaper initialises the central reaper. Idempotent; subsequent calls are
+// no-ops. Installs the SIGCHLD handler synchronously so no exit is missed.
+//
+// Callers outside init mode should NOT start the reaper — it uses wait4(-1)
+// which would steal exit statuses from non-managed children (bash sessions,
+// PTY, isolated sessions) that still rely on Cmd.Wait(). Use
+// startManagedProcessCmd which falls back to Cmd.Wait() when the reaper is
+// not running.
+func StartReaper() {
+	globalReaper.start()
+}
+
+// start initialises the reaper loop in a background goroutine. It installs the
+// SIGCHLD handler synchronously before returning, so no child exit status is
+// lost between registration and reapLoop entering its select loop.
+//
+// Idempotent; must be called before any child is launched.
+func (r *reaper) start() {
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	r.mu.Unlock()
+
+	r.sigchld = make(chan os.Signal, 1)
+	signal.Notify(r.sigchld, syscall.SIGCHLD)
+	go r.reapLoop()
+}
+
+// isStarted reports whether the reaper loop has been started.
+func (r *reaper) isStarted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.started
+}

--- a/components/execd/pkg/runtime/reaper_linux.go
+++ b/components/execd/pkg/runtime/reaper_linux.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package runtime
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// reapLoop uses wait4(-1) to reap all exited children. In init mode this is
+// the only correct behaviour — PID 1 must reap all reparented orphans.
+// Non-managed children (bash sessions, PTY, isolated sessions) that still
+// rely on Cmd.Wait() will lose their exit statuses during init mode. These
+// paths must be migrated to managedProcess before enabling init mode.
+func (r *reaper) reapLoop() {
+	for range r.sigchld {
+		for {
+			var ws unix.WaitStatus
+			pid, err := unix.Wait4(-1, &ws, unix.WNOHANG, nil)
+			if pid <= 0 || err != nil {
+				break
+			}
+			r.dispatch(pid, ws)
+		}
+	}
+}
+
+func (r *reaper) dispatch(pid int, ws unix.WaitStatus) {
+	r.mu.Lock()
+	ch, ok := r.owners[pid]
+	if ok {
+		delete(r.owners, pid)
+		r.mu.Unlock()
+		ch <- ws
+		return
+	}
+	// start/register race: child exited before register() was called.
+	// Buffer in pending so register() delivers it immediately.
+	r.pending[pid] = ws
+	r.mu.Unlock()
+}

--- a/components/execd/pkg/runtime/reaper_nonlinux.go
+++ b/components/execd/pkg/runtime/reaper_nonlinux.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux && !windows
+
+package runtime
+
+import "golang.org/x/sys/unix"
+
+// reapLoop is a stub for non-Linux platforms. Init mode is Linux-only, so the
+// reaper is never started on these platforms.
+func (r *reaper) reapLoop() {}
+
+// dispatch is a stub for non-Linux platforms.
+func (r *reaper) dispatch(pid int, ws unix.WaitStatus) {}

--- a/components/execd/pkg/runtime/reaper_stub.go
+++ b/components/execd/pkg/runtime/reaper_stub.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package runtime
+
+// StartReaper is a no-op on Windows.
+func StartReaper() {}

--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -147,7 +147,7 @@ override it.
 ### CLI Flags
 
 | Flag | Default | Description |
-|---|---|---|
+|---|---|---|---|
 | `--jupyter-host` | `""` | Jupyter server URL reachable by execd. |
 | `--jupyter-token` | `""` | Jupyter token for HTTP/WebSocket auth. |
 | `--port` | `44772` | HTTP listen port. |
@@ -156,6 +156,7 @@ override it.
 | `--graceful-shutdown-timeout` | `1s` | SSE tail-drain wait window before closing. |
 | `--jupyter-idle-poll-interval` | `100ms` | Poll interval after Jupyter reports idle. |
 | `--isolation-config` | `""` | Path to the isolation TOML config (see below). |
+| `--init` | `false` | Run as sandbox init (PID 1). Reaps zombies, forwards signals, manages entrypoint lifecycle. |
 
 ### Environment Variables
 
@@ -167,6 +168,7 @@ override it.
 | `EXECD_API_GRACE_SHUTDOWN` | Same as `--graceful-shutdown-timeout`. |
 | `EXECD_JUPYTER_IDLE_POLL_INTERVAL` | Same as `--jupyter-idle-poll-interval`. |
 | `EXECD_ISOLATION_CONFIG` | Same as `--isolation-config`. |
+| `EXECD_INIT` | Same as `--init` (1/true/yes/on). |
 | `EXECD_CLONE3_COMPAT` | Linux clone3 compatibility switch (see below). |
 | `EXECD_LOG_FILE` | Optional log output file path; default is stdout. |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Preferred OTLP metrics endpoint. |


### PR DESCRIPTION
## Summary

Add feature-flag plumbing for OSEP-0018 (execd as sandbox init). All new behavior is gated behind switches that default to **off** — existing sandboxes are unchanged.

## Changes

### `pkg/flag/` — `--init` flag + `EXECD_INIT` env
- `flags.go`: add `InitMode bool` variable
- `parser.go`: parse `--init` CLI flag and `EXECD_INIT` env var (truthy: 1/true/yes/on)

### `pkg/isolation/config.go` — hardening TOML sections
- Add `HardeningConfig`, `LandlockConfig`, `EbpfConfig` structs with TOML tags
- Extend `Config` with `Hardening`, `Landlock`, `Ebpf` fields (all default `Enabled: false`)
- `DefaultConfig()` initializes them with safe defaults

### `pkg/isolation/hardening.go` — new file
- `HardeningLayerState` enum: active/disabled/degraded/unsupported
- `HardeningLayer` + `HardeningProbe` types (not yet wired into the capabilities endpoint)

### `bootstrap.sh` — `EXECD_INIT` branch
- Command normalization extracted and runs before the branch
- `EXECD_INIT` truthy → `exec "$EXECD" --init -- "$@"`
- `EXECD_INIT` unset → identical to today's background-and-wait behavior

### `configs/isolation.example.toml` — documentation
- Add commented-out `[hardening]`, `[landlock]`, `[ebpf]` sections

### `config_test.go` — tests
- 4 new test cases for hardening/landlock/ebpf TOML parsing + default-off behavior

## Verification

- `go build ./...` ✅
- `go vet ./pkg/flag/... ./pkg/isolation/...` ✅
- `bash -n bootstrap.sh` ✅
- All existing tests pass ✅

## Related

- OSEP-0018 proposal: https://github.com/opensandbox-group/OpenSandbox/pull/1394