### PR TITLE
Scope opensandbox-controller manager role to a namespace instead of cluster-wide

### DIFF
--- a/kubernetes/charts/opensandbox-controller/README.md
+++ b/kubernetes/charts/opensandbox-controller/README.md
@@ -98,6 +98,7 @@ kubectl delete crd sandboxsnapshots.sandbox.opensandbox.io
 | Name | Description | Value |
 |------|-------------|-------|
 | `rbac.create` | Specifies whether RBAC resources should be created | `true` |
+| `sandboxNamespace` | Namespace where BatchSandbox/Pool/SandboxSnapshot resources are expected to live; the manager Role/RoleBinding are scoped here. Defaults to the controller's own namespace if not set | `""` |
 | `serviceAccount.create` | Specifies whether a service account should be created | `true` |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
 | `serviceAccount.name` | The name of the service account to use | `""` |
@@ -264,8 +265,10 @@ kubectl get crd | grep opensandbox
 
 ### Verify RBAC permissions
 
+The manager role is namespace-scoped to `sandboxNamespace` (defaults to the controller's own namespace):
+
 ```bash
-kubectl auth can-i --as=system:serviceaccount:opensandbox-system:opensandbox-controller-controller-manager create pods
+kubectl auth can-i --as=system:serviceaccount:opensandbox-system:opensandbox-controller-controller-manager create pods -n opensandbox-system
 ```
 
 ## Additional Resources

--- a/kubernetes/charts/opensandbox-controller/templates/_helpers.tpl
+++ b/kubernetes/charts/opensandbox-controller/templates/_helpers.tpl
@@ -74,6 +74,19 @@ Get the namespace to use
 {{- end }}
 
 {{/*
+Namespace where sandbox workloads (BatchSandbox/Pool/SandboxSnapshot) run.
+Falls back to the controller's own namespace if not explicitly set, preserving
+the chart's existing single-namespace behavior for anyone who doesn't set it.
+*/}}
+{{- define "opensandbox.sandboxNamespace" -}}
+{{- if .Values.sandboxNamespace }}
+{{- .Values.sandboxNamespace }}
+{{- else }}
+{{- include "opensandbox.namespace" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Controller image with automatic version prefix handling.
 Prepends 'v' to semantic version tags (e.g., 0.0.1 -> v0.0.1) but preserves
 special tags like 'latest', 'dev', 'main', etc. as-is.

--- a/kubernetes/charts/opensandbox-controller/templates/clusterrole.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/clusterrole.yaml
@@ -44,11 +44,14 @@ rules:
   - patch
 
 ---
-# Manager ClusterRole
+# Manager Role — namespace-scoped to sandboxNamespace rather than cluster-wide,
+# since BatchSandbox/Pool/SandboxSnapshot are all namespaced resources and the
+# controller only ever needs to manage them in one (or a small, known) namespace.
 apiVersion: {{ include "opensandbox.rbac.apiVersion" . }}
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "opensandbox.managerRoleName" . }}
+  namespace: {{ include "opensandbox.sandboxNamespace" . }}
   labels:
     {{- include "opensandbox.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac

--- a/kubernetes/charts/opensandbox-controller/templates/clusterrolebinding.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/clusterrolebinding.yaml
@@ -20,17 +20,18 @@ subjects:
   namespace: {{ include "opensandbox.namespace" . }}
 
 ---
-# Manager role binding
+# Manager role binding — namespace-scoped alongside the Role above.
 apiVersion: {{ include "opensandbox.rbac.apiVersion" . }}
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "opensandbox.managerRoleName" . }}
+  namespace: {{ include "opensandbox.sandboxNamespace" . }}
   labels:
     {{- include "opensandbox.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "opensandbox.managerRoleName" . }}
 subjects:
 - kind: ServiceAccount

--- a/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
+++ b/kubernetes/charts/opensandbox-controller/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --leader-elect
         {{- end }}
         - --health-probe-bind-address=:8081
+        - --sandbox-namespace={{ include "opensandbox.sandboxNamespace" . }}
         - --zap-log-level={{ .Values.controller.logLevel }}
         {{- if $metrics.enabled }}
         - --metrics-bind-address=:{{ $metrics.port | default 8080 }}

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -12,9 +12,12 @@ fullnameOverride: ""
 namespaceOverride: ""
 
 # -- Namespace where BatchSandbox/Pool/SandboxSnapshot resources are expected to live.
-# The manager Role/RoleBinding are scoped here instead of cluster-wide. If not set,
-# defaults to the same namespace as the controller (namespaceOverride above), matching
-# the chart's existing single-namespace behavior.
+# The manager Role/RoleBinding are scoped here instead of cluster-wide, and this same
+# value is passed to the controller as --sandbox-namespace to restrict its manager
+# cache/watches to match (the RBAC and the cache scope must agree, or the controller
+# fails to list/watch with forbidden errors). If not set, defaults to the same
+# namespace as the controller (namespaceOverride above), matching the chart's
+# existing single-namespace behavior.
 sandboxNamespace: ""
 
 # Controller configuration

--- a/kubernetes/charts/opensandbox-controller/values.yaml
+++ b/kubernetes/charts/opensandbox-controller/values.yaml
@@ -11,6 +11,12 @@ fullnameOverride: ""
 # If not set, defaults to "opensandbox-system"
 namespaceOverride: ""
 
+# -- Namespace where BatchSandbox/Pool/SandboxSnapshot resources are expected to live.
+# The manager Role/RoleBinding are scoped here instead of cluster-wide. If not set,
+# defaults to the same namespace as the controller (namespaceOverride above), matching
+# the chart's existing single-namespace behavior.
+sandboxNamespace: ""
+
 # Controller configuration
 controller:
   # -- Controller image configuration

--- a/kubernetes/cmd/controller/main.go
+++ b/kubernetes/cmd/controller/main.go
@@ -32,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -226,6 +227,12 @@ func main() {
 	var resumePullSecret string
 	flag.StringVar(&resumePullSecret, "resume-pull-secret", "", "K8s Secret name for pulling snapshot images during resume.")
 
+	var sandboxNamespace string
+	flag.StringVar(&sandboxNamespace, "sandbox-namespace", "", "Namespace to restrict the manager's cache/watches to for "+
+		"BatchSandbox/Pool/SandboxSnapshot/pods/jobs/secrets/configmaps. Must match the RBAC Role's namespace "+
+		"(see the Helm chart's sandboxNamespace value) or the manager will fail to list/watch with forbidden errors. "+
+		"Leave empty to watch cluster-wide (requires a ClusterRole/ClusterRoleBinding instead of the default Role/RoleBinding).")
+
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 
@@ -395,7 +402,7 @@ func main() {
 		config.Burst = kubeClientBurst
 	}
 
-	mgr, err := ctrl.NewManager(config, ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -407,7 +414,24 @@ func main() {
 		// for the full LeaseDuration. This is safe because main() exits immediately after
 		// mgr.Start() returns and performs no post-stop cleanup.
 		LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	if sandboxNamespace != "" {
+		// Restrict the manager's cache (and therefore its list/watch calls) to this
+		// namespace, matching the RBAC Role/RoleBinding scope. Without this, the manager
+		// issues cluster-wide list/watch requests regardless of what the RBAC grants,
+		// which fail with forbidden errors under a namespaced Role.
+		setupLog.Info("restricting manager cache to namespace", "namespace", sandboxNamespace)
+		mgrOptions.Cache = cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				sandboxNamespace: {},
+			},
+		}
+	} else {
+		setupLog.Info("no sandbox-namespace set, manager will watch cluster-wide (requires a ClusterRole/ClusterRoleBinding)")
+	}
+
+	mgr, err := ctrl.NewManager(config, mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Fixes #1348.

The `opensandbox-controller` chart's "Manager" role was a `ClusterRole` bound cluster-wide via a `ClusterRoleBinding`, granting the controller's ServiceAccount `create`/`delete`/`get`/`list`/`patch`/`update`/`watch` on `pods` and `batch/jobs`, `get`/`list`/`watch` on `secrets` and `configmaps`, and full CRUD on the `sandbox.opensandbox.io` CRDs — across every namespace in the cluster, even though `BatchSandbox`/`Pool`/`SandboxSnapshot` are all declared `scope: Namespaced`.

- Adds a `sandboxNamespace` value, defaulting to the controller's own namespace (`namespaceOverride`) if unset — existing single-namespace deployments get identical rendered RBAC to before, just as a `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding`.
- Scopes the manager `Role`/`RoleBinding` to that namespace.
- Leaves the leader-election `Role`/`RoleBinding` unchanged (already namespace-scoped).
- Leaves the metrics auth/reader `ClusterRole`/`ClusterRoleBinding` unchanged — `TokenReview`/`SubjectAccessReview` and the `/metrics` non-resource URL have no namespace concept in Kubernetes RBAC, so those legitimately need to stay cluster-scoped.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` with default values renders the manager role as `Role`/`RoleBinding` in the controller's own namespace (byte-identical scope to today, minus the cluster-wide reach)
- [x] `helm template --set sandboxNamespace=my-sandboxes --set namespaceOverride=my-controller-ns` renders the manager role scoped to `my-sandboxes`, independent of the controller's own namespace
- [x] `helm template --set controller.metrics.enabled=true --set controller.metrics.secure=true` confirms the metrics auth/reader ClusterRoles are untouched