### PR TITLE
feat(sdk-kotlin): defer sandbox.create telemetry when skipHealthCheck is set

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -177,6 +177,42 @@ class Sandbox internal constructor(
         fun resumer(): Resumer = Resumer()
 
         /**
+         * Public entry point for wrappers to report sandbox.create telemetry.
+         *
+         * When a wrapper layer (e.g. AONE SDK) sets `skipHealthCheck=true` on the
+         * builder/connector/resumer, the SDK suppresses its automatic telemetry
+         * reporting so the wrapper owns the timing. The wrapper then calls this
+         * method after its own readiness checks to submit the complete
+         * `sandbox.create` latency event.
+         *
+         * This method never throws and never blocks the caller. It is safe to call
+         * from both Java and Kotlin. Each invocation enqueues one metrics event;
+         * callers should report exactly once per create attempt.
+         *
+         * @param connectionConfig connection configuration (used for URL, headers, opt-out)
+         * @param sandboxId optional created sandbox ID
+         * @param image optional image or snapshot reference
+         * @param createDurationMs measured end-to-end create latency in milliseconds
+         * @param success whether the full create flow succeeded
+         */
+        @JvmStatic
+        fun reportCreateMetrics(
+            connectionConfig: ConnectionConfig,
+            sandboxId: String?,
+            image: String?,
+            createDurationMs: Long,
+            success: Boolean,
+        ) {
+            LifecycleMetricsReporter.reportSandboxCreate(
+                connectionConfig = connectionConfig,
+                sandboxId = sandboxId,
+                image = image,
+                createDurationMs = createDurationMs,
+                success = success,
+            )
+        }
+
+        /**
          * Initialization result indicating the type of sandbox being initialized.
          */
         private sealed class InitializationResult {
@@ -374,22 +410,26 @@ class Sandbox internal constructor(
                         createdSandboxId = response.id
                         InitializationResult.NewSandbox(response.id)
                     }
-                LifecycleMetricsReporter.reportSandboxCreate(
-                    connectionConfig = connectionConfig,
-                    sandboxId = sandbox.id,
-                    image = startupSource,
-                    createDurationMs = elapsedMillis(started),
-                    success = true,
-                )
+                if (!skipHealthCheck) {
+                    LifecycleMetricsReporter.reportSandboxCreate(
+                        connectionConfig = connectionConfig,
+                        sandboxId = sandbox.id,
+                        image = startupSource,
+                        createDurationMs = elapsedMillis(started),
+                        success = true,
+                    )
+                }
                 return sandbox
             } catch (e: Throwable) {
-                LifecycleMetricsReporter.reportSandboxCreate(
-                    connectionConfig = connectionConfig,
-                    sandboxId = createdSandboxId,
-                    image = startupSource,
-                    createDurationMs = elapsedMillis(started),
-                    success = false,
-                )
+                if (!skipHealthCheck) {
+                    LifecycleMetricsReporter.reportSandboxCreate(
+                        connectionConfig = connectionConfig,
+                        sandboxId = createdSandboxId,
+                        image = startupSource,
+                        createDurationMs = elapsedMillis(started),
+                        success = false,
+                    )
+                }
                 throw e
             }
         }


### PR DESCRIPTION
## Summary

When `skipHealthCheck=true` is set on the builder/connector/resumer, the SDK now suppresses its automatic `sandbox.create` telemetry reporting. This gives wrapper SDKs (e.g. AONE) full control over timing — they can call the new public `Sandbox.reportCreateMetrics()` method after completing their own readiness checks.

## Changes

1. **`create()` telemetry is now conditional** — only fires when `skipHealthCheck=false` (default)
2. **New public `Sandbox.reportCreateMetrics()` companion method** — `@JvmStatic`, safe to call from Java/Kotlin. Wrapper SDKs use this to report end-to-end create latency after their own readiness polling.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `skipHealthCheck=false` (default) | auto-report | auto-report (unchanged) |
| `skipHealthCheck=true` | auto-report with incomplete timing | suppressed; caller reports via `reportCreateMetrics()` |