### PR TITLE
perf(kotlin): replenish sandbox pool with rolling warmups

### DIFF
--- a/sdks/sandbox/kotlin/README.md
+++ b/sdks/sandbox/kotlin/README.md
@@ -281,9 +281,18 @@ Pool lifecycle semantics:
 - `ownerId` is the lock owner identity (node/process id), not the pool identifier.
   If omitted, SDK auto-generates a UUID-based default.
 - Use `warmupSandboxPreparer(...)` if you need to prepare a sandbox after warmup readiness succeeds and before it is put into the idle pool.
+- `warmupConcurrency` is the maximum number of in-flight warmups. Replenish uses a
+  rolling window: when one warmup finishes, its slot is refilled immediately if
+  `idle + warming` is still below `maxIdle`; it does not wait for other slower warmups.
+- `reconcileInterval` is the periodic safety-net interval for state convergence,
+  expiration cleanup, and leader acquisition. Normal rolling replenish after a warmup
+  completion does not wait for the next interval.
+- Graceful shutdown stops admitting new warmups, keeps the primary heartbeat and
+  completion controller alive while already-admitted warmups finish, and preserves
+  the existing behavior of allowing those warmups to enter idle before shutdown completes.
 
 
-> For distributed deployment, use the optional `com.alibaba.opensandbox:sandbox-pool-redis` module or provide a custom `PoolStateStore` implementation. The Redis module accepts a caller-managed Jedis client, so your application keeps ownership of Redis connection configuration and lifecycle. Nodes sharing the same pool namespace must use the same sandbox creation and warmup definition; use a new `poolName` or namespace when changing that definition. Configure `primaryLockTtl` greater than `warmupReadyTimeout` plus expected warmup preparer time and buffer, otherwise leadership may expire while a node is creating idle sandboxes.
+> For distributed deployment, use the optional `com.alibaba.opensandbox:sandbox-pool-redis` module or provide a custom `PoolStateStore` implementation. The Redis module accepts a caller-managed Jedis client, so your application keeps ownership of Redis connection configuration and lifecycle. Nodes sharing the same pool namespace must use the same sandbox creation and warmup definition; use a new `poolName` or namespace when changing that definition. The pool renews an owned primary lock independently from warmup execution at an internal interval no greater than `primaryLockTtl / 3`, so one slow warmup does not block leader heartbeats.
 > In distributed mode, `resize(maxIdle)` can be called from any node. The call returns after the target is stored in the shared state store; the current primary applies replenish or shrink work during periodic reconcile. Use `resize(0)` and wait for `snapshot().idleCount == 0` when you need to drain the distributed idle buffer; `releaseAllIdle()` is only a best-effort cleanup pass.
 > `SandboxPoolManager.destroy(poolName)` is a stronger administrative operation: it writes a `DESTROYING` fence, drains visible idle IDs, best-effort kills idle sandboxes, clears persistent pool state, and then writes a `DESTROYED` tombstone for the configured TTL to prevent old nodes from recreating the same pool namespace. If drain or persistent-state cleanup cannot complete, `destroy()` throws `PoolDestroyIncompleteException` and leaves the namespace fenced as `DESTROYING`; retry `destroy()` to finish cleanup.
 

--- a/sdks/sandbox/kotlin/sandbox-pool-redis/README.md
+++ b/sdks/sandbox/kotlin/sandbox-pool-redis/README.md
@@ -76,10 +76,10 @@ try {
 - `releaseAllIdle()` is best-effort in distributed mode. It drains idle IDs visible during the call,
   but a concurrent primary may put new idle sandboxes unless the shared `maxIdle` target has been
   reduced first.
-- Configure `primaryLockTtl` greater than `warmupReadyTimeout` plus the expected
-  `warmupSandboxPreparer` duration and operational buffer. If warmup takes longer than
-  the primary lock TTL, another node may take leadership while the old leader discards
-  the sandboxes it created.
+- Primary-lock heartbeat is independent from warmup execution and runs at an internal
+  interval no greater than `primaryLockTtl / 3`. A slow warmup therefore does not block
+  lock renewal. Configure the TTL with enough margin for Redis latency, process pauses,
+  and scheduling jitter.
 - Redis outages are surfaced as `PoolStateStoreUnavailableException`; the pool does not silently bypass shared state.
 
 TODO: If production deployments need stronger protection against accidental mixed pool definitions,

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconciler.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconciler.kt
@@ -20,52 +20,59 @@ import com.alibaba.opensandbox.sandbox.domain.pool.PoolConfig
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolStateStore
 import org.slf4j.LoggerFactory
 import java.time.Instant
-import java.util.concurrent.Callable
-import java.util.concurrent.ExecutorService
 
 /**
  * Runs one reconcile tick: leader-gated replenish/shrink and TTL reap.
  *
  * Only the current primary lock holder performs idle maintenance writes.
  * Leader does not voluntarily release the lock; it is only lost when renew fails or TTL expires.
- * Call from a periodic scheduler; [createOne] should call lifecycle create and return the new sandbox ID or null on failure.
+ * Call from a periodic or completion-driven scheduler. Warmup submission is non-blocking; completed
+ * warmups are committed independently by the owning pool.
  */
 internal object PoolReconciler {
     private val logger = LoggerFactory.getLogger(PoolReconciler::class.java)
 
     /**
      * Runs a single reconcile tick. If this node does not hold the primary lock, returns immediately.
-     * Otherwise: reaps expired idle, snapshots counters, then shrinks excess idle or creates up to
-     * min(deficit, warmupConcurrency) sandboxes via [createOne] concurrently using [warmupExecutor].
+     * Otherwise: reaps expired idle, snapshots counters, then shrinks excess idle or requests enough
+     * warmups to fill the currently available rolling-window slots.
      * Lock is not released at end of tick (distributed implementations rely on TTL or renew failure to release).
      */
     fun runReconcileTick(
         config: PoolConfig,
         stateStore: PoolStateStore,
-        createOne: () -> String?,
         onDiscardSandbox: (String) -> Unit = {},
         reconcileState: ReconcileState,
-        warmupExecutor: ExecutorService,
-    ) {
+        warmingCount: Int,
+        submitWarmups: (Int) -> Unit,
+    ): Boolean {
         val poolName = config.poolName
         val ownerId = config.ownerId
         val ttl = config.primaryLockTtl
 
         if (!stateStore.tryAcquirePrimaryLock(poolName, ownerId, ttl)) {
             logger.trace("Reconcile skip (not primary): pool_name={}", poolName)
-            return
+            return false
         }
-        runPrimaryReplenishOnce(config, stateStore, createOne, onDiscardSandbox, reconcileState, warmupExecutor)
+        runPrimaryReplenishOnce(
+            config = config,
+            stateStore = stateStore,
+            onDiscardSandbox = onDiscardSandbox,
+            reconcileState = reconcileState,
+            warmingCount = warmingCount,
+            submitWarmups = submitWarmups,
+        )
         // Do not release primary lock here; leader holds until renew fails or TTL expires.
+        return true
     }
 
     private fun runPrimaryReplenishOnce(
         config: PoolConfig,
         stateStore: PoolStateStore,
-        createOne: () -> String?,
         onDiscardSandbox: (String) -> Unit,
         reconcileState: ReconcileState,
-        warmupExecutor: ExecutorService,
+        warmingCount: Int,
+        submitWarmups: (Int) -> Unit,
     ) {
         val poolName = config.poolName
         val ownerId = config.ownerId
@@ -86,121 +93,41 @@ internal object PoolReconciler {
             return
         }
 
-        val deficit = (config.maxIdle - counters.idleCount).coerceAtLeast(0)
-        val toCreate = minOf(deficit, config.warmupConcurrency)
+        val plan =
+            WarmupPlan.calculate(
+                idleCount = counters.idleCount,
+                warmingCount = warmingCount,
+                maxIdle = config.maxIdle,
+                warmupConcurrency = config.warmupConcurrency,
+            )
 
-        if (toCreate == 0 || reconcileState.isBackoffActive(now)) {
+        if (plan.toSubmit == 0 || reconcileState.isBackoffActive(now)) {
             stateStore.renewPrimaryLock(poolName, ownerId, ttl)
             logger.debug(
-                "Reconcile tick: pool_name={} idle={} deficit={} toCreate=0 (backoff={})",
+                "Reconcile tick: pool_name={} idle={} warming={} deficit={} available_slots={} " +
+                    "to_submit=0 backoff={}",
                 poolName,
                 counters.idleCount,
-                deficit,
+                warmingCount,
+                plan.deficit,
+                plan.availableSlots,
                 reconcileState.isBackoffActive(now),
             )
             return
         }
 
         logger.debug(
-            "Reconcile tick: pool_name={} idle={} deficit={} toCreate={}",
+            "Reconcile tick: pool_name={} idle={} warming={} deficit={} available_slots={} to_submit={}",
             poolName,
             counters.idleCount,
-            deficit,
-            toCreate,
+            warmingCount,
+            plan.deficit,
+            plan.availableSlots,
+            plan.toSubmit,
         )
 
         if (!stateStore.renewPrimaryLock(poolName, ownerId, ttl)) return
-        val tasks = List(toCreate) { Callable { createOne() } }
-        val results: List<Pair<String?, String?>> =
-            try {
-                warmupExecutor.invokeAll(tasks).map { f ->
-                    try {
-                        f.get() to null
-                    } catch (e: Exception) {
-                        null to e.message
-                    }
-                }
-            } catch (_: InterruptedException) {
-                Thread.currentThread().interrupt()
-                logger.info("Reconcile interrupted while waiting warmup tasks: pool_name={}", poolName)
-                return
-            }
-
-        val createdSandboxIds = mutableListOf<String>()
-        var failureCount = 0
-        var lastError: String? = null
-        for ((newId, errorMessage) in results) {
-            if (newId != null) {
-                createdSandboxIds += newId
-            } else {
-                failureCount++
-                lastError = errorMessage
-            }
-        }
-        reconcileState.recordFailures(failureCount, lastError)
-
-        var created = 0
-        for (index in createdSandboxIds.indices) {
-            val sandboxId = createdSandboxIds[index]
-            if (!stateStore.renewPrimaryLock(poolName, ownerId, ttl)) {
-                val orphanedCount = createdSandboxIds.size - index
-                for (orphanedIndex in index until createdSandboxIds.size) {
-                    try {
-                        onDiscardSandbox(createdSandboxIds[orphanedIndex])
-                    } catch (e: Exception) {
-                        logger.warn(
-                            "Reconcile orphaned sandbox cleanup failed: pool_name={} sandbox_id={} error={}",
-                            poolName,
-                            createdSandboxIds[orphanedIndex],
-                            e.message,
-                        )
-                    }
-                }
-                logger.warn(
-                    "Reconcile lost primary lock before putIdle; dropped {} newly created sandbox(es): pool_name={}",
-                    orphanedCount,
-                    poolName,
-                )
-                return
-            }
-            try {
-                stateStore.putIdle(poolName, sandboxId)
-                created++
-                reconcileState.recordSuccess()
-            } catch (e: Exception) {
-                reconcileState.recordFailure(e.message)
-                val orphanedCount = createdSandboxIds.size - index
-                for (orphanedIndex in index until createdSandboxIds.size) {
-                    val orphanedId = createdSandboxIds[orphanedIndex]
-                    try {
-                        stateStore.removeIdle(poolName, orphanedId)
-                    } catch (_: Exception) {
-                        // best-effort remove; continue cleanup path
-                    }
-                    try {
-                        onDiscardSandbox(orphanedId)
-                    } catch (cleanupError: Exception) {
-                        logger.warn(
-                            "Reconcile orphaned sandbox cleanup failed after putIdle error: pool_name={} sandbox_id={} error={}",
-                            poolName,
-                            orphanedId,
-                            cleanupError.message,
-                        )
-                    }
-                }
-                logger.warn(
-                    "Reconcile putIdle failed; dropped {} newly created sandbox(es): pool_name={} error={}",
-                    orphanedCount,
-                    poolName,
-                    e.message,
-                )
-                return
-            }
-        }
-
-        if (created > 0) {
-            logger.debug("Reconcile created {} sandboxes: pool_name={}", created, poolName)
-        }
+        submitWarmups(plan.toSubmit)
     }
 
     private fun shrinkExcessIdle(

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/ReconcileState.kt
@@ -61,6 +61,28 @@ internal class ReconcileState(
         recordFailures(1, errorMessage)
     }
 
+    /**
+     * Records one independently completed rolling-window warmup failure.
+     *
+     * Unlike batch failure accounting, multiple tasks that finish while the same backoff window
+     * is active must not advance the exponential delay once per completion. The first failure
+     * that reaches the threshold opens (or, after expiry, advances) one backoff window; remaining
+     * in-flight failures only update counters and the last error.
+     */
+    @Synchronized
+    fun recordAsyncFailure(errorMessage: String?) {
+        failureCount++
+        lastError = errorMessage
+        if (failureCount < degradedThreshold) return
+
+        val now = Instant.now()
+        val activeUntil = backoffUntil
+        if (state == PoolState.DEGRADED && activeUntil != null && now.isBefore(activeUntil)) {
+            return
+        }
+        activateNextBackoff(now)
+    }
+
     @Synchronized
     fun recordFailures(
         count: Int,
@@ -70,17 +92,21 @@ internal class ReconcileState(
         failureCount += count
         lastError = errorMessage
         if (failureCount >= degradedThreshold) {
-            state = PoolState.DEGRADED
-            backoffAttempts++
-            val exponent = (backoffAttempts - 1).coerceAtMost(30)
-            val delaySeconds = backoffBase.seconds * (1L shl exponent)
-            val delayMs =
-                minOf(
-                    Duration.ofSeconds(delaySeconds).toMillis(),
-                    backoffMax.toMillis(),
-                )
-            backoffUntil = Instant.now().plusMillis(delayMs)
+            activateNextBackoff(Instant.now())
         }
+    }
+
+    private fun activateNextBackoff(now: Instant) {
+        state = PoolState.DEGRADED
+        backoffAttempts++
+        val exponent = (backoffAttempts - 1).coerceAtMost(30)
+        val delaySeconds = backoffBase.seconds * (1L shl exponent)
+        val delayMs =
+            minOf(
+                Duration.ofSeconds(delaySeconds).toMillis(),
+                backoffMax.toMillis(),
+            )
+        backoffUntil = now.plusMillis(delayMs)
     }
 
     /** True if reconciler should skip create attempts this tick (in backoff window). */

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/WarmupPlan.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/WarmupPlan.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.pool
+
+/**
+ * Point-in-time replenish plan for the rolling warmup window.
+ *
+ * Both idle sandboxes and already-admitted warmups count toward the target so repeated
+ * reconcile ticks cannot over-submit while earlier warmups are still running.
+ */
+internal data class WarmupPlan(
+    val idleCount: Int,
+    val warmingCount: Int,
+    val maxIdle: Int,
+    val warmupConcurrency: Int,
+    val deficit: Int,
+    val availableSlots: Int,
+    val toSubmit: Int,
+) {
+    companion object {
+        fun calculate(
+            idleCount: Int,
+            warmingCount: Int,
+            maxIdle: Int,
+            warmupConcurrency: Int,
+        ): WarmupPlan {
+            require(idleCount >= 0) { "idleCount must be >= 0" }
+            require(warmingCount >= 0) { "warmingCount must be >= 0" }
+            require(maxIdle >= 0) { "maxIdle must be >= 0" }
+            require(warmupConcurrency > 0) { "warmupConcurrency must be positive" }
+
+            val deficit = (maxIdle - idleCount - warmingCount).coerceAtLeast(0)
+            val availableSlots = (warmupConcurrency - warmingCount).coerceAtLeast(0)
+            return WarmupPlan(
+                idleCount = idleCount,
+                warmingCount = warmingCount,
+                maxIdle = maxIdle,
+                warmupConcurrency = warmupConcurrency,
+                deficit = deficit,
+                availableSlots = availableSlots,
+                toSubmit = minOf(deficit, availableSlots),
+            )
+        }
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -108,6 +108,11 @@ class SandboxPool internal constructor(
     private var scheduler: ScheduledExecutorService? = null
     private var warmupExecutor: ExecutorService? = null
     private var reconcileTask: ScheduledFuture<*>? = null
+    private var primaryHeartbeatTask: ScheduledFuture<*>? = null
+    private val warmingCount = AtomicInteger(0)
+    private val warmupSubmissionsOpen = AtomicBoolean(false)
+    private val reconcileQueued = AtomicBoolean(false)
+    private val primaryOwned = AtomicBoolean(false)
     private val inFlightOperations = AtomicInteger(0)
     private val inFlightLock = ReentrantLock()
     private val inFlightZero: Condition = inFlightLock.newCondition()
@@ -124,7 +129,6 @@ class SandboxPool internal constructor(
         lifecycleState.set(LifecycleState.STARTING)
         try {
             ensurePoolNamespaceActive()
-            warnIfPrimaryLockTtlMayExpireDuringWarmup()
             sandboxManager = createSandboxManager()
             stateStore.setIdleEntryTtl(config.poolName, config.idleTimeout)
             stateStore.setMaxIdle(config.poolName, config.maxIdle)
@@ -138,9 +142,29 @@ class SandboxPool internal constructor(
                 }
             scheduler = exec
             val reconcileIntervalMs = config.reconcileInterval.toMillis()
+            val primaryHeartbeatIntervalMs =
+                minOf(
+                    reconcileIntervalMs,
+                    config.primaryLockTtl.dividedBy(3L).toMillis(),
+                ).coerceAtLeast(1L)
             // The first reconcile may run immediately. Publish RUNNING only after all of its
             // dependencies are initialized, but before scheduling it so that tick is not skipped.
             lifecycleState.set(LifecycleState.RUNNING)
+            warmupSubmissionsOpen.set(true)
+            primaryHeartbeatTask =
+                exec.scheduleAtFixedRate(
+                    {
+                        try {
+                            runPrimaryHeartbeat()
+                        } catch (t: Throwable) {
+                            // Keep periodic heartbeats alive after transient store failures.
+                            logger.error("Pool primary heartbeat failed: pool_name={}", config.poolName, t)
+                        }
+                    },
+                    primaryHeartbeatIntervalMs,
+                    primaryHeartbeatIntervalMs,
+                    TimeUnit.MILLISECONDS,
+                )
             reconcileTask =
                 exec.scheduleAtFixedRate(
                     {
@@ -168,19 +192,6 @@ class SandboxPool internal constructor(
             logger.error("Pool start failed: pool_name={}", config.poolName, e)
             throw e
         }
-    }
-
-    private fun warnIfPrimaryLockTtlMayExpireDuringWarmup() {
-        if (config.primaryLockTtl > config.warmupReadyTimeout) return
-        logger.warn(
-            "Pool primary lock TTL may expire during warmup: pool_name={} primary_lock_ttl_ms={} " +
-                "warmup_ready_timeout_ms={}. In distributed mode, configure primaryLockTtl greater than " +
-                "warmupReadyTimeout plus expected warmupSandboxPreparer time and buffer to avoid losing leadership " +
-                "while creating idle sandboxes.",
-            config.poolName,
-            config.primaryLockTtl.toMillis(),
-            config.warmupReadyTimeout.toMillis(),
-        )
     }
 
     /**
@@ -546,9 +557,10 @@ class SandboxPool internal constructor(
     @Synchronized
     fun shutdown(graceful: Boolean = true) {
         if (lifecycleState.get() == LifecycleState.STOPPED) return
+        warmupSubmissionsOpen.set(false)
         if (!graceful) {
-            stopReconcile()
             lifecycleState.set(LifecycleState.STOPPED)
+            stopReconcile()
             closeProvider()
             logger.info("Pool stopped (non-graceful): pool_name={} state={}", config.poolName, LifecycleState.STOPPED)
             return
@@ -573,6 +585,7 @@ class SandboxPool internal constructor(
             if (drained) {
                 completeGracefulReconcileStop()
             } else {
+                lifecycleState.set(LifecycleState.STOPPED)
                 forceStopReconcileAfterGracefulDrain()
             }
             lifecycleState.set(LifecycleState.STOPPED)
@@ -647,9 +660,12 @@ class SandboxPool internal constructor(
         }
     }
 
-    private fun completeDroppedCleanupTasks(dropped: List<Runnable>) {
+    private fun completeDroppedTasks(dropped: List<Runnable>) {
         dropped.forEach { task ->
-            (task as? TrackedCleanupTask)?.completeIfDropped()
+            when (task) {
+                is TrackedCleanupTask -> task.completeIfDropped()
+                is TrackedWarmupTask -> task.completeIfDropped()
+            }
         }
     }
 
@@ -706,16 +722,212 @@ class SandboxPool internal constructor(
             if (lifecycleState.get() != LifecycleState.RUNNING) return
             if (!isPoolNamespaceActive()) return
             val reconcileConfig = config.withMaxIdle(resolveMaxIdle())
-            PoolReconciler.runReconcileTick(
-                config = reconcileConfig,
-                stateStore = stateStore,
-                createOne = { createOneSandbox() },
-                onDiscardSandbox = { sandboxId -> killSandboxBestEffort(sandboxId) },
-                reconcileState = reconcileState,
-                warmupExecutor = executor,
-            )
+            try {
+                primaryOwned.set(
+                    PoolReconciler.runReconcileTick(
+                        config = reconcileConfig,
+                        stateStore = stateStore,
+                        onDiscardSandbox = { sandboxId -> killSandboxBestEffort(sandboxId) },
+                        reconcileState = reconcileState,
+                        warmingCount = warmingCount.get(),
+                        submitWarmups = { count -> submitWarmups(count, executor) },
+                    ),
+                )
+            } catch (e: Exception) {
+                primaryOwned.set(false)
+                throw e
+            }
         } finally {
             endOperation()
+        }
+    }
+
+    private fun runPrimaryHeartbeat() {
+        val state = lifecycleState.get()
+        if (state != LifecycleState.RUNNING && state != LifecycleState.DRAINING) return
+        if (!primaryOwned.get()) return
+        val renewed =
+            stateStore.renewPrimaryLock(
+                config.poolName,
+                config.ownerId,
+                config.primaryLockTtl,
+            )
+        if (!renewed) {
+            primaryOwned.set(false)
+            logger.trace(
+                "Pool primary heartbeat skipped (not current owner): pool_name={} owner_id={}",
+                config.poolName,
+                config.ownerId,
+            )
+        }
+    }
+
+    private fun requestReconcile() {
+        if (lifecycleState.get() != LifecycleState.RUNNING || !warmupSubmissionsOpen.get()) return
+        val exec = scheduler ?: return
+        if (!reconcileQueued.compareAndSet(false, true)) return
+        try {
+            exec.execute {
+                reconcileQueued.set(false)
+                try {
+                    runReconcileTick()
+                } catch (t: Throwable) {
+                    logger.error("Pool completion-driven reconcile failed: pool_name={}", config.poolName, t)
+                }
+            }
+        } catch (e: Exception) {
+            reconcileQueued.set(false)
+            if (lifecycleState.get() == LifecycleState.RUNNING) {
+                logger.debug(
+                    "Pool completion-driven reconcile submit rejected: pool_name={} error={}",
+                    config.poolName,
+                    e.message,
+                )
+            }
+        }
+    }
+
+    private fun submitWarmups(
+        count: Int,
+        executor: ExecutorService,
+    ) {
+        repeat(count) {
+            if (lifecycleState.get() != LifecycleState.RUNNING || !warmupSubmissionsOpen.get()) return
+            val task = TrackedWarmupTask()
+            try {
+                executor.execute(task)
+            } catch (e: Exception) {
+                logger.debug(
+                    "Pool warmup submit rejected: pool_name={} error={}",
+                    config.poolName,
+                    e.message,
+                )
+                task.completeIfDropped()
+                return
+            }
+        }
+    }
+
+    private inner class TrackedWarmupTask : Runnable {
+        private val completed = AtomicBoolean(false)
+
+        init {
+            warmingCount.incrementAndGet()
+            beginOperation()
+        }
+
+        override fun run() {
+            val outcome =
+                try {
+                    WarmupOutcome.Success(createOneSandbox())
+                } catch (e: Exception) {
+                    WarmupOutcome.Failure(e)
+                }
+            dispatchCompletion(outcome)
+        }
+
+        fun completeIfDropped() {
+            complete(WarmupOutcome.Cancelled)
+        }
+
+        private fun dispatchCompletion(outcome: WarmupOutcome) {
+            val completion = Runnable { complete(outcome) }
+            val exec = scheduler
+            if (exec == null) {
+                completion.run()
+                return
+            }
+            try {
+                exec.execute(completion)
+            } catch (e: Exception) {
+                logger.debug(
+                    "Pool warmup completion submit rejected, handling inline: pool_name={} error={}",
+                    config.poolName,
+                    e.message,
+                )
+                completion.run()
+            }
+        }
+
+        private fun complete(outcome: WarmupOutcome) {
+            if (!completed.compareAndSet(false, true)) return
+            try {
+                handleWarmupOutcome(outcome)
+            } finally {
+                warmingCount.decrementAndGet()
+                endOperation()
+                requestReconcile()
+            }
+        }
+    }
+
+    private sealed interface WarmupOutcome {
+        class Success(
+            val sandboxId: String,
+        ) : WarmupOutcome
+
+        class Failure(
+            val error: Exception,
+        ) : WarmupOutcome
+
+        data object Cancelled : WarmupOutcome
+    }
+
+    private fun handleWarmupOutcome(outcome: WarmupOutcome) {
+        when (outcome) {
+            is WarmupOutcome.Success -> commitWarmupSandbox(outcome.sandboxId)
+            is WarmupOutcome.Failure -> {
+                if (lifecycleState.get() == LifecycleState.RUNNING) {
+                    reconcileState.recordAsyncFailure(outcome.error.message)
+                }
+            }
+            WarmupOutcome.Cancelled -> Unit
+        }
+    }
+
+    private fun commitWarmupSandbox(sandboxId: String) {
+        val state = lifecycleState.get()
+        if (state != LifecycleState.RUNNING && state != LifecycleState.DRAINING) {
+            scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-stopped")
+            return
+        }
+
+        try {
+            ensurePoolNamespaceActive()
+            if (!stateStore.renewPrimaryLock(config.poolName, config.ownerId, config.primaryLockTtl)) {
+                primaryOwned.set(false)
+                logger.warn(
+                    "Pool lost primary lock before putIdle; dropping warmup sandbox: " +
+                        "pool_name={} sandbox_id={}",
+                    config.poolName,
+                    sandboxId,
+                )
+                scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-lock-lost")
+                return
+            }
+            stateStore.putIdle(config.poolName, sandboxId)
+            reconcileState.recordSuccess()
+            logger.debug(
+                "Pool warmup sandbox entered idle: pool_name={} sandbox_id={}",
+                config.poolName,
+                sandboxId,
+            )
+        } catch (e: Exception) {
+            if (lifecycleState.get() == LifecycleState.RUNNING) {
+                reconcileState.recordAsyncFailure(e.message)
+            }
+            try {
+                stateStore.removeIdle(config.poolName, sandboxId)
+            } catch (_: Exception) {
+                // best-effort remove before remote cleanup
+            }
+            scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-commit-failed")
+            logger.warn(
+                "Pool warmup commit failed; dropped sandbox: pool_name={} sandbox_id={} error={}",
+                config.poolName,
+                sandboxId,
+                e.message,
+            )
         }
     }
 
@@ -724,8 +936,7 @@ class SandboxPool internal constructor(
      * id into the store; the created [Sandbox] is closed immediately so only the id is
      * kept in the pool.
      */
-    private fun createOneSandbox(): String? {
-        beginOperation()
+    private fun createOneSandbox(): String {
         return try {
             val sandbox = buildWarmupSandbox()
             try {
@@ -747,8 +958,6 @@ class SandboxPool internal constructor(
         } catch (e: Exception) {
             logger.warn("Pool create sandbox failed: poolName={}", config.poolName, e)
             throw e
-        } finally {
-            endOperation()
         }
     }
 
@@ -1082,35 +1291,42 @@ class SandboxPool internal constructor(
     private fun stopReconcile() {
         reconcileTask?.cancel(true)
         reconcileTask = null
-        scheduler?.let { shutdownExecutor(it, "scheduler") }
-        scheduler = null
+        primaryHeartbeatTask?.cancel(true)
+        primaryHeartbeatTask = null
         warmupExecutor?.let { shutdownExecutor(it, "warmup") }
         warmupExecutor = null
+        scheduler?.let { shutdownExecutor(it, "scheduler") }
+        scheduler = null
+        reconcileQueued.set(false)
         releasePrimaryLockBestEffort()
     }
 
     private fun beginGracefulReconcileStop() {
         reconcileTask?.cancel(false)
         reconcileTask = null
-        scheduler?.shutdown()
     }
 
     private fun completeGracefulReconcileStop() {
-        scheduler?.let { shutdownExecutor(it, "scheduler") }
-        scheduler = null
         warmupExecutor?.let { shutdownExecutor(it, "warmup") }
         warmupExecutor = null
+        primaryHeartbeatTask?.cancel(false)
+        primaryHeartbeatTask = null
+        scheduler?.let { shutdownExecutor(it, "scheduler") }
+        scheduler = null
+        reconcileQueued.set(false)
         releasePrimaryLockBestEffort()
     }
 
     private fun forceStopReconcileAfterGracefulDrain() {
-        // Stop warmup workers first and let their failure cleanup finish before interrupting
-        // the scheduler. Interrupting the scheduler while it waits in invokeAll() would cancel
-        // the same warmup futures again and could re-interrupt an in-progress cleanup DELETE.
+        // Stop warmup workers first while the controller remains alive so interrupted workers can
+        // still deliver completion cleanup and release their tracked operation slots.
         warmupExecutor?.let { forceShutdownExecutor(it, "warmup") }
         warmupExecutor = null
-        scheduler?.let { forceShutdownExecutor(it, "scheduler") }
+        primaryHeartbeatTask?.cancel(true)
+        primaryHeartbeatTask = null
+        scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
+        reconcileQueued.set(false)
         releasePrimaryLockBestEffort()
     }
 
@@ -1118,10 +1334,14 @@ class SandboxPool internal constructor(
         if (!lifecycleState.compareAndSet(LifecycleState.RUNNING, LifecycleState.STOPPED)) return
         reconcileTask?.cancel(false)
         reconcileTask = null
+        primaryHeartbeatTask?.cancel(false)
+        primaryHeartbeatTask = null
+        warmupSubmissionsOpen.set(false)
+        warmupExecutor?.let { completeDroppedTasks(it.shutdownNow()) }
+        warmupExecutor = null
         scheduler?.shutdown()
         scheduler = null
-        warmupExecutor?.let { completeDroppedCleanupTasks(it.shutdownNow()) }
-        warmupExecutor = null
+        reconcileQueued.set(false)
         releasePrimaryLockBestEffort()
         closeProvider()
     }
@@ -1136,6 +1356,8 @@ class SandboxPool internal constructor(
                 config.ownerId,
                 e.message,
             )
+        } finally {
+            primaryOwned.set(false)
         }
     }
 
@@ -1147,7 +1369,7 @@ class SandboxPool internal constructor(
         try {
             if (executor.awaitTermination(5, TimeUnit.SECONDS)) return
             val dropped = executor.shutdownNow()
-            completeDroppedCleanupTasks(dropped)
+            completeDroppedTasks(dropped)
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 logger.warn(
                     "Pool {} executor did not terminate after forced stop: pool_name={} dropped_tasks={}",
@@ -1158,7 +1380,7 @@ class SandboxPool internal constructor(
             }
         } catch (_: InterruptedException) {
             val dropped = executor.shutdownNow()
-            completeDroppedCleanupTasks(dropped)
+            completeDroppedTasks(dropped)
             Thread.currentThread().interrupt()
             logger.warn(
                 "Pool {} executor shutdown interrupted; forced stop issued: pool_name={} dropped_tasks={}",
@@ -1174,7 +1396,7 @@ class SandboxPool internal constructor(
         role: String,
     ) {
         val dropped = executor.shutdownNow()
-        completeDroppedCleanupTasks(dropped)
+        completeDroppedTasks(dropped)
         try {
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 logger.warn(

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -47,6 +47,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
@@ -109,13 +110,13 @@ class SandboxPool internal constructor(
     private var warmupExecutor: ExecutorService? = null
     private var reconcileTask: ScheduledFuture<*>? = null
     private var primaryHeartbeatTask: ScheduledFuture<*>? = null
-    private val warmingCount = AtomicInteger(0)
-    private val warmupSubmissionsOpen = AtomicBoolean(false)
-    private val reconcileQueued = AtomicBoolean(false)
-    private val primaryOwned = AtomicBoolean(false)
     private val inFlightOperations = AtomicInteger(0)
     private val inFlightLock = ReentrantLock()
     private val inFlightZero: Condition = inFlightLock.newCondition()
+    private val runSequence = AtomicLong(0)
+
+    @Volatile
+    private var currentRun: RunContext? = null
 
     /**
      * Starts the pool: begins the background reconcile loop and, if [PoolConfig.maxIdle] > 0,
@@ -132,15 +133,18 @@ class SandboxPool internal constructor(
             sandboxManager = createSandboxManager()
             stateStore.setIdleEntryTtl(config.poolName, config.idleTimeout)
             stateStore.setMaxIdle(config.poolName, config.maxIdle)
-            warmupExecutor =
+            val warmupExec =
                 Executors.newFixedThreadPool(config.warmupConcurrency.coerceAtLeast(1)) { r ->
                     Thread(r, "sandbox-pool-warmup-${config.poolName}").apply { isDaemon = true }
                 }
+            warmupExecutor = warmupExec
             val exec =
                 Executors.newSingleThreadScheduledExecutor { r ->
                     Thread(r, "sandbox-pool-reconcile-${config.poolName}").apply { isDaemon = true }
                 }
             scheduler = exec
+            val run = RunContext(runSequence.incrementAndGet(), exec, warmupExec)
+            currentRun = run
             val reconcileIntervalMs = config.reconcileInterval.toMillis()
             val primaryHeartbeatIntervalMs =
                 minOf(
@@ -150,12 +154,11 @@ class SandboxPool internal constructor(
             // The first reconcile may run immediately. Publish RUNNING only after all of its
             // dependencies are initialized, but before scheduling it so that tick is not skipped.
             lifecycleState.set(LifecycleState.RUNNING)
-            warmupSubmissionsOpen.set(true)
             primaryHeartbeatTask =
                 exec.scheduleAtFixedRate(
                     {
                         try {
-                            runPrimaryHeartbeat()
+                            runPrimaryHeartbeat(run)
                         } catch (t: Throwable) {
                             // Keep periodic heartbeats alive after transient store failures.
                             logger.error("Pool primary heartbeat failed: pool_name={}", config.poolName, t)
@@ -169,7 +172,7 @@ class SandboxPool internal constructor(
                 exec.scheduleAtFixedRate(
                     {
                         try {
-                            runReconcileTick()
+                            runReconcileTick(run)
                         } catch (t: Throwable) {
                             // Keep periodic scheduling alive even if one tick fails unexpectedly.
                             logger.error("Pool reconcile tick failed unexpectedly: pool_name={}", config.poolName, t)
@@ -557,7 +560,8 @@ class SandboxPool internal constructor(
     @Synchronized
     fun shutdown(graceful: Boolean = true) {
         if (lifecycleState.get() == LifecycleState.STOPPED) return
-        warmupSubmissionsOpen.set(false)
+        val run = currentRun
+        run?.warmupSubmissionsOpen?.set(false)
         if (!graceful) {
             lifecycleState.set(LifecycleState.STOPPED)
             stopReconcile()
@@ -605,10 +609,10 @@ class SandboxPool internal constructor(
         poolName: String,
         sandboxIds: List<String>,
         source: String,
+        executor: ExecutorService? = warmupExecutor,
     ) {
         if (sandboxIds.isEmpty()) return
         val cleanupTask = TrackedCleanupTask(poolName, sandboxIds.toList(), source)
-        val executor = warmupExecutor
         if (executor == null) {
             cleanupTask.run()
             return
@@ -684,22 +688,50 @@ class SandboxPool internal constructor(
         source: String,
     ) {
         if (sandboxIds.isEmpty()) return
-        val manager = sandboxManager ?: return
-        for (sandboxId in sandboxIds) {
-            try {
-                manager.killSandbox(sandboxId)
-                logger.debug(
-                    "Killed near-expiry idle sandbox: pool_name={} sandbox_id={} source={}",
-                    poolName,
-                    sandboxId,
-                    source,
-                )
+        var temporaryManager: SandboxManager? = null
+        val manager =
+            sandboxManager ?: try {
+                createSandboxManager().also { temporaryManager = it }
             } catch (e: Exception) {
                 logger.warn(
-                    "Failed to kill near-expiry idle sandbox (best-effort, will expire server-side): " +
-                        "pool_name={} sandbox_id={} source={} error={}",
+                    "Failed to create manager for discarded sandbox cleanup: " +
+                        "pool_name={} count={} source={} error={}",
                     poolName,
-                    sandboxId,
+                    sandboxIds.size,
+                    source,
+                    e.message,
+                )
+                return
+            }
+        try {
+            for (sandboxId in sandboxIds) {
+                try {
+                    manager.killSandbox(sandboxId)
+                    logger.debug(
+                        "Killed discarded sandbox: pool_name={} sandbox_id={} source={}",
+                        poolName,
+                        sandboxId,
+                        source,
+                    )
+                } catch (e: Exception) {
+                    logger.warn(
+                        "Failed to kill discarded sandbox (best-effort, will expire server-side): " +
+                            "pool_name={} sandbox_id={} source={} error={}",
+                        poolName,
+                        sandboxId,
+                        source,
+                        e.message,
+                    )
+                }
+            }
+        } finally {
+            try {
+                temporaryManager?.close()
+            } catch (e: Exception) {
+                logger.warn(
+                    "Failed to close temporary manager after discarded sandbox cleanup: " +
+                        "pool_name={} source={} error={}",
+                    poolName,
                     source,
                     e.message,
                 )
@@ -709,32 +741,31 @@ class SandboxPool internal constructor(
 
     private fun createSandboxManager(): SandboxManager = sandboxManagerFactory(connectionConfig.copyWithoutConnectionPool())
 
-    private fun runReconcileTick() {
-        if (lifecycleState.get() != LifecycleState.RUNNING) return
+    private fun runReconcileTick(run: RunContext) {
+        if (!isCurrentRun(run) || lifecycleState.get() != LifecycleState.RUNNING) return
         if (!isPoolNamespaceActive()) {
             logger.info("Pool namespace is destroyed; stopping local pool: pool_name={}", config.poolName)
             stopAfterNamespaceDestroyed()
             return
         }
-        val executor = warmupExecutor ?: return
         beginOperation()
         try {
-            if (lifecycleState.get() != LifecycleState.RUNNING) return
+            if (!isCurrentRun(run) || lifecycleState.get() != LifecycleState.RUNNING) return
             if (!isPoolNamespaceActive()) return
             val reconcileConfig = config.withMaxIdle(resolveMaxIdle())
             try {
-                primaryOwned.set(
+                run.primaryOwned.set(
                     PoolReconciler.runReconcileTick(
                         config = reconcileConfig,
                         stateStore = stateStore,
                         onDiscardSandbox = { sandboxId -> killSandboxBestEffort(sandboxId) },
                         reconcileState = reconcileState,
-                        warmingCount = warmingCount.get(),
-                        submitWarmups = { count -> submitWarmups(count, executor) },
+                        warmingCount = run.warmingCount.get(),
+                        submitWarmups = { count -> submitWarmups(run, count) },
                     ),
                 )
             } catch (e: Exception) {
-                primaryOwned.set(false)
+                run.primaryOwned.set(false)
                 throw e
             }
         } finally {
@@ -742,10 +773,11 @@ class SandboxPool internal constructor(
         }
     }
 
-    private fun runPrimaryHeartbeat() {
+    private fun runPrimaryHeartbeat(run: RunContext) {
+        if (!isCurrentRun(run)) return
         val state = lifecycleState.get()
         if (state != LifecycleState.RUNNING && state != LifecycleState.DRAINING) return
-        if (!primaryOwned.get()) return
+        if (!run.primaryOwned.get()) return
         val renewed =
             stateStore.renewPrimaryLock(
                 config.poolName,
@@ -753,7 +785,7 @@ class SandboxPool internal constructor(
                 config.primaryLockTtl,
             )
         if (!renewed) {
-            primaryOwned.set(false)
+            run.primaryOwned.set(false)
             logger.trace(
                 "Pool primary heartbeat skipped (not current owner): pool_name={} owner_id={}",
                 config.poolName,
@@ -762,21 +794,26 @@ class SandboxPool internal constructor(
         }
     }
 
-    private fun requestReconcile() {
-        if (lifecycleState.get() != LifecycleState.RUNNING || !warmupSubmissionsOpen.get()) return
-        val exec = scheduler ?: return
-        if (!reconcileQueued.compareAndSet(false, true)) return
+    private fun requestReconcile(run: RunContext) {
+        if (!isCurrentRun(run) ||
+            lifecycleState.get() != LifecycleState.RUNNING ||
+            !run.warmupSubmissionsOpen.get()
+        ) {
+            return
+        }
+        val exec = run.scheduler
+        if (!run.reconcileQueued.compareAndSet(false, true)) return
         try {
             exec.execute {
-                reconcileQueued.set(false)
+                run.reconcileQueued.set(false)
                 try {
-                    runReconcileTick()
+                    runReconcileTick(run)
                 } catch (t: Throwable) {
                     logger.error("Pool completion-driven reconcile failed: pool_name={}", config.poolName, t)
                 }
             }
         } catch (e: Exception) {
-            reconcileQueued.set(false)
+            run.reconcileQueued.set(false)
             if (lifecycleState.get() == LifecycleState.RUNNING) {
                 logger.debug(
                     "Pool completion-driven reconcile submit rejected: pool_name={} error={}",
@@ -788,14 +825,19 @@ class SandboxPool internal constructor(
     }
 
     private fun submitWarmups(
+        run: RunContext,
         count: Int,
-        executor: ExecutorService,
     ) {
         repeat(count) {
-            if (lifecycleState.get() != LifecycleState.RUNNING || !warmupSubmissionsOpen.get()) return
-            val task = TrackedWarmupTask()
+            if (!isCurrentRun(run) ||
+                lifecycleState.get() != LifecycleState.RUNNING ||
+                !run.warmupSubmissionsOpen.get()
+            ) {
+                return
+            }
+            val task = TrackedWarmupTask(run)
             try {
-                executor.execute(task)
+                run.warmupExecutor.execute(task)
             } catch (e: Exception) {
                 logger.debug(
                     "Pool warmup submit rejected: pool_name={} error={}",
@@ -808,11 +850,13 @@ class SandboxPool internal constructor(
         }
     }
 
-    private inner class TrackedWarmupTask : Runnable {
+    private inner class TrackedWarmupTask(
+        private val run: RunContext,
+    ) : Runnable {
         private val completed = AtomicBoolean(false)
 
         init {
-            warmingCount.incrementAndGet()
+            run.warmingCount.incrementAndGet()
             beginOperation()
         }
 
@@ -832,13 +876,8 @@ class SandboxPool internal constructor(
 
         private fun dispatchCompletion(outcome: WarmupOutcome) {
             val completion = Runnable { complete(outcome) }
-            val exec = scheduler
-            if (exec == null) {
-                completion.run()
-                return
-            }
             try {
-                exec.execute(completion)
+                run.scheduler.execute(completion)
             } catch (e: Exception) {
                 logger.debug(
                     "Pool warmup completion submit rejected, handling inline: pool_name={} error={}",
@@ -852,11 +891,11 @@ class SandboxPool internal constructor(
         private fun complete(outcome: WarmupOutcome) {
             if (!completed.compareAndSet(false, true)) return
             try {
-                handleWarmupOutcome(outcome)
+                handleWarmupOutcome(run, outcome)
             } finally {
-                warmingCount.decrementAndGet()
+                run.warmingCount.decrementAndGet()
                 endOperation()
-                requestReconcile()
+                requestReconcile(run)
             }
         }
     }
@@ -873,11 +912,14 @@ class SandboxPool internal constructor(
         data object Cancelled : WarmupOutcome
     }
 
-    private fun handleWarmupOutcome(outcome: WarmupOutcome) {
+    private fun handleWarmupOutcome(
+        run: RunContext,
+        outcome: WarmupOutcome,
+    ) {
         when (outcome) {
-            is WarmupOutcome.Success -> commitWarmupSandbox(outcome.sandboxId)
+            is WarmupOutcome.Success -> commitWarmupSandbox(run, outcome.sandboxId)
             is WarmupOutcome.Failure -> {
-                if (lifecycleState.get() == LifecycleState.RUNNING) {
+                if (isCurrentRun(run) && lifecycleState.get() == LifecycleState.RUNNING) {
                     reconcileState.recordAsyncFailure(outcome.error.message)
                 }
             }
@@ -885,48 +927,67 @@ class SandboxPool internal constructor(
         }
     }
 
-    private fun commitWarmupSandbox(sandboxId: String) {
-        val state = lifecycleState.get()
-        if (state != LifecycleState.RUNNING && state != LifecycleState.DRAINING) {
-            scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-stopped")
-            return
-        }
-
+    private fun commitWarmupSandbox(
+        run: RunContext,
+        sandboxId: String,
+    ) {
+        var cleanupSource: String? = null
+        run.commitLock.lock()
         try {
-            ensurePoolNamespaceActive()
-            if (!stateStore.renewPrimaryLock(config.poolName, config.ownerId, config.primaryLockTtl)) {
-                primaryOwned.set(false)
-                logger.warn(
-                    "Pool lost primary lock before putIdle; dropping warmup sandbox: " +
-                        "pool_name={} sandbox_id={}",
-                    config.poolName,
-                    sandboxId,
-                )
-                scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-lock-lost")
-                return
+            val state = lifecycleState.get()
+            if (!isCurrentRun(run) || (state != LifecycleState.RUNNING && state != LifecycleState.DRAINING)) {
+                cleanupSource = "warmup-stale-run"
+            } else {
+                try {
+                    ensurePoolNamespaceActive()
+                    if (!stateStore.renewPrimaryLock(config.poolName, config.ownerId, config.primaryLockTtl)) {
+                        run.primaryOwned.set(false)
+                        logger.warn(
+                            "Pool lost primary lock before putIdle; dropping warmup sandbox: " +
+                                "pool_name={} sandbox_id={} run={}",
+                            config.poolName,
+                            sandboxId,
+                            run.generation,
+                        )
+                        cleanupSource = "warmup-lock-lost"
+                    } else {
+                        stateStore.putIdle(config.poolName, sandboxId)
+                        reconcileState.recordSuccess()
+                        logger.debug(
+                            "Pool warmup sandbox entered idle: pool_name={} sandbox_id={} run={}",
+                            config.poolName,
+                            sandboxId,
+                            run.generation,
+                        )
+                    }
+                } catch (e: Exception) {
+                    if (isCurrentRun(run) && lifecycleState.get() == LifecycleState.RUNNING) {
+                        reconcileState.recordAsyncFailure(e.message)
+                    }
+                    try {
+                        stateStore.removeIdle(config.poolName, sandboxId)
+                    } catch (_: Exception) {
+                        // best-effort remove before remote cleanup
+                    }
+                    cleanupSource = "warmup-commit-failed"
+                    logger.warn(
+                        "Pool warmup commit failed; dropped sandbox: pool_name={} sandbox_id={} run={} error={}",
+                        config.poolName,
+                        sandboxId,
+                        run.generation,
+                        e.message,
+                    )
+                }
             }
-            stateStore.putIdle(config.poolName, sandboxId)
-            reconcileState.recordSuccess()
-            logger.debug(
-                "Pool warmup sandbox entered idle: pool_name={} sandbox_id={}",
+        } finally {
+            run.commitLock.unlock()
+        }
+        cleanupSource?.let { source ->
+            scheduleKillDiscardedAlive(
                 config.poolName,
-                sandboxId,
-            )
-        } catch (e: Exception) {
-            if (lifecycleState.get() == LifecycleState.RUNNING) {
-                reconcileState.recordAsyncFailure(e.message)
-            }
-            try {
-                stateStore.removeIdle(config.poolName, sandboxId)
-            } catch (_: Exception) {
-                // best-effort remove before remote cleanup
-            }
-            scheduleKillDiscardedAlive(config.poolName, listOf(sandboxId), source = "warmup-commit-failed")
-            logger.warn(
-                "Pool warmup commit failed; dropped sandbox: pool_name={} sandbox_id={} error={}",
-                config.poolName,
-                sandboxId,
-                e.message,
+                listOf(sandboxId),
+                source = source,
+                executor = run.warmupExecutor,
             )
         }
     }
@@ -1289,6 +1350,9 @@ class SandboxPool internal constructor(
     }
 
     private fun stopReconcile() {
+        val run = currentRun
+        run?.warmupSubmissionsOpen?.set(false)
+        retireRun(run)
         reconcileTask?.cancel(true)
         reconcileTask = null
         primaryHeartbeatTask?.cancel(true)
@@ -1297,8 +1361,8 @@ class SandboxPool internal constructor(
         warmupExecutor = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
-        reconcileQueued.set(false)
-        releasePrimaryLockBestEffort()
+        run?.reconcileQueued?.set(false)
+        releasePrimaryLockBestEffort(run)
     }
 
     private fun beginGracefulReconcileStop() {
@@ -1307,17 +1371,21 @@ class SandboxPool internal constructor(
     }
 
     private fun completeGracefulReconcileStop() {
+        val run = currentRun
+        retireRun(run)
         warmupExecutor?.let { shutdownExecutor(it, "warmup") }
         warmupExecutor = null
         primaryHeartbeatTask?.cancel(false)
         primaryHeartbeatTask = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
-        reconcileQueued.set(false)
-        releasePrimaryLockBestEffort()
+        run?.reconcileQueued?.set(false)
+        releasePrimaryLockBestEffort(run)
     }
 
     private fun forceStopReconcileAfterGracefulDrain() {
+        val run = currentRun
+        retireRun(run)
         // Stop warmup workers first while the controller remains alive so interrupted workers can
         // still deliver completion cleanup and release their tracked operation slots.
         warmupExecutor?.let { forceShutdownExecutor(it, "warmup") }
@@ -1326,27 +1394,29 @@ class SandboxPool internal constructor(
         primaryHeartbeatTask = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
-        reconcileQueued.set(false)
-        releasePrimaryLockBestEffort()
+        run?.reconcileQueued?.set(false)
+        releasePrimaryLockBestEffort(run)
     }
 
     private fun stopAfterNamespaceDestroyed() {
         if (!lifecycleState.compareAndSet(LifecycleState.RUNNING, LifecycleState.STOPPED)) return
+        val run = currentRun
+        run?.warmupSubmissionsOpen?.set(false)
+        retireRun(run)
         reconcileTask?.cancel(false)
         reconcileTask = null
         primaryHeartbeatTask?.cancel(false)
         primaryHeartbeatTask = null
-        warmupSubmissionsOpen.set(false)
         warmupExecutor?.let { completeDroppedTasks(it.shutdownNow()) }
         warmupExecutor = null
         scheduler?.shutdown()
         scheduler = null
-        reconcileQueued.set(false)
-        releasePrimaryLockBestEffort()
+        run?.reconcileQueued?.set(false)
+        releasePrimaryLockBestEffort(run)
         closeProvider()
     }
 
-    private fun releasePrimaryLockBestEffort() {
+    private fun releasePrimaryLockBestEffort(run: RunContext? = currentRun) {
         try {
             stateStore.releasePrimaryLock(config.poolName, config.ownerId)
         } catch (e: Exception) {
@@ -1357,7 +1427,7 @@ class SandboxPool internal constructor(
                 e.message,
             )
         } finally {
-            primaryOwned.set(false)
+            run?.primaryOwned?.set(false)
         }
     }
 
@@ -1424,6 +1494,41 @@ class SandboxPool internal constructor(
             logger.warn("Error closing pool SandboxManager", e)
         }
         sandboxManager = null
+    }
+
+    private fun isCurrentRun(run: RunContext): Boolean = currentRun === run && run.active.get()
+
+    private fun retireRun(run: RunContext?) {
+        if (run == null) return
+        run.commitLock.lock()
+        try {
+            run.active.set(false)
+            if (currentRun === run) {
+                currentRun = null
+            }
+        } finally {
+            run.commitLock.unlock()
+        }
+    }
+
+    /**
+     * Internal identity and executors for one start/shutdown lifecycle.
+     *
+     * Warmup workers capture this context so a task that outlives forced shutdown can only
+     * complete against the scheduler that submitted it. [commitLock] linearizes retirement
+     * with the final primary-lock renewal and idle-store commit.
+     */
+    private class RunContext(
+        val generation: Long,
+        val scheduler: ScheduledExecutorService,
+        val warmupExecutor: ExecutorService,
+    ) {
+        val active = AtomicBoolean(true)
+        val commitLock = ReentrantLock()
+        val warmingCount = AtomicInteger(0)
+        val warmupSubmissionsOpen = AtomicBoolean(true)
+        val reconcileQueued = AtomicBoolean(false)
+        val primaryOwned = AtomicBoolean(false)
     }
 
     @Suppress("ktlint:standard:property-naming")

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -110,9 +110,6 @@ class SandboxPool internal constructor(
     private var warmupExecutor: ExecutorService? = null
     private var reconcileTask: ScheduledFuture<*>? = null
     private var primaryHeartbeatTask: ScheduledFuture<*>? = null
-    private val inFlightOperations = AtomicInteger(0)
-    private val inFlightLock = ReentrantLock()
-    private val inFlightZero: Condition = inFlightLock.newCondition()
     private val runSequence = AtomicLong(0)
 
     @Volatile
@@ -232,9 +229,10 @@ class SandboxPool internal constructor(
             logger.info("Pool not running, acquire rejected: pool_name={} state={}", config.poolName, state)
             throw PoolNotRunningException("Cannot acquire when pool state is $state")
         }
-        beginOperation()
+        val run = currentRun ?: throw PoolNotRunningException("Cannot acquire without an active pool run")
+        beginOperation(run)
         try {
-            if (lifecycleState.get() != LifecycleState.RUNNING) {
+            if (!isCurrentRun(run) || lifecycleState.get() != LifecycleState.RUNNING) {
                 val state = lifecycleState.get()
                 throwIfPoolNamespaceDestroyed()
                 logger.info("Pool not running after acquire started, rejected: pool_name={} state={}", config.poolName, state)
@@ -263,7 +261,7 @@ class SandboxPool internal constructor(
                         // Under non-fallthrough policies (FAIL_FAST / RETRY_NEXT_IDLE) we surface
                         // the outage as-is so callers can react.
                         if (!policyFallsThroughToDirectCreate(policy)) {
-                            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                             throw e
                         }
                         logger.warn(
@@ -300,7 +298,7 @@ class SandboxPool internal constructor(
                                 config.acquireHealthCheck?.let { healthCheck(it) } ?: this
                             }.connect()
                 } catch (e: PoolDestroyedException) {
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                     throw e
                 } catch (e: Exception) {
                     // Connect / readiness / health-check failure — the idle candidate itself is
@@ -323,13 +321,13 @@ class SandboxPool internal constructor(
                     // RETRY_NEXT_IDLE. scheduleKillDiscardedAlive uses the same executor path
                     // as discarded-alive cleanup and falls back to inline execution when the
                     // pool is mid-shutdown so cleanup is never silently dropped.
-                    scheduleKillDiscardedAlive(poolName, listOf(sandboxId), source = "acquire-stale")
+                    scheduleKillDiscardedAlive(poolName, listOf(sandboxId), source = "acquire-stale", run = run)
                     // Re-check lifecycle between iterations so an in-flight shutdown / namespace
                     // destroy short-circuits the retry loop instead of paying another readyTimeout.
                     if (lifecycleState.get() != LifecycleState.RUNNING) {
                         val state = lifecycleState.get()
                         throwIfPoolNamespaceDestroyed()
-                        scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                        scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                         throw PoolNotRunningException("Cannot acquire when pool state is $state")
                     }
                     ensurePoolNamespaceActive()
@@ -343,7 +341,7 @@ class SandboxPool internal constructor(
                     sandboxTimeout?.let { sandbox.renew(it) }
                     ensurePoolNamespaceActiveOrDispose(sandbox)
                 } catch (e: PoolDestroyedException) {
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                     throw e
                 } catch (e: Exception) {
                     // Renew failed against a healthy sandbox. Retrying another idle will not fix a
@@ -376,13 +374,13 @@ class SandboxPool internal constructor(
                     } catch (_: Exception) {
                         // best-effort local resource release
                     }
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                     throw e
                 }
                 // Candidate is connected and renewed. Now safe to clean up the discarded-alive
                 // sandboxes; offload to the warmup executor so the caller does not wait for
                 // N kill RPCs.
-                scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+                scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                 logger.debug(
                     "Acquire from idle: pool_name={} sandbox_id={} policy={} attempt={}/{}",
                     poolName,
@@ -396,7 +394,7 @@ class SandboxPool internal constructor(
             // Reaching here means we did not return a sandbox from idle. Fire the deferred cleanup
             // so the discarded-alive sandboxes do not linger; both the fail-fast and direct-create
             // fallthroughs below benefit from asynchronous cleanup instead of a synchronous kill.
-            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire")
+            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
 
             val reason =
                 when {
@@ -422,7 +420,7 @@ class SandboxPool internal constructor(
             logger.debug("Acquire direct create: pool_name={} reason={} policy={}", poolName, reason, policy)
             return directCreate(sandboxTimeout, policy)
         } finally {
-            endOperation()
+            endOperation(run)
         }
     }
 
@@ -540,7 +538,7 @@ class SandboxPool internal constructor(
             failureCount = reconcileState.failureCount,
             backoffActive = reconcileState.isBackoffActive(),
             lastError = reconcileState.lastError,
-            inFlightOperations = inFlightOperations.get(),
+            inFlightOperations = currentRun?.inFlightOperations?.get() ?: 0,
         )
     }
 
@@ -573,12 +571,12 @@ class SandboxPool internal constructor(
         var drained = false
         try {
             beginGracefulReconcileStop()
-            drained = awaitInFlightDrain(config.drainTimeout)
+            drained = awaitInFlightDrain(run, config.drainTimeout)
             if (!drained) {
                 logger.warn(
                     "Pool graceful shutdown timed out waiting in-flight operations: pool_name={} in_flight={} timeout_ms={}",
                     config.poolName,
-                    inFlightOperations.get(),
+                    run?.inFlightOperations?.get() ?: 0,
                     config.drainTimeout.toMillis(),
                 )
             }
@@ -610,9 +608,10 @@ class SandboxPool internal constructor(
         sandboxIds: List<String>,
         source: String,
         executor: ExecutorService? = warmupExecutor,
+        run: RunContext? = currentRun,
     ) {
         if (sandboxIds.isEmpty()) return
-        val cleanupTask = TrackedCleanupTask(poolName, sandboxIds.toList(), source)
+        val cleanupTask = TrackedCleanupTask(poolName, sandboxIds.toList(), source, run)
         if (executor == null) {
             cleanupTask.run()
             return
@@ -638,11 +637,12 @@ class SandboxPool internal constructor(
         private val poolName: String,
         private val sandboxIds: List<String>,
         private val source: String,
+        private val run: RunContext?,
     ) : Runnable {
         private val completed = AtomicBoolean(false)
 
         init {
-            beginOperation()
+            run?.let { beginOperation(it) }
         }
 
         override fun run() {
@@ -659,7 +659,7 @@ class SandboxPool internal constructor(
 
         private fun complete() {
             if (completed.compareAndSet(false, true)) {
-                endOperation()
+                run?.let { endOperation(it) }
             }
         }
     }
@@ -748,7 +748,7 @@ class SandboxPool internal constructor(
             stopAfterNamespaceDestroyed()
             return
         }
-        beginOperation()
+        beginOperation(run)
         try {
             if (!isCurrentRun(run) || lifecycleState.get() != LifecycleState.RUNNING) return
             if (!isPoolNamespaceActive()) return
@@ -769,7 +769,7 @@ class SandboxPool internal constructor(
                 throw e
             }
         } finally {
-            endOperation()
+            endOperation(run)
         }
     }
 
@@ -857,7 +857,7 @@ class SandboxPool internal constructor(
 
         init {
             run.warmingCount.incrementAndGet()
-            beginOperation()
+            beginOperation(run)
         }
 
         override fun run() {
@@ -894,7 +894,7 @@ class SandboxPool internal constructor(
                 handleWarmupOutcome(run, outcome)
             } finally {
                 run.warmingCount.decrementAndGet()
-                endOperation()
+                endOperation(run)
                 requestReconcile(run)
             }
         }
@@ -988,6 +988,7 @@ class SandboxPool internal constructor(
                 listOf(sandboxId),
                 source = source,
                 executor = run.warmupExecutor,
+                run = run,
             )
         }
     }
@@ -1300,52 +1301,60 @@ class SandboxPool internal constructor(
         }
     }
 
-    private fun beginOperation() {
-        inFlightOperations.incrementAndGet()
+    private fun beginOperation(run: RunContext) {
+        run.inFlightOperations.incrementAndGet()
     }
 
-    private fun endOperation() {
-        val remaining = inFlightOperations.decrementAndGet()
+    private fun endOperation(run: RunContext) {
+        val remaining = run.inFlightOperations.decrementAndGet()
         if (remaining < 0) {
-            inFlightOperations.set(0)
-            logger.warn("Pool in-flight counter underflow corrected: pool_name={}", config.poolName)
-            inFlightLock.lock()
+            run.inFlightOperations.set(0)
+            logger.warn(
+                "Pool in-flight counter underflow corrected: pool_name={} run={}",
+                config.poolName,
+                run.generation,
+            )
+            run.inFlightLock.lock()
             try {
-                inFlightZero.signalAll()
+                run.inFlightZero.signalAll()
             } finally {
-                inFlightLock.unlock()
+                run.inFlightLock.unlock()
             }
             return
         }
         if (remaining == 0) {
-            inFlightLock.lock()
+            run.inFlightLock.lock()
             try {
-                inFlightZero.signalAll()
+                run.inFlightZero.signalAll()
             } finally {
-                inFlightLock.unlock()
+                run.inFlightLock.unlock()
             }
         }
     }
 
     @Throws(InterruptedException::class)
-    private fun awaitInFlightDrain(timeout: Duration): Boolean {
+    private fun awaitInFlightDrain(
+        run: RunContext?,
+        timeout: Duration,
+    ): Boolean {
+        if (run == null) return true
         val timeoutNanos = timeout.toNanos()
         if (timeoutNanos <= 0) {
-            return inFlightOperations.get() == 0
+            return run.inFlightOperations.get() == 0
         }
         val deadline = System.nanoTime() + timeoutNanos
-        inFlightLock.lock()
+        run.inFlightLock.lock()
         try {
-            while (inFlightOperations.get() > 0) {
+            while (run.inFlightOperations.get() > 0) {
                 val remaining = deadline - System.nanoTime()
                 if (remaining <= 0) {
                     return false
                 }
-                inFlightZero.awaitNanos(remaining)
+                run.inFlightZero.awaitNanos(remaining)
             }
             return true
         } finally {
-            inFlightLock.unlock()
+            run.inFlightLock.unlock()
         }
     }
 
@@ -1529,6 +1538,9 @@ class SandboxPool internal constructor(
         val warmupSubmissionsOpen = AtomicBoolean(true)
         val reconcileQueued = AtomicBoolean(false)
         val primaryOwned = AtomicBoolean(false)
+        val inFlightOperations = AtomicInteger(0)
+        val inFlightLock = ReentrantLock()
+        val inFlightZero: Condition = inFlightLock.newCondition()
     }
 
     @Suppress("ktlint:standard:property-naming")

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -40,6 +40,7 @@ import com.alibaba.opensandbox.sandbox.infrastructure.pool.PoolReconciler
 import com.alibaba.opensandbox.sandbox.infrastructure.pool.ReconcileState
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -669,6 +670,7 @@ class SandboxPool internal constructor(
             when (task) {
                 is TrackedCleanupTask -> task.completeIfDropped()
                 is TrackedWarmupTask -> task.completeIfDropped()
+                is TrackedWarmupCompletionTask -> task.completeIfDropped()
             }
         }
     }
@@ -875,7 +877,8 @@ class SandboxPool internal constructor(
         }
 
         private fun dispatchCompletion(outcome: WarmupOutcome) {
-            val completion = Runnable { complete(outcome) }
+            val completion = TrackedWarmupCompletionTask(run, this, outcome)
+            run.pendingWarmupCompletions.add(completion)
             try {
                 run.scheduler.execute(completion)
             } catch (e: Exception) {
@@ -888,7 +891,7 @@ class SandboxPool internal constructor(
             }
         }
 
-        private fun complete(outcome: WarmupOutcome) {
+        fun complete(outcome: WarmupOutcome) {
             if (!completed.compareAndSet(false, true)) return
             try {
                 handleWarmupOutcome(run, outcome)
@@ -898,6 +901,36 @@ class SandboxPool internal constructor(
                 requestReconcile(run)
             }
         }
+    }
+
+    /**
+     * Tracks a warmup outcome while it waits in the controller queue.
+     *
+     * Scheduled executors may wrap submitted [Runnable]s before returning them from `shutdownNow()`,
+     * so [RunContext.pendingWarmupCompletions] is the authoritative registry. Both normal execution
+     * and forced shutdown finish the original warmup through this task; the warmup's CAS keeps that
+     * completion exactly once.
+     */
+    private inner class TrackedWarmupCompletionTask(
+        private val run: RunContext,
+        private val warmupTask: TrackedWarmupTask,
+        private val outcome: WarmupOutcome,
+    ) : Runnable {
+        override fun run() {
+            try {
+                warmupTask.complete(outcome)
+            } finally {
+                run.pendingWarmupCompletions.remove(this)
+            }
+        }
+
+        fun completeIfDropped() {
+            run()
+        }
+    }
+
+    private fun completePendingWarmupCompletions(run: RunContext?) {
+        run?.pendingWarmupCompletions?.toList()?.forEach { it.completeIfDropped() }
     }
 
     private sealed interface WarmupOutcome {
@@ -1370,6 +1403,7 @@ class SandboxPool internal constructor(
         warmupExecutor = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
+        completePendingWarmupCompletions(run)
         run?.reconcileQueued?.set(false)
         releasePrimaryLockBestEffort(run)
     }
@@ -1388,6 +1422,7 @@ class SandboxPool internal constructor(
         primaryHeartbeatTask = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
+        completePendingWarmupCompletions(run)
         run?.reconcileQueued?.set(false)
         releasePrimaryLockBestEffort(run)
     }
@@ -1403,6 +1438,7 @@ class SandboxPool internal constructor(
         primaryHeartbeatTask = null
         scheduler?.let { shutdownExecutor(it, "scheduler") }
         scheduler = null
+        completePendingWarmupCompletions(run)
         run?.reconcileQueued?.set(false)
         releasePrimaryLockBestEffort(run)
     }
@@ -1420,6 +1456,7 @@ class SandboxPool internal constructor(
         warmupExecutor = null
         scheduler?.shutdown()
         scheduler = null
+        completePendingWarmupCompletions(run)
         run?.reconcileQueued?.set(false)
         releasePrimaryLockBestEffort(run)
         closeProvider()
@@ -1541,6 +1578,7 @@ class SandboxPool internal constructor(
         val inFlightOperations = AtomicInteger(0)
         val inFlightLock = ReentrantLock()
         val inFlightZero: Condition = inFlightLock.newCondition()
+        val pendingWarmupCompletions = ConcurrentHashMap.newKeySet<TrackedWarmupCompletionTask>()
     }
 
     @Suppress("ktlint:standard:property-naming")

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/PoolReconcilerStateTest.kt
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
 class PoolReconcilerStateTest {
@@ -67,142 +66,15 @@ class PoolReconcilerStateTest {
     }
 
     @Test
-    fun `reconcile batch failures only advance backoff once`() {
-        val stateStore = InMemoryPoolStateStore()
-        val config =
-            PoolConfig.builder()
-                .poolName("pool-batch-failure-test")
-                .ownerId("owner-1")
-                .maxIdle(10)
-                .warmupConcurrency(10)
-                .stateStore(stateStore)
-                .connectionConfig(ConnectionConfig.builder().build())
-                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
-                .build()
+    fun `rolling failures advance backoff once while current window is active`() {
         val state = ReconcileState(degradedThreshold = 3)
-        val warmupExecutor = Executors.newFixedThreadPool(10)
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { throw RuntimeException("boom") },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        repeat(10) { state.recordAsyncFailure("boom-$it") }
 
         assertEquals(10, state.failureCount)
+        assertEquals(PoolState.DEGRADED, state.state)
         assertEquals(true, state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(29))))
         assertFalse(state.isBackoffActive(Instant.now().plus(Duration.ofSeconds(31))))
-    }
-
-    @Test
-    fun `reconcile create exception increments failure count once per task`() {
-        val stateStore = InMemoryPoolStateStore()
-        val config =
-            PoolConfig.builder()
-                .poolName("pool-reconcile-test")
-                .ownerId("owner-1")
-                .maxIdle(1)
-                .warmupConcurrency(1)
-                .stateStore(stateStore)
-                .connectionConfig(ConnectionConfig.builder().build())
-                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
-                .build()
-        val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
-
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { throw RuntimeException("boom") },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
-
-        assertEquals(1, state.failureCount)
-    }
-
-    @Test
-    fun `reconcile stops putIdle and cleans orphaned sandboxes after lock renew failure`() {
-        val stateStore = RenewFailAfterSecondPutStore()
-        val config =
-            PoolConfig.builder()
-                .poolName("pool-lock-window-test")
-                .ownerId("owner-1")
-                .maxIdle(2)
-                .warmupConcurrency(2)
-                .stateStore(stateStore)
-                .connectionConfig(ConnectionConfig.builder().build())
-                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
-                .build()
-        val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(2)
-        val idGen = AtomicInteger(0)
-        val orphaned = mutableListOf<String>()
-
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { "id-${idGen.incrementAndGet()}" },
-                onDiscardSandbox = { orphaned += it },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
-
-        assertEquals(1, stateStore.putIdleIds.size)
-        assertEquals(1, orphaned.size)
-        val idle = stateStore.putIdleIds.first()
-        val dropped = orphaned.first()
-        assertFalse(idle == dropped)
-        assertEquals(setOf("id-1", "id-2"), setOf(idle, dropped))
-    }
-
-    @Test
-    fun `reconcile putIdle failure records failure and cleans remaining created sandboxes`() {
-        val stateStore = PutIdleFailStore()
-        val config =
-            PoolConfig.builder()
-                .poolName("pool-put-failure-test")
-                .ownerId("owner-1")
-                .maxIdle(2)
-                .warmupConcurrency(2)
-                .stateStore(stateStore)
-                .connectionConfig(ConnectionConfig.builder().build())
-                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
-                .build()
-        val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(2)
-        val idGen = AtomicInteger(0)
-        val orphaned = mutableListOf<String>()
-
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { "id-${idGen.incrementAndGet()}" },
-                onDiscardSandbox = { orphaned += it },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
-
-        assertEquals(1, state.failureCount)
-        assertEquals(2, orphaned.size)
-        assertEquals(setOf("id-1", "id-2"), orphaned.toSet())
     }
 
     @Test
@@ -219,87 +91,64 @@ class PoolReconcilerStateTest {
                 .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
                 .build()
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
-        val createCalls = AtomicInteger(0)
+        val submitted = AtomicInteger(0)
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = {
-                    createCalls.incrementAndGet()
-                    "id-1"
-                },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = config,
+            stateStore = stateStore,
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { submitted.addAndGet(it) },
+        )
 
-        assertEquals(0, createCalls.get())
+        assertEquals(0, submitted.get())
         assertEquals(emptyList<String>(), stateStore.putIdleIds)
     }
 
     @Test
-    fun `only primary owner can reconcile create for same pool`() {
+    fun `only primary owner can submit warmups for same pool`() {
         val stateStore = OwnerLockingStore()
         val primaryConfig = buildConfig(ownerId = "owner-primary", maxIdle = 1, stateStore = stateStore, poolName = "pool-owner-lock")
         val secondaryConfig = buildConfig(ownerId = "owner-secondary", maxIdle = 1, stateStore = stateStore, poolName = "pool-owner-lock")
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
-        val secondaryCreateCalls = AtomicInteger(0)
+        val primarySubmissions = AtomicInteger(0)
+        val secondarySubmissions = AtomicInteger(0)
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = primaryConfig,
-                stateStore = stateStore,
-                createOne = { "id-primary-1" },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-            PoolReconciler.runReconcileTick(
-                config = secondaryConfig,
-                stateStore = stateStore,
-                createOne = {
-                    secondaryCreateCalls.incrementAndGet()
-                    "id-secondary-1"
-                },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = primaryConfig,
+            stateStore = stateStore,
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { primarySubmissions.addAndGet(it) },
+        )
+        PoolReconciler.runReconcileTick(
+            config = secondaryConfig,
+            stateStore = stateStore,
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { secondarySubmissions.addAndGet(it) },
+        )
 
-        assertEquals(0, secondaryCreateCalls.get())
-        assertEquals(listOf("id-primary-1"), stateStore.putIdleIds)
+        assertEquals(1, primarySubmissions.get())
+        assertEquals(0, secondarySubmissions.get())
     }
 
     @Test
-    fun `reconcile does not create when initial renew fails`() {
+    fun `reconcile does not submit warmups when initial renew fails`() {
         val stateStore = RenewFailsOnFirstCallStore()
         val config = buildConfig(ownerId = "owner-1", maxIdle = 1, stateStore = stateStore, poolName = "pool-renew-first-fail")
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
-        val createCalls = AtomicInteger(0)
+        val submitted = AtomicInteger(0)
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = {
-                    createCalls.incrementAndGet()
-                    "id-1"
-                },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = config,
+            stateStore = stateStore,
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { submitted.addAndGet(it) },
+        )
 
-        assertEquals(0, createCalls.get())
+        assertEquals(0, submitted.get())
         assertEquals(emptyList<String>(), stateStore.putIdleIds)
     }
 
@@ -317,27 +166,19 @@ class PoolReconcilerStateTest {
                 .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
                 .build()
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
         val discarded = mutableListOf<String>()
-        val createCalls = AtomicInteger(0)
+        val submitted = AtomicInteger(0)
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = {
-                    createCalls.incrementAndGet()
-                    "new-id"
-                },
-                onDiscardSandbox = { discarded += it },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = config,
+            stateStore = stateStore,
+            onDiscardSandbox = { discarded += it },
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { submitted.addAndGet(it) },
+        )
 
-        assertEquals(0, createCalls.get())
+        assertEquals(0, submitted.get())
         assertEquals(listOf("id-1", "id-2"), discarded)
         assertEquals(listOf("id-3", "id-4", "id-5"), stateStore.idleIds)
     }
@@ -347,21 +188,16 @@ class PoolReconcilerStateTest {
         val stateStore = SecondaryShrinkStore(idleIds = listOf("id-1", "id-2", "id-3"))
         val config = buildConfig(ownerId = "owner-2", maxIdle = 1, stateStore = stateStore, poolName = "pool-secondary-shrink")
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
         val discarded = mutableListOf<String>()
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { "new-id" },
-                onDiscardSandbox = { discarded += it },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = config,
+            stateStore = stateStore,
+            onDiscardSandbox = { discarded += it },
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { error("secondary must not submit warmups: $it") },
+        )
 
         assertEquals(emptyList<String>(), discarded)
         assertEquals(listOf("id-1", "id-2", "id-3"), stateStore.idleIds)
@@ -381,21 +217,16 @@ class PoolReconcilerStateTest {
                 .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
                 .build()
         val state = ReconcileState(degradedThreshold = 10)
-        val warmupExecutor = Executors.newFixedThreadPool(1)
         val discarded = mutableListOf<String>()
 
-        try {
-            PoolReconciler.runReconcileTick(
-                config = config,
-                stateStore = stateStore,
-                createOne = { "new-id" },
-                onDiscardSandbox = { discarded += it },
-                reconcileState = state,
-                warmupExecutor = warmupExecutor,
-            )
-        } finally {
-            warmupExecutor.shutdownNow()
-        }
+        PoolReconciler.runReconcileTick(
+            config = config,
+            stateStore = stateStore,
+            onDiscardSandbox = { discarded += it },
+            reconcileState = state,
+            warmingCount = 0,
+            submitWarmups = { error("shrink must not submit warmups: $it") },
+        )
 
         assertEquals(listOf("id-1"), discarded)
         assertEquals(listOf("id-2", "id-3"), stateStore.idleIds)
@@ -416,118 +247,6 @@ class PoolReconcilerStateTest {
             .connectionConfig(ConnectionConfig.builder().build())
             .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
             .build()
-    }
-
-    private class RenewFailAfterSecondPutStore : PoolStateStore {
-        private val renewCalls = AtomicInteger(0)
-        val putIdleIds = mutableListOf<String>()
-
-        override fun tryTakeIdle(poolName: String): String? = null
-
-        override fun putIdle(
-            poolName: String,
-            sandboxId: String,
-        ) {
-            putIdleIds += sandboxId
-        }
-
-        override fun removeIdle(
-            poolName: String,
-            sandboxId: String,
-        ) {
-        }
-
-        override fun tryAcquirePrimaryLock(
-            poolName: String,
-            ownerId: String,
-            ttl: Duration,
-        ): Boolean = true
-
-        override fun renewPrimaryLock(
-            poolName: String,
-            ownerId: String,
-            ttl: Duration,
-        ): Boolean {
-            val call = renewCalls.incrementAndGet()
-            return call < 3
-        }
-
-        override fun releasePrimaryLock(
-            poolName: String,
-            ownerId: String,
-        ) {
-        }
-
-        override fun reapExpiredIdle(
-            poolName: String,
-            now: Instant,
-        ) {
-        }
-
-        override fun snapshotCounters(poolName: String): StoreCounters = StoreCounters(idleCount = 0)
-
-        override fun snapshotIdleEntries(poolName: String) = emptyList<com.alibaba.opensandbox.sandbox.domain.pool.IdleEntry>()
-
-        override fun getMaxIdle(poolName: String): Int? = null
-
-        override fun setMaxIdle(
-            poolName: String,
-            maxIdle: Int,
-        ) {
-        }
-    }
-
-    private class PutIdleFailStore : PoolStateStore {
-        override fun tryTakeIdle(poolName: String): String? = null
-
-        override fun putIdle(
-            poolName: String,
-            sandboxId: String,
-        ) {
-            throw RuntimeException("put failed")
-        }
-
-        override fun removeIdle(
-            poolName: String,
-            sandboxId: String,
-        ) {
-        }
-
-        override fun tryAcquirePrimaryLock(
-            poolName: String,
-            ownerId: String,
-            ttl: Duration,
-        ): Boolean = true
-
-        override fun renewPrimaryLock(
-            poolName: String,
-            ownerId: String,
-            ttl: Duration,
-        ): Boolean = true
-
-        override fun releasePrimaryLock(
-            poolName: String,
-            ownerId: String,
-        ) {
-        }
-
-        override fun reapExpiredIdle(
-            poolName: String,
-            now: Instant,
-        ) {
-        }
-
-        override fun snapshotCounters(poolName: String): StoreCounters = StoreCounters(idleCount = 0)
-
-        override fun snapshotIdleEntries(poolName: String) = emptyList<com.alibaba.opensandbox.sandbox.domain.pool.IdleEntry>()
-
-        override fun getMaxIdle(poolName: String): Int? = null
-
-        override fun setMaxIdle(
-            poolName: String,
-            maxIdle: Int,
-        ) {
-        }
     }
 
     private class AlwaysSecondaryStore : PoolStateStore {

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/WarmupPlanTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/pool/WarmupPlanTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.infrastructure.pool
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WarmupPlanTest {
+    @Test
+    fun `empty pool fills all available warmup slots`() {
+        val plan =
+            WarmupPlan.calculate(
+                idleCount = 0,
+                warmingCount = 0,
+                maxIdle = 10,
+                warmupConcurrency = 3,
+            )
+
+        assertEquals(10, plan.deficit)
+        assertEquals(3, plan.availableSlots)
+        assertEquals(3, plan.toSubmit)
+    }
+
+    @Test
+    fun `in-flight warmups count toward idle target and concurrency`() {
+        val plan =
+            WarmupPlan.calculate(
+                idleCount = 4,
+                warmingCount = 2,
+                maxIdle = 8,
+                warmupConcurrency = 3,
+            )
+
+        assertEquals(2, plan.deficit)
+        assertEquals(1, plan.availableSlots)
+        assertEquals(1, plan.toSubmit)
+    }
+
+    @Test
+    fun `full warmup window submits no additional work`() {
+        val plan =
+            WarmupPlan.calculate(
+                idleCount = 0,
+                warmingCount = 4,
+                maxIdle = 10,
+                warmupConcurrency = 4,
+            )
+
+        assertEquals(6, plan.deficit)
+        assertEquals(0, plan.availableSlots)
+        assertEquals(0, plan.toSubmit)
+    }
+
+    @Test
+    fun `satisfied or zero target submits no warmups`() {
+        assertEquals(
+            0,
+            WarmupPlan.calculate(
+                idleCount = 5,
+                warmingCount = 0,
+                maxIdle = 5,
+                warmupConcurrency = 2,
+            ).toSubmit,
+        )
+        assertEquals(
+            0,
+            WarmupPlan.calculate(
+                idleCount = 0,
+                warmingCount = 0,
+                maxIdle = 0,
+                warmupConcurrency = 1,
+            ).toSubmit,
+        )
+    }
+}

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -129,6 +129,191 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `rolling warmup fills a released slot without waiting for slow tail`() {
+        val store = InMemoryPoolStateStore()
+        val created = AtomicInteger(0)
+        val active = AtomicInteger(0)
+        val maxActive = AtomicInteger(0)
+        val slowWarmupStarted = CountDownLatch(1)
+        val releaseSlowWarmup = CountDownLatch(1)
+        val thirdWarmupStarted = CountDownLatch(1)
+
+        val pool =
+            SandboxPool.builder()
+                .poolName("rolling-pool")
+                .ownerId("rolling-owner")
+                .maxIdle(4)
+                .warmupConcurrency(2)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(
+                    PooledSandboxCreator {
+                        val index = created.incrementAndGet()
+                        mockk<Sandbox>(relaxed = true).also { sandbox ->
+                            every { sandbox.id } returns "rolling-$index"
+                        }
+                    },
+                ).warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer { sandbox ->
+                        val currentActive = active.incrementAndGet()
+                        maxActive.updateAndGet { current -> maxOf(current, currentActive) }
+                        try {
+                            when (sandbox.id) {
+                                "rolling-1" -> {
+                                    slowWarmupStarted.countDown()
+                                    releaseSlowWarmup.await()
+                                }
+                                "rolling-3" -> thirdWarmupStarted.countDown()
+                            }
+                        } finally {
+                            active.decrementAndGet()
+                        }
+                    },
+                ).reconcileInterval(Duration.ofSeconds(30))
+                .drainTimeout(Duration.ofSeconds(2))
+                .build()
+
+        pool.start()
+        try {
+            assertTrue(slowWarmupStarted.await(5, TimeUnit.SECONDS))
+            assertTrue(
+                thirdWarmupStarted.await(5, TimeUnit.SECONDS),
+                "a fast completion should refill its slot before the slow first warmup finishes",
+            )
+            assertEquals(1L, releaseSlowWarmup.count, "slow warmup must still be blocked")
+            assertTrue(maxActive.get() <= 2, "rolling warmup must respect warmupConcurrency")
+
+            releaseSlowWarmup.countDown()
+            awaitCondition { store.snapshotCounters("rolling-pool").idleCount == 4 }
+            assertEquals(4, created.get())
+        } finally {
+            releaseSlowWarmup.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `primary heartbeat continues while warmup is blocked`() {
+        val store = HeartbeatRecordingStore()
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val warmupStarted = CountDownLatch(1)
+        val releaseWarmup = CountDownLatch(1)
+        every { sandbox.id } returns "heartbeat-warmup"
+
+        val pool =
+            SandboxPool.builder()
+                .poolName("heartbeat-pool")
+                .ownerId("heartbeat-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .primaryLockTtl(Duration.ofMillis(300))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(PooledSandboxCreator { sandbox })
+                .warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer {
+                        warmupStarted.countDown()
+                        releaseWarmup.await()
+                    },
+                ).drainTimeout(Duration.ofSeconds(2))
+                .build()
+
+        pool.start()
+        try {
+            assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            awaitCondition { store.renewCalls.get() >= 3 }
+            assertEquals(1L, releaseWarmup.count, "warmup must remain blocked while heartbeat renews")
+        } finally {
+            releaseWarmup.countDown()
+            pool.shutdown(graceful = true)
+        }
+    }
+
+    @Test
+    fun `warmup result is killed instead of entering idle after primary lock loss`() {
+        val store = RenewFailsAfterAdmissionStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val killed = CountDownLatch(1)
+        every { sandbox.id } returns "lost-lock-warmup"
+        every { manager.killSandbox("lost-lock-warmup") } answers {
+            killed.countDown()
+        }
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("lost-lock-pool")
+                        .ownerId("lost-lock-owner")
+                        .maxIdle(1)
+                        .warmupConcurrency(1)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(PooledSandboxCreator { sandbox })
+                        .warmupSkipHealthCheck()
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { manager },
+            )
+
+        pool.start()
+        try {
+            assertTrue(killed.await(5, TimeUnit.SECONDS))
+            assertEquals(0, store.snapshotCounters("lost-lock-pool").idleCount)
+            verify(exactly = 1) { manager.killSandbox("lost-lock-warmup") }
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `warmup put failure records backoff and cleans remote sandbox`() {
+        val store = PutIdleFailureStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val killed = CountDownLatch(1)
+        every { sandbox.id } returns "put-failed-warmup"
+        every { manager.killSandbox("put-failed-warmup") } answers {
+            killed.countDown()
+        }
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("put-failed-pool")
+                        .ownerId("put-failed-owner")
+                        .maxIdle(1)
+                        .warmupConcurrency(1)
+                        .degradedThreshold(1)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(PooledSandboxCreator { sandbox })
+                        .warmupSkipHealthCheck()
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { manager },
+            )
+
+        pool.start()
+        try {
+            assertTrue(killed.await(5, TimeUnit.SECONDS))
+            awaitCondition { pool.snapshot().backoffActive }
+            assertEquals(PoolState.DEGRADED, pool.snapshot().state)
+            assertEquals(0, store.snapshotCounters("put-failed-pool").idleCount)
+            verify(exactly = 1) { manager.killSandbox("put-failed-warmup") }
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `shutdown graceful waits for in-flight warmup without interrupting it`() {
         val store = InMemoryPoolStateStore()
         val sandbox = mockk<Sandbox>(relaxed = true)
@@ -1239,6 +1424,51 @@ class SandboxPoolTest {
         val field = target.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(target, value)
+    }
+
+    private fun awaitCondition(
+        timeout: Duration = Duration.ofSeconds(5),
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        while (!condition()) {
+            if (System.nanoTime() >= deadline) {
+                throw AssertionError("Condition was not satisfied within $timeout")
+            }
+            Thread.sleep(10)
+        }
+    }
+
+    private class HeartbeatRecordingStore : PoolStateStore by InMemoryPoolStateStore() {
+        val renewCalls = AtomicInteger(0)
+
+        override fun renewPrimaryLock(
+            poolName: String,
+            ownerId: String,
+            ttl: Duration,
+        ): Boolean {
+            renewCalls.incrementAndGet()
+            return true
+        }
+    }
+
+    private class RenewFailsAfterAdmissionStore : PoolStateStore by InMemoryPoolStateStore() {
+        private val renewCalls = AtomicInteger(0)
+
+        override fun renewPrimaryLock(
+            poolName: String,
+            ownerId: String,
+            ttl: Duration,
+        ): Boolean = renewCalls.incrementAndGet() == 1
+    }
+
+    private class PutIdleFailureStore : PoolStateStore by InMemoryPoolStateStore() {
+        override fun putIdle(
+            poolName: String,
+            sandboxId: String,
+        ) {
+            throw RuntimeException("put failed")
+        }
     }
 
     /**

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -438,6 +438,193 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `warmup success from retired run is killed and cannot enter restarted pool`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val oldSandbox = mockk<Sandbox>(relaxed = true)
+        val newSandbox = mockk<Sandbox>(relaxed = true)
+        val createCount = AtomicInteger(0)
+        val oldWarmupStarted = CountDownLatch(1)
+        val releaseOldWarmup = CountDownLatch(1)
+        val oldSandboxKilled = CountDownLatch(1)
+        every { oldSandbox.id } returns "old-run-sandbox"
+        every { newSandbox.id } returns "new-run-sandbox"
+        every { manager.killSandbox("old-run-sandbox") } answers {
+            oldSandboxKilled.countDown()
+        }
+
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("restart-pool")
+                        .ownerId("test-owner")
+                        .maxIdle(1)
+                        .warmupConcurrency(1)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(
+                            PooledSandboxCreator {
+                                if (createCount.getAndIncrement() == 0) oldSandbox else newSandbox
+                            },
+                        ).warmupSkipHealthCheck()
+                        .warmupSandboxPreparer(
+                            SandboxPreparer { sandbox ->
+                                if (sandbox === oldSandbox) {
+                                    oldWarmupStarted.countDown()
+                                    awaitIgnoringInterrupt(releaseOldWarmup)
+                                }
+                            },
+                        ).drainTimeout(Duration.ofMillis(50))
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { manager },
+            )
+
+        pool.start()
+        try {
+            assertTrue(oldWarmupStarted.await(5, TimeUnit.SECONDS))
+            shutdownWithoutWaitingForUncooperativeWorker(pool)
+
+            pool.start()
+            awaitCondition {
+                pool.snapshotIdleEntries().map { it.sandboxId } == listOf("new-run-sandbox")
+            }
+
+            releaseOldWarmup.countDown()
+            assertTrue(oldSandboxKilled.await(5, TimeUnit.SECONDS))
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+
+            assertEquals(listOf("new-run-sandbox"), pool.snapshotIdleEntries().map { it.sandboxId })
+            verify(exactly = 1) { manager.killSandbox("old-run-sandbox") }
+        } finally {
+            releaseOldWarmup.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `warmup success after shutdown uses temporary manager for cleanup`() {
+        val store = InMemoryPoolStateStore()
+        val runningManager = mockk<SandboxManager>(relaxed = true)
+        val cleanupManager = mockk<SandboxManager>(relaxed = true)
+        val managerCount = AtomicInteger(0)
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val warmupStarted = CountDownLatch(1)
+        val releaseWarmup = CountDownLatch(1)
+        val sandboxKilled = CountDownLatch(1)
+        every { sandbox.id } returns "late-warmup-sandbox"
+        every { cleanupManager.killSandbox("late-warmup-sandbox") } answers {
+            sandboxKilled.countDown()
+        }
+
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("shutdown-cleanup-pool")
+                        .ownerId("test-owner")
+                        .maxIdle(1)
+                        .warmupConcurrency(1)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(PooledSandboxCreator { sandbox })
+                        .warmupSkipHealthCheck()
+                        .warmupSandboxPreparer(
+                            SandboxPreparer {
+                                warmupStarted.countDown()
+                                awaitIgnoringInterrupt(releaseWarmup)
+                            },
+                        ).drainTimeout(Duration.ofMillis(50))
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = {
+                    if (managerCount.getAndIncrement() == 0) runningManager else cleanupManager
+                },
+            )
+
+        pool.start()
+        try {
+            assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            shutdownWithoutWaitingForUncooperativeWorker(pool)
+
+            releaseWarmup.countDown()
+            assertTrue(sandboxKilled.await(5, TimeUnit.SECONDS))
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+
+            assertEquals(emptyList<String>(), pool.snapshotIdleEntries().map { it.sandboxId })
+            verify(exactly = 1) { cleanupManager.killSandbox("late-warmup-sandbox") }
+            verify(exactly = 1) { cleanupManager.close() }
+        } finally {
+            releaseWarmup.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `warmup failure from retired run cannot degrade restarted pool`() {
+        val store = InMemoryPoolStateStore()
+        val oldSandbox = mockk<Sandbox>(relaxed = true)
+        val newSandbox = mockk<Sandbox>(relaxed = true)
+        val createCount = AtomicInteger(0)
+        val oldWarmupStarted = CountDownLatch(1)
+        val releaseOldWarmup = CountDownLatch(1)
+        every { oldSandbox.id } returns "old-failed-sandbox"
+        every { newSandbox.id } returns "new-run-sandbox"
+
+        val pool =
+            SandboxPool.builder()
+                .poolName("restart-failure-pool")
+                .ownerId("test-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(
+                    PooledSandboxCreator {
+                        if (createCount.getAndIncrement() == 0) oldSandbox else newSandbox
+                    },
+                ).warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer { sandbox ->
+                        if (sandbox === oldSandbox) {
+                            oldWarmupStarted.countDown()
+                            awaitIgnoringInterrupt(releaseOldWarmup)
+                            throw RuntimeException("retired run warmup failed")
+                        }
+                    },
+                ).degradedThreshold(1)
+                .drainTimeout(Duration.ofMillis(50))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+
+        pool.start()
+        try {
+            assertTrue(oldWarmupStarted.await(5, TimeUnit.SECONDS))
+            shutdownWithoutWaitingForUncooperativeWorker(pool)
+
+            pool.start()
+            awaitCondition {
+                pool.snapshotIdleEntries().map { it.sandboxId } == listOf("new-run-sandbox")
+            }
+
+            releaseOldWarmup.countDown()
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+
+            assertEquals(0, pool.snapshot().failureCount)
+            assertEquals(false, pool.snapshot().backoffActive)
+            assertEquals(PoolState.HEALTHY, pool.snapshot().state)
+            verify(exactly = 1) { oldSandbox.kill() }
+        } finally {
+            releaseOldWarmup.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `shutdown graceful waits for asynchronous discarded sandbox cleanup`() {
         val store = DiscardingPoolStateStore()
         val manager = mockk<SandboxManager>(relaxed = true)
@@ -1436,6 +1623,26 @@ class SandboxPoolTest {
                 throw AssertionError("Condition was not satisfied within $timeout")
             }
             Thread.sleep(10)
+        }
+    }
+
+    private fun awaitIgnoringInterrupt(latch: CountDownLatch) {
+        while (true) {
+            try {
+                latch.await()
+                return
+            } catch (_: InterruptedException) {
+                // Simulates an external preparer that does not cooperate with executor cancellation.
+            }
+        }
+    }
+
+    private fun shutdownWithoutWaitingForUncooperativeWorker(pool: SandboxPool) {
+        Thread.currentThread().interrupt()
+        try {
+            pool.shutdown(graceful = false)
+        } finally {
+            Thread.interrupted()
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -96,10 +96,16 @@ class SandboxPoolTest {
     @Test
     fun `snapshot reports in flight operations`() {
         val pool = buildPool()
-        val inFlight = AtomicInteger(3)
-        setPrivateField(pool, "inFlightOperations", inFlight)
-
-        val snap = pool.snapshot()
+        pool.start()
+        val inFlight = currentRunInFlight(pool)
+        inFlight.set(3)
+        val snap =
+            try {
+                pool.snapshot()
+            } finally {
+                inFlight.set(0)
+                pool.shutdown(graceful = false)
+            }
 
         assertEquals(3, snap.inFlightOperations)
     }
@@ -485,16 +491,18 @@ class SandboxPoolTest {
         pool.start()
         try {
             assertTrue(oldWarmupStarted.await(5, TimeUnit.SECONDS))
+            val retiredRunInFlight = currentRunInFlight(pool)
             shutdownWithoutWaitingForUncooperativeWorker(pool)
 
             pool.start()
             awaitCondition {
                 pool.snapshotIdleEntries().map { it.sandboxId } == listOf("new-run-sandbox")
             }
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
 
             releaseOldWarmup.countDown()
             assertTrue(oldSandboxKilled.await(5, TimeUnit.SECONDS))
-            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+            awaitCondition { retiredRunInFlight.get() == 0 }
 
             assertEquals(listOf("new-run-sandbox"), pool.snapshotIdleEntries().map { it.sandboxId })
             verify(exactly = 1) { manager.killSandbox("old-run-sandbox") }
@@ -548,11 +556,13 @@ class SandboxPoolTest {
         pool.start()
         try {
             assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            val retiredRunInFlight = currentRunInFlight(pool)
             shutdownWithoutWaitingForUncooperativeWorker(pool)
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
 
             releaseWarmup.countDown()
             assertTrue(sandboxKilled.await(5, TimeUnit.SECONDS))
-            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+            awaitCondition { retiredRunInFlight.get() == 0 }
 
             assertEquals(emptyList<String>(), pool.snapshotIdleEntries().map { it.sandboxId })
             verify(exactly = 1) { cleanupManager.killSandbox("late-warmup-sandbox") }
@@ -604,15 +614,17 @@ class SandboxPoolTest {
         pool.start()
         try {
             assertTrue(oldWarmupStarted.await(5, TimeUnit.SECONDS))
+            val retiredRunInFlight = currentRunInFlight(pool)
             shutdownWithoutWaitingForUncooperativeWorker(pool)
 
             pool.start()
             awaitCondition {
                 pool.snapshotIdleEntries().map { it.sandboxId } == listOf("new-run-sandbox")
             }
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
 
             releaseOldWarmup.countDown()
-            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+            awaitCondition { retiredRunInFlight.get() == 0 }
 
             assertEquals(0, pool.snapshot().failureCount)
             assertEquals(false, pool.snapshot().backoffActive)
@@ -1611,6 +1623,11 @@ class SandboxPoolTest {
         val field = target.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(target, value)
+    }
+
+    private fun currentRunInFlight(pool: SandboxPool): AtomicInteger {
+        val run = getPrivateField<Any>(pool, "currentRun")
+        return getPrivateField(run, "inFlightOperations")
     }
 
     private fun awaitCondition(

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -637,6 +637,80 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `forced scheduler shutdown completes queued warmup outcome and cleans sandbox`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val sandbox = mockk<Sandbox>(relaxed = true)
+        val warmupStarted = CountDownLatch(1)
+        val releaseWarmup = CountDownLatch(1)
+        val warmupClosed = CountDownLatch(1)
+        val controllerBlocked = CountDownLatch(1)
+        val releaseController = CountDownLatch(1)
+        val sandboxKilled = CountDownLatch(1)
+        every { sandbox.id } returns "queued-completion-sandbox"
+        every { sandbox.close() } answers {
+            warmupClosed.countDown()
+        }
+        every { manager.killSandbox("queued-completion-sandbox") } answers {
+            sandboxKilled.countDown()
+        }
+
+        val pool =
+            SandboxPool(
+                config =
+                    PoolConfig.builder()
+                        .poolName("queued-completion-pool")
+                        .ownerId("test-owner")
+                        .maxIdle(1)
+                        .warmupConcurrency(1)
+                        .stateStore(store)
+                        .connectionConfig(ConnectionConfig.builder().build())
+                        .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                        .sandboxCreator(PooledSandboxCreator { sandbox })
+                        .warmupSkipHealthCheck()
+                        .warmupSandboxPreparer(
+                            SandboxPreparer {
+                                warmupStarted.countDown()
+                                releaseWarmup.await()
+                            },
+                        ).drainTimeout(Duration.ofMillis(50))
+                        .reconcileInterval(Duration.ofSeconds(30))
+                        .build(),
+                sandboxManagerFactory = { manager },
+            )
+
+        pool.start()
+        try {
+            assertTrue(warmupStarted.await(5, TimeUnit.SECONDS))
+            val retiredRunInFlight = currentRunInFlight(pool)
+            val pendingCompletions = currentRunPendingWarmupCompletions(pool)
+            val controller = getPrivateField<ScheduledExecutorService>(pool, "scheduler")
+            controller.execute {
+                controllerBlocked.countDown()
+                awaitIgnoringInterrupt(releaseController)
+            }
+            assertTrue(controllerBlocked.await(5, TimeUnit.SECONDS))
+
+            releaseWarmup.countDown()
+            assertTrue(warmupClosed.await(5, TimeUnit.SECONDS))
+            awaitCondition { pendingCompletions.size == 1 }
+            assertEquals(1, retiredRunInFlight.get())
+            assertEquals(0, store.snapshotCounters("queued-completion-pool").idleCount)
+
+            shutdownWithoutWaitingForUncooperativeWorker(pool)
+
+            assertTrue(sandboxKilled.await(5, TimeUnit.SECONDS))
+            awaitCondition { retiredRunInFlight.get() == 0 }
+            assertEquals(0, store.snapshotCounters("queued-completion-pool").idleCount)
+            verify(exactly = 1) { manager.killSandbox("queued-completion-sandbox") }
+        } finally {
+            releaseWarmup.countDown()
+            releaseController.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `shutdown graceful waits for asynchronous discarded sandbox cleanup`() {
         val store = DiscardingPoolStateStore()
         val manager = mockk<SandboxManager>(relaxed = true)
@@ -1628,6 +1702,11 @@ class SandboxPoolTest {
     private fun currentRunInFlight(pool: SandboxPool): AtomicInteger {
         val run = getPrivateField<Any>(pool, "currentRun")
         return getPrivateField(run, "inFlightOperations")
+    }
+
+    private fun currentRunPendingWarmupCompletions(pool: SandboxPool): Set<*> {
+        val run = getPrivateField<Any>(pool, "currentRun")
+        return getPrivateField(run, "pendingWarmupCompletions")
     }
 
     private fun awaitCondition(

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
@@ -19,6 +19,7 @@ package com.alibaba.opensandbox.e2e;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.alibaba.opensandbox.sandbox.SandboxManager;
@@ -36,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
@@ -140,6 +142,88 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("graceful shutdown drains admitted rolling warmups without refilling slots")
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
+    void testGracefulShutdownDrainsAdmittedRollingWarmupsWithoutRefill() throws Exception {
+        tag = uniqueTag("graceful-rolling");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch admittedWarmupsEntered = new CountDownLatch(2);
+        CountDownLatch releaseWarmups = new CountDownLatch(1);
+        AtomicInteger preparerCalls = new AtomicInteger();
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        SandboxPool pool =
+                createPool(
+                        stateStore,
+                        Duration.ofSeconds(20),
+                        sandbox -> {
+                            preparerCalls.incrementAndGet();
+                            admittedWarmupsEntered.countDown();
+                            awaitLatch(releaseWarmups);
+                        },
+                        3,
+                        2);
+        Thread shutdownThread = null;
+
+        try {
+            pool.start();
+            assertTrue(
+                    admittedWarmupsEntered.await(2, TimeUnit.MINUTES),
+                    "both rolling warmup slots should be admitted before shutdown");
+            assertEquals(2, preparerCalls.get());
+
+            shutdownThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    pool.shutdown(true);
+                                } catch (Throwable throwable) {
+                                    shutdownFailure.set(throwable);
+                                }
+                            },
+                            "sandbox-pool-e2e-graceful-rolling-shutdown");
+            shutdownThread.start();
+
+            eventually(
+                    "pool enters draining before warmups are released",
+                    Duration.ofSeconds(10),
+                    Duration.ofMillis(100),
+                    () -> pool.snapshot().getLifecycleState() == PoolLifecycleState.DRAINING);
+            releaseWarmups.countDown();
+
+            shutdownThread.join(30_000);
+            assertFalse(shutdownThread.isAlive(), "graceful shutdown should finish after drain");
+            assertNull(shutdownFailure.get(), "graceful shutdown should not fail");
+            assertEquals(PoolLifecycleState.STOPPED, pool.snapshot().getLifecycleState());
+            assertEquals(
+                    2,
+                    pool.snapshot().getIdleCount(),
+                    "both pre-admitted warmups should be persisted");
+            assertEquals(
+                    2,
+                    preparerCalls.get(),
+                    "shutdown must close admissions instead of refilling the released slots");
+            eventually(
+                    "only the two pre-admitted sandboxes remain remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 2);
+
+            pool.releaseAllIdle();
+            eventually(
+                    "drained rolling warmups are deleted remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 0);
+        } finally {
+            releaseWarmups.countDown();
+            if (shutdownThread != null) {
+                shutdownThread.join(5_000);
+            }
+            shutdownAndRelease(pool);
+        }
+    }
+
+    @Test
     @DisplayName("forced shutdown deletes interrupted warmup sandbox not persisted as idle")
     @Timeout(value = 4, unit = TimeUnit.MINUTES)
     void testForcedShutdownDeletesInterruptedWarmupSandboxNotPersistedAsIdle() throws Exception {
@@ -208,9 +292,16 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
     }
 
     private SandboxPool createPool(
+            InMemoryPoolStateStore stateStore, Duration drainTimeout, SandboxPreparer preparer) {
+        return createPool(stateStore, drainTimeout, preparer, 1, 1);
+    }
+
+    private SandboxPool createPool(
             InMemoryPoolStateStore stateStore,
             Duration drainTimeout,
-            SandboxPreparer preparer) {
+            SandboxPreparer preparer,
+            int maxIdle,
+            int warmupConcurrency) {
         PoolCreationSpec creationSpec =
                 PoolCreationSpec.builder()
                         .image(getSandboxImage())
@@ -228,8 +319,8 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
         return SandboxPool.builder()
                 .poolName("pool-" + tag)
                 .ownerId("owner-" + tag)
-                .maxIdle(1)
-                .warmupConcurrency(1)
+                .maxIdle(maxIdle)
+                .warmupConcurrency(warmupConcurrency)
                 .stateStore(stateStore)
                 .connectionConfig(sharedConnectionConfig)
                 .creationSpec(creationSpec)

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolGracefulShutdownE2ETest.java
@@ -291,6 +291,104 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
         }
     }
 
+    @Test
+    @DisplayName("restart fences and deletes a late warmup from the retired run")
+    @Timeout(value = 6, unit = TimeUnit.MINUTES)
+    void testRestartFencesLateWarmupFromRetiredRun() throws Exception {
+        tag = uniqueTag("restart-late-warmup");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch oldWarmupEntered = new CountDownLatch(1);
+        CountDownLatch releaseOldWarmup = new CountDownLatch(1);
+        CountDownLatch newWarmupEntered = new CountDownLatch(1);
+        AtomicInteger warmupSequence = new AtomicInteger();
+        AtomicBoolean oldWarmupInterrupted = new AtomicBoolean(false);
+        AtomicReference<String> oldSandboxId = new AtomicReference<>();
+        AtomicReference<String> newSandboxId = new AtomicReference<>();
+        SandboxPool pool =
+                createPool(
+                        stateStore,
+                        Duration.ofMillis(300),
+                        sandbox -> {
+                            if (warmupSequence.incrementAndGet() == 1) {
+                                oldSandboxId.set(sandbox.getId());
+                                oldWarmupEntered.countDown();
+                                awaitIgnoringInterrupt(releaseOldWarmup, oldWarmupInterrupted);
+                            } else {
+                                newSandboxId.set(sandbox.getId());
+                                newWarmupEntered.countDown();
+                            }
+                        });
+
+        try {
+            pool.start();
+            assertTrue(
+                    oldWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "the first lifecycle should enter its deliberately uncooperative warmup");
+            assertNotNull(oldSandboxId.get());
+            eventually(
+                    "old lifecycle warmup is visible remotely",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> taggedSandboxExists(oldSandboxId.get()));
+
+            pool.shutdown(true);
+
+            assertTrue(
+                    oldWarmupInterrupted.get(),
+                    "forced shutdown should interrupt the old preparer even though it keeps waiting");
+            assertEquals(PoolLifecycleState.STOPPED, pool.snapshot().getLifecycleState());
+            assertEquals(
+                    1L,
+                    releaseOldWarmup.getCount(),
+                    "old warmup must still be blocked after its lifecycle has stopped");
+            assertEquals(0, pool.snapshot().getInFlightOperations());
+
+            pool.start();
+            assertTrue(
+                    newWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "the restarted lifecycle should admit a new warmup independently");
+            eventually(
+                    "restarted lifecycle publishes only its new warmup",
+                    Duration.ofMinutes(2),
+                    Duration.ofMillis(500),
+                    () ->
+                            newSandboxId.get() != null
+                                    && pool.snapshot().getIdleCount() == 1
+                                    && pool.snapshot().getInFlightOperations() == 0
+                                    && pool.snapshotIdleEntries().stream()
+                                            .allMatch(
+                                                    entry ->
+                                                            newSandboxId
+                                                                    .get()
+                                                                    .equals(entry.getSandboxId())));
+            eventually(
+                    "old and restarted sandboxes overlap before the old warmup is released",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 2);
+
+            releaseOldWarmup.countDown();
+
+            eventually(
+                    "retired lifecycle sandbox is deleted after its late completion",
+                    Duration.ofSeconds(60),
+                    Duration.ofMillis(500),
+                    () ->
+                            !taggedSandboxExists(oldSandboxId.get())
+                                    && taggedSandboxExists(newSandboxId.get())
+                                    && countTaggedSandboxes() == 1);
+            assertEquals(1, pool.snapshot().getIdleCount());
+            assertEquals(0, pool.snapshot().getInFlightOperations());
+            assertTrue(
+                    pool.snapshotIdleEntries().stream()
+                            .allMatch(entry -> newSandboxId.get().equals(entry.getSandboxId())),
+                    "late old-run completion must never enter the restarted idle pool");
+        } finally {
+            releaseOldWarmup.countDown();
+            shutdownAndRelease(pool);
+        }
+    }
+
     private SandboxPool createPool(
             InMemoryPoolStateStore stateStore, Duration drainTimeout, SandboxPreparer preparer) {
         return createPool(stateStore, drainTimeout, preparer, 1, 1);
@@ -372,6 +470,16 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
         return infos.getSandboxInfos().size();
     }
 
+    private boolean taggedSandboxExists(String sandboxId) {
+        if (sandboxId == null) {
+            return false;
+        }
+        PagedSandboxInfos infos =
+                sandboxManager.listSandboxInfos(
+                        SandboxFilter.builder().metadata(Map.of("tag", tag)).pageSize(20).build());
+        return infos.getSandboxInfos().stream().anyMatch(info -> sandboxId.equals(info.getId()));
+    }
+
     private void cleanupTaggedSandboxes() {
         if (sandboxManager == null || tag == null || tag.isBlank()) {
             return;
@@ -406,6 +514,17 @@ public class SandboxPoolGracefulShutdownE2ETest extends BaseE2ETest {
         try {
             pool.releaseAllIdle();
         } catch (Exception ignored) {
+        }
+    }
+
+    private static void awaitIgnoringInterrupt(CountDownLatch latch, AtomicBoolean interrupted) {
+        while (true) {
+            try {
+                latch.await();
+                return;
+            } catch (InterruptedException exception) {
+                interrupted.set(true);
+            }
         }
     }
 

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolRedisDistributedE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolRedisDistributedE2ETest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -228,6 +229,88 @@ public class SandboxPoolRedisDistributedE2ETest extends BaseE2ETest {
                 Duration.ofSeconds(1),
                 () -> poolB.snapshot().getIdleCount() >= 1);
         assertTrue(beforeShutdown >= 1, "poolA should have warmed idle before shutdown");
+    }
+
+    @Test
+    @DisplayName("Redis primary heartbeat survives a warmup blocked beyond the lock TTL")
+    @Timeout(value = 6, unit = TimeUnit.MINUTES)
+    void testPrimaryHeartbeatSurvivesBlockedWarmup() throws Exception {
+        tag = "e2e-redis-heartbeat-" + UUID.randomUUID().toString().substring(0, 8);
+        String poolName = "redis-heartbeat-" + tag;
+        String ownerA = "owner-a-" + tag;
+        String ownerB = "owner-b-" + tag;
+        String lockKey = poolKey(poolName, "lock");
+        Duration lockTtl = Duration.ofSeconds(3);
+        Duration reconcileInterval = Duration.ofMillis(250);
+        sandboxManager = SandboxManager.builder().connectionConfig(sharedConnectionConfig).build();
+
+        CountDownLatch leaderWarmupEntered = new CountDownLatch(1);
+        CountDownLatch releaseLeaderWarmup = new CountDownLatch(1);
+        AtomicInteger followerWarmupCalls = new AtomicInteger();
+        RedisPoolStateStore storeA = new RedisPoolStateStore(redis, keyPrefix);
+        RedisPoolStateStore storeB = new RedisPoolStateStore(redis, keyPrefix);
+        SandboxPool poolA =
+                createPoolBuilder(poolName, ownerA, storeA, 1)
+                        .reconcileInterval(reconcileInterval)
+                        .primaryLockTtl(lockTtl)
+                        .warmupSandboxPreparer(
+                                sandbox -> {
+                                    leaderWarmupEntered.countDown();
+                                    awaitLatch(releaseLeaderWarmup);
+                                })
+                        .build();
+        SandboxPool poolB =
+                createPoolBuilder(poolName, ownerB, storeB, 1)
+                        .reconcileInterval(reconcileInterval)
+                        .primaryLockTtl(lockTtl)
+                        .warmupSandboxPreparer(sandbox -> followerWarmupCalls.incrementAndGet())
+                        .build();
+        pools.add(poolA);
+        pools.add(poolB);
+
+        try {
+            poolA.start();
+            assertTrue(
+                    leaderWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "leader should create a remote sandbox and block in its preparer");
+            eventually(
+                    "first node owns the Redis primary lock",
+                    Duration.ofSeconds(10),
+                    Duration.ofMillis(100),
+                    () -> ownerA.equals(redis.get(lockKey)));
+
+            poolB.start();
+            long stableUntil = System.nanoTime() + lockTtl.multipliedBy(2).toNanos();
+            while (System.nanoTime() < stableUntil) {
+                assertEquals(
+                        ownerA,
+                        redis.get(lockKey),
+                        "blocked warmup must not let the primary lock expire or change owner");
+                assertTrue(redis.pttl(lockKey) > 0, "primary lock must retain a positive TTL");
+                assertEquals(
+                        0,
+                        followerWarmupCalls.get(),
+                        "follower must not start warmup while the leader heartbeat is healthy");
+                Thread.sleep(200);
+            }
+            assertEquals(
+                    1,
+                    countTaggedSandboxes(tag),
+                    "healthy heartbeat must prevent split-brain over-provisioning");
+
+            releaseLeaderWarmup.countDown();
+            eventually(
+                    "leader warmup enters idle after the blocking preparer is released",
+                    AWAIT_TIMEOUT,
+                    Duration.ofMillis(500),
+                    () ->
+                            ownerA.equals(redis.get(lockKey))
+                                    && poolA.snapshot().getIdleCount() == 1);
+            assertEquals(0, followerWarmupCalls.get());
+            assertEquals(1, countTaggedSandboxes(tag));
+        } finally {
+            releaseLeaderWarmup.countDown();
+        }
     }
 
     @Test
@@ -761,6 +844,15 @@ public class SandboxPoolRedisDistributedE2ETest extends BaseE2ETest {
                         .withoutPadding()
                         .encodeToString(poolName.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         return keyPrefix + ":{" + tag + "}:" + suffix;
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("warmup interrupted unexpectedly", exception);
+        }
     }
 
     private void cleanupRedisKeys() {

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolRedisDistributedE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolRedisDistributedE2ETest.java
@@ -33,6 +33,7 @@ import com.alibaba.opensandbox.sandbox.domain.pool.PoolCreationSpec;
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolDestroyOptions;
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolDestroyResult;
 import com.alibaba.opensandbox.sandbox.domain.pool.PoolDestroyState;
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolLifecycleState;
 import com.alibaba.opensandbox.sandbox.infrastructure.pool.RedisPoolStateStore;
 import com.alibaba.opensandbox.sandbox.pool.SandboxPool;
 import com.alibaba.opensandbox.sandbox.pool.SandboxPoolManager;
@@ -51,6 +52,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -310,6 +312,147 @@ public class SandboxPoolRedisDistributedE2ETest extends BaseE2ETest {
             assertEquals(1, countTaggedSandboxes(tag));
         } finally {
             releaseLeaderWarmup.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("Redis failover fences an in-flight warmup from the retired primary")
+    @Timeout(value = 7, unit = TimeUnit.MINUTES)
+    void testFailoverFencesInflightWarmupFromRetiredPrimary() throws Exception {
+        tag = "e2e-redis-inflight-failover-" + UUID.randomUUID().toString().substring(0, 8);
+        String poolName = "redis-inflight-failover-" + tag;
+        String ownerA = "owner-a-" + tag;
+        String ownerB = "owner-b-" + tag;
+        String lockKey = poolKey(poolName, "lock");
+        Duration lockTtl = Duration.ofSeconds(3);
+        Duration reconcileInterval = Duration.ofMillis(250);
+        sandboxManager = SandboxManager.builder().connectionConfig(sharedConnectionConfig).build();
+
+        CountDownLatch leaderWarmupEntered = new CountDownLatch(1);
+        CountDownLatch releaseLeaderWarmup = new CountDownLatch(1);
+        CountDownLatch followerWarmupEntered = new CountDownLatch(1);
+        AtomicBoolean leaderWarmupInterrupted = new AtomicBoolean(false);
+        AtomicReference<String> leaderSandboxId = new AtomicReference<>();
+        AtomicReference<String> followerSandboxId = new AtomicReference<>();
+        AtomicReference<Throwable> leaderShutdownFailure = new AtomicReference<>();
+        RedisPoolStateStore storeA = new RedisPoolStateStore(redis, keyPrefix);
+        RedisPoolStateStore storeB = new RedisPoolStateStore(redis, keyPrefix);
+        SandboxPool poolA =
+                createPoolBuilder(poolName, ownerA, storeA, 1)
+                        .reconcileInterval(reconcileInterval)
+                        .primaryLockTtl(lockTtl)
+                        .drainTimeout(Duration.ofMillis(300))
+                        .warmupSandboxPreparer(
+                                sandbox -> {
+                                    leaderSandboxId.set(sandbox.getId());
+                                    leaderWarmupEntered.countDown();
+                                    awaitIgnoringInterrupt(
+                                            releaseLeaderWarmup, leaderWarmupInterrupted);
+                                })
+                        .build();
+        SandboxPool poolB =
+                createPoolBuilder(poolName, ownerB, storeB, 1)
+                        .reconcileInterval(reconcileInterval)
+                        .primaryLockTtl(lockTtl)
+                        .warmupSandboxPreparer(
+                                sandbox -> {
+                                    followerSandboxId.set(sandbox.getId());
+                                    followerWarmupEntered.countDown();
+                                })
+                        .build();
+        pools.add(poolA);
+        pools.add(poolB);
+        Thread leaderShutdownThread = null;
+
+        try {
+            poolA.start();
+            assertTrue(
+                    leaderWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "the first primary should enter its deliberately blocked warmup");
+            assertNotNull(leaderSandboxId.get());
+            eventually(
+                    "first node owns the Redis primary lock",
+                    Duration.ofSeconds(10),
+                    Duration.ofMillis(100),
+                    () -> ownerA.equals(redis.get(lockKey)));
+
+            poolB.start();
+            leaderShutdownThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    poolA.shutdown(true);
+                                } catch (Throwable throwable) {
+                                    leaderShutdownFailure.set(throwable);
+                                }
+                            },
+                            "sandbox-pool-e2e-inflight-primary-shutdown");
+            leaderShutdownThread.start();
+
+            eventually(
+                    "old primary lifecycle retires while its warmup remains blocked",
+                    Duration.ofSeconds(10),
+                    Duration.ofMillis(100),
+                    () -> poolA.snapshot().getLifecycleState() == PoolLifecycleState.STOPPED);
+            assertEquals(
+                    1L,
+                    releaseLeaderWarmup.getCount(),
+                    "the old-primary warmup must still be blocked after retirement");
+
+            assertTrue(
+                    followerWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "the follower should take over and start replacement warmup");
+            eventually(
+                    "new primary publishes its replacement while old warmup remains in flight",
+                    AWAIT_TIMEOUT,
+                    Duration.ofMillis(250),
+                    () ->
+                            ownerB.equals(redis.get(lockKey))
+                                    && followerSandboxId.get() != null
+                                    && poolB.snapshot().getIdleCount() == 1
+                                    && poolB.snapshotIdleEntries().stream()
+                                            .allMatch(
+                                                    entry ->
+                                                            followerSandboxId
+                                                                    .get()
+                                                                    .equals(entry.getSandboxId())));
+            eventually(
+                    "old and replacement sandboxes overlap before old completion",
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes(tag) == 2);
+
+            releaseLeaderWarmup.countDown();
+            if (leaderShutdownThread != null) {
+                leaderShutdownThread.join(15_000);
+                assertFalse(
+                        leaderShutdownThread.isAlive(),
+                        "old primary shutdown should finish after releasing its warmup");
+            }
+            assertNull(leaderShutdownFailure.get(), "old primary shutdown should not fail");
+
+            eventually(
+                    "late old-primary sandbox is deleted and shared idle remains bounded",
+                    Duration.ofSeconds(60),
+                    Duration.ofMillis(500),
+                    () ->
+                            !taggedSandboxExists(tag, leaderSandboxId.get())
+                                    && taggedSandboxExists(tag, followerSandboxId.get())
+                                    && countTaggedSandboxes(tag) == 1
+                                    && poolB.snapshot().getIdleCount() == 1);
+            assertTrue(
+                    poolB.snapshotIdleEntries().stream()
+                            .allMatch(
+                                    entry -> followerSandboxId.get().equals(entry.getSandboxId())),
+                    "retired primary result must never enter shared Redis idle membership");
+            assertTrue(
+                    leaderWarmupInterrupted.get(),
+                    "old primary shutdown should interrupt the uncooperative preparer");
+        } finally {
+            releaseLeaderWarmup.countDown();
+            if (leaderShutdownThread != null) {
+                leaderShutdownThread.join(15_000);
+            }
         }
     }
 
@@ -838,6 +981,19 @@ public class SandboxPoolRedisDistributedE2ETest extends BaseE2ETest {
         return infos.getSandboxInfos().size();
     }
 
+    private boolean taggedSandboxExists(String queryTag, String sandboxId) {
+        if (sandboxManager == null || queryTag == null || queryTag.isBlank() || sandboxId == null) {
+            return false;
+        }
+        PagedSandboxInfos infos =
+                sandboxManager.listSandboxInfos(
+                        SandboxFilter.builder()
+                                .metadata(Map.of("tag", queryTag))
+                                .pageSize(50)
+                                .build());
+        return infos.getSandboxInfos().stream().anyMatch(info -> sandboxId.equals(info.getId()));
+    }
+
     private String poolKey(String poolName, String suffix) {
         String tag =
                 java.util.Base64.getUrlEncoder()
@@ -852,6 +1008,17 @@ public class SandboxPoolRedisDistributedE2ETest extends BaseE2ETest {
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("warmup interrupted unexpectedly", exception);
+        }
+    }
+
+    private static void awaitIgnoringInterrupt(CountDownLatch latch, AtomicBoolean interrupted) {
+        while (true) {
+            try {
+                latch.await();
+                return;
+            } catch (InterruptedException exception) {
+                interrupted.set(true);
+            }
         }
     }
 

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolSingleNodeE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolSingleNodeE2ETest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
@@ -1149,6 +1150,125 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
 
     @Test
     @Order(18)
+    @DisplayName("slow warmup does not block rolling slot replenishment")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void testSlowWarmupDoesNotBlockRollingSlotReplenishment() throws Exception {
+        pool.resize(0);
+        pool.releaseAllIdle();
+        pool.shutdown(false);
+
+        String rollingTag =
+                "e2e-pool-rolling-warmup-" + UUID.randomUUID().toString().substring(0, 8);
+        CountDownLatch slowWarmupEntered = new CountDownLatch(1);
+        CountDownLatch releaseSlowWarmup = new CountDownLatch(1);
+        CountDownLatch laterWarmupsEntered = new CountDownLatch(3);
+        AtomicInteger warmupSequence = new AtomicInteger();
+        AtomicInteger activePreparers = new AtomicInteger();
+        AtomicInteger maxActivePreparers = new AtomicInteger();
+        SandboxPool rollingPool = null;
+        try {
+            rollingPool =
+                    SandboxPool.builder()
+                            .poolName("pool-rolling-warmup-" + rollingTag)
+                            .ownerId("owner-rolling-warmup-" + rollingTag)
+                            .maxIdle(4)
+                            .warmupConcurrency(2)
+                            .stateStore(new InMemoryPoolStateStore())
+                            .connectionConfig(sharedConnectionConfig)
+                            .creationSpec(
+                                    PoolCreationSpec.builder()
+                                            .image(getSandboxImage())
+                                            .entrypoint(List.of("tail -f /dev/null"))
+                                            .metadata(
+                                                    Map.of(
+                                                            "tag",
+                                                            rollingTag,
+                                                            "suite",
+                                                            "sandbox-pool-e2e"))
+                                            .env(
+                                                    Map.of(
+                                                            "E2E_TEST",
+                                                            "true",
+                                                            "EXECD_API_GRACE_SHUTDOWN",
+                                                            "3s",
+                                                            "EXECD_JUPYTER_IDLE_POLL_INTERVAL",
+                                                            "1s"))
+                                            .build())
+                            .warmupSandboxPreparer(
+                                    sandbox -> {
+                                        int active = activePreparers.incrementAndGet();
+                                        maxActivePreparers.accumulateAndGet(active, Math::max);
+                                        int sequence = warmupSequence.incrementAndGet();
+                                        try {
+                                            if (sequence == 1) {
+                                                slowWarmupEntered.countDown();
+                                                awaitLatch(releaseSlowWarmup);
+                                            } else {
+                                                laterWarmupsEntered.countDown();
+                                            }
+                                        } finally {
+                                            activePreparers.decrementAndGet();
+                                        }
+                                    })
+                            // The test must prove completion-driven refill, not a periodic tick.
+                            .reconcileInterval(Duration.ofMinutes(5))
+                            .drainTimeout(Duration.ofSeconds(10))
+                            .build();
+            rollingPool.start();
+
+            assertTrue(
+                    slowWarmupEntered.await(2, TimeUnit.MINUTES),
+                    "one warmup should enter the deliberately slow preparer");
+            assertTrue(
+                    laterWarmupsEntered.await(2, TimeUnit.MINUTES),
+                    "three later warmups should reuse the free slot while the first stays blocked");
+
+            SandboxPool finalRollingPool = rollingPool;
+            eventually(
+                    "three fast warmups become idle before the slow tail completes",
+                    Duration.ofMinutes(2),
+                    Duration.ofMillis(500),
+                    () -> finalRollingPool.snapshot().getIdleCount() == 3);
+            assertEquals(
+                    1L,
+                    releaseSlowWarmup.getCount(),
+                    "the first warmup must still be blocked when later slots refill");
+            assertTrue(
+                    maxActivePreparers.get() <= 2,
+                    "rolling replenishment must respect warmupConcurrency");
+            assertTrue(
+                    countTaggedSandboxes(rollingTag) <= 4,
+                    "rolling replenishment must not create beyond maxIdle");
+
+            releaseSlowWarmup.countDown();
+            eventually(
+                    "rolling pool converges after the slow tail completes",
+                    Duration.ofMinutes(1),
+                    Duration.ofMillis(500),
+                    () -> finalRollingPool.snapshot().getIdleCount() == 4);
+            assertEquals(4, warmupSequence.get(), "exactly maxIdle warmups should be admitted");
+            assertTrue(
+                    countTaggedSandboxes(rollingTag) <= 4,
+                    "remote sandbox count must remain bounded by maxIdle");
+        } finally {
+            releaseSlowWarmup.countDown();
+            if (rollingPool != null) {
+                try {
+                    rollingPool.resize(0);
+                    rollingPool.releaseAllIdle();
+                } catch (Exception ignored) {
+                }
+                try {
+                    rollingPool.shutdown(false);
+                } catch (Exception ignored) {
+                }
+            }
+            cleanupTaggedSandboxes(rollingTag);
+        }
+    }
+
+    @Test
+    @Order(19)
     @DisplayName("snapshot exposes lifecycle maxIdle and idle entry details")
     @Timeout(value = 4, unit = TimeUnit.MINUTES)
     void testSnapshotExposesLifecycleAndIdleEntries() throws InterruptedException {
@@ -1194,7 +1314,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
     }
 
     @Test
-    @Order(19)
+    @Order(20)
     @DisplayName("RETRY_NEXT_IDLE skips stale idle candidate and returns healthy warm sandbox")
     @Timeout(value = 4, unit = TimeUnit.MINUTES)
     void testRetryNextIdleSkipsStaleAndReturnsHealthyWarm() throws Exception {
@@ -1300,7 +1420,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
     }
 
     @Test
-    @Order(20)
+    @Order(21)
     @DisplayName(
             "RETRY_NEXT_IDLE_THEN_CREATE falls through to direct-create when all idle are stale")
     @Timeout(value = 4, unit = TimeUnit.MINUTES)
@@ -1403,7 +1523,7 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
     }
 
     @Test
-    @Order(21)
+    @Order(22)
     @DisplayName(
             "RETRY_NEXT_IDLE raises PoolAcquireFailedException after bounded retries on all-stale queue")
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
@@ -1541,6 +1661,15 @@ public class SandboxPoolSingleNodeE2ETest extends BaseE2ETest {
                             + lastError.getMessage());
         } else {
             fail("Timed out waiting for " + description);
+        }
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("warmup interrupted unexpectedly", exception);
         }
     }
 


### PR DESCRIPTION
# Summary

This PR changes Kotlin `SandboxPool` replenishment from blocking batches to a rolling in-flight window.

- Treat `warmupConcurrency` as the maximum number of admitted, unfinished warmups instead of a batch size.
- Refill a released warmup slot immediately after an individual warmup completes; one slow tail no longer blocks later replenishment.
- Count idle and warming sandboxes together when planning, so periodic and completion-driven reconciles cannot over-submit.
- Keep warmup creation off the single-threaded controller, allowing the distributed primary heartbeat to continue while a warmup is blocked.
- Adapt backoff, lock fencing, cleanup, and graceful shutdown to independently completing warmups.
- Preserve all existing public APIs and configuration names.

## Motivation

The previous reconciler submitted up to `warmupConcurrency` tasks with `invokeAll` and waited for the entire batch:

```text
submit [A slow, B fast]
        |
        +-- wait for both tasks
        |
submit the next batch
```

If one warmup was slow, every completed worker in that batch stayed unused until the slowest task returned. Increasing `warmupConcurrency` enlarged the batch but did not remove this tail barrier.

The new execution model keeps the available slots rolling:

```text
[A slow][B fast] -> [A slow][empty] -> [A slow][C new]
```

## Design

### 1. Rolling warmup plan

Every reconcile calculates a point-in-time plan:

```text
deficit        = max(maxIdle - idleCount - warmingCount, 0)
availableSlots = max(warmupConcurrency - warmingCount, 0)
toSubmit       = min(deficit, availableSlots)
```

`warmingCount` is incremented when a warmup is admitted, before it is submitted to the worker executor. It is decremented exactly once by completion handling, including rejected or dropped tasks.

The two invariants are:

```text
warmingCount <= warmupConcurrency
idleCount + warmingCount <= maxIdle at admission time
```

The latter is an admission invariant rather than a permanent store invariant: external acquires, distributed resize, expiry, and failover may change shared state between snapshots, and the periodic reconciler remains responsible for convergence.

### 2. Controller and workers

`Controller` is a logical role implemented by the pool's single-threaded scheduled executor; it is not a new public class.

The controller serializes:

- periodic reconcile ticks;
- completion result handling;
- completion-driven reconcile requests;
- primary heartbeat scheduling.

The fixed-size warmup executor only performs slow remote work:

- create the sandbox;
- wait for readiness and health checks;
- run the optional warmup preparer.

Workers never decide whether to create the next sandbox. They report an outcome to the controller, which commits or cleans it up, releases the tracked slot, and recalculates the plan.

### 3. Reconcile triggers

There are two triggers:

1. **Periodic reconcile**
   - runs immediately at startup when `maxIdle > 0`;
   - continues at `reconcileInterval`;
   - discovers shared-state changes, handles expiry/shrink, recovers from missed events, and provides the distributed safety net.

2. **Warmup completion**
   - commits the outcome independently;
   - decrements `warmingCount`;
   - requests an immediate reconcile so the released slot can be reused.

`reconcileQueued` coalesces a burst of completion-driven requests. Individual outcomes are still handled exactly once, but multiple simultaneous completions normally result in one follow-up reconcile.

Periodic and completion-driven reconciles may both be queued, but normal admission decisions are serialized on the same controller. The later reconcile sees the updated `warmingCount` and submits zero if an earlier reconcile already consumed the slot.

### 4. Distributed primary ownership

The distributed model is unchanged:

- `idleCount` and `maxIdle` are shared through `PoolStateStore`;
- each node has a local controller;
- only the current primary lock holder may submit warmups;
- `warmingCount` is local to the primary that admitted those tasks.

The primary lock is no longer held by a thread blocked in `invokeAll`. A periodic heartbeat renews ownership while warmup workers execute.

Before a successful warmup is written to idle storage, the owning node renews the primary lock again. If leadership was lost, the result is fenced out and the remote sandbox is cleaned up instead of entering the shared idle pool.

During an actual failover, a new primary may temporarily create replacements while old-primary warmups still exist remotely. Old-primary results cannot enter the idle pool after fencing and are deleted on completion, keeping shared membership convergent.

### 5. Lifecycle run fencing

Each `start()` creates a private `RunContext` containing its generation identity, controller scheduler, warmup executor, warming count, admission flag, reconcile coalescing flag, primary-ownership flag, and in-flight drain accounting. Periodic ticks, warmup workers, and completions capture this context instead of looking up mutable executors or counters from a later lifecycle.

Shutdown retires the current context under a commit lock. The same lock fences the final primary-lock renewal and `putIdle`, giving shutdown and warmup commit a clear ordering:

- a completion linearized before retirement may commit under the existing RUNNING/DRAINING rules;
- a successful completion observed after retirement is never admitted and is killed best-effort;
- a failed or cancelled completion from a retired run cannot update the restarted run backoff state;
- an old completion is delivered to its original controller, never to a scheduler created by a later `start()`.

If the original provider has already closed, late-success cleanup creates a temporary `SandboxManager`. This closes the new shutdown-time orphan window while retaining the existing best-effort contract: if manager creation or the kill RPC itself ultimately fails, the sandbox still falls back to server-side TTL expiry.

### 6. Backoff

Warmups now fail independently rather than as a completed batch.

- Each asynchronous failure increments the failure count.
- Reaching `degradedThreshold` activates backoff.
- Other concurrent failures completing inside the same active backoff window update counters and the last error but do not advance the exponential delay once per completion.
- A successful committed warmup restores the existing success behavior and clears backoff.
- Completion may still request reconcile during backoff, but the planner submits no new warmups until the window expires.

This preserves failure throttling without allowing one concurrent wave to multiply the exponential delay immediately.

### 7. Graceful shutdown

Graceful shutdown first closes warmup admission and stops periodic reconcile, then drains already-admitted operations:

```text
close new admissions
stop periodic reconcile
keep controller + heartbeat alive
wait for admitted warmups to complete
stop executors and release the primary lock
```

Pre-admitted warmups may still be committed while the pool is `DRAINING`, matching the existing behavior. Their completions cannot refill released slots because admission is already closed.

If the drain timeout expires, warmup workers are stopped before the controller so interrupted or dropped tasks can still release their tracked operation/slot state.

Warmup outcomes queued behind a busy controller are registered in the owning `RunContext`; forced scheduler shutdown explicitly drains that registry so successful sandboxes are cleaned and slot/in-flight accounting completes exactly once.

A worker that ignores interruption may outlive a forced shutdown. Its captured `RunContext` remains retired, so a later result cannot enter a restarted pool or consume/release that run’s slots. A late successful result is routed to cleanup even after the normal provider has closed.

## Compatibility

- No public Kotlin API changes.
- No configuration names or defaults change.
- `warmupConcurrency` remains user-configurable; only its internal scheduling semantics improve from batch size to rolling in-flight capacity.
- `reconcileInterval` remains the periodic recovery interval.
- Acquire policies, resize APIs, snapshots, lifecycle states, and store interfaces remain compatible.
- In-memory and Redis-backed pools keep the same coordination model.

## Known boundaries

### First idle vacancy

An acquire does not directly wake the distributed primary. The first vacancy is still discovered by the next periodic reconcile; once a refill wave has started, individual warmup completions refill slots immediately.

This is intentional for this PR because acquire and replenish may run on different nodes. A future optimization can add a durable shared reconcile marker plus an optional wake-up notification, with the periodic tick retained as the correctness fallback.

### Long controller operations

Slow warmup work no longer blocks the controller or primary heartbeat. However, the heartbeat currently shares the controller scheduler, so a long reconcile/store/cleanup operation can still delay completion handling and lock renewal. Separating heartbeat scheduling and moving remaining remote cleanup off the controller are possible follow-ups.

### Capacity limits

Rolling scheduling removes batch-tail waste but cannot exceed backend creation capacity. If pool consumption is faster than the environment can create sandboxes, idle inventory will still drain and backoff/rate limits still apply. `warmupConcurrency` should be sized for the environment rather than set to `maxIdle` only to avoid the old batch barrier.

## Benchmark interpretation

This change is expected to improve:

- time to reach a warm idle target;
- utilization of configured warmup concurrency;
- behavior when one warmup is much slower than its peers;
- refill continuity between completed warmups.

It does not change the steady-state supply/demand limit. For example, a benchmark consuming approximately 67 sandboxes/s against an environment creating approximately 8 sandboxes/s will still drain the pool. Also, when `maxIdle` is much larger than the benchmark's start threshold, background rolling warmup continues during the benchmark and its creation load must be counted together with direct-create load.

# Testing

- [x] Unit tests
- [x] Redis integration tests
- [x] Automated E2E

Local verification:

- `./gradlew :sandbox:test spotlessCheck --no-configuration-cache --rerun-tasks` (249 tests)
- `OPENSANDBOX_TEST_REDIS_URL=redis://127.0.0.1:16379 ./gradlew :sandbox-pool-redis:test --no-configuration-cache --rerun-tasks` (15 tests)

Added coverage includes:

- a fast completion refills its slot while a slow warmup remains blocked;
- rolling replenishment respects `warmupConcurrency` and converges to `maxIdle`;
- primary heartbeat continues while warmup is blocked beyond the lock TTL;
- followers do not warm while the primary heartbeat is healthy;
- a warmup result is dropped and cleaned after primary lock loss;
- async commit failures enter backoff and clean remote sandboxes;
- graceful shutdown drains admitted warmups without refilling slots;
- Redis failover and lost-lock recovery remain bounded;
- single-node graceful shutdown/restart with an interruption-ignoring preparer: the restarted run fills independently and the retired run late result is deleted rather than published idle;
- Redis primary failover with an interruption-ignoring in-flight warmup: the new primary fills the shared vacancy while the retired primary late result is fenced, deleted, and never enters shared idle membership;
- a successful warmup from a retired run is fenced out, killed, and cannot enter a restarted pool;
- a failed warmup from a retired run cannot degrade or back off a restarted pool;
- retired-run operations do not appear in or delay the restarted run snapshot/drain;
- a queued completion dropped by forced controller shutdown is completed exactly once and its successful sandbox is killed;
- a successful warmup finishing after shutdown uses a temporary manager for remote cleanup;

GitHub Actions passed, including Java E2E against the real Docker bridge and Redis service. Local Java E2E sources also compile and the two changed files pass Spotless.

# Breaking Changes

- [x] None
- [ ] Yes

# Checklist

- [x] Motivation and design documented
- [x] Added/updated documentation
- [x] Added/updated unit and E2E coverage
- [x] Distributed ownership and cleanup considered
- [x] Graceful shutdown and backoff considered
- [x] Backward compatibility considered



