### PR TITLE
fix(kotlin): harden pool acquire lifecycle

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/Sandbox.kt
@@ -46,6 +46,7 @@ import com.alibaba.opensandbox.sandbox.domain.services.Metrics
 import com.alibaba.opensandbox.sandbox.domain.services.Sandboxes
 import com.alibaba.opensandbox.sandbox.infrastructure.factory.AdapterFactory
 import com.alibaba.opensandbox.sandbox.internal.LifecycleMetricsReporter
+import com.alibaba.opensandbox.sandbox.internal.isCausedByInterruption
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.OffsetDateTime
@@ -270,28 +271,47 @@ class Sandbox internal constructor(
                 }
 
                 return sandbox
-            } catch (e: Exception) {
-                if (initResult is InitializationResult.NewSandbox && sandboxService != null) {
+            } catch (failure: Throwable) {
+                // InterruptedException clears the thread flag when thrown. Keep cleanup RPCs
+                // usable by restoring the flag only after remote/local resources are released.
+                val restoreInterrupt = Thread.interrupted() || failure.isCausedByInterruption()
+                try {
+                    if (initResult is InitializationResult.NewSandbox && sandboxService != null) {
+                        try {
+                            logger.warn(
+                                "Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: {}",
+                                initResult.id,
+                            )
+                            sandboxService.killSandbox(initResult.id)
+                        } catch (cleanupFailure: Throwable) {
+                            logger.error(
+                                "Failed to clean up sandbox {} after creation failure",
+                                initResult.id,
+                                cleanupFailure,
+                            )
+                            failure.addSuppressed(cleanupFailure)
+                        }
+                    }
+
                     try {
-                        logger.warn(
-                            "Sandbox creation failed during initialization. Attempting to terminate zombie sandbox: {}",
-                            initResult.id,
-                        )
-                        sandboxService.killSandbox(initResult.id)
-                    } catch (cleanupEx: Exception) {
-                        logger.error("Failed to clean up sandbox {} after creation failure", initResult.id, cleanupEx)
-                        e.addSuppressed(cleanupEx)
+                        httpClientProvider.close()
+                    } catch (cleanupFailure: Throwable) {
+                        failure.addSuppressed(cleanupFailure)
+                    }
+                } finally {
+                    if (restoreInterrupt) {
+                        Thread.currentThread().interrupt()
                     }
                 }
 
-                httpClientProvider.close()
-                when (e) {
-                    is SandboxException -> throw e
+                when (failure) {
+                    is Error -> throw failure
+                    is SandboxException -> throw failure
                     else -> {
-                        logger.error("Unexpected exception during {}", operationName, e)
+                        logger.error("Unexpected exception during {}", operationName, failure)
                         throw SandboxInternalException(
-                            message = "Failed to $operationName: ${e.message}",
-                            cause = e,
+                            message = "Failed to $operationName: ${failure.message}",
+                            cause = failure,
                         )
                     }
                 }
@@ -666,6 +686,10 @@ class Sandbox internal constructor(
                 try {
                     isHealthy()
                 } catch (e: Exception) {
+                    if (Thread.currentThread().isInterrupted || e.isCausedByInterruption()) {
+                        Thread.currentThread().interrupt()
+                        throw e
+                    }
                     lastException = e
                     logger.debug("Health check attempt #{} failed with exception: {}", attempt, e.message)
                     false

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/internal/ThrowableUtils.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/internal/ThrowableUtils.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.internal
+
+internal fun Throwable.isCausedByInterruption(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is InterruptedException) return true
+        val next = current.cause
+        if (next === current) return false
+        current = next
+    }
+    return false
+}

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * Client-side sandbox pool for acquiring ready sandboxes with predictable latency.
@@ -257,11 +258,15 @@ class SandboxPool internal constructor(
             var attempt = 0
             var loopExhausted = true
             while (attempt < maxAttempts) {
-                ensureAcquireRunActive(run)
                 attempt++
                 val takeResult =
                     try {
-                        stateStore.tryTakeIdle(poolName, config.acquireMinRemainingTtl)
+                        // Linearize the active-run fence with the destructive take against retireRun.
+                        // Otherwise an old acquire could pop an idle committed by a restarted run.
+                        run.commitLock.withLock {
+                            ensureAcquireRunActive(run)
+                            stateStore.tryTakeIdle(poolName, config.acquireMinRemainingTtl)
+                        }
                     } catch (e: PoolStateStoreUnavailableException) {
                         // State store outage. Per OSEP-0005, under policies that fall through to
                         // direct-create on empty idle we degrade to that fallback so the pool

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -38,6 +38,7 @@ import com.alibaba.opensandbox.sandbox.domain.pool.PooledSandboxCreator
 import com.alibaba.opensandbox.sandbox.domain.pool.SandboxPreparer
 import com.alibaba.opensandbox.sandbox.infrastructure.pool.PoolReconciler
 import com.alibaba.opensandbox.sandbox.infrastructure.pool.ReconcileState
+import com.alibaba.opensandbox.sandbox.internal.isCausedByInterruption
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
@@ -89,10 +90,20 @@ import java.util.concurrent.locks.ReentrantLock
  */
 class SandboxPool internal constructor(
     config: PoolConfig,
-    private val sandboxManagerFactory: (ConnectionConfig) -> SandboxManager = { cfg ->
-        SandboxManager.builder().connectionConfig(cfg).build()
-    },
+    private val sandboxManagerFactory: (ConnectionConfig) -> SandboxManager,
+    private val idleSandboxConnector: (String) -> Sandbox,
 ) {
+    internal constructor(
+        config: PoolConfig,
+        sandboxManagerFactory: (ConnectionConfig) -> SandboxManager = { cfg ->
+            SandboxManager.builder().connectionConfig(cfg).build()
+        },
+    ) : this(
+        config = config,
+        sandboxManagerFactory = sandboxManagerFactory,
+        idleSandboxConnector = defaultIdleSandboxConnector(config),
+    )
+
     private val logger = LoggerFactory.getLogger(SandboxPool::class.java)
 
     private val config: PoolConfig = config
@@ -231,26 +242,22 @@ class SandboxPool internal constructor(
             throw PoolNotRunningException("Cannot acquire when pool state is $state")
         }
         val run = currentRun ?: throw PoolNotRunningException("Cannot acquire without an active pool run")
+        val poolName = config.poolName
+        val pendingKill = ArrayList<String>()
         beginOperation(run)
         try {
-            if (!isCurrentRun(run) || lifecycleState.get() != LifecycleState.RUNNING) {
-                val state = lifecycleState.get()
-                throwIfPoolNamespaceDestroyed()
-                logger.info("Pool not running after acquire started, rejected: pool_name={} state={}", config.poolName, state)
-                throw PoolNotRunningException("Cannot acquire when pool state is $state")
-            }
+            ensureAcquireRunActive(run)
             ensurePoolNamespaceActiveForAcquire(policy)
-            val poolName = config.poolName
             val maxAttempts = effectiveMaxIdleAttempts(policy)
             // Accumulate discarded-alive sandbox IDs across all take iterations so we schedule
             // a single deferred cleanup, instead of one kill batch per retry.
-            val pendingKill = ArrayList<String>()
             var lastSandboxId: String? = null
             var lastIdleConnectFailure: Exception? = null
             var attemptedAny = false
             var attempt = 0
             var loopExhausted = true
             while (attempt < maxAttempts) {
+                ensureAcquireRunActive(run)
                 attempt++
                 val takeResult =
                     try {
@@ -262,9 +269,9 @@ class SandboxPool internal constructor(
                         // Under non-fallthrough policies (FAIL_FAST / RETRY_NEXT_IDLE) we surface
                         // the outage as-is so callers can react.
                         if (!policyFallsThroughToDirectCreate(policy)) {
-                            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
                             throw e
                         }
+                        ensureAcquireRunActive(run)
                         logger.warn(
                             "Acquire: state store unavailable, falling through to direct create " +
                                 "per policy={} error={}",
@@ -288,100 +295,45 @@ class SandboxPool internal constructor(
                 attemptedAny = true
                 val sandbox: Sandbox
                 try {
-                    sandbox =
-                        Sandbox.connector()
-                            .sandboxId(sandboxId)
-                            .connectTimeout(config.acquireReadyTimeout)
-                            .healthCheckPollingInterval(config.acquireHealthCheckPollingInterval)
-                            .skipHealthCheck(config.acquireSkipHealthCheck)
-                            .connectionConfig(connectionConfig)
-                            .run {
-                                config.acquireHealthCheck?.let { healthCheck(it) } ?: this
-                            }.connect()
-                } catch (e: PoolDestroyedException) {
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
-                    throw e
-                } catch (e: Exception) {
-                    // Connect / readiness / health-check failure — the idle candidate itself is
-                    // unusable. Remove it, best-effort kill, then let the loop try the next.
-                    lastIdleConnectFailure = e
-                    logger.warn(
-                        "Idle connect failed (stale or unreachable), removed from pool: " +
-                            "pool_name={} sandbox_id={} policy={} attempt={}/{} error={}",
-                        poolName,
-                        sandboxId,
-                        policy,
-                        attempt,
-                        maxAttempts,
-                        e.message,
-                    )
-                    stateStore.removeIdle(poolName, sandboxId)
-                    // Fire-and-forget the remote kill on the warmup executor. Awaiting kill
-                    // inline would let a slow DELETE (up to the lifecycle client's request
-                    // timeout) block the next retry iteration, defeating the point of
-                    // RETRY_NEXT_IDLE. scheduleKillDiscardedAlive uses the same executor path
-                    // as discarded-alive cleanup and falls back to inline execution when the
-                    // pool is mid-shutdown so cleanup is never silently dropped.
-                    scheduleKillDiscardedAlive(poolName, listOf(sandboxId), source = "acquire-stale", run = run)
-                    // Re-check lifecycle between iterations so an in-flight shutdown / namespace
-                    // destroy short-circuits the retry loop instead of paying another readyTimeout.
-                    if (lifecycleState.get() != LifecycleState.RUNNING) {
-                        val state = lifecycleState.get()
-                        throwIfPoolNamespaceDestroyed()
-                        scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
-                        throw PoolNotRunningException("Cannot acquire when pool state is $state")
-                    }
-                    ensurePoolNamespaceActive()
-                    continue
-                }
-                // Connect + readiness succeeded. From here on the sandbox is a healthy, borrowable
-                // idle: any failure below (renew rejection, namespace fenced) is NOT a candidate-
-                // specific problem, so we must not treat it as "stale idle" and burn another retry.
-                // Dispose the sandbox and rethrow instead.
-                try {
-                    sandboxTimeout?.let { sandbox.renew(it) }
-                    ensurePoolNamespaceActiveOrDispose(sandbox)
-                } catch (e: PoolDestroyedException) {
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
-                    throw e
-                } catch (e: Exception) {
-                    // Renew failed against a healthy sandbox. Retrying another idle will not fix a
-                    // lifecycle-API renew rejection, so we must not loop. But `tryTakeIdle` has
-                    // already popped this ID out of the idle store — if we only close() locally,
-                    // the remote sandbox stays alive on the server until its TTL expires and is
-                    // no longer tracked anywhere (leaks against pool capacity accounting). Kill
-                    // the remote sandbox best-effort, then close local resources and rethrow.
-                    logger.warn(
-                        "Acquire renew failed after idle connect; killing remote sandbox and not " +
-                            "retrying (renew errors are not candidate-specific): " +
-                            "pool_name={} sandbox_id={} policy={} error={}",
-                        poolName,
-                        sandboxId,
-                        policy,
-                        e.message,
-                    )
+                    sandbox = idleSandboxConnector(sandboxId)
+                } catch (failure: Throwable) {
+                    val restoreInterrupt = Thread.interrupted() || failure.isCausedByInterruption()
                     try {
-                        sandbox.kill()
-                    } catch (killEx: Exception) {
+                        discardAcquireCandidate(run, sandboxId, failure)
+                        if (failure is PoolDestroyedException) throw failure
+                        if (restoreInterrupt || failure !is Exception) throw failure
+
+                        lastIdleConnectFailure = failure
                         logger.warn(
-                            "Best-effort kill after renew failure failed: pool_name={} sandbox_id={} error={}",
+                            "Idle connect failed (stale or unreachable), removed from pool: " +
+                                "pool_name={} sandbox_id={} policy={} attempt={}/{} error={}",
                             poolName,
                             sandboxId,
-                            killEx.message,
+                            policy,
+                            attempt,
+                            maxAttempts,
+                            failure.message,
                         )
+                        ensureAcquireRunActive(run)
+                        ensurePoolNamespaceActive()
+                        continue
+                    } finally {
+                        if (restoreInterrupt) {
+                            Thread.currentThread().interrupt()
+                        }
                     }
-                    try {
-                        sandbox.close()
-                    } catch (_: Exception) {
-                        // best-effort local resource release
-                    }
-                    scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
-                    throw e
                 }
-                // Candidate is connected and renewed. Now safe to clean up the discarded-alive
-                // sandboxes; offload to the warmup executor so the caller does not wait for
-                // N kill RPCs.
-                scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
+                // Connect + readiness succeeded. From here on the sandbox is a healthy, borrowable
+                // idle: renew and namespace failures are operation-wide and must not consume another
+                // candidate. Dispose the popped sandbox before propagating either failure.
+                try {
+                    sandboxTimeout?.let { sandbox.renew(it) }
+                } catch (failure: Throwable) {
+                    disposeSandboxAfterAcquireFailure(sandbox, failure)
+                    throw failure
+                }
+                ensurePoolNamespaceActiveOrDispose(sandbox)
+                ensureAcquireRunActive(run, sandbox)
                 logger.debug(
                     "Acquire from idle: pool_name={} sandbox_id={} policy={} attempt={}/{}",
                     poolName,
@@ -392,10 +344,6 @@ class SandboxPool internal constructor(
                 )
                 return sandbox
             }
-            // Reaching here means we did not return a sandbox from idle. Fire the deferred cleanup
-            // so the discarded-alive sandboxes do not linger; both the fail-fast and direct-create
-            // fallthroughs below benefit from asynchronous cleanup instead of a synchronous kill.
-            scheduleKillDiscardedAlive(poolName, pendingKill, source = "acquire", run = run)
 
             val reason =
                 when {
@@ -417,11 +365,25 @@ class SandboxPool internal constructor(
                 }
                 throw PoolEmptyException("Cannot acquire: $reason; policy is $policy")
             }
+            ensureAcquireRunActive(run)
             ensurePoolNamespaceActiveForAcquire(policy)
             logger.debug("Acquire direct create: pool_name={} reason={} policy={}", poolName, reason, policy)
-            return directCreate(sandboxTimeout, policy)
+            val sandbox = directCreate(sandboxTimeout, policy)
+            ensureAcquireRunActive(run, sandbox)
+            return sandbox
         } finally {
-            endOperation(run)
+            val restoreInterrupt = Thread.interrupted()
+            try {
+                scheduleAcquireCleanup(run, pendingKill, source = "acquire")
+            } finally {
+                try {
+                    endOperation(run)
+                } finally {
+                    if (restoreInterrupt) {
+                        Thread.currentThread().interrupt()
+                    }
+                }
+            }
         }
     }
 
@@ -598,6 +560,96 @@ class SandboxPool internal constructor(
     }
 
     private fun resolveMaxIdle(): Int = stateStore.getMaxIdle(config.poolName) ?: currentMaxIdle
+
+    private fun ensureAcquireRunActive(
+        run: RunContext,
+        sandbox: Sandbox? = null,
+    ) {
+        if (isCurrentRun(run) && lifecycleState.get() == LifecycleState.RUNNING) return
+
+        val state = lifecycleState.get()
+        val failure =
+            try {
+                throwIfPoolNamespaceDestroyed()
+                PoolNotRunningException(
+                    "Cannot acquire after pool run ${run.generation} was retired; current state is $state",
+                )
+            } catch (t: Throwable) {
+                t
+            }
+        sandbox?.let { disposeSandboxAfterAcquireFailure(it, failure) }
+        throw failure
+    }
+
+    private fun discardAcquireCandidate(
+        run: RunContext,
+        sandboxId: String,
+        failure: Throwable,
+    ) {
+        try {
+            stateStore.removeIdle(config.poolName, sandboxId)
+        } catch (cleanupFailure: Throwable) {
+            if (cleanupFailure !== failure) {
+                failure.addSuppressed(cleanupFailure)
+            }
+        }
+        scheduleAcquireCleanup(run, listOf(sandboxId), source = "acquire-stale")
+    }
+
+    private fun scheduleAcquireCleanup(
+        run: RunContext,
+        sandboxIds: List<String>,
+        source: String,
+    ) {
+        scheduleKillDiscardedAlive(
+            config.poolName,
+            sandboxIds,
+            source = source,
+            executor = run.warmupExecutor,
+            run = run,
+        )
+    }
+
+    private fun disposeSandboxAfterAcquireFailure(
+        sandbox: Sandbox,
+        failure: Throwable,
+    ) {
+        val restoreInterrupt = Thread.interrupted() || failure.isCausedByInterruption()
+        try {
+            try {
+                sandbox.kill()
+            } catch (cleanupFailure: Throwable) {
+                if (cleanupFailure !== failure) {
+                    failure.addSuppressed(cleanupFailure)
+                }
+                logger.warn(
+                    "Pool sandbox cleanup after acquire failure failed: " +
+                        "pool_name={} sandbox_id={} operation=kill error={}",
+                    config.poolName,
+                    sandbox.id,
+                    cleanupFailure.message,
+                )
+            }
+            try {
+                sandbox.close()
+            } catch (cleanupFailure: Throwable) {
+                if (cleanupFailure !== failure) {
+                    failure.addSuppressed(cleanupFailure)
+                }
+                logger.warn(
+                    "Pool sandbox cleanup after acquire failure failed: " +
+                        "pool_name={} sandbox_id={} operation=close error={}",
+                    config.poolName,
+                    sandbox.id,
+                    cleanupFailure.message,
+                )
+            }
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt()
+            }
+        }
+    }
 
     /**
      * Offload [killDiscardedAlive] to the warmup executor so the caller does not block on the
@@ -866,8 +918,8 @@ class SandboxPool internal constructor(
             val outcome =
                 try {
                     WarmupOutcome.Success(createOneSandbox())
-                } catch (e: Exception) {
-                    WarmupOutcome.Failure(e)
+                } catch (failure: Throwable) {
+                    WarmupOutcome.Failure(failure)
                 }
             dispatchCompletion(outcome)
         }
@@ -939,7 +991,7 @@ class SandboxPool internal constructor(
         ) : WarmupOutcome
 
         class Failure(
-            val error: Exception,
+            val error: Throwable,
         ) : WarmupOutcome
 
         data object Cancelled : WarmupOutcome
@@ -1034,6 +1086,7 @@ class SandboxPool internal constructor(
     private fun createOneSandbox(): String {
         return try {
             val sandbox = buildWarmupSandbox()
+            var failure: Throwable? = null
             try {
                 config.warmupSandboxPreparer?.prepare(sandbox)
                 // The server-side TTL has been ticking since sandbox creation; readiness
@@ -1044,37 +1097,51 @@ class SandboxPool internal constructor(
                 // remaining TTL by the warmup duration.
                 sandbox.renew(config.idleTimeout)
                 sandbox.id
-            } catch (e: Exception) {
-                killWarmupSandboxAfterFailure(sandbox, e)
-                throw e
+            } catch (t: Throwable) {
+                failure = t
+                killWarmupSandboxAfterFailure(sandbox, t)
+                throw t
             } finally {
-                sandbox.close()
+                try {
+                    sandbox.close()
+                } catch (closeFailure: Throwable) {
+                    if (failure != null) {
+                        if (closeFailure !== failure) {
+                            failure.addSuppressed(closeFailure)
+                        }
+                    } else {
+                        killWarmupSandboxAfterFailure(sandbox, closeFailure)
+                        throw closeFailure
+                    }
+                }
             }
-        } catch (e: Exception) {
-            logger.warn("Pool create sandbox failed: poolName={}", config.poolName, e)
-            throw e
+        } catch (failure: Throwable) {
+            logger.warn("Pool create sandbox failed: poolName={}", config.poolName, failure)
+            throw failure
         }
     }
 
     private fun killWarmupSandboxAfterFailure(
         sandbox: Sandbox,
-        failure: Exception,
+        failure: Throwable,
     ) {
         // A warmup preparer may restore the thread's interrupted status before propagating an
         // InterruptedException. OkHttp treats that status as cancellation and can reject the
         // cleanup request before the DELETE is sent. Temporarily clear it for the synchronous
         // cleanup, then restore it so executor shutdown semantics are preserved.
-        val restoreInterrupt = Thread.interrupted()
+        val restoreInterrupt = Thread.interrupted() || failure.isCausedByInterruption()
         try {
             sandbox.kill()
-        } catch (cleanupEx: Exception) {
+        } catch (cleanupFailure: Throwable) {
             logger.warn(
                 "Pool warmup sandbox preparer cleanup failed: pool_name={} sandbox_id={} error={}",
                 config.poolName,
                 sandbox.id,
-                cleanupEx.message,
+                cleanupFailure.message,
             )
-            failure.addSuppressed(cleanupEx)
+            if (cleanupFailure !== failure) {
+                failure.addSuppressed(cleanupFailure)
+            }
         } finally {
             if (restoreInterrupt) {
                 Thread.currentThread().interrupt()
@@ -1131,13 +1198,9 @@ class SandboxPool internal constructor(
             sandboxTimeout?.let { timeout ->
                 try {
                     sandbox.renew(timeout)
-                } catch (e: Exception) {
-                    try {
-                        sandbox.kill()
-                    } finally {
-                        sandbox.close()
-                    }
-                    throw e
+                } catch (failure: Throwable) {
+                    disposeSandboxAfterAcquireFailure(sandbox, failure)
+                    throw failure
                 }
             }
             ensurePoolNamespaceActiveOrDispose(sandbox, policy)
@@ -1158,13 +1221,9 @@ class SandboxPool internal constructor(
         // Renew is a candidate-specific step; failure means kill+close and rethrow.
         try {
             sandboxTimeout?.let { sandbox.renew(it) }
-        } catch (e: Exception) {
-            try {
-                sandbox.kill()
-            } finally {
-                sandbox.close()
-            }
-            throw e
+        } catch (failure: Throwable) {
+            disposeSandboxAfterAcquireFailure(sandbox, failure)
+            throw failure
         }
         // Post-create fence check uses the policy-aware helper so full state-store
         // outages degrade correctly under fallthrough policies; on rethrow the helper
@@ -1251,49 +1310,11 @@ class SandboxPool internal constructor(
                 )
                 return
             }
-            try {
-                sandbox.kill()
-            } catch (cleanupError: Exception) {
-                logger.warn(
-                    "Pool sandbox cleanup after store-outage fence failed: pool_name={} sandbox_id={} operation=kill error={}",
-                    config.poolName,
-                    sandbox.id,
-                    cleanupError.message,
-                )
-            }
-            try {
-                sandbox.close()
-            } catch (cleanupError: Exception) {
-                logger.warn(
-                    "Pool sandbox cleanup after store-outage fence failed: pool_name={} sandbox_id={} operation=close error={}",
-                    config.poolName,
-                    sandbox.id,
-                    cleanupError.message,
-                )
-            }
+            disposeSandboxAfterAcquireFailure(sandbox, e)
             throw e
-        } catch (e: Exception) {
-            try {
-                sandbox.kill()
-            } catch (cleanupError: Exception) {
-                logger.warn(
-                    "Pool sandbox cleanup after fence failed: pool_name={} sandbox_id={} operation=kill error={}",
-                    config.poolName,
-                    sandbox.id,
-                    cleanupError.message,
-                )
-            }
-            try {
-                sandbox.close()
-            } catch (cleanupError: Exception) {
-                logger.warn(
-                    "Pool sandbox cleanup after fence failed: pool_name={} sandbox_id={} operation=close error={}",
-                    config.poolName,
-                    sandbox.id,
-                    cleanupError.message,
-                )
-            }
-            throw e
+        } catch (failure: Throwable) {
+            disposeSandboxAfterAcquireFailure(sandbox, failure)
+            throw failure
         }
     }
 
@@ -1603,6 +1624,19 @@ class SandboxPool internal constructor(
     companion object {
         @JvmStatic
         fun builder(): Builder = Builder()
+
+        private fun defaultIdleSandboxConnector(config: PoolConfig): (String) -> Sandbox =
+            { sandboxId ->
+                Sandbox.connector()
+                    .sandboxId(sandboxId)
+                    .connectTimeout(config.acquireReadyTimeout)
+                    .healthCheckPollingInterval(config.acquireHealthCheckPollingInterval)
+                    .skipHealthCheck(config.acquireSkipHealthCheck)
+                    .connectionConfig(config.connectionConfig)
+                    .run {
+                        config.acquireHealthCheck?.let { healthCheck(it) } ?: this
+                    }.connect()
+            }
     }
 
     class Builder internal constructor() {

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/SandboxTest.kt
@@ -310,6 +310,43 @@ class SandboxTest {
     }
 
     @Test
+    fun `checkReady should propagate wrapped interruption and restore interrupt status`() {
+        val interrupted = InterruptedException("acquire cancelled")
+        val wrapped = RuntimeException("health check interrupted", interrupted)
+        val sandboxWithInterruptingHealthCheck =
+            Sandbox(
+                id = sandboxId,
+                sandboxService = sandboxService,
+                fileSystemService = fileSystemService,
+                commandService = commandService,
+                healthService = healthService,
+                metricsService = metricsService,
+                egressService = egressService,
+                credentialVaultService = credentialVaultService,
+                isolatedService = mockk(),
+                customHealthCheck = { throw wrapped },
+                httpClientProvider = httpClientProvider,
+                diagnosticsService = diagnosticsService,
+            )
+
+        Thread.interrupted()
+        try {
+            val actual =
+                assertThrows(RuntimeException::class.java) {
+                    sandboxWithInterruptingHealthCheck.checkReady(
+                        Duration.ofSeconds(1),
+                        Duration.ofMillis(10),
+                    )
+                }
+
+            assertSame(wrapped, actual)
+            assertTrue(Thread.currentThread().isInterrupted)
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
     fun `checkReady should throw exception when timeout`() {
         every { healthService.ping(sandboxId) } returns false
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -61,6 +61,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -1123,6 +1124,71 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `run retirement is atomic with taking idle`() {
+        val store = BlockingTakePoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val newSandbox = mockk<Sandbox>(relaxed = true)
+        every { newSandbox.id } returns "new-run-idle"
+
+        val config =
+            PoolConfig.builder()
+                .poolName("atomic-take-pool")
+                .ownerId("atomic-take-owner")
+                .maxIdle(0)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .drainTimeout(Duration.ofMillis(50))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { manager },
+                idleSandboxConnector = { newSandbox },
+            )
+        val acquireExecutor = Executors.newSingleThreadExecutor()
+        val restartExecutor = Executors.newSingleThreadExecutor()
+        val restartStarted = CountDownLatch(1)
+
+        pool.start()
+        try {
+            val oldAcquire =
+                acquireExecutor.submit<Sandbox> {
+                    pool.acquire(policy = AcquirePolicy.FAIL_FAST)
+                }
+            assertTrue(store.takeStarted.await(5, TimeUnit.SECONDS))
+
+            val restart =
+                restartExecutor.submit {
+                    restartStarted.countDown()
+                    pool.shutdown(graceful = false)
+                    pool.start()
+                    store.putIdle("atomic-take-pool", "new-run-idle")
+                }
+            assertTrue(restartStarted.await(5, TimeUnit.SECONDS))
+            assertThrows(TimeoutException::class.java) {
+                restart.get(100, TimeUnit.MILLISECONDS)
+            }
+
+            store.releaseTake.countDown()
+            restart.get(5, TimeUnit.SECONDS)
+            assertThrows(ExecutionException::class.java) {
+                oldAcquire.get(5, TimeUnit.SECONDS)
+            }
+
+            assertEquals(1, store.snapshotCounters("atomic-take-pool").idleCount)
+            assertSame(newSandbox, pool.acquire(policy = AcquirePolicy.FAIL_FAST))
+            verify(exactly = 0) { manager.killSandbox("new-run-idle") }
+        } finally {
+            store.releaseTake.countDown()
+            acquireExecutor.shutdownNow()
+            restartExecutor.shutdownNow()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `retired acquire cannot consume idle from restarted run`() {
         val store = InMemoryPoolStateStore()
         val manager = mockk<SandboxManager>(relaxed = true)
@@ -1923,6 +1989,22 @@ class SandboxPoolTest {
                 sandboxId = null,
                 discardedAliveSandboxIds = listOf("near-expiry-id"),
             )
+    }
+
+    private class BlockingTakePoolStateStore(
+        private val delegate: InMemoryPoolStateStore = InMemoryPoolStateStore(),
+    ) : PoolStateStore by delegate {
+        val takeStarted = CountDownLatch(1)
+        val releaseTake = CountDownLatch(1)
+
+        override fun tryTakeIdle(
+            poolName: String,
+            minRemainingTtl: Duration,
+        ): TakeIdleResult {
+            takeStarted.countDown()
+            releaseTake.await()
+            return delegate.tryTakeIdle(poolName, minRemainingTtl)
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -55,7 +55,9 @@ import java.io.InterruptedIOException
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -1046,6 +1048,250 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `cancelled acquire propagates interruption without direct create fallback`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val connectStarted = CountDownLatch(1)
+        val releaseConnect = CountDownLatch(1)
+        val acquireExited = CountDownLatch(1)
+        val killed = CountDownLatch(1)
+        val directCreates = AtomicInteger(0)
+        val interruptedAtExit = AtomicBoolean(false)
+        val directSandbox = mockk<Sandbox>(relaxed = true)
+        every { directSandbox.id } returns "unexpected-direct"
+        every { manager.killSandbox("idle-interrupted") } answers { killed.countDown() }
+        val connectIdle: (String) -> Sandbox = {
+            connectStarted.countDown()
+            try {
+                releaseConnect.await()
+                error("connect should be interrupted")
+            } catch (e: InterruptedException) {
+                throw RuntimeException("idle readiness interrupted", e)
+            }
+        }
+
+        val config =
+            PoolConfig.builder()
+                .poolName("interrupt-pool")
+                .ownerId("interrupt-owner")
+                .maxIdle(0)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(
+                    PooledSandboxCreator {
+                        directCreates.incrementAndGet()
+                        directSandbox
+                    },
+                ).drainTimeout(Duration.ofMillis(50))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { manager },
+                idleSandboxConnector = connectIdle,
+            )
+        val executor = Executors.newSingleThreadExecutor()
+
+        pool.start()
+        store.putIdle("interrupt-pool", "idle-interrupted")
+        try {
+            val future =
+                executor.submit<Sandbox> {
+                    try {
+                        pool.acquire(policy = AcquirePolicy.RETRY_NEXT_IDLE_THEN_CREATE)
+                    } finally {
+                        interruptedAtExit.set(Thread.currentThread().isInterrupted)
+                        acquireExited.countDown()
+                    }
+                }
+            assertTrue(connectStarted.await(5, TimeUnit.SECONDS))
+
+            assertTrue(future.cancel(true))
+            assertTrue(acquireExited.await(5, TimeUnit.SECONDS))
+            assertTrue(killed.await(5, TimeUnit.SECONDS))
+
+            assertEquals(0, directCreates.get(), "cancelled acquire must not fall through to create")
+            assertEquals(true, interruptedAtExit.get(), "acquire must restore the worker interrupt status")
+            assertEquals(0, store.snapshotCounters("interrupt-pool").idleCount)
+        } finally {
+            releaseConnect.countDown()
+            executor.shutdownNow()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `retired acquire cannot consume idle from restarted run`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val firstConnectStarted = CountDownLatch(1)
+        val releaseFirstConnect = CountDownLatch(1)
+        val oldSandboxKilled = CountDownLatch(1)
+        val connectCalls = AtomicInteger(0)
+        val newSandbox = mockk<Sandbox>(relaxed = true)
+        every { newSandbox.id } returns "new-run-idle"
+        every { manager.killSandbox("old-run-idle") } answers { oldSandboxKilled.countDown() }
+        val connectIdle: (String) -> Sandbox = {
+            if (connectCalls.incrementAndGet() == 1) {
+                firstConnectStarted.countDown()
+                releaseFirstConnect.await()
+                throw RuntimeException("old candidate failed readiness")
+            }
+            newSandbox
+        }
+
+        val config =
+            PoolConfig.builder()
+                .poolName("restart-acquire-pool")
+                .ownerId("restart-acquire-owner")
+                .maxIdle(0)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .maxAcquireRetries(2)
+                .drainTimeout(Duration.ofMillis(50))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { manager },
+                idleSandboxConnector = connectIdle,
+            )
+        val executor = Executors.newSingleThreadExecutor()
+
+        pool.start()
+        store.putIdle("restart-acquire-pool", "old-run-idle")
+        try {
+            val oldAcquire =
+                executor.submit<Sandbox> {
+                    pool.acquire(policy = AcquirePolicy.RETRY_NEXT_IDLE)
+                }
+            assertTrue(firstConnectStarted.await(5, TimeUnit.SECONDS))
+
+            pool.shutdown(graceful = false)
+            pool.start()
+            store.putIdle("restart-acquire-pool", "new-run-idle")
+            releaseFirstConnect.countDown()
+
+            val failure =
+                assertThrows(ExecutionException::class.java) {
+                    oldAcquire.get(5, TimeUnit.SECONDS)
+                }
+            assertTrue(failure.cause is PoolNotRunningException)
+            assertTrue(oldSandboxKilled.await(5, TimeUnit.SECONDS))
+            assertEquals(1, store.snapshotCounters("restart-acquire-pool").idleCount)
+
+            val acquired = pool.acquire(policy = AcquirePolicy.FAIL_FAST)
+            assertSame(newSandbox, acquired)
+            assertEquals(2, connectCalls.get())
+        } finally {
+            releaseFirstConnect.countDown()
+            executor.shutdownNow()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `acquire health check Error cleans popped idle before propagating`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val expected = AssertionError("user health check failed")
+        val killed = CountDownLatch(1)
+        every { manager.killSandbox("error-idle") } answers { killed.countDown() }
+        val connectIdle: (String) -> Sandbox = { throw expected }
+
+        val config =
+            PoolConfig.builder()
+                .poolName("error-acquire-pool")
+                .ownerId("error-acquire-owner")
+                .maxIdle(0)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .drainTimeout(Duration.ofMillis(50))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { manager },
+                idleSandboxConnector = connectIdle,
+            )
+
+        pool.start()
+        store.putIdle("error-acquire-pool", "error-idle")
+        try {
+            val actual =
+                assertThrows(AssertionError::class.java) {
+                    pool.acquire(policy = AcquirePolicy.FAIL_FAST)
+                }
+
+            assertSame(expected, actual)
+            assertTrue(killed.await(5, TimeUnit.SECONDS))
+            assertEquals(0, store.snapshotCounters("error-acquire-pool").idleCount)
+            awaitCondition { pool.snapshot().inFlightOperations == 0 }
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `warmup Error cleans sandbox and releases rolling slot`() {
+        val store = InMemoryPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val firstSandbox = mockk<Sandbox>(relaxed = true)
+        val replacementSandbox = mockk<Sandbox>(relaxed = true)
+        val created = AtomicInteger(0)
+        every { firstSandbox.id } returns "warmup-error"
+        every { replacementSandbox.id } returns "warmup-replacement"
+
+        val config =
+            PoolConfig.builder()
+                .poolName("warmup-error-pool")
+                .ownerId("warmup-error-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(
+                    PooledSandboxCreator {
+                        if (created.incrementAndGet() == 1) firstSandbox else replacementSandbox
+                    },
+                ).warmupSkipHealthCheck()
+                .warmupSandboxPreparer(
+                    SandboxPreparer { sandbox ->
+                        if (sandbox.id == "warmup-error") {
+                            throw AssertionError("user warmup callback failed")
+                        }
+                    },
+                ).drainTimeout(Duration.ofSeconds(2))
+                .reconcileInterval(Duration.ofSeconds(30))
+                .build()
+        val pool = SandboxPool(config = config, sandboxManagerFactory = { manager })
+
+        pool.start()
+        try {
+            awaitCondition {
+                store.snapshotCounters("warmup-error-pool").idleCount == 1 &&
+                    pool.snapshot().inFlightOperations == 0 &&
+                    currentRunWarming(pool).get() == 0
+            }
+
+            assertEquals(2, created.get())
+            verify(exactly = 1) { firstSandbox.kill() }
+            verify(exactly = 1) { firstSandbox.close() }
+            assertEquals("warmup-replacement", pool.snapshotIdleEntries().single().sandboxId)
+        } finally {
+            pool.releaseAllIdle()
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `acquire with RETRY_NEXT_IDLE_THEN_CREATE and empty idle falls through immediately`() {
         val store = InMemoryPoolStateStore()
         val createdSandbox = mockk<Sandbox>(relaxed = true)
@@ -1702,6 +1948,11 @@ class SandboxPoolTest {
     private fun currentRunInFlight(pool: SandboxPool): AtomicInteger {
         val run = getPrivateField<Any>(pool, "currentRun")
         return getPrivateField(run, "inFlightOperations")
+    }
+
+    private fun currentRunWarming(pool: SandboxPool): AtomicInteger {
+        val run = getPrivateField<Any>(pool, "currentRun")
+        return getPrivateField(run, "warmingCount")
     }
 
     private fun currentRunPendingWarmupCompletions(pool: SandboxPool): Set<*> {

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/BaseE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/BaseE2ETest.java
@@ -59,7 +59,8 @@ public abstract class BaseE2ETest {
     }
 
     protected static String getSandboxImage() {
-        return configValue(PROP_IMG_DEFAULT, ENV_IMG_DEFAULT, "opensandbox/code-interpreter:latest");
+        return configValue(
+                PROP_IMG_DEFAULT, ENV_IMG_DEFAULT, "opensandbox/code-interpreter:latest");
     }
 
     protected static ConnectionConfig createConnectionConfig(boolean useServerProxy) {

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/IsolatedSessionE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/IsolatedSessionE2ETest.java
@@ -72,7 +72,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
                 caps.getVersion(),
                 caps.getMessage());
         if (!caps.getAvailable()) {
-            fail("Isolation NOT available: " + (caps.getMessage() != null ? caps.getMessage() : "unknown reason"));
+            fail(
+                    "Isolation NOT available: "
+                            + (caps.getMessage() != null ? caps.getMessage() : "unknown reason"));
         }
     }
 
@@ -96,9 +98,18 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testSessionLifecycle() {
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         assertNotNull(session.getSessionId());
 
         var state = session.get();
@@ -112,11 +123,21 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testRunEcho() {
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
-            Execution exec = session.run(new IsolatedRunRequest("echo hello-isolation", null, null));
+            Execution exec =
+                    session.run(new IsolatedRunRequest("echo hello-isolation", null, null));
             assertTrue(stdoutText(exec).contains("hello-isolation"));
         } finally {
             session.delete();
@@ -128,9 +149,18 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testPidIsolation() {
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
             Execution exec = session.run(new IsolatedRunRequest("echo $$", null, null));
             int pid = Integer.parseInt(stdoutText(exec).trim());
@@ -145,15 +175,23 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testRunWithEnvs() {
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
             Execution exec =
-                    session.run(new IsolatedRunRequest(
-                            "echo $MY_VAR",
-                            Map.of("MY_VAR", "test-value-42"),
-                            null));
+                    session.run(
+                            new IsolatedRunRequest(
+                                    "echo $MY_VAR", Map.of("MY_VAR", "test-value-42"), null));
             assertTrue(stdoutText(exec).contains("test-value-42"));
         } finally {
             session.delete();
@@ -165,9 +203,18 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testSessionStatePersists() {
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
             session.run(new IsolatedRunRequest("export PERSIST_VAR=abc123", null, null));
             Execution exec = session.run(new IsolatedRunRequest("echo $PERSIST_VAR", null, null));
@@ -184,19 +231,42 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
 
         IsolationSession sessionA =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/workspace", "rw"),
-                                "strict", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/workspace", "rw"),
+                                        "strict",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         IsolationSession sessionB =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/workspace", "rw"),
-                                "strict", null, null, null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/workspace", "rw"),
+                                        "strict",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
-            sessionA.run(new IsolatedRunRequest(
-                    "echo secret > /tmp/isolated_test_file.txt", null, null));
-            Execution exec = sessionB.run(new IsolatedRunRequest(
-                    "cat /tmp/isolated_test_file.txt 2>&1 || echo NOT_FOUND", null, null));
+            sessionA.run(
+                    new IsolatedRunRequest(
+                            "echo secret > /tmp/isolated_test_file.txt", null, null));
+            Execution exec =
+                    sessionB.run(
+                            new IsolatedRunRequest(
+                                    "cat /tmp/isolated_test_file.txt 2>&1 || echo NOT_FOUND",
+                                    null,
+                                    null));
             String text = stdoutText(exec);
             assertTrue(
                     text.contains("NOT_FOUND") || text.contains("No such file"),
@@ -211,9 +281,18 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
 
     private IsolationSession createSession(String mode, String path) {
         return sandbox.isolation()
-                .create(new CreateIsolatedSessionRequest(
-                        new IsolatedWorkspaceSpec(path, mode),
-                        "balanced", null, null, null, null, null, null, null, null));
+                .create(
+                        new CreateIsolatedSessionRequest(
+                                new IsolatedWorkspaceSpec(path, mode),
+                                "balanced",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null));
     }
 
     private IsolationSession createSession(String mode) {
@@ -226,8 +305,14 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/upload_rw_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("rw upload").mode(644).build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(path)
+                                            .data("rw upload")
+                                            .mode(644)
+                                            .build()));
             String content = session.getFiles().readFile(path);
             assertEquals("rw upload", content);
         } finally {
@@ -241,9 +326,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/bytes_rw_" + System.currentTimeMillis() + ".bin";
-            byte[] data = new byte[]{0x00, 0x01, 0x02, (byte) 0xff};
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data(data).mode(644).build()));
+            byte[] data = new byte[] {0x00, 0x01, 0x02, (byte) 0xff};
+            session.getFiles()
+                    .write(List.of(WriteEntry.builder().path(path).data(data).mode(644).build()));
             byte[] read = session.getFiles().readByteArray(path);
             assertArrayEquals(data, read);
         } finally {
@@ -257,8 +342,8 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/info_rw_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("info").mode(644).build()));
+            session.getFiles()
+                    .write(List.of(WriteEntry.builder().path(path).data("info").mode(644).build()));
             Map<String, EntryInfo> infoMap = session.getFiles().readFileInfo(List.of(path));
             assertTrue(infoMap.containsKey(path));
             assertEquals(4, infoMap.get(path).getSize());
@@ -275,14 +360,30 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         try {
             String prefix = "/tmp/search_rw_" + System.currentTimeMillis();
             session.run(new IsolatedRunRequest("mkdir -p " + prefix, null, null));
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(prefix + "/a.txt").data("a").mode(644).build(),
-                    WriteEntry.builder().path(prefix + "/b.txt").data("b").mode(644).build(),
-                    WriteEntry.builder().path(prefix + "/c.log").data("c").mode(644).build()));
-            List<EntryInfo> results = session.getFiles().search(
-                    SearchEntry.builder().path(prefix).pattern("*.txt").build());
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(prefix + "/a.txt")
+                                            .data("a")
+                                            .mode(644)
+                                            .build(),
+                                    WriteEntry.builder()
+                                            .path(prefix + "/b.txt")
+                                            .data("b")
+                                            .mode(644)
+                                            .build(),
+                                    WriteEntry.builder()
+                                            .path(prefix + "/c.log")
+                                            .data("c")
+                                            .mode(644)
+                                            .build()));
+            List<EntryInfo> results =
+                    session.getFiles()
+                            .search(SearchEntry.builder().path(prefix).pattern("*.txt").build());
             assertEquals(2, results.size());
-            List<String> paths = results.stream().map(EntryInfo::getPath).collect(Collectors.toList());
+            List<String> paths =
+                    results.stream().map(EntryInfo::getPath).collect(Collectors.toList());
             assertTrue(paths.stream().anyMatch(p -> p.contains("a.txt")));
             assertTrue(paths.stream().anyMatch(p -> p.contains("b.txt")));
         } finally {
@@ -296,8 +397,8 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String dir = "/tmp/mkdir_rw_" + System.currentTimeMillis();
-            session.getFiles().createDirectories(List.of(
-                    WriteEntry.builder().path(dir).mode(755).build()));
+            session.getFiles()
+                    .createDirectories(List.of(WriteEntry.builder().path(dir).mode(755).build()));
             Map<String, EntryInfo> infoMap = session.getFiles().readFileInfo(List.of(dir));
             assertTrue(infoMap.containsKey(dir));
         } finally {
@@ -311,11 +412,11 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/delete_rw_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("del").mode(644).build()));
+            session.getFiles()
+                    .write(List.of(WriteEntry.builder().path(path).data("del").mode(644).build()));
             session.getFiles().deleteFiles(List.of(path));
-            assertThrows(SandboxException.class,
-                    () -> session.getFiles().readFileInfo(List.of(path)));
+            assertThrows(
+                    SandboxException.class, () -> session.getFiles().readFileInfo(List.of(path)));
         } finally {
             session.delete();
         }
@@ -328,10 +429,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         try {
             String src = "/tmp/mv_rw_src_" + System.currentTimeMillis() + ".txt";
             String dst = "/tmp/mv_rw_dst_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(src).data("move").mode(644).build()));
-            session.getFiles().moveFiles(List.of(
-                    MoveEntry.builder().src(src).dest(dst).build()));
+            session.getFiles()
+                    .write(List.of(WriteEntry.builder().path(src).data("move").mode(644).build()));
+            session.getFiles().moveFiles(List.of(MoveEntry.builder().src(src).dest(dst).build()));
             assertEquals("move", session.getFiles().readFile(dst));
         } finally {
             session.delete();
@@ -344,10 +444,11 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/chmod_rw_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("ch").mode(644).build()));
-            session.getFiles().setPermissions(List.of(
-                    SetPermissionEntry.builder().path(path).mode(755).build()));
+            session.getFiles()
+                    .write(List.of(WriteEntry.builder().path(path).data("ch").mode(644).build()));
+            session.getFiles()
+                    .setPermissions(
+                            List.of(SetPermissionEntry.builder().path(path).mode(755).build()));
             Map<String, EntryInfo> infoMap = session.getFiles().readFileInfo(List.of(path));
             assertEquals(755, infoMap.get(path).getMode());
         } finally {
@@ -361,11 +462,22 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("rw");
         try {
             String path = "/tmp/replace_rw_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("hello old world").mode(644).build()));
-            session.getFiles().replaceContents(List.of(
-                    ContentReplaceEntry.builder()
-                            .path(path).oldContent("old").newContent("new").build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(path)
+                                            .data("hello old world")
+                                            .mode(644)
+                                            .build()));
+            session.getFiles()
+                    .replaceContents(
+                            List.of(
+                                    ContentReplaceEntry.builder()
+                                            .path(path)
+                                            .oldContent("old")
+                                            .newContent("new")
+                                            .build()));
             String content = session.getFiles().readFile(path);
             assertTrue(content.contains("new"));
             assertFalse(content.contains("old"));
@@ -381,11 +493,22 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         try {
             String prefix = "/tmp/listdir_rw_" + System.currentTimeMillis();
             session.run(new IsolatedRunRequest("mkdir -p " + prefix + "/sub", null, null));
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(prefix + "/f1.txt").data("f1").mode(644).build(),
-                    WriteEntry.builder().path(prefix + "/sub/f2.txt").data("f2").mode(644).build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(prefix + "/f1.txt")
+                                            .data("f1")
+                                            .mode(644)
+                                            .build(),
+                                    WriteEntry.builder()
+                                            .path(prefix + "/sub/f2.txt")
+                                            .data("f2")
+                                            .mode(644)
+                                            .build()));
             List<EntryInfo> entries = session.getFiles().listDirectory(prefix);
-            List<String> names = entries.stream().map(EntryInfo::getPath).collect(Collectors.toList());
+            List<String> names =
+                    entries.stream().map(EntryInfo::getPath).collect(Collectors.toList());
             assertTrue(names.stream().anyMatch(n -> n.contains("f1.txt")));
             assertTrue(names.stream().anyMatch(n -> n.contains("sub")));
         } finally {
@@ -402,8 +525,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("echo ro-data > /tmp/" + marker);
         IsolationSession session = createSession("ro");
         try {
-            Execution exec = session.run(
-                    new IsolatedRunRequest("cat /tmp/" + marker, null, null));
+            Execution exec = session.run(new IsolatedRunRequest("cat /tmp/" + marker, null, null));
             assertTrue(stdoutText(exec).contains("ro-data"));
         } finally {
             session.delete();
@@ -416,11 +538,17 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testRoCannotWrite() {
         IsolationSession session = createSession("ro");
         try {
-            Execution exec = session.run(new IsolatedRunRequest(
-                    "echo fail > /tmp/ro_write_test.txt 2>&1; echo EXIT=$?", null, null));
+            Execution exec =
+                    session.run(
+                            new IsolatedRunRequest(
+                                    "echo fail > /tmp/ro_write_test.txt 2>&1; echo EXIT=$?",
+                                    null,
+                                    null));
             String text = stdoutText(exec);
             assertTrue(
-                    text.contains("EXIT=1") || text.contains("Read-only") || text.contains("Permission denied"),
+                    text.contains("EXIT=1")
+                            || text.contains("Read-only")
+                            || text.contains("Permission denied"),
                     "expected write failure in RO mode, got: " + text);
         } finally {
             session.delete();
@@ -449,8 +577,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("mkdir -p " + prefix + " && echo x > " + prefix + "/file.txt");
         IsolationSession session = createSession("ro");
         try {
-            List<EntryInfo> results = session.getFiles().search(
-                    SearchEntry.builder().path(prefix).pattern("*.txt").build());
+            List<EntryInfo> results =
+                    session.getFiles()
+                            .search(SearchEntry.builder().path(prefix).pattern("*.txt").build());
             assertTrue(results.size() >= 1);
         } finally {
             session.delete();
@@ -489,10 +618,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         String marker = "overlay_invis_" + System.currentTimeMillis() + ".txt";
         IsolationSession session = createSession("overlay");
         try {
-            session.run(new IsolatedRunRequest(
-                    "echo overlay-data > /tmp/" + marker, null, null));
-            Execution hostCheck = sandbox.commands().run(
-                    "cat /tmp/" + marker + " 2>&1 || echo NOT_FOUND");
+            session.run(new IsolatedRunRequest("echo overlay-data > /tmp/" + marker, null, null));
+            Execution hostCheck =
+                    sandbox.commands().run("cat /tmp/" + marker + " 2>&1 || echo NOT_FOUND");
             String text = stdoutText(hostCheck);
             assertTrue(
                     text.contains("NOT_FOUND") || text.contains("No such file"),
@@ -510,8 +638,7 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("echo lower-data > /tmp/" + marker);
         IsolationSession session = createSession("overlay");
         try {
-            Execution exec = session.run(new IsolatedRunRequest(
-                    "cat /tmp/" + marker, null, null));
+            Execution exec = session.run(new IsolatedRunRequest("cat /tmp/" + marker, null, null));
             assertTrue(stdoutText(exec).contains("lower-data"));
         } finally {
             session.delete();
@@ -527,10 +654,9 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("echo original > /tmp/" + marker);
         IsolationSession session = createSession("overlay");
         try {
-            session.run(new IsolatedRunRequest(
-                    "echo modified > /tmp/" + marker, null, null));
-            Execution inSession = session.run(new IsolatedRunRequest(
-                    "cat /tmp/" + marker, null, null));
+            session.run(new IsolatedRunRequest("echo modified > /tmp/" + marker, null, null));
+            Execution inSession =
+                    session.run(new IsolatedRunRequest("cat /tmp/" + marker, null, null));
             assertTrue(stdoutText(inSession).contains("modified"));
             Execution hostCheck = sandbox.commands().run("cat /tmp/" + marker);
             assertTrue(stdoutText(hostCheck).contains("original"));
@@ -547,13 +673,18 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("overlay");
         try {
             String path = "/tmp/ov_upload_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(path).data("overlay file").mode(644).build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(path)
+                                            .data("overlay file")
+                                            .mode(644)
+                                            .build()));
             String content = session.getFiles().readFile(path);
             assertEquals("overlay file", content);
             // Host should NOT see it
-            Execution hostCheck = sandbox.commands().run(
-                    "cat " + path + " 2>&1 || echo NOT_FOUND");
+            Execution hostCheck = sandbox.commands().run("cat " + path + " 2>&1 || echo NOT_FOUND");
             String hostText = stdoutText(hostCheck);
             assertTrue(
                     hostText.contains("NOT_FOUND") || hostText.contains("No such file"),
@@ -571,11 +702,19 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("mkdir -p " + prefix + " && echo lower > " + prefix + "/lower.txt");
         IsolationSession session = createSession("overlay");
         try {
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(prefix + "/upper.txt").data("upper").mode(644).build()));
-            List<EntryInfo> results = session.getFiles().search(
-                    SearchEntry.builder().path(prefix).pattern("*.txt").build());
-            List<String> paths = results.stream().map(EntryInfo::getPath).collect(Collectors.toList());
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(prefix + "/upper.txt")
+                                            .data("upper")
+                                            .mode(644)
+                                            .build()));
+            List<EntryInfo> results =
+                    session.getFiles()
+                            .search(SearchEntry.builder().path(prefix).pattern("*.txt").build());
+            List<String> paths =
+                    results.stream().map(EntryInfo::getPath).collect(Collectors.toList());
             assertTrue(paths.stream().anyMatch(p -> p.contains("lower.txt")));
             assertTrue(paths.stream().anyMatch(p -> p.contains("upper.txt")));
         } finally {
@@ -593,7 +732,8 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         IsolationSession session = createSession("overlay");
         try {
             session.getFiles().deleteFiles(List.of(prefix + "/target.txt"));
-            assertThrows(SandboxException.class,
+            assertThrows(
+                    SandboxException.class,
                     () -> session.getFiles().readFileInfo(List.of(prefix + "/target.txt")));
             // Host file should be untouched
             Execution hostCheck = sandbox.commands().run("cat " + prefix + "/target.txt");
@@ -612,10 +752,15 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         try {
             String src = "/tmp/ov_mv_src_" + System.currentTimeMillis() + ".txt";
             String dst = "/tmp/ov_mv_dst_" + System.currentTimeMillis() + ".txt";
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(src).data("moveme").mode(644).build()));
-            session.getFiles().moveFiles(List.of(
-                    MoveEntry.builder().src(src).dest(dst).build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(src)
+                                            .data("moveme")
+                                            .mode(644)
+                                            .build()));
+            session.getFiles().moveFiles(List.of(MoveEntry.builder().src(src).dest(dst).build()));
             assertEquals("moveme", session.getFiles().readFile(dst));
         } finally {
             session.delete();
@@ -630,8 +775,13 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("echo ch > /tmp/" + marker + " && chmod 644 /tmp/" + marker);
         IsolationSession session = createSession("overlay");
         try {
-            session.getFiles().setPermissions(List.of(
-                    SetPermissionEntry.builder().path("/tmp/" + marker).mode(755).build()));
+            session.getFiles()
+                    .setPermissions(
+                            List.of(
+                                    SetPermissionEntry.builder()
+                                            .path("/tmp/" + marker)
+                                            .mode(755)
+                                            .build()));
             Map<String, EntryInfo> infoMap =
                     session.getFiles().readFileInfo(List.of("/tmp/" + marker));
             assertEquals(755, infoMap.get("/tmp/" + marker).getMode());
@@ -652,12 +802,14 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("printf 'hello old world' > /tmp/" + marker);
         IsolationSession session = createSession("overlay");
         try {
-            session.getFiles().replaceContents(List.of(
-                    ContentReplaceEntry.builder()
-                            .path("/tmp/" + marker)
-                            .oldContent("old")
-                            .newContent("new")
-                            .build()));
+            session.getFiles()
+                    .replaceContents(
+                            List.of(
+                                    ContentReplaceEntry.builder()
+                                            .path("/tmp/" + marker)
+                                            .oldContent("old")
+                                            .newContent("new")
+                                            .build()));
             String content = session.getFiles().readFile("/tmp/" + marker);
             assertTrue(content.contains("new"));
             assertFalse(content.contains("old"));
@@ -678,10 +830,17 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         sandbox.commands().run("mkdir -p " + prefix + " && echo l > " + prefix + "/lower.txt");
         IsolationSession session = createSession("overlay");
         try {
-            session.getFiles().write(List.of(
-                    WriteEntry.builder().path(prefix + "/upper.txt").data("u").mode(644).build()));
+            session.getFiles()
+                    .write(
+                            List.of(
+                                    WriteEntry.builder()
+                                            .path(prefix + "/upper.txt")
+                                            .data("u")
+                                            .mode(644)
+                                            .build()));
             List<EntryInfo> entries = session.getFiles().listDirectory(prefix);
-            List<String> names = entries.stream().map(EntryInfo::getPath).collect(Collectors.toList());
+            List<String> names =
+                    entries.stream().map(EntryInfo::getPath).collect(Collectors.toList());
             assertTrue(names.stream().anyMatch(n -> n.contains("lower.txt")));
             assertTrue(names.stream().anyMatch(n -> n.contains("upper.txt")));
         } finally {
@@ -695,54 +854,88 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     @Test
     @Order(33)
     void testRunOnce() {
-        Execution exec = sandbox.isolation()
-                .runOnce("echo runonce-e2e", "/tmp", "rw", null, null, null, null, null);
+        Execution exec =
+                sandbox.isolation()
+                        .runOnce("echo runonce-e2e", "/tmp", "rw", null, null, null, null, null);
         assertTrue(stdoutText(exec).contains("runonce-e2e"));
     }
 
     @Test
     @Order(34)
     void testRunOnceWithEnvs() {
-        Execution exec = sandbox.isolation()
-                .runOnce(
-                        "echo $E2E_RUN_ONCE",
-                        "/tmp",
-                        "rw",
-                        Map.of("E2E_RUN_ONCE", "kt-value"),
-                        null,
-                        null,
-                        null,
-                        null);
+        Execution exec =
+                sandbox.isolation()
+                        .runOnce(
+                                "echo $E2E_RUN_ONCE",
+                                "/tmp",
+                                "rw",
+                                Map.of("E2E_RUN_ONCE", "kt-value"),
+                                null,
+                                null,
+                                null,
+                                null);
         assertTrue(stdoutText(exec).contains("kt-value"));
     }
 
     @Test
     @Order(35)
     void testWithSession() {
-        String output = sandbox.isolation().withSession(
-                new CreateIsolatedSessionRequest(
-                        new IsolatedWorkspaceSpec("/tmp", "rw"),
-                        "balanced", null, null, null, null, null, null, null, null),
-                session -> {
-                    session.run(new IsolatedRunRequest("export WS_VAR=with-session-kt", null, null));
-                    Execution exec = session.run(new IsolatedRunRequest("echo $WS_VAR", null, null));
-                    return stdoutText(exec);
-                });
+        String output =
+                sandbox.isolation()
+                        .withSession(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null),
+                                session -> {
+                                    session.run(
+                                            new IsolatedRunRequest(
+                                                    "export WS_VAR=with-session-kt", null, null));
+                                    Execution exec =
+                                            session.run(
+                                                    new IsolatedRunRequest(
+                                                            "echo $WS_VAR", null, null));
+                                    return stdoutText(exec);
+                                });
         assertTrue(output.contains("with-session-kt"));
     }
 
     @Test
     @Order(36)
     void testWithSessionMultiRun() {
-        String output = sandbox.isolation().withSession(
-                new CreateIsolatedSessionRequest(
-                        new IsolatedWorkspaceSpec("/tmp", "rw"),
-                        "balanced", null, null, null, null, null, null, null, null),
-                session -> {
-                    session.run(new IsolatedRunRequest("echo step1 > /tmp/ws_test_kt.txt", null, null));
-                    Execution exec = session.run(new IsolatedRunRequest("cat /tmp/ws_test_kt.txt", null, null));
-                    return stdoutText(exec);
-                });
+        String output =
+                sandbox.isolation()
+                        .withSession(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null),
+                                session -> {
+                                    session.run(
+                                            new IsolatedRunRequest(
+                                                    "echo step1 > /tmp/ws_test_kt.txt",
+                                                    null,
+                                                    null));
+                                    Execution exec =
+                                            session.run(
+                                                    new IsolatedRunRequest(
+                                                            "cat /tmp/ws_test_kt.txt", null, null));
+                                    return stdoutText(exec);
+                                });
         assertTrue(output.contains("step1"));
     }
 
@@ -764,17 +957,34 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
 
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced",
-                                null,
-                                List.of(new BindMount(srcDir, dest, null)),
-                                null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        List.of(new BindMount(srcDir, dest, null)),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
-            Execution exec = session.run(new IsolatedRunRequest(
-                    "echo -n " + content + " > " + dest + "/" + fileName
-                            + " && cat " + dest + "/" + fileName,
-                    null, null));
+            Execution exec =
+                    session.run(
+                            new IsolatedRunRequest(
+                                    "echo -n "
+                                            + content
+                                            + " > "
+                                            + dest
+                                            + "/"
+                                            + fileName
+                                            + " && cat "
+                                            + dest
+                                            + "/"
+                                            + fileName,
+                                    null,
+                                    null));
             assertTrue(stdoutText(exec).contains(content));
 
             Execution hostCheck = sandbox.commands().run("cat " + srcDir + "/" + fileName);
@@ -790,14 +1000,21 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
     void testBindIllegalRejected() {
         assertThrows(
                 SandboxException.class,
-                () -> sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced",
-                                null,
-                                // /etc is not in the writable allowlist.
-                                List.of(new BindMount("/etc", "/mnt/etc", null)),
-                                null, null, null, null, null, null)));
+                () ->
+                        sandbox.isolation()
+                                .create(
+                                        new CreateIsolatedSessionRequest(
+                                                new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                                "balanced",
+                                                null,
+                                                // /etc is not in the writable allowlist.
+                                                List.of(new BindMount("/etc", "/mnt/etc", null)),
+                                                null,
+                                                null,
+                                                null,
+                                                null,
+                                                null,
+                                                null)));
     }
 
     @Test
@@ -809,27 +1026,50 @@ public class IsolatedSessionE2ETest extends BaseE2ETest {
         String fileName = "host_created.txt";
         String content = "bind-ro-host-content";
 
-        sandbox.commands().run(
-                "mkdir -p " + srcDir + " " + dest + " && echo -n " + content + " > " + srcDir + "/" + fileName);
+        sandbox.commands()
+                .run(
+                        "mkdir -p "
+                                + srcDir
+                                + " "
+                                + dest
+                                + " && echo -n "
+                                + content
+                                + " > "
+                                + srcDir
+                                + "/"
+                                + fileName);
 
         IsolationSession session =
                 sandbox.isolation()
-                        .create(new CreateIsolatedSessionRequest(
-                                new IsolatedWorkspaceSpec("/tmp", "rw"),
-                                "balanced",
-                                null,
-                                List.of(new BindMount(srcDir, dest, true)),
-                                null, null, null, null, null, null));
+                        .create(
+                                new CreateIsolatedSessionRequest(
+                                        new IsolatedWorkspaceSpec("/tmp", "rw"),
+                                        "balanced",
+                                        null,
+                                        List.of(new BindMount(srcDir, dest, true)),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         try {
-            Execution exec = session.run(new IsolatedRunRequest("cat " + dest + "/" + fileName, null, null));
+            Execution exec =
+                    session.run(new IsolatedRunRequest("cat " + dest + "/" + fileName, null, null));
             assertTrue(stdoutText(exec).contains(content));
 
-            Execution write = session.run(new IsolatedRunRequest(
-                    "echo x > " + dest + "/newfile.txt 2>&1; echo EXIT=$?", null, null));
+            Execution write =
+                    session.run(
+                            new IsolatedRunRequest(
+                                    "echo x > " + dest + "/newfile.txt 2>&1; echo EXIT=$?",
+                                    null,
+                                    null));
             String text = stdoutText(write);
             assertTrue(
-                    text.contains("EXIT=1") || text.contains("Read-only")
-                            || text.contains("read-only") || text.contains("Permission denied"),
+                    text.contains("EXIT=1")
+                            || text.contains("Read-only")
+                            || text.contains("read-only")
+                            || text.contains("Permission denied"),
                     "expected write to fail through read-only bind, got: " + text);
         } finally {
             session.delete();

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxE2ETest.java
@@ -530,7 +530,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 1: Verify the host marker file is visible inside the sandbox
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readMarker = runWithRetry(volumeSandbox, "cat " + containerMountPath + "/marker.txt");
+            Execution readMarker =
+                    runWithRetry(volumeSandbox, "cat " + containerMountPath + "/marker.txt");
             assertNull(readMarker.getError(), "Failed to read marker file");
             assertEquals(1, readMarker.getLogs().getStdout().size());
             assertEquals(
@@ -551,7 +552,9 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 3: Verify the written file is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readBack = runWithRetry(volumeSandbox, "cat " + containerMountPath + "/sandbox-output.txt");
+            Execution readBack =
+                    runWithRetry(
+                            volumeSandbox, "cat " + containerMountPath + "/sandbox-output.txt");
             assertNull(readBack.getError());
             assertEquals(1, readBack.getLogs().getStdout().size());
             assertEquals("written-from-sandbox", readBack.getLogs().getStdout().get(0).getText());
@@ -604,7 +607,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 1: Verify the host marker file is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readMarker = runWithRetry(roSandbox, "cat " + containerMountPath + "/marker.txt");
+            Execution readMarker =
+                    runWithRetry(roSandbox, "cat " + containerMountPath + "/marker.txt");
             assertNull(readMarker.getError(), "Failed to read marker file on read-only mount");
             assertEquals(1, readMarker.getLogs().getStdout().size());
             assertEquals(
@@ -661,7 +665,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 1: Verify the marker file seeded into the named volume is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readMarker = runWithRetry(pvcSandbox, "cat " + containerMountPath + "/marker.txt");
+            Execution readMarker =
+                    runWithRetry(pvcSandbox, "cat " + containerMountPath + "/marker.txt");
             assertNull(readMarker.getError(), "Failed to read marker file from PVC volume");
             assertEquals(1, readMarker.getLogs().getStdout().size());
             assertEquals("pvc-marker-data", readMarker.getLogs().getStdout().get(0).getText());
@@ -681,7 +686,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 3: Verify the written file is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readBack = runWithRetry(pvcSandbox, "cat " + containerMountPath + "/pvc-output.txt");
+            Execution readBack =
+                    runWithRetry(pvcSandbox, "cat " + containerMountPath + "/pvc-output.txt");
             assertNull(readBack.getError());
             assertEquals(1, readBack.getLogs().getStdout().size());
             assertEquals("written-to-pvc", readBack.getLogs().getStdout().get(0).getText());
@@ -734,7 +740,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 1: Verify the marker file is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readMarker = runWithRetry(roSandbox, "cat " + containerMountPath + "/marker.txt");
+            Execution readMarker =
+                    runWithRetry(roSandbox, "cat " + containerMountPath + "/marker.txt");
             assertNull(readMarker.getError(), "Failed to read marker file on read-only PVC mount");
             assertEquals(1, readMarker.getLogs().getStdout().size());
             assertEquals("pvc-marker-data", readMarker.getLogs().getStdout().get(0).getText());
@@ -791,7 +798,8 @@ public class SandboxE2ETest extends BaseE2ETest {
 
             // Step 1: Verify the subpath marker file is readable
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readMarker = runWithRetry(subpathSandbox, "cat " + containerMountPath + "/marker.txt");
+            Execution readMarker =
+                    runWithRetry(subpathSandbox, "cat " + containerMountPath + "/marker.txt");
             assertNull(readMarker.getError(), "Failed to read subpath marker file");
             assertEquals(1, readMarker.getLogs().getStdout().size());
             assertEquals("pvc-subpath-marker", readMarker.getLogs().getStdout().get(0).getText());
@@ -826,7 +834,8 @@ public class SandboxE2ETest extends BaseE2ETest {
             assertNull(writeResult.getError(), "Failed to write file to PVC subPath");
 
             // Retry: bind mount propagation can sometimes lag on first access
-            Execution readBack = runWithRetry(subpathSandbox, "cat " + containerMountPath + "/output.txt");
+            Execution readBack =
+                    runWithRetry(subpathSandbox, "cat " + containerMountPath + "/output.txt");
             assertNull(readBack.getError());
             assertEquals(1, readBack.getLogs().getStdout().size());
             assertEquals("subpath-write-test", readBack.getLogs().getStdout().get(0).getText());
@@ -1371,14 +1380,15 @@ public class SandboxE2ETest extends BaseE2ETest {
             Thread.sleep(50);
         } catch (InterruptedException ignored) {
         }
-        var replaceResults = sandbox.files()
-                .replaceContentsDetailed(
-                        List.of(
-                                ContentReplaceEntry.builder()
-                                        .path(testFile1)
-                                        .oldContent("Appended line to file1")
-                                        .newContent("Replaced line in file1")
-                                        .build()));
+        var replaceResults =
+                sandbox.files()
+                        .replaceContentsDetailed(
+                                List.of(
+                                        ContentReplaceEntry.builder()
+                                                .path(testFile1)
+                                                .oldContent("Appended line to file1")
+                                                .newContent("Replaced line in file1")
+                                                .build()));
         assertEquals(1, replaceResults.size());
         assertEquals(testFile1, replaceResults.get(0).getPath());
         assertEquals(1, replaceResults.get(0).getReplacedCount());
@@ -1389,52 +1399,81 @@ public class SandboxE2ETest extends BaseE2ETest {
         assertModifiedUpdated(beforeReplace.getModifiedAt(), afterReplace.getModifiedAt(), 1, 1000);
 
         // No match → replacedCount=0
-        var noMatchResults = sandbox.files().replaceContentsDetailed(List.of(
-                ContentReplaceEntry.builder()
-                        .path(testFile1)
-                        .oldContent("nonexistent string")
-                        .newContent("irrelevant")
-                        .build()));
+        var noMatchResults =
+                sandbox.files()
+                        .replaceContentsDetailed(
+                                List.of(
+                                        ContentReplaceEntry.builder()
+                                                .path(testFile1)
+                                                .oldContent("nonexistent string")
+                                                .newContent("irrelevant")
+                                                .build()));
         assertEquals(1, noMatchResults.size());
         assertEquals(0, noMatchResults.get(0).getReplacedCount());
 
         // Multiple matches
-        sandbox.files().write(List.of(
-                WriteEntry.builder().path(testDir1 + "/multi.txt").data("foo bar foo baz foo").build()));
-        var multiResults = sandbox.files().replaceContentsDetailed(List.of(
-                ContentReplaceEntry.builder()
-                        .path(testDir1 + "/multi.txt")
-                        .oldContent("foo")
-                        .newContent("qux")
-                        .build()));
+        sandbox.files()
+                .write(
+                        List.of(
+                                WriteEntry.builder()
+                                        .path(testDir1 + "/multi.txt")
+                                        .data("foo bar foo baz foo")
+                                        .build()));
+        var multiResults =
+                sandbox.files()
+                        .replaceContentsDetailed(
+                                List.of(
+                                        ContentReplaceEntry.builder()
+                                                .path(testDir1 + "/multi.txt")
+                                                .oldContent("foo")
+                                                .newContent("qux")
+                                                .build()));
         assertEquals(1, multiResults.size());
         assertEquals(3, multiResults.get(0).getReplacedCount());
 
         // Batch replace across multiple files
         String batchFileA = testDir1 + "/batch_a.txt";
         String batchFileB = testDir1 + "/batch_b.txt";
-        sandbox.files().write(List.of(
-                WriteEntry.builder().path(batchFileA).data("hello world").build(),
-                WriteEntry.builder().path(batchFileB).data("hello hello").build()));
-        var batchResults = sandbox.files().replaceContentsDetailed(List.of(
-                ContentReplaceEntry.builder().path(batchFileA).oldContent("hello").newContent("hi").build(),
-                ContentReplaceEntry.builder().path(batchFileB).oldContent("hello").newContent("hi").build()));
+        sandbox.files()
+                .write(
+                        List.of(
+                                WriteEntry.builder().path(batchFileA).data("hello world").build(),
+                                WriteEntry.builder().path(batchFileB).data("hello hello").build()));
+        var batchResults =
+                sandbox.files()
+                        .replaceContentsDetailed(
+                                List.of(
+                                        ContentReplaceEntry.builder()
+                                                .path(batchFileA)
+                                                .oldContent("hello")
+                                                .newContent("hi")
+                                                .build(),
+                                        ContentReplaceEntry.builder()
+                                                .path(batchFileB)
+                                                .oldContent("hello")
+                                                .newContent("hi")
+                                                .build()));
         assertEquals(2, batchResults.size());
-        var resultsByPath = batchResults.stream()
-                .collect(java.util.stream.Collectors.toMap(
-                        ContentReplaceResult::getPath, ContentReplaceResult::getReplacedCount));
+        var resultsByPath =
+                batchResults.stream()
+                        .collect(
+                                java.util.stream.Collectors.toMap(
+                                        ContentReplaceResult::getPath,
+                                        ContentReplaceResult::getReplacedCount));
         assertEquals(1, resultsByPath.get(batchFileA));
         assertEquals(2, resultsByPath.get(batchFileB));
         assertEquals("hi world", sandbox.files().readFile(batchFileA, "UTF-8", null));
         assertEquals("hi hi", sandbox.files().readFile(batchFileB, "UTF-8", null));
 
         // Verify original replaceContents (verbose=false, void return) still works
-        sandbox.files().replaceContents(List.of(
-                ContentReplaceEntry.builder()
-                        .path(testFile1)
-                        .oldContent("Replaced line in file1")
-                        .newContent("Final line in file1")
-                        .build()));
+        sandbox.files()
+                .replaceContents(
+                        List.of(
+                                ContentReplaceEntry.builder()
+                                        .path(testFile1)
+                                        .oldContent("Replaced line in file1")
+                                        .newContent("Final line in file1")
+                                        .build()));
         String finalContent = sandbox.files().readFile(testFile1, "UTF-8", null);
         assertTrue(finalContent.contains("Final line in file1"));
         assertFalse(finalContent.contains("Replaced line in file1"));
@@ -1510,13 +1549,7 @@ public class SandboxE2ETest extends BaseE2ETest {
 
         String testPath = "/tmp/line-read-e2e.txt";
         String content = "line1\nline2\nline3\nline4\nline5";
-        sandbox.files()
-                .write(
-                        List.of(
-                                WriteEntry.builder()
-                                        .path(testPath)
-                                        .data(content)
-                                        .build()));
+        sandbox.files().write(List.of(WriteEntry.builder().path(testPath).data(content).build()));
 
         // offset=2, limit=2 → lines 2-3
         String result1 = sandbox.files().readFile(testPath, "UTF-8", null, 2, 2);
@@ -1697,30 +1730,34 @@ public class SandboxE2ETest extends BaseE2ETest {
     private Execution runWithRetry(Sandbox sandbox, String command, int maxAttempts, long delayMs) {
         Execution result = null;
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
-            result = sandbox.commands().run(
-                RunCommandRequest.builder().command(command).build());
+            result = sandbox.commands().run(RunCommandRequest.builder().command(command).build());
             if (result.getError() == null && !result.getLogs().getStdout().isEmpty()) {
                 return result;
             }
             if (attempt < maxAttempts - 1) {
-                try { Thread.sleep(delayMs); } catch (InterruptedException e) { Thread.currentThread().interrupt(); break; }
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
             }
         }
         return result;
     }
 
     /**
-     * Polls the sandbox running curl until the given URL is blocked by the
-     * network policy. Returns once curl reports an error (egress active), or
-     * fails the test if the timeout elapses.
+     * Polls the sandbox running curl until the given URL is blocked by the network policy. Returns
+     * once curl reports an error (egress active), or fails the test if the timeout elapses.
      */
     private void waitUntilEgressBlocks(Sandbox sandbox, String url, Duration timeout) {
         long deadline = System.currentTimeMillis() + timeout.toMillis();
         Execution last = null;
         while (System.currentTimeMillis() < deadline) {
             try {
-                last = sandbox.commands().run(
-                        RunCommandRequest.builder().command("curl -I " + url).build());
+                last =
+                        sandbox.commands()
+                                .run(RunCommandRequest.builder().command("curl -I " + url).build());
                 if (last != null && last.getError() != null) {
                     return;
                 }
@@ -1734,7 +1771,13 @@ public class SandboxE2ETest extends BaseE2ETest {
                 break;
             }
         }
-        fail("Egress policy did not block " + url + " within " + timeout
-                + " (last execution error=" + (last == null ? "null" : last.getError()) + ")");
+        fail(
+                "Egress policy did not block "
+                        + url
+                        + " within "
+                        + timeout
+                        + " (last execution error="
+                        + (last == null ? "null" : last.getError())
+                        + ")");
     }
 }

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolAcquireLifecycleE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SandboxPoolAcquireLifecycleE2ETest.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.opensandbox.sandbox.Sandbox;
+import com.alibaba.opensandbox.sandbox.SandboxManager;
+import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolNotRunningException;
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos;
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter;
+import com.alibaba.opensandbox.sandbox.domain.pool.AcquirePolicy;
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolCreationSpec;
+import com.alibaba.opensandbox.sandbox.infrastructure.pool.InMemoryPoolStateStore;
+import com.alibaba.opensandbox.sandbox.pool.SandboxPool;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Tag("e2e")
+@DisplayName("SandboxPool acquire lifecycle E2E Tests")
+public class SandboxPoolAcquireLifecycleE2ETest extends BaseE2ETest {
+    private SandboxManager sandboxManager;
+    private SandboxPool pool;
+    private String tag;
+
+    @BeforeEach
+    void setup() {
+        sandboxManager = SandboxManager.builder().connectionConfig(sharedConnectionConfig).build();
+    }
+
+    @AfterEach
+    void teardown() {
+        shutdownAndRelease(pool);
+        cleanupTaggedSandboxes();
+        if (sandboxManager != null) {
+            sandboxManager.close();
+        }
+    }
+
+    @Test
+    @DisplayName("cancelled acquire stops policy fallback and deletes the popped idle")
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
+    void testCancelledAcquireStopsFallbackAndDeletesPoppedIdle() throws Exception {
+        tag = uniqueTag("cancel");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch healthCheckEntered = new CountDownLatch(1);
+        CountDownLatch releaseHealthCheck = new CountDownLatch(1);
+        CountDownLatch acquireExited = new CountDownLatch(1);
+        AtomicBoolean healthCheckInterrupted = new AtomicBoolean(false);
+        AtomicBoolean interruptRestoredAtExit = new AtomicBoolean(false);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        pool =
+                createPool(
+                        stateStore,
+                        1,
+                        sandbox -> {
+                            healthCheckEntered.countDown();
+                            try {
+                                releaseHealthCheck.await();
+                                return true;
+                            } catch (InterruptedException exception) {
+                                healthCheckInterrupted.set(true);
+                                throw new RuntimeException(
+                                        "acquire health check interrupted", exception);
+                            }
+                        },
+                        null);
+
+        try {
+            pool.start();
+            eventually(
+                    "initial idle sandbox is warmed",
+                    Duration.ofMinutes(2),
+                    Duration.ofMillis(500),
+                    () -> pool.snapshot().getIdleCount() == 1);
+
+            Future<Sandbox> acquire =
+                    executor.submit(
+                            () -> {
+                                try {
+                                    return pool.acquire(
+                                            Duration.ofMinutes(5), AcquirePolicy.DIRECT_CREATE);
+                                } finally {
+                                    interruptRestoredAtExit.set(
+                                            Thread.currentThread().isInterrupted());
+                                    acquireExited.countDown();
+                                }
+                            });
+            assertTrue(
+                    healthCheckEntered.await(30, TimeUnit.SECONDS),
+                    "acquire should enter the custom health check");
+            pool.resize(0);
+
+            assertTrue(acquire.cancel(true), "the in-flight acquire should be cancellable");
+            assertTrue(acquireExited.await(30, TimeUnit.SECONDS), "cancelled acquire should exit");
+            assertTrue(healthCheckInterrupted.get(), "health check should receive interruption");
+            assertTrue(
+                    interruptRestoredAtExit.get(),
+                    "the acquire worker interrupt status should be restored before exit");
+            eventually(
+                    "cancelled candidate is deleted without direct-create fallback",
+                    Duration.ofSeconds(60),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 0);
+            assertEquals(0, pool.snapshot().getInFlightOperations());
+        } finally {
+            releaseHealthCheck.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("retired acquire cannot consume idle warmed by a restarted run")
+    @Timeout(value = 6, unit = TimeUnit.MINUTES)
+    void testRetiredAcquireCannotConsumeRestartedRunIdle() throws Exception {
+        tag = uniqueTag("restart-acquire");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        CountDownLatch oldHealthCheckEntered = new CountDownLatch(1);
+        CountDownLatch releaseOldHealthCheck = new CountDownLatch(1);
+        AtomicReference<String> oldSandboxId = new AtomicReference<>();
+        AtomicReference<String> newSandboxId = new AtomicReference<>();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        pool =
+                createPool(
+                        stateStore,
+                        1,
+                        sandbox -> {
+                            if (sandbox.getId().equals(oldSandboxId.get())) {
+                                oldHealthCheckEntered.countDown();
+                                awaitLatch(releaseOldHealthCheck);
+                                return false;
+                            }
+                            return true;
+                        },
+                        null);
+
+        try {
+            pool.start();
+            eventually(
+                    "old run warms one idle",
+                    Duration.ofMinutes(2),
+                    Duration.ofMillis(500),
+                    () -> pool.snapshot().getIdleCount() == 1);
+            oldSandboxId.set(pool.snapshotIdleEntries().get(0).getSandboxId());
+
+            Future<Sandbox> oldAcquire =
+                    executor.submit(
+                            () ->
+                                    pool.acquire(
+                                            Duration.ofMinutes(5), AcquirePolicy.RETRY_NEXT_IDLE));
+            assertTrue(
+                    oldHealthCheckEntered.await(30, TimeUnit.SECONDS),
+                    "old acquire should block in readiness");
+
+            pool.shutdown(false);
+            pool.start();
+            eventually(
+                    "new run warms a replacement idle",
+                    Duration.ofMinutes(2),
+                    Duration.ofMillis(500),
+                    () -> pool.snapshot().getIdleCount() == 1);
+            newSandboxId.set(pool.snapshotIdleEntries().get(0).getSandboxId());
+            releaseOldHealthCheck.countDown();
+
+            ExecutionException failure =
+                    assertThrows(
+                            ExecutionException.class, () -> oldAcquire.get(30, TimeUnit.SECONDS));
+            assertTrue(
+                    failure.getCause() instanceof PoolNotRunningException,
+                    "the retired acquire should fail at the run-generation fence");
+            assertEquals(1, pool.snapshot().getIdleCount());
+            assertEquals(
+                    newSandboxId.get(),
+                    pool.snapshotIdleEntries().get(0).getSandboxId(),
+                    "the restarted run idle must remain in the store");
+
+            pool.resize(0);
+            Sandbox acquired = pool.acquire(Duration.ofMinutes(5), AcquirePolicy.FAIL_FAST);
+            assertEquals(newSandboxId.get(), acquired.getId());
+            acquired.kill();
+            acquired.close();
+            eventually(
+                    "old and new run sandboxes are deleted",
+                    Duration.ofSeconds(60),
+                    Duration.ofMillis(500),
+                    () -> countTaggedSandboxes() == 0);
+        } finally {
+            releaseOldHealthCheck.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("acquire health-check Error cleans the popped idle before propagation")
+    @Timeout(value = 4, unit = TimeUnit.MINUTES)
+    void testAcquireHealthCheckErrorCleansPoppedIdle() throws Exception {
+        tag = uniqueTag("acquire-error");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        AssertionError expected = new AssertionError("user acquire health check failed");
+        pool =
+                createPool(
+                        stateStore,
+                        1,
+                        sandbox -> {
+                            throw expected;
+                        },
+                        null);
+
+        pool.start();
+        eventually(
+                "idle is available before Error injection",
+                Duration.ofMinutes(2),
+                Duration.ofMillis(500),
+                () -> pool.snapshot().getIdleCount() == 1);
+        pool.resize(0);
+
+        AssertionError actual =
+                assertThrows(
+                        AssertionError.class,
+                        () -> pool.acquire(Duration.ofMinutes(5), AcquirePolicy.FAIL_FAST));
+        assertSame(expected, actual);
+        eventually(
+                "popped idle is deleted after health-check Error",
+                Duration.ofSeconds(60),
+                Duration.ofMillis(500),
+                () -> countTaggedSandboxes() == 0);
+        assertEquals(0, pool.snapshot().getIdleCount());
+        assertEquals(0, pool.snapshot().getInFlightOperations());
+    }
+
+    @Test
+    @DisplayName("warmup health-check Error releases counters and allows replacement")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void testWarmupHealthCheckErrorReleasesCountersAndAllowsReplacement() throws Exception {
+        tag = uniqueTag("warmup-error");
+        InMemoryPoolStateStore stateStore = new InMemoryPoolStateStore();
+        AtomicInteger healthChecks = new AtomicInteger();
+        pool =
+                createPool(
+                        stateStore,
+                        1,
+                        null,
+                        sandbox -> {
+                            if (healthChecks.incrementAndGet() == 1) {
+                                throw new AssertionError("user warmup health check failed");
+                            }
+                            return true;
+                        });
+
+        pool.start();
+        eventually(
+                "replacement warmup succeeds after the first Error",
+                Duration.ofMinutes(2),
+                Duration.ofMillis(500),
+                () ->
+                        healthChecks.get() >= 2
+                                && pool.snapshot().getIdleCount() == 1
+                                && pool.snapshot().getInFlightOperations() == 0
+                                && countTaggedSandboxes() == 1);
+        assertEquals(1, pool.snapshotIdleEntries().size());
+    }
+
+    private SandboxPool createPool(
+            InMemoryPoolStateStore stateStore,
+            int maxIdle,
+            Function<Sandbox, Boolean> acquireHealthCheck,
+            Function<Sandbox, Boolean> warmupHealthCheck) {
+        PoolCreationSpec creationSpec =
+                PoolCreationSpec.builder()
+                        .image(getSandboxImage())
+                        .entrypoint(List.of("tail -f /dev/null"))
+                        .metadata(Map.of("tag", tag, "suite", "sandbox-pool-acquire-lifecycle-e2e"))
+                        .env(Map.of("E2E_TEST", "true"))
+                        .build();
+        SandboxPool.Builder builder =
+                SandboxPool.builder()
+                        .poolName("pool-" + tag)
+                        .ownerId("owner-" + tag)
+                        .maxIdle(maxIdle)
+                        .warmupConcurrency(1)
+                        .stateStore(stateStore)
+                        .connectionConfig(sharedConnectionConfig)
+                        .creationSpec(creationSpec)
+                        .acquireReadyTimeout(Duration.ofSeconds(30))
+                        .acquireHealthCheckPollingInterval(Duration.ofMillis(50))
+                        .warmupReadyTimeout(Duration.ofMinutes(2))
+                        .warmupHealthCheckPollingInterval(Duration.ofMillis(100))
+                        .reconcileInterval(Duration.ofSeconds(1))
+                        .drainTimeout(Duration.ofSeconds(2));
+        if (acquireHealthCheck != null) {
+            builder.acquireHealthCheck(acquireHealthCheck::apply);
+        }
+        if (warmupHealthCheck != null) {
+            builder.warmupHealthCheck(warmupHealthCheck::apply);
+        }
+        return builder.build();
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("health check interrupted unexpectedly", exception);
+        }
+    }
+
+    private void eventually(
+            String description, Duration timeout, Duration interval, BooleanSupplier condition)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        Throwable lastError = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                if (condition.getAsBoolean()) {
+                    return;
+                }
+            } catch (Throwable throwable) {
+                lastError = throwable;
+            }
+            Thread.sleep(interval.toMillis());
+        }
+        if (lastError != null) {
+            throw new AssertionError(
+                    "Timed out waiting for "
+                            + description
+                            + ", last error: "
+                            + lastError.getMessage(),
+                    lastError);
+        }
+        throw new AssertionError("Timed out waiting for " + description);
+    }
+
+    private int countTaggedSandboxes() {
+        PagedSandboxInfos infos =
+                sandboxManager.listSandboxInfos(
+                        SandboxFilter.builder().metadata(Map.of("tag", tag)).pageSize(20).build());
+        return infos.getSandboxInfos().size();
+    }
+
+    private void cleanupTaggedSandboxes() {
+        if (sandboxManager == null || tag == null || tag.isBlank()) {
+            return;
+        }
+        try {
+            PagedSandboxInfos infos =
+                    sandboxManager.listSandboxInfos(
+                            SandboxFilter.builder()
+                                    .metadata(Map.of("tag", tag))
+                                    .pageSize(20)
+                                    .build());
+            infos.getSandboxInfos()
+                    .forEach(
+                            info -> {
+                                try {
+                                    sandboxManager.killSandbox(info.getId());
+                                } catch (Exception ignored) {
+                                }
+                            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void shutdownAndRelease(SandboxPool pool) {
+        if (pool == null) {
+            return;
+        }
+        try {
+            pool.shutdown(false);
+        } catch (Exception ignored) {
+        }
+        try {
+            pool.releaseAllIdle();
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static String uniqueTag(String scenario) {
+        return "e2e-pool-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SnapshotE2ETest.java
+++ b/tests/java/src/test/java/com/alibaba/opensandbox/e2e/SnapshotE2ETest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary

- propagate acquire interruption instead of classifying cancellation as a retryable candidate failure
- fence retry, direct-create fallback, and return paths by the captured pool run generation
- bind acquire cleanup work to the captured run executor/accounting context
- guarantee remote/local resource and warmup counter cleanup for non-Exception failures such as AssertionError
- add focused Kotlin regression tests and Java E2E coverage under tests/java
- apply the current Java Spotless rules to existing E2E sources touched by the formatter

## Tests

- `cd sdks/sandbox/kotlin && ./gradlew spotlessCheck :sandbox:test`
- `cd tests/java && ./gradlew --include-build ../../sdks/sandbox/kotlin spotlessCheck testClasses`
- real Java E2E execution is delegated to this PR's CI environment