### PR TITLE
fix(chart/server): roll the server Deployment when config.toml changes

### DIFF
--- a/kubernetes/charts/opensandbox-server/templates/server.yaml
+++ b/kubernetes/charts/opensandbox-server/templates/server.yaml
@@ -89,10 +89,14 @@ spec:
         {{- with .Values.server.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.server.podAnnotations }}
       annotations:
+        # The server parses config.toml once at startup, so an in-place update
+        # of the ConfigMap leaves the running pod on the previous configuration.
+        # Hashing the rendered TOML rolls the Deployment whenever it changes.
+        checksum/config: {{ printf "%s%s" .Values.configToml (include "opensandbox-server.ingressConfigToml" .) | sha256sum }}
+        {{- with .Values.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
# Summary

- The server parses `config.toml` **once at startup**, but `opensandbox-server` mounts it from a ConfigMap with no content hash on the pod template. Helm (or a GitOps sync) updates the ConfigMap in place, so the running pod keeps serving the **previous** configuration — the mounted file shows the new values while the process does not.
- We hit this in production with `[kubernetes].sandbox_create_timeout_seconds`: the ConfigMap carried `180` for days while the server kept timing out sandbox creates at the `60` default (`KUBERNETES::POD_READY_TIMEOUT … Elapsed: 60.0s`), and the only reason it eventually picked the new value up was an unrelated node rotation. Our client's create-retry masked it, so the misconfiguration was invisible for four days.
- Fix: add a `checksum/config` pod annotation over the rendered TOML — `.Values.configToml` plus the `[ingress]` block the chart appends via `opensandbox-server.ingressConfigToml` — so any config change rolls the Deployment. `server.podAnnotations` still merge on top.

```diff
-      {{- with .Values.server.podAnnotations }}
       annotations:
+        checksum/config: {{ printf "%s%s" .Values.configToml (include "opensandbox-server.ingressConfigToml" .) | sha256sum }}
+        {{- with .Values.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
```

Scoped to the server Deployment: the ingress gateway does not mount the config ConfigMap, so it needs no equivalent. Secrets consumed as env (e.g. `server.gateway.secureAccess.existingSecret`) are out of scope — `values.yaml` already documents the manual restart for those.

Happy to swap this for an opt-in `server.deploymentAnnotations` value instead (so operators can wire Stakater Reloader themselves) if you prefer the chart not to force rollouts — just say which you'd rather have.

# Testing

- [x] e2e / manual verification
- `helm lint` passes.
- `helm template` renders the annotation on the server Deployment; the digest changes when `configToml` changes, and again when `server.gateway.enabled=true` alters the appended `[ingress]` section.
- `--set server.podAnnotations.foo=bar` renders alongside `checksum/config` (no override, correct indentation).
- Verified against the real failure mode: a server pod started before the ConfigMap change kept logging `Waiting for sandbox … (timeout: 60s)`; a restarted pod on the same ConfigMap logs `(timeout: 180s)`.

# Breaking Changes

- [x] None
- Behavioural note: a `configToml` change now rolls the server pod, which is the intended fix. Sandbox state lives in the CRs, so the stateless server can be rolled safely.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — the annotation carries an inline comment; no user-facing values change
- [x] Added/updated tests (if needed) — chart has no test suite; verified via `helm lint` / `helm template`
- [x] Security impact considered — no new RBAC, no secret material in annotations; the digest is over non-secret TOML (`api_key` is supplied via env)
- [x] Backward compatibility considered — no values added or removed; existing `podAnnotations` behaviour preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)