### PR TITLE
fix(ingress): use constant-time comparison for route signature

### DIFF
--- a/components/ingress/pkg/signature/signature.go
+++ b/components/ingress/pkg/signature/signature.go
@@ -16,6 +16,7 @@ package signature
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -226,7 +227,10 @@ func (v *Verifier) VerifySignature(signature, sandboxID string, port int, expire
 	canonical := CanonicalBytes(sandboxID, port, expiresB36)
 	inner := Inner(secret, canonical)
 	want := ExpectedHex8(inner)
-	if hex8 != want {
+	// Constant-time comparison to avoid timing side-channels leaking the
+	// expected signature byte-by-byte. Both hex8 and want are the fixed
+	// 8-hex-char output of ExpectedHex8, so length is already equal.
+	if subtle.ConstantTimeCompare([]byte(hex8), []byte(want)) != 1 {
 		return fmt.Errorf("%w: signature mismatch", ErrUnauthorized)
 	}
 	return nil

--- a/components/ingress/pkg/signature/signature_test.go
+++ b/components/ingress/pkg/signature/signature_test.go
@@ -90,6 +90,33 @@ func TestVerifySignature_OKAnd401(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestVerifySignature_SingleByteDiffRejected guards the constant-time
+// signature comparison in VerifySignature: a signature that differs from
+// the expected value in a single hex character must still be rejected.
+// This locks in the behavior that the check is not merely length-based
+// and catches a regression where an equal-length forgery could slip
+// through a misused crypto/subtle call.
+func TestVerifySignature_SingleByteDiffRejected(t *testing.T) {
+	secret := []byte("test-secret-bytes")
+	sb := "my-sandbox"
+	port := 9000
+	exp := testExpiresB36(t)
+	hex8 := ExpectedHex8(Inner(secret, CanonicalBytes(sb, port, exp)))
+	v := &Verifier{Keys: map[string][]byte{"z": secret}}
+
+	// Replace the last hex char of the expected signature with a
+	// deterministically different lowercase hex digit. Same length,
+	// same key id, only one nibble different.
+	other := byte('0')
+	if hex8[7] == '0' {
+		other = '1'
+	}
+	tampered := hex8[:7] + string(other) + "z"
+	err := v.VerifySignature(tampered, sb, port, exp)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized))
+}
+
 func TestVerifySignature_ExpiryComparisonAvoidsUint64Overflow(t *testing.T) {
 	secret := []byte("test-secret-bytes")
 	sb := "my-sandbox"


### PR DESCRIPTION
# Summary

`VerifySignature` in `components/ingress/pkg/signature/signature.go` compared the computed 8-hex-char HMAC digest with the plain `!=` operator. In Go, `string` inequality on unequal-content strings short-circuits at the first differing byte, which leaks the expected signature byte-by-byte through timing observations. That is inconsistent with how the sibling `OpenSandbox-Secure-Access` token is validated in `server/opensandbox_server/api/proxy.py:242`, which already uses `hmac.compare_digest` for the same reason.

This PR switches the comparison to `crypto/subtle.ConstantTimeCompare`, bringing the ingress-side route signature check in line with the server-side secure-access check.

Both `hex8` and `want` come from `ExpectedHex8`, whose output is always exactly 8 bytes, so no length adaptation is needed.

Also adds `TestVerifySignature_SingleByteDiffRejected`: a regression guard that a signature differing from the expected value in a single hex character (same length, same key id) is still rejected with `ErrUnauthorized`. This locks in the behavior against a future accidental misuse of `crypto/subtle` (e.g. a length-only comparison) that could silently accept an equal-length forgery.

# Testing

- [x] Unit tests — `cd components/ingress && go test ./pkg/...` — all packages pass (signature: 8 → 9 tests).
- [x] `gofmt -l` clean on touched files; `go vet ./pkg/signature/...` clean.
- [ ] Integration tests — not run; change is confined to one comparison and its unit test.
- [ ] e2e / manual verification — not run.

# Breaking Changes

- [x] None. Same input → same output; only observable difference is that timing no longer varies with how many leading bytes of a candidate signature match the expected value.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — no user-facing docs affected
- [x] Added/updated tests (if needed)
- [x] Security impact considered — hardening against timing side-channels; matches server-side pattern
- [x] Backward compatibility considered — no API or wire-format change
