### PR TITLE
fix(python-sdk): preserve Unicode separators in SSE data

### DIFF
--- a/sdks/sandbox/python/pyproject.toml
+++ b/sdks/sandbox/python/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "python-dateutil>=2.8.2,<3.0",
     "attrs>=21.3.0",
     "httpx>=0.27.0,<1.0",
+    "httpx-sse>=0.4.3,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -42,6 +42,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
     handle_api_error,
 )
+from opensandbox.adapters.sse import aiter_sse_lines
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.execd import (
@@ -238,7 +239,7 @@ class CommandsAdapter(Commands):
                 raise build_api_exception_from_httpx(response, failure_message)
 
             dispatcher = ExecutionEventDispatcher(execution, handlers)
-            async for line in response.aiter_lines():
+            async for line in aiter_sse_lines(response.aiter_bytes()):
                 event_node = _decode_sse_event_line(line)
                 if event_node is None:
                     continue

--- a/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/command_adapter.py
@@ -42,7 +42,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
     handle_api_error,
 )
-from opensandbox.adapters.sse import aiter_sse_lines
+from opensandbox.adapters.sse import aiter_sse_events
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.execd import (
@@ -102,22 +102,15 @@ def _build_run_in_session_request_body(
     )
 
 
-def _decode_sse_event_line(line: str) -> EventNode | None:
-    if not line.strip():
-        return None
-
-    if line.startswith((":", "event:", "id:", "retry:")):
-        return None
-
-    data = line[5:].strip() if line.startswith("data:") else line
-    if not data:
+def _decode_sse_event_data(data: str) -> EventNode | None:
+    if not data.strip():
         return None
 
     try:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
+        logger.error(f"Failed to parse SSE event data: {data}", exc_info=e)
         return None
 
 
@@ -239,8 +232,8 @@ class CommandsAdapter(Commands):
                 raise build_api_exception_from_httpx(response, failure_message)
 
             dispatcher = ExecutionEventDispatcher(execution, handlers)
-            async for line in aiter_sse_lines(response.aiter_bytes()):
-                event_node = _decode_sse_event_line(line)
+            async for event in aiter_sse_events(response):
+                event_node = _decode_sse_event_data(event.data)
                 if event_node is None:
                     continue
                 await dispatcher.dispatch(event_node)

--- a/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
@@ -33,7 +33,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
 )
 from opensandbox.adapters.isolated_filesystem_adapter import IsolatedFilesystemAdapter
-from opensandbox.adapters.sse import aiter_sse_lines
+from opensandbox.adapters.sse import aiter_sse_events
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException
 from opensandbox.models.execd import Execution, ExecutionHandlers
@@ -57,19 +57,14 @@ from opensandbox.transport import unwrap_retry_transport
 logger = logging.getLogger(__name__)
 
 
-def _decode_sse_event_line(line: str) -> EventNode | None:
-    if not line.strip():
-        return None
-    if line.startswith((":", "event:", "id:", "retry:")):
-        return None
-    data = line[5:].strip() if line.startswith("data:") else line
-    if not data:
+def _decode_sse_event_data(data: str) -> EventNode | None:
+    if not data.strip():
         return None
     try:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
+        logger.error(f"Failed to parse SSE event data: {data}", exc_info=e)
         return None
 
 
@@ -333,8 +328,8 @@ class IsolatedSessionsAdapter(IsolationServiceMixin, IsolationService):
                     )
 
                 dispatcher = ExecutionEventDispatcher(execution, handlers)
-                async for line in aiter_sse_lines(response.aiter_bytes()):
-                    event_node = _decode_sse_event_line(line)
+                async for event in aiter_sse_events(response):
+                    event_node = _decode_sse_event_data(event.data)
                     if event_node is None:
                         continue
                     await dispatcher.dispatch(event_node)

--- a/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/isolated_adapter.py
@@ -33,6 +33,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
 )
 from opensandbox.adapters.isolated_filesystem_adapter import IsolatedFilesystemAdapter
+from opensandbox.adapters.sse import aiter_sse_lines
 from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException
 from opensandbox.models.execd import Execution, ExecutionHandlers
@@ -332,7 +333,7 @@ class IsolatedSessionsAdapter(IsolationServiceMixin, IsolationService):
                     )
 
                 dispatcher = ExecutionEventDispatcher(execution, handlers)
-                async for line in response.aiter_lines():
+                async for line in aiter_sse_lines(response.aiter_bytes()):
                     event_node = _decode_sse_event_line(line)
                     if event_node is None:
                         continue

--- a/sdks/sandbox/python/src/opensandbox/adapters/sse.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sse.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""SSE framing helpers shared by synchronous and asynchronous adapters."""
+
+import codecs
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
+
+
+class _SseLineDecoder:
+    """Incrementally split UTF-8 SSE content on CR, LF, or CRLF only.
+
+    ``httpx`` line iterators implement Python's universal ``splitlines``
+    semantics, which also split on Unicode separators such as U+0085, U+2028,
+    and U+2029. Those characters are valid inside a JSON string and are not
+    SSE line endings, so streaming adapters need protocol-specific framing.
+    """
+
+    def __init__(self) -> None:
+        self._decoder = codecs.getincrementaldecoder("utf-8")()
+        self._buffer = ""
+
+    def decode(self, chunk: bytes) -> list[str]:
+        self._buffer += self._decoder.decode(chunk)
+        return self._drain(final=False)
+
+    def flush(self) -> list[str]:
+        self._buffer += self._decoder.decode(b"", final=True)
+        return self._drain(final=True)
+
+    def _drain(self, *, final: bool) -> list[str]:
+        lines: list[str] = []
+        start = 0
+        index = 0
+
+        while index < len(self._buffer):
+            character = self._buffer[index]
+            if character == "\n":
+                lines.append(self._buffer[start:index])
+                index += 1
+                start = index
+                continue
+            if character == "\r":
+                if index + 1 == len(self._buffer) and not final:
+                    break
+                lines.append(self._buffer[start:index])
+                index += 1
+                if index < len(self._buffer) and self._buffer[index] == "\n":
+                    index += 1
+                start = index
+                continue
+            index += 1
+
+        self._buffer = self._buffer[start:]
+        if final and self._buffer:
+            lines.append(self._buffer)
+            self._buffer = ""
+        return lines
+
+
+def iter_sse_lines(chunks: Iterable[bytes]) -> Iterator[str]:
+    """Yield SSE lines from byte chunks without splitting Unicode separators."""
+    decoder = _SseLineDecoder()
+    for chunk in chunks:
+        yield from decoder.decode(chunk)
+    yield from decoder.flush()
+
+
+async def aiter_sse_lines(chunks: AsyncIterable[bytes]) -> AsyncIterator[str]:
+    """Yield SSE lines asynchronously without splitting Unicode separators."""
+    decoder = _SseLineDecoder()
+    async for chunk in chunks:
+        for line in decoder.decode(chunk):
+            yield line
+    for line in decoder.flush():
+        yield line

--- a/sdks/sandbox/python/src/opensandbox/adapters/sse.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/sse.py
@@ -13,76 +13,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""SSE framing helpers shared by synchronous and asynchronous adapters."""
+"""SSE parsing with compatibility for execd's legacy bare-JSON frames."""
 
-import codecs
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 
+import httpx
+from httpx_sse import EventSource, ServerSentEvent
 
-class _SseLineDecoder:
-    """Incrementally split UTF-8 SSE content on CR, LF, or CRLF only.
 
-    ``httpx`` line iterators implement Python's universal ``splitlines``
-    semantics, which also split on Unicode separators such as U+0085, U+2028,
-    and U+2029. Those characters are valid inside a JSON string and are not
-    SSE line endings, so streaming adapters need protocol-specific framing.
+class _LegacyJsonSseNormalizer:
+    """Turn legacy ``JSON\n\n`` frames into standard SSE data events.
+
+    Current and older execd versions write one bare JSON object followed by
+    two LF bytes. Standard SSE streams are passed through byte-for-byte and
+    parsed entirely by ``httpx-sse``.
     """
 
     def __init__(self) -> None:
-        self._decoder = codecs.getincrementaldecoder("utf-8")()
-        self._buffer = ""
+        self._legacy: bool | None = None
+        self._buffer = bytearray()
 
-    def decode(self, chunk: bytes) -> list[str]:
-        self._buffer += self._decoder.decode(chunk)
-        return self._drain(final=False)
+    def decode(self, chunk: bytes) -> list[bytes]:
+        if self._legacy is False:
+            return [chunk]
 
-    def flush(self) -> list[str]:
-        self._buffer += self._decoder.decode(b"", final=True)
-        return self._drain(final=True)
+        self._buffer.extend(chunk)
+        if self._legacy is None:
+            first = bytes(self._buffer).lstrip()[:1]
+            if not first:
+                return []
+            self._legacy = first in (b"{", b"[")
+            if not self._legacy:
+                data = bytes(self._buffer)
+                self._buffer.clear()
+                return [data]
 
-    def _drain(self, *, final: bool) -> list[str]:
-        lines: list[str] = []
-        start = 0
-        index = 0
+        output: list[bytes] = []
+        separator = b"\n\n"
+        while True:
+            boundary = self._buffer.find(separator)
+            if boundary < 0:
+                break
+            frame = bytes(self._buffer[:boundary])
+            del self._buffer[: boundary + len(separator)]
+            output.append(b"data: " + frame + separator)
+        return output
 
-        while index < len(self._buffer):
-            character = self._buffer[index]
-            if character == "\n":
-                lines.append(self._buffer[start:index])
-                index += 1
-                start = index
-                continue
-            if character == "\r":
-                if index + 1 == len(self._buffer) and not final:
-                    break
-                lines.append(self._buffer[start:index])
-                index += 1
-                if index < len(self._buffer) and self._buffer[index] == "\n":
-                    index += 1
-                start = index
-                continue
-            index += 1
-
-        self._buffer = self._buffer[start:]
-        if final and self._buffer:
-            lines.append(self._buffer)
-            self._buffer = ""
-        return lines
+    def flush(self) -> list[bytes]:
+        if not self._buffer:
+            return []
+        data = bytes(self._buffer)
+        self._buffer.clear()
+        if self._legacy:
+            return [b"data: " + data + b"\n\n"]
+        return [data]
 
 
-def iter_sse_lines(chunks: Iterable[bytes]) -> Iterator[str]:
-    """Yield SSE lines from byte chunks without splitting Unicode separators."""
-    decoder = _SseLineDecoder()
-    for chunk in chunks:
-        yield from decoder.decode(chunk)
-    yield from decoder.flush()
+class _SyncSseStream(httpx.SyncByteStream):
+    def __init__(self, chunks: Iterable[bytes]) -> None:
+        self._chunks = chunks
+
+    def __iter__(self) -> Iterator[bytes]:
+        normalizer = _LegacyJsonSseNormalizer()
+        for chunk in self._chunks:
+            yield from normalizer.decode(chunk)
+        yield from normalizer.flush()
 
 
-async def aiter_sse_lines(chunks: AsyncIterable[bytes]) -> AsyncIterator[str]:
-    """Yield SSE lines asynchronously without splitting Unicode separators."""
-    decoder = _SseLineDecoder()
-    async for chunk in chunks:
-        for line in decoder.decode(chunk):
-            yield line
-    for line in decoder.flush():
-        yield line
+class _AsyncSseStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: AsyncIterable[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        normalizer = _LegacyJsonSseNormalizer()
+        async for chunk in self._chunks:
+            for data in normalizer.decode(chunk):
+                yield data
+        for data in normalizer.flush():
+            yield data
+
+
+def _copy_response(
+    response: httpx.Response, stream: httpx.SyncByteStream | httpx.AsyncByteStream
+) -> httpx.Response:
+    headers = response.headers.copy()
+    # ``iter_bytes``/``aiter_bytes`` already apply HTTP content decoding. The
+    # synthetic response must not try to decode the normalized bytes again.
+    headers.pop("content-encoding", None)
+    headers.pop("content-length", None)
+    return httpx.Response(
+        status_code=response.status_code,
+        headers=headers,
+        request=response.request,
+        extensions=response.extensions,
+        stream=stream,
+    )
+
+
+def iter_sse_events(response: httpx.Response) -> Iterator[ServerSentEvent]:
+    """Parse sync SSE events, accepting standard and legacy execd framing."""
+    compatible_response = _copy_response(
+        response, _SyncSseStream(response.iter_bytes())
+    )
+    yield from EventSource(compatible_response).iter_sse()
+
+
+async def aiter_sse_events(
+    response: httpx.Response,
+) -> AsyncIterator[ServerSentEvent]:
+    """Parse async SSE events, accepting standard and legacy execd framing."""
+    compatible_response = _copy_response(
+        response, _AsyncSseStream(response.aiter_bytes())
+    )
+    async for event in EventSource(compatible_response).aiter_sse():
+        yield event

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -34,7 +34,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
     handle_api_error,
 )
-from opensandbox.adapters.sse import iter_sse_lines
+from opensandbox.adapters.sse import iter_sse_events
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.execd import (
@@ -97,22 +97,15 @@ def _build_run_in_session_request_body(
     )
 
 
-def _decode_sse_event_line(line: str) -> EventNode | None:
-    if not line or not line.strip():
-        return None
-
-    if line.startswith((":", "event:", "id:", "retry:")):
-        return None
-
-    data = line[5:].strip() if line.startswith("data:") else line
-    if not data:
+def _decode_sse_event_data(data: str) -> EventNode | None:
+    if not data.strip():
         return None
 
     try:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
+        logger.error(f"Failed to parse SSE event data: {data}", exc_info=e)
         return None
 
 
@@ -206,8 +199,8 @@ class CommandsAdapterSync(CommandsSync):
                 response.read()
                 raise build_api_exception_from_httpx(response, failure_message)
 
-            for line in iter_sse_lines(response.iter_bytes()):
-                event_node = _decode_sse_event_line(line)
+            for event in iter_sse_events(response):
+                event_node = _decode_sse_event_data(event.data)
                 if event_node is None:
                     continue
                 dispatcher.dispatch(event_node)

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/command_adapter.py
@@ -34,6 +34,7 @@ from opensandbox.adapters.converter.response_handler import (
     build_api_exception_from_httpx,
     handle_api_error,
 )
+from opensandbox.adapters.sse import iter_sse_lines
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.execd import (
@@ -205,7 +206,7 @@ class CommandsAdapterSync(CommandsSync):
                 response.read()
                 raise build_api_exception_from_httpx(response, failure_message)
 
-            for line in response.iter_lines():
+            for line in iter_sse_lines(response.iter_bytes()):
                 event_node = _decode_sse_event_line(line)
                 if event_node is None:
                     continue

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
@@ -31,6 +31,7 @@ from opensandbox.adapters.isolated_adapter import (
     _build_attach_info,
     _build_session_state,
 )
+from opensandbox.adapters.sse import iter_sse_lines
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import InvalidArgumentException
 from opensandbox.models.execd import Execution
@@ -274,7 +275,7 @@ class IsolatedSessionsAdapterSync(IsolationServiceSyncMixin, IsolationServiceSyn
                     raise build_api_exception_from_httpx(
                         response, "run in isolated session"
                     )
-                for line in response.iter_lines():
+                for line in iter_sse_lines(response.iter_bytes()):
                     event_node = _decode_sse_event_line(line)
                     if event_node is None:
                         continue

--- a/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
+++ b/sdks/sandbox/python/src/opensandbox/sync/adapters/isolated_adapter.py
@@ -31,7 +31,7 @@ from opensandbox.adapters.isolated_adapter import (
     _build_attach_info,
     _build_session_state,
 )
-from opensandbox.adapters.sse import iter_sse_lines
+from opensandbox.adapters.sse import iter_sse_events
 from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.exceptions import InvalidArgumentException
 from opensandbox.models.execd import Execution
@@ -58,19 +58,14 @@ from opensandbox.transport import unwrap_retry_transport
 logger = logging.getLogger(__name__)
 
 
-def _decode_sse_event_line(line: str) -> EventNode | None:
-    if not line or not line.strip():
-        return None
-    if line.startswith((":", "event:", "id:", "retry:")):
-        return None
-    data = line[5:].strip() if line.startswith("data:") else line
-    if not data:
+def _decode_sse_event_data(data: str) -> EventNode | None:
+    if not data.strip():
         return None
     try:
         event_dict = json.loads(data)
         return EventNode(**event_dict)
     except Exception as e:
-        logger.error(f"Failed to parse SSE line: {line}", exc_info=e)
+        logger.error(f"Failed to parse SSE event data: {data}", exc_info=e)
         return None
 
 
@@ -275,8 +270,8 @@ class IsolatedSessionsAdapterSync(IsolationServiceSyncMixin, IsolationServiceSyn
                     raise build_api_exception_from_httpx(
                         response, "run in isolated session"
                     )
-                for line in iter_sse_lines(response.iter_bytes()):
-                    event_node = _decode_sse_event_line(line)
+                for event in iter_sse_events(response):
+                    event_node = _decode_sse_event_data(event.data)
                     if event_node is None:
                         continue
                     dispatcher.dispatch(event_node)

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -68,7 +68,7 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 },
             ]
             sse = b"".join(
-                f"data: {json.dumps(event, ensure_ascii=False)}\r\n\r\n".encode()
+                f"{json.dumps(event, ensure_ascii=False)}\n\n".encode()
                 for event in events
             )
             return httpx.Response(

--- a/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_command_service_adapter_streaming.py
@@ -26,6 +26,8 @@ from opensandbox.config import ConnectionConfig
 from opensandbox.exceptions import InvalidArgumentException, SandboxApiException
 from opensandbox.models.sandboxes import SandboxEndpoint
 
+_UNICODE_SEPARATORS = "before\u0085middle\u2028middle\u2029after"
+
 
 class _SseTransport(httpx.AsyncBaseTransport):
     def __init__(self) -> None:
@@ -44,6 +46,30 @@ class _SseTransport(httpx.AsyncBaseTransport):
                 b"not-json\n\n"
                 b'data: {"type":"result","results":{"text":"ok"},"timestamp":3}\n\n'
                 b'data: {"type":"execution_complete","timestamp":4,"execution_time":5}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
+
+        if (
+            request.url.path == "/command"
+            and payload.get("command") == "unicode separators"
+        ):
+            events = [
+                {"type": "init", "text": "exec-unicode", "timestamp": 1},
+                {"type": "stdout", "text": _UNICODE_SEPARATORS, "timestamp": 2},
+                {
+                    "type": "execution_complete",
+                    "timestamp": 3,
+                    "execution_time": 4,
+                },
+            ]
+            sse = b"".join(
+                f"data: {json.dumps(event, ensure_ascii=False)}\r\n\r\n".encode()
+                for event in events
             )
             return httpx.Response(
                 200,
@@ -110,6 +136,19 @@ async def test_run_command_streaming_happy_path_updates_execution() -> None:
 
     assert transport.last_request is not None
     assert transport.last_request.headers.get("accept") == "text/event-stream"
+
+
+@pytest.mark.asyncio
+async def test_run_command_streaming_preserves_unicode_separators() -> None:
+    cfg = ConnectionConfig(protocol="http", transport=_SseTransport())
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapter(cfg, endpoint)
+
+    execution = await adapter.run("unicode separators")
+
+    assert execution.logs.stdout[0].text == _UNICODE_SEPARATORS
+    assert execution.complete is not None
+    assert execution.exit_code == 0
 
 
 @pytest.mark.asyncio

--- a/sdks/sandbox/python/tests/test_sse.py
+++ b/sdks/sandbox/python/tests/test_sse.py
@@ -15,37 +15,87 @@
 #
 from __future__ import annotations
 
+import gzip
+from collections.abc import AsyncIterator, Iterator
+
+import httpx
 import pytest
 
-from opensandbox.adapters.sse import aiter_sse_lines, iter_sse_lines
+from opensandbox.adapters.sse import aiter_sse_events, iter_sse_events
 
 _UNICODE_SEPARATORS = "before\u0085middle\u2028middle\u2029after"
-_SSE_CONTENT = f"data: {_UNICODE_SEPARATORS}\r\ndata: second\r\n\r\ndata: final"
 
 
-def _chunks() -> list[bytes]:
-    content = _SSE_CONTENT.encode()
-    return [content[index : index + 1] for index in range(len(content))]
+class _OneByteStream(httpx.SyncByteStream):
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    def __iter__(self) -> Iterator[bytes]:
+        for byte in self._content:
+            yield bytes([byte])
 
 
-def test_iter_sse_lines_only_splits_protocol_line_endings() -> None:
-    assert list(iter_sse_lines(_chunks())) == [
-        f"data: {_UNICODE_SEPARATORS}",
-        "data: second",
-        "",
-        "data: final",
-    ]
+class _AsyncOneByteStream(httpx.AsyncByteStream):
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for byte in self._content:
+            yield bytes([byte])
+
+
+def _response(stream: httpx.SyncByteStream | httpx.AsyncByteStream) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "text/event-stream"},
+        request=httpx.Request("GET", "http://localhost/events"),
+        stream=stream,
+    )
+
+
+def test_iter_sse_events_uses_standard_parser() -> None:
+    content = (
+        f"event: stdout\r\ndata: {_UNICODE_SEPARATORS}\r\ndata: second line\r\n\r\n"
+    ).encode()
+
+    events = list(iter_sse_events(_response(_OneByteStream(content))))
+
+    assert len(events) == 1
+    assert events[0].event == "stdout"
+    assert events[0].data == f"{_UNICODE_SEPARATORS}\nsecond line"
+
+
+def test_iter_sse_events_does_not_decode_compressed_content_twice() -> None:
+    content = f'data: {{"text":"{_UNICODE_SEPARATORS}"}}\n\n'.encode()
+    response = httpx.Response(
+        200,
+        headers={
+            "Content-Type": "text/event-stream",
+            "Content-Encoding": "gzip",
+            "Content-Length": str(len(gzip.compress(content))),
+        },
+        request=httpx.Request("GET", "http://localhost/events"),
+        stream=_OneByteStream(gzip.compress(content)),
+    )
+
+    events = list(iter_sse_events(response))
+
+    assert [event.data for event in events] == [f'{{"text":"{_UNICODE_SEPARATORS}"}}']
 
 
 @pytest.mark.asyncio
-async def test_aiter_sse_lines_only_splits_protocol_line_endings() -> None:
-    async def chunks():
-        for chunk in _chunks():
-            yield chunk
+async def test_aiter_sse_events_accepts_legacy_bare_json() -> None:
+    content = (
+        f'{{"type":"stdout","text":"{_UNICODE_SEPARATORS}"}}\n\n'
+        '{"type":"execution_complete"}\n\n'
+    ).encode()
 
-    assert [line async for line in aiter_sse_lines(chunks())] == [
-        f"data: {_UNICODE_SEPARATORS}",
-        "data: second",
-        "",
-        "data: final",
+    events = [
+        event
+        async for event in aiter_sse_events(_response(_AsyncOneByteStream(content)))
+    ]
+
+    assert [event.data for event in events] == [
+        f'{{"type":"stdout","text":"{_UNICODE_SEPARATORS}"}}',
+        '{"type":"execution_complete"}',
     ]

--- a/sdks/sandbox/python/tests/test_sse.py
+++ b/sdks/sandbox/python/tests/test_sse.py
@@ -1,0 +1,51 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import pytest
+
+from opensandbox.adapters.sse import aiter_sse_lines, iter_sse_lines
+
+_UNICODE_SEPARATORS = "before\u0085middle\u2028middle\u2029after"
+_SSE_CONTENT = f"data: {_UNICODE_SEPARATORS}\r\ndata: second\r\n\r\ndata: final"
+
+
+def _chunks() -> list[bytes]:
+    content = _SSE_CONTENT.encode()
+    return [content[index : index + 1] for index in range(len(content))]
+
+
+def test_iter_sse_lines_only_splits_protocol_line_endings() -> None:
+    assert list(iter_sse_lines(_chunks())) == [
+        f"data: {_UNICODE_SEPARATORS}",
+        "data: second",
+        "",
+        "data: final",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aiter_sse_lines_only_splits_protocol_line_endings() -> None:
+    async def chunks():
+        for chunk in _chunks():
+            yield chunk
+
+    assert [line async for line in aiter_sse_lines(chunks())] == [
+        f"data: {_UNICODE_SEPARATORS}",
+        "data: second",
+        "",
+        "data: final",
+    ]

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -59,7 +59,7 @@ class _SseTransport(httpx.BaseTransport):
                 },
             ]
             sse = b"".join(
-                f"data: {json.dumps(event, ensure_ascii=False)}\r\n\r\n".encode()
+                f"{json.dumps(event, ensure_ascii=False)}\n\n".encode()
                 for event in events
             )
             return httpx.Response(

--- a/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
+++ b/sdks/sandbox/python/tests/test_sync_command_service_adapter_streaming.py
@@ -24,6 +24,8 @@ from opensandbox.config.connection_sync import ConnectionConfigSync
 from opensandbox.models.sandboxes import SandboxEndpoint
 from opensandbox.sync.adapters.command_adapter import CommandsAdapterSync
 
+_UNICODE_SEPARATORS = "before\u0085middle\u2028middle\u2029after"
+
 
 class _SseTransport(httpx.BaseTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
@@ -35,6 +37,30 @@ class _SseTransport(httpx.BaseTransport):
                 b'data: {"type":"init","text":"exec-1","timestamp":1}\n\n'
                 b'data: {"type":"stdout","text":"hi","timestamp":2}\n\n'
                 b'data: {"type":"execution_complete","timestamp":4,"execution_time":5}\n\n'
+            )
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=sse,
+                request=request,
+            )
+
+        if (
+            request.url.path == "/command"
+            and payload.get("command") == "unicode separators"
+        ):
+            events = [
+                {"type": "init", "text": "exec-unicode", "timestamp": 1},
+                {"type": "stdout", "text": _UNICODE_SEPARATORS, "timestamp": 2},
+                {
+                    "type": "execution_complete",
+                    "timestamp": 3,
+                    "execution_time": 4,
+                },
+            ]
+            sse = b"".join(
+                f"data: {json.dumps(event, ensure_ascii=False)}\r\n\r\n".encode()
+                for event in events
             )
             return httpx.Response(
                 200,
@@ -103,6 +129,18 @@ def test_sync_run_command_streaming_happy_path_updates_execution() -> None:
     assert execution.logs.stdout[0].text == "hi"
     assert execution.complete is not None
     assert execution.complete.execution_time_in_millis == 5
+    assert execution.exit_code == 0
+
+
+def test_sync_run_command_streaming_preserves_unicode_separators() -> None:
+    cfg = ConnectionConfigSync(protocol="http", transport=_SseTransport())
+    endpoint = SandboxEndpoint(endpoint="localhost:44772", port=44772)
+    adapter = CommandsAdapterSync(cfg, endpoint)
+
+    execution = adapter.run("unicode separators")
+
+    assert execution.logs.stdout[0].text == _UNICODE_SEPARATORS
+    assert execution.complete is not None
     assert execution.exit_code == 0
 
 

--- a/sdks/sandbox/python/uv.lock
+++ b/sdks/sandbox/python/uv.lock
@@ -243,6 +243,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -414,6 +423,7 @@ source = { editable = "." }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
@@ -439,6 +449,7 @@ dev = [
 requires-dist = [
     { name = "attrs", specifier = ">=21.3.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
+    { name = "httpx-sse", specifier = ">=0.4.3,<0.5" },
     { name = "pydantic", specifier = ">=2.4.2,<3.0" },
     { name = "pyjwt", marker = "extra == 'pool-redis'", specifier = ">=2.13.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0" },


### PR DESCRIPTION
# Summary

- parse standard SSE with the focused httpx-sse 0.4.3 library instead of HTTPX universal line splitting
- preserve compatibility with current and older execd versions by normalizing legacy bare JSON frames into standard data events before parsing
- apply the shared parser to command and isolated execution streams in both async and sync Python Sandbox SDK adapters
- cover U+0085, U+2028, U+2029, CRLF, multiline data fields, one-byte chunk boundaries, legacy framing, and compressed responses

HTTPX iter_lines/aiter_lines treat additional Unicode separators as line endings, splitting valid JSON strings and causing decode failures. httpx-sse 0.4.3 implements SSE-specific CR/LF framing and full event parsing.

## Compatibility

No execd wire-format change is required. Standard data events pass through unchanged; legacy JSON followed by two LF bytes is normalized locally. Code Interpreter SDK and CLI are independently released packages and remain outside this package-scoped fix.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests: uv run pytest tests/ -q
- [ ] Integration tests
- [ ] e2e / manual verification
- [x] Static checks: uv run ruff check; uv run pyright
- [x] Package build: uv build
- [x] Push-before review: no remaining findings

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Clearly described motivation
- [x] Added/updated tests
- [x] Documentation not needed for this internal parser correction
- [x] Security impact considered
- [x] Backward compatibility considered
