### PR TITLE
fix(execd): stop holding resultMutex across blocking resultChan sends

### DIFF
--- a/components/execd/pkg/jupyter/execute/deadlock_repro_test.go
+++ b/components/execd/pkg/jupyter/execute/deadlock_repro_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execute
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestResultMutexNotHeldAcrossBlockingChannelSend is a minimal reproduction of a deadlock in
+// handleStreamOutput (and, identically, handleExecuteResult / handleExecutionError /
+// finalizeExecution): each sends into resultChan while still holding state.resultMutex.
+//
+// resultChan is a bounded buffer (capacity 10 in production, via runtime.runJupyterCode). If its
+// consumer falls behind -- entirely realistic under bursty stdout (module imports, logging
+// setup, an LLM streaming its output) compounded by node/network contention from concurrent
+// sandboxes -- a handler's send blocks. Because that send happens *while holding the mutex*, it
+// wedges every other goroutine that needs the same mutex, including finalizeExecution's poll
+// loop, which is the only thing that ever closes resultChan and lets the request complete.
+// receiveMessages() dispatches every incoming kernel message through this same synchronous path,
+// so once one handler is stuck, no further message -- including the kernel's real completion
+// signal -- can ever be read off the websocket again. The kernel connection is now permanently
+// wedged for the rest of that execution, exactly matching the intermittent stuck-sandbox
+// behavior this reproduces: the run just goes silent forever until an external timeout tears the
+// pod down.
+//
+// This test proves the defect directly and deterministically, without a real websocket: a
+// second, logically independent goroutine that only needs the mutex to check completion state
+// (exactly what finalizeExecution's poll loop does) must not be blocked by a handler stuck
+// mid-send on a full channel.
+func TestResultMutexNotHeldAcrossBlockingChannelSend(t *testing.T) {
+	c := &Client{handlers: make(map[MessageType]func(*Message))}
+	state := newStreamExecutionState(time.Now())
+
+	// Capacity 1 makes the repro deterministic with a single extra send, instead of needing to
+	// race 10+ messages against a websocket.
+	resultChan := make(chan *ExecutionResult, 1)
+
+	content, err := json.Marshal(StreamOutput{Name: StreamStdout, Text: "line"})
+	if err != nil {
+		t.Fatalf("failed to marshal stream output: %v", err)
+	}
+	msg := &Message{Content: json.RawMessage(content)}
+
+	// Fill the only buffer slot -- this call returns immediately.
+	c.handleStreamOutput(msg, state, resultChan)
+
+	// Second call has nowhere to send: resultChan is full and nothing is draining it (simulating
+	// a consumer that has fallen behind, e.g. runJupyterCode's HTTP relay stalling under load).
+	// Under the bug this call never returns, so it must run in its own goroutine.
+	go func() {
+		c.handleStreamOutput(msg, state, resultChan)
+	}()
+
+	// Give the goroutine above time to reach (and block on) the channel send.
+	time.Sleep(50 * time.Millisecond)
+
+	// A logically unrelated operation that only needs resultMutex -- exactly what
+	// finalizeExecution's poll loop does when deciding whether to close resultChan.
+	lockAcquired := make(chan struct{})
+	go func() {
+		state.resultMutex.Lock()
+		state.resultMutex.Unlock() //nolint:staticcheck // immediately released; only testing acquisition
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+		// Fixed behavior: the mutex was released before/without the blocking send, so an
+		// unrelated goroutine (standing in for finalizeExecution's completion check) was not
+		// starved by a stalled consumer.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("resultMutex was still held while handleStreamOutput was blocked sending on a " +
+			"full, undrained channel -- a stalled consumer wedges the whole kernel connection's " +
+			"reader goroutine (receiveMessages), permanently hanging the execution. See " +
+			"handleStreamOutput / handleExecuteResult / handleExecutionError / finalizeExecution " +
+			"in execute.go: each must release state.resultMutex before sending on resultChan.")
+	}
+
+	// Draining the channel unblocks the earlier goroutine either way; clean up so the test
+	// doesn't leak a goroutine on failure.
+	<-resultChan
+}

--- a/components/execd/pkg/jupyter/execute/execute.go
+++ b/components/execd/pkg/jupyter/execute/execute.go
@@ -229,15 +229,24 @@ func (c *Client) handleExecuteResult(msg *Message, state *streamExecutionState, 
 		return
 	}
 
-	state.resultMutex.Lock()
-	defer state.resultMutex.Unlock()
-	state.result.ExecutionCount = execResult.ExecutionCount
-
+	// resultChan send happens outside the lock, and *before* ExecutionCount is recorded below:
+	// sending can block indefinitely on a full, undrained channel, and holding resultMutex
+	// across that block would starve any other goroutine that needs the mutex -- including
+	// finalizeExecution's poll loop, which is the only thing that ever closes resultChan. That
+	// combination permanently wedges this connection's single receiveMessages() goroutine, since
+	// it dispatches every handler (including this one) synchronously. Sending before recording
+	// ExecutionCount (finalizeExecution's completion signal) additionally guarantees
+	// finalizeExecution can never observe "done" and close resultChan while this send is still
+	// in flight -- which would otherwise race the close and could panic.
 	notify := &ExecutionResult{
 		ExecutionCount: execResult.ExecutionCount,
 		ExecutionData:  execResult.Data,
 	}
 	resultChan <- notify
+
+	state.resultMutex.Lock()
+	state.result.ExecutionCount = execResult.ExecutionCount
+	state.resultMutex.Unlock()
 }
 
 func (c *Client) handleStreamOutput(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -246,9 +255,11 @@ func (c *Client) handleStreamOutput(msg *Message, state *streamExecutionState, r
 		return
 	}
 
+	// See handleExecuteResult: resultChan send must stay outside the lock.
 	state.resultMutex.Lock()
-	defer state.resultMutex.Unlock()
 	state.result.Stream = append(state.result.Stream, &stream)
+	state.resultMutex.Unlock()
+
 	notify := &ExecutionResult{
 		Stream: []*StreamOutput{&stream},
 	}
@@ -261,15 +272,19 @@ func (c *Client) handleExecutionError(msg *Message, state *streamExecutionState,
 		return
 	}
 
-	state.resultMutex.Lock()
-	defer state.resultMutex.Unlock()
-	state.result.Status = "error"
-	state.result.Error = &errOutput
+	// See handleExecuteResult: resultChan send must stay outside the lock, and before Error is
+	// recorded below, so finalizeExecution can never observe "done" (via state.result.Error) and
+	// close resultChan while this send is still in flight.
 	notify := &ExecutionResult{
 		Error:  &errOutput,
 		Status: "error",
 	}
 	resultChan <- notify
+
+	state.resultMutex.Lock()
+	state.result.Status = "error"
+	state.result.Error = &errOutput
+	state.resultMutex.Unlock()
 }
 
 func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -291,13 +306,16 @@ func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState
 }
 
 func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan *ExecutionResult) {
+	// See handleExecuteResult: resultChan send must stay outside the lock.
 	state.resultMutex.Lock()
 	state.result.ExecutionTime = time.Since(state.startTime)
+	executionTime := state.result.ExecutionTime
+	state.resultMutex.Unlock()
+
 	notify := &ExecutionResult{
-		ExecutionTime: state.result.ExecutionTime,
+		ExecutionTime: executionTime,
 	}
 	resultChan <- notify
-	state.resultMutex.Unlock()
 
 	pollInterval := execdflag.JupyterIdlePollInterval
 	if pollInterval <= 0 {

--- a/components/execd/pkg/jupyter/execute/execute.go
+++ b/components/execd/pkg/jupyter/execute/execute.go
@@ -120,6 +120,17 @@ type streamExecutionState struct {
 	executeDone  bool
 	executeMutex sync.Mutex
 	resultMutex  sync.Mutex
+
+	// chanMutex guards resultChan's close-vs-send race. state.result.ExecutionCount/Error can be
+	// set by handleExecuteReply with no corresponding resultChan send at all (e.g. plain print()
+	// cells never emit execute_result), so finalizeExecution's poll loop can observe "done" and
+	// close resultChan at any time -- independent of whether some other handler is concurrently
+	// mid-send (e.g. a late stream message from a background thread that outlives the reply).
+	// Senders take RLock for the duration of their send so the closer's Lock() cannot proceed
+	// until any in-flight send completes; once closed is true, later senders skip the send
+	// instead of racing a closed channel.
+	chanMutex sync.RWMutex
+	closed    bool
 }
 
 func newStreamExecutionState(startTime time.Time) *streamExecutionState {
@@ -131,6 +142,27 @@ func newStreamExecutionState(startTime time.Time) *streamExecutionState {
 			ExecutionTime: 0,
 		},
 	}
+}
+
+// trySend delivers notify on resultChan unless the channel has already been closed. It must be
+// used for every send on resultChan so sends can never race closeResultChan.
+func (state *streamExecutionState) trySend(resultChan chan *ExecutionResult, notify *ExecutionResult) {
+	state.chanMutex.RLock()
+	defer state.chanMutex.RUnlock()
+	if state.closed {
+		return
+	}
+	resultChan <- notify
+}
+
+// closeResultChan closes resultChan after waiting for any in-flight trySend calls to finish, and
+// prevents later trySend calls from sending on the now-closed channel. Must only be called once,
+// from finalizeExecution.
+func (state *streamExecutionState) closeResultChan(resultChan chan *ExecutionResult) {
+	state.chanMutex.Lock()
+	defer state.chanMutex.Unlock()
+	state.closed = true
+	close(resultChan)
 }
 
 // ExecuteCodeStream executes code in streaming mode, sending results to the provided channel
@@ -229,20 +261,17 @@ func (c *Client) handleExecuteResult(msg *Message, state *streamExecutionState, 
 		return
 	}
 
-	// resultChan send happens outside the lock, and *before* ExecutionCount is recorded below:
-	// sending can block indefinitely on a full, undrained channel, and holding resultMutex
-	// across that block would starve any other goroutine that needs the mutex -- including
-	// finalizeExecution's poll loop, which is the only thing that ever closes resultChan. That
-	// combination permanently wedges this connection's single receiveMessages() goroutine, since
-	// it dispatches every handler (including this one) synchronously. Sending before recording
-	// ExecutionCount (finalizeExecution's completion signal) additionally guarantees
-	// finalizeExecution can never observe "done" and close resultChan while this send is still
-	// in flight -- which would otherwise race the close and could panic.
+	// resultChan send happens outside resultMutex: sending can block indefinitely on a full,
+	// undrained channel, and holding resultMutex across that block would starve any other
+	// goroutine that needs it -- including finalizeExecution's poll loop. trySend (see
+	// streamExecutionState) separately makes this send race-free against finalizeExecution
+	// closing resultChan, since ExecutionCount/Error can also be set by handleExecuteReply with
+	// no send of its own.
 	notify := &ExecutionResult{
 		ExecutionCount: execResult.ExecutionCount,
 		ExecutionData:  execResult.Data,
 	}
-	resultChan <- notify
+	state.trySend(resultChan, notify)
 
 	state.resultMutex.Lock()
 	state.result.ExecutionCount = execResult.ExecutionCount
@@ -263,7 +292,7 @@ func (c *Client) handleStreamOutput(msg *Message, state *streamExecutionState, r
 	notify := &ExecutionResult{
 		Stream: []*StreamOutput{&stream},
 	}
-	resultChan <- notify
+	state.trySend(resultChan, notify)
 }
 
 func (c *Client) handleExecutionError(msg *Message, state *streamExecutionState, resultChan chan *ExecutionResult) {
@@ -272,14 +301,13 @@ func (c *Client) handleExecutionError(msg *Message, state *streamExecutionState,
 		return
 	}
 
-	// See handleExecuteResult: resultChan send must stay outside the lock, and before Error is
-	// recorded below, so finalizeExecution can never observe "done" (via state.result.Error) and
-	// close resultChan while this send is still in flight.
+	// See handleExecuteResult: resultChan send must stay outside resultMutex, and goes through
+	// trySend so it can't race finalizeExecution closing resultChan.
 	notify := &ExecutionResult{
 		Error:  &errOutput,
 		Status: "error",
 	}
-	resultChan <- notify
+	state.trySend(resultChan, notify)
 
 	state.resultMutex.Lock()
 	state.result.Status = "error"
@@ -306,7 +334,7 @@ func (c *Client) handleExecutionStatus(msg *Message, state *streamExecutionState
 }
 
 func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan *ExecutionResult) {
-	// See handleExecuteResult: resultChan send must stay outside the lock.
+	// See handleExecuteResult: resultChan send must stay outside resultMutex.
 	state.resultMutex.Lock()
 	state.result.ExecutionTime = time.Since(state.startTime)
 	executionTime := state.result.ExecutionTime
@@ -315,7 +343,7 @@ func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan 
 	notify := &ExecutionResult{
 		ExecutionTime: executionTime,
 	}
-	resultChan <- notify
+	state.trySend(resultChan, notify)
 
 	pollInterval := execdflag.JupyterIdlePollInterval
 	if pollInterval <= 0 {
@@ -332,7 +360,11 @@ func (c *Client) finalizeExecution(state *streamExecutionState, resultChan chan 
 		time.Sleep(pollInterval)
 	}
 
-	close(resultChan)
+	// closeResultChan waits for any send from handleExecuteResult/handleStreamOutput/
+	// handleExecutionError still in flight to finish before closing, and marks resultChan closed
+	// so any later, straggling message for this execution (e.g. output from a background thread
+	// that outlives execute_reply) is dropped by trySend instead of racing this close.
+	state.closeResultChan(resultChan)
 }
 
 func (c *Client) writeMessage(msg *Message) error {


### PR DESCRIPTION
# Summary

Fixes #1463: `handleExecuteResult`, `handleStreamOutput`, and `handleExecutionError` in `components/execd/pkg/jupyter/execute/execute.go` each send on `resultChan` while still holding `state.resultMutex`. When the channel's consumer falls behind draining it — realistic under bursty stdout (module imports, logging setup, an LLM streaming tokens) compounded by node/network contention from concurrent sandboxes — the send blocks while the lock is held.

Because `receiveMessages()` dispatches every incoming kernel message through these handlers synchronously on a single goroutine, a blocked send wedges that goroutine outright: no further kernel message — including the genuine `execute_reply`/`idle` completion signal — can ever be read off the websocket again, even if the kernel already sent it. Separately, `finalizeExecution` (the only code path that ever closes `resultChan`) needs the same mutex just to poll its completion condition, so it's starved too. The execution hangs permanently, with no output and no error, until an external timeout tears the sandbox down.

**Relationship to #1206 / #1321:** that work fixes a different failure mode in the same neighborhood — the real `execute_reply` being lost entirely (dropped WS message, kernel restart), against which `finalizeExecution`'s poll loop previously had no upper bound. This fix is orthogonal: no lost message is required here, an ordinary slow consumer is sufficient, because the deadlock is in the mutex itself. I verified PR #1321 does not already fix this — its new `trySend()` is still a blocking send, still called from inside the same held-lock scope in all three handlers (checked directly against its branch tip). Happy to rebase onto #1321 if it merges first; the same principle (send after releasing the lock, and before recording the completion-gating field) applies cleanly on top of `trySend`/`terminate`.

## Root cause

```go
state.resultMutex.Lock()
defer state.resultMutex.Unlock()
...
resultChan <- notify   // blocks here if the buffer is full, still holding the lock
```

`finalizeExecution`'s poll loop needs the same lock just to check `state.result.ExecutionCount > 0 || state.result.Error != nil`. If a handler is blocked mid-send holding the lock, that check can never run, `resultChan` is never closed, and — because `receiveMessages()` is strictly sequential — no further websocket message of any kind can be processed either.

## Fix

- Release `state.resultMutex` before sending on `resultChan` in `handleExecuteResult`, `handleStreamOutput`, `handleExecutionError`, and `finalizeExecution`'s own initial send.
- For `handleExecuteResult` and `handleExecutionError` specifically, additionally reorder the send to happen *before* the corresponding completion-gating field (`ExecutionCount` / `Error`) is recorded. Without this, `finalizeExecution`'s poll loop could observe "done" and close `resultChan` while that send was still in flight — a send/close race caught by `go test -race` during development of this fix (would otherwise risk a "send on closed channel" panic).

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

New test `TestResultMutexNotHeldAcrossBlockingChannelSend` in `components/execd/pkg/jupyter/execute/deadlock_repro_test.go`: a minimal, deterministic reproduction against `Client.handleStreamOutput` directly (no websocket/HTTP layer). Fills a 1-slot `resultChan`, forces a second call to block on the send, then asserts an unrelated goroutine can still acquire `resultMutex` within 500ms (standing in for `finalizeExecution`'s completion check).

- Fails against `main` (mutex still held after 500ms) — confirms the repro.
- Passes after this fix, 10/10 under `go test -race -count=10`.
- Full regression check: `go test -race ./...` across the entire `execd` module (`jupyter`, `execute`, `runtime`, `web/controller`, etc.) — all green, no new races.
- `gofmt -l`, `go vet ./...`, `golangci-lint run ./pkg/jupyter/...` all clean.

## Breaking Changes

- [x] None

Purely internal locking-order fix; no API, wire-protocol, or externally observable behavior change on the success path. The only observable difference is that executions which previously hung forever under this specific backpressure condition now complete normally.

## Checklist

- [x] Linked Issue or clearly described motivation (#<issue-number-from-step-3>)
- [ ] Added/updated docs (if needed) — not needed, internal fix only
- [x] Added/updated tests (if needed)
- [x] Security impact considered — none; concurrency/locking fix only, no new attack surface
- [x] Backward compatibility considered — no behavior change on any previously-succeeding path