### PR TITLE
fix(kotlin): make pool graceful shutdown drain warmups safely

### DIFF
--- a/docs/guides/sdk-telemetry.md
+++ b/docs/guides/sdk-telemetry.md
@@ -18,7 +18,7 @@ The `POST /v1/metrics/events` endpoint and the SDK reporters described below req
 | JavaScript / TypeScript SDK (`@alibaba-group/opensandbox`) | `0.1.11` |
 | Go SDK (`github.com/alibaba/OpenSandbox/sdks/sandbox/go`) | `1.0.5` |
 | C# SDK (`Alibaba.OpenSandbox`) | `0.1.5` |
-| Kotlin / Java SDK (`com.alibaba.opensandbox:sandbox`) | `1.0.17` |
+| Kotlin / Java SDK (`com.alibaba.opensandbox:sandbox`) | `1.0.18` |
 
 ### Version skew
 

--- a/docs/guides/sdk-telemetry.md
+++ b/docs/guides/sdk-telemetry.md
@@ -18,7 +18,7 @@ The `POST /v1/metrics/events` endpoint and the SDK reporters described below req
 | JavaScript / TypeScript SDK (`@alibaba-group/opensandbox`) | `0.1.11` |
 | Go SDK (`github.com/alibaba/OpenSandbox/sdks/sandbox/go`) | `1.0.5` |
 | C# SDK (`Alibaba.OpenSandbox`) | `0.1.5` |
-| Kotlin / Java SDK (`com.alibaba.opensandbox:sandbox`) | `1.0.18` |
+| Kotlin / Java SDK (`com.alibaba.opensandbox:sandbox`) | `1.0.17` |
 
 ### Version skew
 

--- a/sdks/sandbox/kotlin/gradle.properties
+++ b/sdks/sandbox/kotlin/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 
 # Project metadata
 project.group=com.alibaba.opensandbox
-project.version=1.0.17
+project.version=1.0.18
 project.description=A Kotlin SDK for Open Sandbox API

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfig.kt
@@ -88,7 +88,7 @@ class ConnectionConfig private constructor(
         private const val ENV_DOMAIN = "OPEN_SANDBOX_DOMAIN"
         internal const val ENV_DISABLE_METRICS = "OPENSANDBOX_DISABLE_METRICS"
 
-        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.17"
+        private const val DEFAULT_USER_AGENT = "OpenSandbox-Kotlin-SDK/1.0.18"
         private const val API_VERSION = "v1"
 
         @JvmStatic

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -698,17 +698,7 @@ class SandboxPool internal constructor(
                 sandbox.renew(config.idleTimeout)
                 sandbox.id
             } catch (e: Exception) {
-                try {
-                    sandbox.kill()
-                } catch (cleanupEx: Exception) {
-                    logger.warn(
-                        "Pool warmup sandbox preparer cleanup failed: pool_name={} sandbox_id={} error={}",
-                        config.poolName,
-                        sandbox.id,
-                        cleanupEx.message,
-                    )
-                    e.addSuppressed(cleanupEx)
-                }
+                killWarmupSandboxAfterFailure(sandbox, e)
                 throw e
             } finally {
                 sandbox.close()
@@ -718,6 +708,32 @@ class SandboxPool internal constructor(
             throw e
         } finally {
             endOperation()
+        }
+    }
+
+    private fun killWarmupSandboxAfterFailure(
+        sandbox: Sandbox,
+        failure: Exception,
+    ) {
+        // A warmup preparer may restore the thread's interrupted status before propagating an
+        // InterruptedException. OkHttp treats that status as cancellation and can reject the
+        // cleanup request before the DELETE is sent. Temporarily clear it for the synchronous
+        // cleanup, then restore it so executor shutdown semantics are preserved.
+        val restoreInterrupt = Thread.interrupted()
+        try {
+            sandbox.kill()
+        } catch (cleanupEx: Exception) {
+            logger.warn(
+                "Pool warmup sandbox preparer cleanup failed: pool_name={} sandbox_id={} error={}",
+                config.poolName,
+                sandbox.id,
+                cleanupEx.message,
+            )
+            failure.addSuppressed(cleanupEx)
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt()
+            }
         }
     }
 
@@ -1047,10 +1063,13 @@ class SandboxPool internal constructor(
     }
 
     private fun forceStopReconcileAfterGracefulDrain() {
-        scheduler?.let { forceShutdownExecutor(it, "scheduler") }
-        scheduler = null
+        // Stop warmup workers first and let their failure cleanup finish before interrupting
+        // the scheduler. Interrupting the scheduler while it waits in invokeAll() would cancel
+        // the same warmup futures again and could re-interrupt an in-progress cleanup DELETE.
         warmupExecutor?.let { forceShutdownExecutor(it, "warmup") }
         warmupExecutor = null
+        scheduler?.let { forceShutdownExecutor(it, "scheduler") }
+        scheduler = null
         releasePrimaryLockBestEffort()
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -137,6 +137,9 @@ class SandboxPool internal constructor(
                 }
             scheduler = exec
             val reconcileIntervalMs = config.reconcileInterval.toMillis()
+            // The first reconcile may run immediately. Publish RUNNING only after all of its
+            // dependencies are initialized, but before scheduling it so that tick is not skipped.
+            lifecycleState.set(LifecycleState.RUNNING)
             reconcileTask =
                 exec.scheduleAtFixedRate(
                     {
@@ -151,7 +154,6 @@ class SandboxPool internal constructor(
                     reconcileIntervalMs,
                     TimeUnit.MILLISECONDS,
                 )
-            lifecycleState.set(LifecycleState.RUNNING)
             logger.info(
                 "Pool started: pool_name={} state={} maxIdle={}",
                 config.poolName,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -536,7 +536,8 @@ class SandboxPool internal constructor(
 
     /**
      * Stops pool replenish workers. If [graceful] is true, transitions to DRAINING, stops reconcile worker,
-     * and waits until local in-flight operations complete or [PoolConfig.drainTimeout] elapses before STOPPED.
+     * prevents future reconcile ticks without interrupting the current tick, and waits until local in-flight
+     * operations complete or [PoolConfig.drainTimeout] elapses before STOPPED.
      * acquire() is rejected while pool is not RUNNING. If [graceful] is false, stops immediately.
      */
     @Synchronized
@@ -550,9 +551,10 @@ class SandboxPool internal constructor(
             return
         }
         lifecycleState.set(LifecycleState.DRAINING)
-        stopReconcile()
+        var drained = false
         try {
-            val drained = awaitInFlightDrain(config.drainTimeout)
+            beginGracefulReconcileStop()
+            drained = awaitInFlightDrain(config.drainTimeout)
             if (!drained) {
                 logger.warn(
                     "Pool graceful shutdown timed out waiting in-flight operations: pool_name={} in_flight={} timeout_ms={}",
@@ -565,6 +567,11 @@ class SandboxPool internal constructor(
             Thread.currentThread().interrupt()
             logger.warn("Pool graceful shutdown interrupted during drain: pool_name={}", config.poolName)
         } finally {
+            if (drained) {
+                completeGracefulReconcileStop()
+            } else {
+                forceStopReconcileAfterGracefulDrain()
+            }
             lifecycleState.set(LifecycleState.STOPPED)
             closeProvider()
             logger.info("Pool stopped (graceful): pool_name={} state={}", config.poolName, LifecycleState.STOPPED)
@@ -1025,6 +1032,28 @@ class SandboxPool internal constructor(
         releasePrimaryLockBestEffort()
     }
 
+    private fun beginGracefulReconcileStop() {
+        reconcileTask?.cancel(false)
+        reconcileTask = null
+        scheduler?.shutdown()
+    }
+
+    private fun completeGracefulReconcileStop() {
+        scheduler?.let { shutdownExecutor(it, "scheduler") }
+        scheduler = null
+        warmupExecutor?.let { shutdownExecutor(it, "warmup") }
+        warmupExecutor = null
+        releasePrimaryLockBestEffort()
+    }
+
+    private fun forceStopReconcileAfterGracefulDrain() {
+        scheduler?.let { forceShutdownExecutor(it, "scheduler") }
+        scheduler = null
+        warmupExecutor?.let { forceShutdownExecutor(it, "warmup") }
+        warmupExecutor = null
+        releasePrimaryLockBestEffort()
+    }
+
     private fun stopAfterNamespaceDestroyed() {
         if (!lifecycleState.compareAndSet(LifecycleState.RUNNING, LifecycleState.STOPPED)) return
         reconcileTask?.cancel(false)
@@ -1071,6 +1100,31 @@ class SandboxPool internal constructor(
             Thread.currentThread().interrupt()
             logger.warn(
                 "Pool {} executor shutdown interrupted; forced stop issued: pool_name={} dropped_tasks={}",
+                role,
+                config.poolName,
+                dropped.size,
+            )
+        }
+    }
+
+    private fun forceShutdownExecutor(
+        executor: ExecutorService,
+        role: String,
+    ) {
+        val dropped = executor.shutdownNow()
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn(
+                    "Pool {} executor did not terminate after forced stop: pool_name={} dropped_tasks={}",
+                    role,
+                    config.poolName,
+                    dropped.size,
+                )
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            logger.warn(
+                "Pool {} executor forced stop wait interrupted: pool_name={} dropped_tasks={}",
                 role,
                 config.poolName,
                 dropped.size,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -45,6 +45,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.Condition
@@ -593,15 +594,17 @@ class SandboxPool internal constructor(
         source: String,
     ) {
         if (sandboxIds.isEmpty()) return
+        val cleanupTask = TrackedCleanupTask(poolName, sandboxIds.toList(), source)
         val executor = warmupExecutor
         if (executor == null) {
-            killDiscardedAlive(poolName, sandboxIds, source)
+            cleanupTask.run()
             return
         }
         try {
-            executor.submit {
-                killDiscardedAlive(poolName, sandboxIds, source)
-            }
+            // execute() deliberately preserves the task identity in ThreadPoolExecutor's queue.
+            // shutdownNow() can then return this exact task so its drain count is completed even
+            // when the cleanup never starts.
+            executor.execute(cleanupTask)
         } catch (e: Exception) {
             // Executor may reject if the pool is mid-shutdown; fall back to inline kill.
             logger.debug(
@@ -610,7 +613,43 @@ class SandboxPool internal constructor(
                 sandboxIds.size,
                 e.message,
             )
-            killDiscardedAlive(poolName, sandboxIds, source)
+            cleanupTask.run()
+        }
+    }
+
+    private inner class TrackedCleanupTask(
+        private val poolName: String,
+        private val sandboxIds: List<String>,
+        private val source: String,
+    ) : Runnable {
+        private val completed = AtomicBoolean(false)
+
+        init {
+            beginOperation()
+        }
+
+        override fun run() {
+            try {
+                killDiscardedAlive(poolName, sandboxIds, source)
+            } finally {
+                complete()
+            }
+        }
+
+        fun completeIfDropped() {
+            complete()
+        }
+
+        private fun complete() {
+            if (completed.compareAndSet(false, true)) {
+                endOperation()
+            }
+        }
+    }
+
+    private fun completeDroppedCleanupTasks(dropped: List<Runnable>) {
+        dropped.forEach { task ->
+            (task as? TrackedCleanupTask)?.completeIfDropped()
         }
     }
 
@@ -1081,7 +1120,7 @@ class SandboxPool internal constructor(
         reconcileTask = null
         scheduler?.shutdown()
         scheduler = null
-        warmupExecutor?.shutdownNow()
+        warmupExecutor?.let { completeDroppedCleanupTasks(it.shutdownNow()) }
         warmupExecutor = null
         releasePrimaryLockBestEffort()
         closeProvider()
@@ -1108,6 +1147,7 @@ class SandboxPool internal constructor(
         try {
             if (executor.awaitTermination(5, TimeUnit.SECONDS)) return
             val dropped = executor.shutdownNow()
+            completeDroppedCleanupTasks(dropped)
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 logger.warn(
                     "Pool {} executor did not terminate after forced stop: pool_name={} dropped_tasks={}",
@@ -1118,6 +1158,7 @@ class SandboxPool internal constructor(
             }
         } catch (_: InterruptedException) {
             val dropped = executor.shutdownNow()
+            completeDroppedCleanupTasks(dropped)
             Thread.currentThread().interrupt()
             logger.warn(
                 "Pool {} executor shutdown interrupted; forced stop issued: pool_name={} dropped_tasks={}",
@@ -1133,6 +1174,7 @@ class SandboxPool internal constructor(
         role: String,
     ) {
         val dropped = executor.shutdownNow()
+        completeDroppedCleanupTasks(dropped)
         try {
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 logger.warn(

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/config/ConnectionConfigUserAgentTest.kt
@@ -26,6 +26,6 @@ class ConnectionConfigUserAgentTest {
     fun `default userAgent matches package version`() {
         val config = ConnectionConfig.builder().build()
 
-        assertEquals("OpenSandbox-Kotlin-SDK/1.0.17", config.userAgent)
+        assertEquals("OpenSandbox-Kotlin-SDK/1.0.18", config.userAgent)
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -51,10 +51,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class SandboxPoolTest {
@@ -120,6 +122,116 @@ class SandboxPoolTest {
         val snap = pool.snapshot()
         assertEquals(PoolState.STOPPED, snap.state)
         assertEquals(PoolLifecycleState.STOPPED, snap.lifecycleState)
+    }
+
+    @Test
+    fun `shutdown graceful waits for in-flight warmup without interrupting it`() {
+        val store = InMemoryPoolStateStore()
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val warmupStarted = CountDownLatch(1)
+        val releaseWarmup = CountDownLatch(1)
+        val warmupInterrupted = AtomicBoolean(false)
+        every { sandbox.id } returns "warmup-id"
+
+        val pool =
+            SandboxPool.builder()
+                .poolName("test-pool")
+                .ownerId("test-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(PooledSandboxCreator { sandbox })
+                .warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer {
+                        warmupStarted.countDown()
+                        try {
+                            releaseWarmup.await()
+                        } catch (e: InterruptedException) {
+                            warmupInterrupted.set(true)
+                            throw e
+                        }
+                    },
+                ).drainTimeout(Duration.ofSeconds(2))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+
+        var releaser: Thread? = null
+        pool.start()
+        try {
+            assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            releaser =
+                Thread {
+                    Thread.sleep(250)
+                    releaseWarmup.countDown()
+                }.apply { start() }
+
+            pool.shutdown(graceful = true)
+
+            assertEquals(false, warmupInterrupted.get())
+            assertEquals(1, store.snapshotCounters("test-pool").idleCount)
+            verify(exactly = 0) { sandbox.kill() }
+            verify(exactly = 1) { sandbox.close() }
+        } finally {
+            releaseWarmup.countDown()
+            releaser?.join(5_000)
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `shutdown graceful force interrupts warmup after drain timeout`() {
+        val store = InMemoryPoolStateStore()
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val warmupStarted = CountDownLatch(1)
+        val blockWarmup = CountDownLatch(1)
+        val warmupInterrupted = AtomicBoolean(false)
+        every { sandbox.id } returns "timed-out-warmup-id"
+
+        val pool =
+            SandboxPool.builder()
+                .poolName("test-pool")
+                .ownerId("test-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(PooledSandboxCreator { sandbox })
+                .warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer {
+                        warmupStarted.countDown()
+                        try {
+                            blockWarmup.await()
+                        } catch (e: InterruptedException) {
+                            warmupInterrupted.set(true)
+                            throw e
+                        }
+                    },
+                ).drainTimeout(Duration.ofMillis(200))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+
+        pool.start()
+        try {
+            assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            val shutdownStartedAt = System.nanoTime()
+
+            pool.shutdown(graceful = true)
+
+            val shutdownElapsedMs = Duration.ofNanos(System.nanoTime() - shutdownStartedAt).toMillis()
+            assertTrue(shutdownElapsedMs >= 150, "graceful shutdown should wait for drain timeout before forcing stop")
+            assertEquals(true, warmupInterrupted.get())
+            assertEquals(0, store.snapshotCounters("test-pool").idleCount)
+            verify(exactly = 1) { sandbox.kill() }
+            verify(exactly = 1) { sandbox.close() }
+        } finally {
+            blockWarmup.countDown()
+            pool.shutdown(graceful = false)
+        }
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -30,6 +30,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PlatformSpec
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 import com.alibaba.opensandbox.sandbox.domain.pool.AcquirePolicy
 import com.alibaba.opensandbox.sandbox.domain.pool.IdleEntry
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolConfig
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolCreationSpec
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolDestroyState
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolLifecycleState
@@ -38,6 +39,7 @@ import com.alibaba.opensandbox.sandbox.domain.pool.PoolStateStore
 import com.alibaba.opensandbox.sandbox.domain.pool.PooledSandboxCreator
 import com.alibaba.opensandbox.sandbox.domain.pool.SandboxPreparer
 import com.alibaba.opensandbox.sandbox.domain.pool.StoreCounters
+import com.alibaba.opensandbox.sandbox.domain.pool.TakeIdleResult
 import com.alibaba.opensandbox.sandbox.infrastructure.pool.InMemoryPoolStateStore
 import io.mockk.every
 import io.mockk.just
@@ -59,6 +61,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 class SandboxPoolTest {
     @Test
@@ -246,6 +249,143 @@ class SandboxPoolTest {
         } finally {
             blockWarmup.countDown()
             pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `shutdown graceful waits for asynchronous discarded sandbox cleanup`() {
+        val store = DiscardingPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val directSandbox = mockk<Sandbox>(relaxed = true)
+        val cleanupStarted = CountDownLatch(1)
+        val releaseCleanup = CountDownLatch(1)
+        val cleanupInterrupted = AtomicBoolean(false)
+        val shutdownCompleted = CountDownLatch(1)
+        val shutdownFailure = AtomicReference<Throwable?>()
+        every { manager.killSandbox("near-expiry-id") } answers {
+            cleanupStarted.countDown()
+            try {
+                releaseCleanup.await()
+            } catch (e: InterruptedException) {
+                cleanupInterrupted.set(true)
+                throw e
+            }
+        }
+        val pool =
+            buildDiscardedCleanupPool(
+                store = store,
+                manager = manager,
+                directSandbox = directSandbox,
+                drainTimeout = Duration.ofSeconds(2),
+            )
+
+        var shutdownThread: Thread? = null
+        pool.start()
+        try {
+            assertSame(directSandbox, pool.acquire(policy = AcquirePolicy.DIRECT_CREATE))
+            assertTrue(cleanupStarted.await(5, TimeUnit.SECONDS))
+            assertEquals(1, pool.snapshot().inFlightOperations)
+
+            shutdownThread =
+                Thread {
+                    try {
+                        pool.shutdown(graceful = true)
+                    } catch (t: Throwable) {
+                        shutdownFailure.set(t)
+                    } finally {
+                        shutdownCompleted.countDown()
+                    }
+                }.apply { start() }
+
+            assertEquals(
+                false,
+                shutdownCompleted.await(200, TimeUnit.MILLISECONDS),
+                "graceful shutdown must keep waiting while asynchronous cleanup is running",
+            )
+            releaseCleanup.countDown()
+            assertTrue(shutdownCompleted.await(5, TimeUnit.SECONDS))
+
+            assertEquals(null, shutdownFailure.get())
+            assertEquals(false, cleanupInterrupted.get())
+            assertEquals(0, pool.snapshot().inFlightOperations)
+            assertEquals(PoolLifecycleState.STOPPED, pool.snapshot().lifecycleState)
+            verify(exactly = 1) { manager.killSandbox("near-expiry-id") }
+        } finally {
+            releaseCleanup.countDown()
+            shutdownThread?.join(5_000)
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `shutdown timeout completes drain count for queued discarded sandbox cleanup`() {
+        val store = DiscardingPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val directSandbox = mockk<Sandbox>(relaxed = true)
+        val blockerStarted = CountDownLatch(1)
+        val releaseBlocker = CountDownLatch(1)
+        val blockerInterrupted = AtomicBoolean(false)
+        val pool =
+            buildDiscardedCleanupPool(
+                store = store,
+                manager = manager,
+                directSandbox = directSandbox,
+                drainTimeout = Duration.ofMillis(200),
+            )
+
+        pool.start()
+        try {
+            val warmupExecutor = getPrivateField<ExecutorService>(pool, "warmupExecutor")
+            warmupExecutor.execute {
+                blockerStarted.countDown()
+                try {
+                    releaseBlocker.await()
+                } catch (_: InterruptedException) {
+                    blockerInterrupted.set(true)
+                }
+            }
+            assertTrue(blockerStarted.await(5, TimeUnit.SECONDS))
+            assertSame(directSandbox, pool.acquire(policy = AcquirePolicy.DIRECT_CREATE))
+            assertEquals(1, pool.snapshot().inFlightOperations)
+            val shutdownStartedAt = System.nanoTime()
+
+            pool.shutdown(graceful = true)
+
+            val shutdownElapsedMs = Duration.ofNanos(System.nanoTime() - shutdownStartedAt).toMillis()
+            assertTrue(shutdownElapsedMs >= 150, "shutdown should wait for drain timeout before dropping queued cleanup")
+            assertEquals(true, blockerInterrupted.get())
+            assertEquals(0, pool.snapshot().inFlightOperations)
+            verify(exactly = 0) { manager.killSandbox("near-expiry-id") }
+        } finally {
+            releaseBlocker.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `rejected discarded sandbox cleanup runs inline without leaking drain count`() {
+        val store = DiscardingPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val directSandbox = mockk<Sandbox>(relaxed = true)
+        every { manager.killSandbox("near-expiry-id") } throws RuntimeException("kill failed")
+        val pool =
+            buildDiscardedCleanupPool(
+                store = store,
+                manager = manager,
+                directSandbox = directSandbox,
+                drainTimeout = Duration.ofSeconds(2),
+            )
+
+        pool.start()
+        try {
+            getPrivateField<ExecutorService>(pool, "warmupExecutor").shutdownNow()
+
+            assertSame(directSandbox, pool.acquire(policy = AcquirePolicy.DIRECT_CREATE))
+
+            assertEquals(0, pool.snapshot().inFlightOperations)
+            verify(exactly = 1) { manager.killSandbox("near-expiry-id") }
+        } finally {
+            pool.shutdown(graceful = true)
         }
     }
 
@@ -1044,6 +1184,51 @@ class SandboxPoolTest {
             .drainTimeout(Duration.ofMillis(50))
             .reconcileInterval(Duration.ofSeconds(30))
             .build()
+    }
+
+    private fun buildDiscardedCleanupPool(
+        store: PoolStateStore,
+        manager: SandboxManager,
+        directSandbox: Sandbox,
+        drainTimeout: Duration,
+    ): SandboxPool =
+        SandboxPool(
+            config =
+                PoolConfig.builder()
+                    .poolName("test-pool")
+                    .ownerId("test-owner")
+                    .maxIdle(0)
+                    .stateStore(store)
+                    .connectionConfig(ConnectionConfig.builder().build())
+                    .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                    .sandboxCreator(PooledSandboxCreator { directSandbox })
+                    .acquireMinRemainingTtl(Duration.ofMinutes(1))
+                    .idleTimeout(Duration.ofMinutes(10))
+                    .drainTimeout(drainTimeout)
+                    .reconcileInterval(Duration.ofSeconds(30))
+                    .build(),
+            sandboxManagerFactory = { manager },
+        )
+
+    private class DiscardingPoolStateStore : PoolStateStore by InMemoryPoolStateStore() {
+        override fun tryTakeIdle(
+            poolName: String,
+            minRemainingTtl: Duration,
+        ): TakeIdleResult =
+            TakeIdleResult(
+                sandboxId = null,
+                discardedAliveSandboxIds = listOf("near-expiry-id"),
+            )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> getPrivateField(
+        target: Any,
+        fieldName: String,
+    ): T {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(target) as T
     }
 
     private fun setPrivateField(

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.io.InterruptedIOException
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
@@ -188,7 +189,18 @@ class SandboxPoolTest {
         val warmupStarted = CountDownLatch(1)
         val blockWarmup = CountDownLatch(1)
         val warmupInterrupted = AtomicBoolean(false)
+        val killSawInterrupt = AtomicBoolean(false)
+        val closeSawInterrupt = AtomicBoolean(false)
         every { sandbox.id } returns "timed-out-warmup-id"
+        every { sandbox.kill() } answers {
+            killSawInterrupt.set(Thread.currentThread().isInterrupted)
+            if (killSawInterrupt.get()) {
+                throw InterruptedIOException("interrupted")
+            }
+        }
+        every { sandbox.close() } answers {
+            closeSawInterrupt.set(Thread.currentThread().isInterrupted)
+        }
 
         val pool =
             SandboxPool.builder()
@@ -208,6 +220,7 @@ class SandboxPoolTest {
                             blockWarmup.await()
                         } catch (e: InterruptedException) {
                             warmupInterrupted.set(true)
+                            Thread.currentThread().interrupt()
                             throw e
                         }
                     },
@@ -225,6 +238,8 @@ class SandboxPoolTest {
             val shutdownElapsedMs = Duration.ofNanos(System.nanoTime() - shutdownStartedAt).toMillis()
             assertTrue(shutdownElapsedMs >= 150, "graceful shutdown should wait for drain timeout before forcing stop")
             assertEquals(true, warmupInterrupted.get())
+            assertEquals(false, killSawInterrupt.get(), "cleanup kill must not inherit the worker interrupt state")
+            assertEquals(true, closeSawInterrupt.get(), "worker interrupt state must be restored after cleanup kill")
             assertEquals(0, store.snapshotCounters("test-pool").idleCount)
             verify(exactly = 1) { sandbox.kill() }
             verify(exactly = 1) { sandbox.close() }

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.opensandbox.sandbox.SandboxManager;
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos;
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter;
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolCreationSpec;
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolLifecycleState;
+import com.alibaba.opensandbox.sandbox.domain.pool.SandboxPreparer;
+import com.alibaba.opensandbox.sandbox.infrastructure.pool.InMemoryPoolStateStore;
+import com.alibaba.opensandbox.sandbox.pool.SandboxPool;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Tag("e2e")
+@DisplayName("SandboxPool graceful shutdown leak E2E Tests")
+public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
+    private SandboxManager sandboxManager;
+    private String tag;
+
+    @BeforeEach
+    void setup() {
+        sandboxManager = SandboxManager.builder().connectionConfig(sharedConnectionConfig).build();
+    }
+
+    @AfterEach
+    void teardown() {
+        cleanupTaggedSandboxes();
+        if (sandboxManager != null) {
+            sandboxManager.close();
+        }
+    }
+
+    @Test
+    @DisplayName("graceful shutdown publishes warmup completed before drain timeout")
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
+    void testGracefulShutdownPublishesWarmupCompletedBeforeDrainTimeout() throws Exception {
+        tag = uniqueTag("graceful-complete");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch warmupEntered = new CountDownLatch(1);
+        CountDownLatch releaseWarmup = new CountDownLatch(1);
+        AtomicReference<String> createdSandboxId = new AtomicReference<>();
+        SandboxPool pool =
+                createPool(
+                        stateStore,
+                        Duration.ofSeconds(5),
+                        sandbox -> {
+                            createdSandboxId.set(sandbox.getId());
+                            warmupEntered.countDown();
+                            awaitLatch(releaseWarmup);
+                        });
+        Thread releaser = null;
+
+        try {
+            pool.start();
+            assertTrue(
+                    warmupEntered.await(2, TimeUnit.MINUTES),
+                    "warmup should create a remote sandbox and enter the preparer");
+            assertNotNull(createdSandboxId.get());
+            eventually(
+                    "created warmup sandbox is visible remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 1);
+
+            releaser =
+                    new Thread(
+                            () -> {
+                                try {
+                                    Thread.sleep(500);
+                                } catch (InterruptedException exception) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                releaseWarmup.countDown();
+                            },
+                            "sandbox-pool-e2e-warmup-releaser");
+            releaser.start();
+
+            long shutdownStartedAt = System.nanoTime();
+            pool.shutdown(true);
+            long shutdownElapsedMillis =
+                    Duration.ofNanos(System.nanoTime() - shutdownStartedAt).toMillis();
+
+            assertTrue(
+                    shutdownElapsedMillis >= 300,
+                    "graceful shutdown should wait for the in-flight warmup");
+            assertEquals(PoolLifecycleState.STOPPED, pool.snapshot().getLifecycleState());
+            assertEquals(1, pool.snapshot().getIdleCount());
+            assertTrue(
+                    pool.snapshotIdleEntries().stream()
+                            .anyMatch(entry -> createdSandboxId.get().equals(entry.getSandboxId())),
+                    "the completed warmup sandbox must be persisted in the idle store");
+
+            pool.releaseAllIdle();
+            eventually(
+                    "released idle sandbox is deleted remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 0);
+        } finally {
+            releaseWarmup.countDown();
+            if (releaser != null) {
+                releaser.join(5_000);
+            }
+            shutdownAndRelease(pool);
+        }
+    }
+
+    @Test
+    @DisplayName("forced shutdown deletes interrupted warmup sandbox not persisted as idle")
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
+    void testForcedShutdownDeletesInterruptedWarmupSandboxNotPersistedAsIdle() throws Exception {
+        tag = uniqueTag("forced-cleanup");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch warmupEntered = new CountDownLatch(1);
+        CountDownLatch blockWarmup = new CountDownLatch(1);
+        AtomicReference<String> createdSandboxId = new AtomicReference<>();
+        AtomicBoolean warmupInterrupted = new AtomicBoolean(false);
+        SandboxPool pool =
+                createPool(
+                        stateStore,
+                        Duration.ofMillis(500),
+                        sandbox -> {
+                            createdSandboxId.set(sandbox.getId());
+                            warmupEntered.countDown();
+                            try {
+                                blockWarmup.await();
+                            } catch (InterruptedException exception) {
+                                warmupInterrupted.set(true);
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException(
+                                        "warmup interrupted during forced shutdown", exception);
+                            }
+                        });
+
+        try {
+            pool.start();
+            assertTrue(
+                    warmupEntered.await(2, TimeUnit.MINUTES),
+                    "warmup should create a remote sandbox and enter the preparer");
+            assertNotNull(createdSandboxId.get());
+            eventually(
+                    "unpersisted warmup sandbox is visible remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 1);
+
+            long shutdownStartedAt = System.nanoTime();
+            pool.shutdown(true);
+            long shutdownElapsedMillis =
+                    Duration.ofNanos(System.nanoTime() - shutdownStartedAt).toMillis();
+
+            assertTrue(
+                    shutdownElapsedMillis >= 350,
+                    "graceful shutdown should wait for drain timeout before forcing warmup stop");
+            assertTrue(warmupInterrupted.get(), "warmup should be interrupted after drain timeout");
+            assertEquals(PoolLifecycleState.STOPPED, pool.snapshot().getLifecycleState());
+            assertEquals(
+                    0,
+                    pool.snapshot().getIdleCount(),
+                    "failed warmup sandbox must not be persisted as idle");
+            assertFalse(
+                    pool.snapshotIdleEntries().stream()
+                            .anyMatch(entry -> createdSandboxId.get().equals(entry.getSandboxId())),
+                    "failed warmup sandbox ID must not remain in the idle store");
+            eventually(
+                    "interrupted warmup sandbox is deleted remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 0);
+        } finally {
+            blockWarmup.countDown();
+            shutdownAndRelease(pool);
+        }
+    }
+
+    private SandboxPool createPool(
+            InMemoryPoolStateStore stateStore,
+            Duration drainTimeout,
+            SandboxPreparer preparer) {
+        PoolCreationSpec creationSpec =
+                PoolCreationSpec.builder()
+                        .image(getSandboxImage())
+                        .entrypoint(List.of("tail -f /dev/null"))
+                        .metadata(Map.of("tag", tag, "suite", "sandbox-pool-graceful-shutdown-e2e"))
+                        .env(
+                                Map.of(
+                                        "E2E_TEST",
+                                        "true",
+                                        "EXECD_API_GRACE_SHUTDOWN",
+                                        "3s",
+                                        "EXECD_JUPYTER_IDLE_POLL_INTERVAL",
+                                        "1s"))
+                        .build();
+        return SandboxPool.builder()
+                .poolName("pool-" + tag)
+                .ownerId("owner-" + tag)
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(stateStore)
+                .connectionConfig(sharedConnectionConfig)
+                .creationSpec(creationSpec)
+                .warmupSandboxPreparer(preparer)
+                .reconcileInterval(Duration.ofMinutes(5))
+                .drainTimeout(drainTimeout)
+                .build();
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("warmup interrupted unexpectedly", exception);
+        }
+    }
+
+    private void eventually(
+            String description, Duration timeout, Duration interval, BooleanSupplier condition)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        Throwable lastError = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                if (condition.getAsBoolean()) {
+                    return;
+                }
+            } catch (Throwable throwable) {
+                lastError = throwable;
+            }
+            Thread.sleep(interval.toMillis());
+        }
+        if (lastError != null) {
+            throw new AssertionError(
+                    "Timed out waiting for "
+                            + description
+                            + ", last error: "
+                            + lastError.getMessage(),
+                    lastError);
+        }
+        throw new AssertionError("Timed out waiting for " + description);
+    }
+
+    private int countTaggedSandboxes() {
+        PagedSandboxInfos infos =
+                sandboxManager.listSandboxInfos(
+                        SandboxFilter.builder().metadata(Map.of("tag", tag)).pageSize(20).build());
+        return infos.getSandboxInfos().size();
+    }
+
+    private void cleanupTaggedSandboxes() {
+        if (sandboxManager == null || tag == null || tag.isBlank()) {
+            return;
+        }
+        try {
+            PagedSandboxInfos infos =
+                    sandboxManager.listSandboxInfos(
+                            SandboxFilter.builder()
+                                    .metadata(Map.of("tag", tag))
+                                    .pageSize(20)
+                                    .build());
+            infos.getSandboxInfos()
+                    .forEach(
+                            info -> {
+                                try {
+                                    sandboxManager.killSandbox(info.getId());
+                                } catch (Exception ignored) {
+                                }
+                            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void shutdownAndRelease(SandboxPool pool) {
+        if (pool == null) {
+            return;
+        }
+        try {
+            pool.shutdown(false);
+        } catch (Exception ignored) {
+        }
+        try {
+            pool.releaseAllIdle();
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static String uniqueTag(String scenario) {
+        return "e2e-pool-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}


### PR DESCRIPTION
## Summary

- stop future reconcile ticks without interrupting an active warmup during graceful shutdown
- wait for in-flight warmups up to the configured drain timeout before forcing executor shutdown
- temporarily clear the worker interrupt flag while deleting a failed warmup sandbox, then restore it
- stop warmup workers before the scheduler to prevent a second interrupt during cleanup DELETE
- add Java E2E coverage for warmup completion before timeout and remote cleanup after forced interruption
- bump the Kotlin/Java Sandbox SDK release version and User-Agent to 1.0.18

## Why

The previous graceful shutdown path cancelled the reconcile task with interruption before draining in-flight warmups. A readiness check could restore the worker interrupt flag and then cleanup DELETE calls would fail immediately with InterruptedIOException, leaving a sandbox created remotely but absent from the pool store.

## E2E coverage

The new SandboxPoolGracefulShutdownE2ETest uses the real lifecycle backend and unique metadata tags to verify:

1. a warmup completed within drainTimeout is persisted as idle before shutdown returns;
2. a warmup interrupted after drainTimeout is not persisted and its remote sandbox is eventually deleted.

The real-e2e workflow publishes the SDK from the PR checkout to Maven Local before running tests/java, so these cases exercise the code in this PR.

## Local validation

- ./gradlew spotlessApply :sandbox:test
- tests/java ./gradlew testClasses
- Java 11 internal integration A/B: 1.0.17 reproduces two interrupted cleanup attempts; the fixed build observes a successful non-interrupted fallback DELETE

The real backend E2E is delegated to this PRs GitHub Actions workflow as requested.