### PR TITLE
docs(kubernetes): document shared PVCs in pools

### DIFF
--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -137,6 +137,7 @@ spec:
       containers:
         - name: sandbox-container
           image: python:3.11
+          command: ["sleep", "3600"]
           volumeMounts:
             - name: shared-workspace
               mountPath: /workspace

--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -152,9 +152,7 @@ spec:
     poolMin: 5
 ```
 
-The lifecycle server's `POST /v1/pools` endpoint accepts the same Kubernetes
-`PodTemplateSpec` under its `template` field, so the `containers` and `volumes`
-sections above can also be supplied when a Pool is created through the server.
+Apply the Pool manifest to the cluster before allocating sandboxes from it.
 Sandboxes then select the preconfigured Pool with `extensions.poolRef` and do
 not pass a per-sandbox `volumes` list.
 

--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -107,6 +107,64 @@ python examples/kubernetes-pvc-volume-mount/main.py
 
 The script creates a sandbox, writes a marker file under `/mnt/data`, kills it, then creates a second sandbox bound to the same PVC and confirms the marker is still there.
 
+## Pool mode: pre-mount a shared PVC
+
+Pool pods are created before a sandbox is allocated, so storage shared by a
+pool must be part of the Pool pod template. Create the PVC first, then mount it
+in every warm pod through `Pool.spec.template`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-workspace-pvc
+  namespace: opensandbox
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: <your-rwx-storage-class>
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: sandbox.opensandbox.io/v1alpha1
+kind: Pool
+metadata:
+  name: shared-workspace-pool
+  namespace: opensandbox
+spec:
+  template:
+    spec:
+      containers:
+        - name: sandbox-container
+          image: python:3.11
+          volumeMounts:
+            - name: shared-workspace
+              mountPath: /workspace
+      volumes:
+        - name: shared-workspace
+          persistentVolumeClaim:
+            claimName: shared-workspace-pvc
+  capacitySpec:
+    bufferMax: 10
+    bufferMin: 2
+    poolMax: 20
+    poolMin: 5
+```
+
+The lifecycle server's `POST /v1/pools` endpoint accepts the same Kubernetes
+`PodTemplateSpec` under its `template` field, so the `containers` and `volumes`
+sections above can also be supplied when a Pool is created through the server.
+Sandboxes then select the preconfigured Pool with `extensions.poolRef` and do
+not pass a per-sandbox `volumes` list.
+
+::: warning Static pool storage only
+The PVC must already exist, and its access mode and storage backend must allow
+all scheduled warm pods to mount it. OpenSandbox does not create, mutate, or
+delete PVCs referenced by a Pool template. A sandbox creation request cannot
+add `volumes` while also using `extensions.poolRef`, because the selected warm
+pod already exists.
+:::
+
 ## Mode 2: Server-managed PVC
 
 Use this when the sandbox should own its storage. The server creates the PVC on demand the first time the claim name is referenced. You control whether the claim survives sandbox termination through `deleteOnSandboxTermination`.
@@ -184,7 +242,9 @@ Both paths only match server-labeled PVCs, so BYO and opted-out claims are never
 ## Important notes
 
 ::: warning
-- **Pool mode does not support volumes.** Use template mode instead.
+- Per-sandbox `volumes` cannot be combined with `extensions.poolRef`. For Pool
+  mode, pre-mount an existing shared PVC in `Pool.spec.template` as described
+  above.
 - Multiple sandboxes can mount the same PVC if the access mode allows (e.g. `ReadWriteMany`) — but only when the PVC is **not** opted into auto-cleanup. PVCs created with `deleteOnSandboxTermination=true` are owned exclusively by the creating sandbox; the server rejects attempts by other sandboxes to mount them with `409 CONFLICT`.
 - All mounts of the same `claimName` in a single request must agree on `createIfNotExists` and `deleteOnSandboxTermination`; mismatches are rejected with `400 INVALID_PARAMETER`.
 :::

--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -403,8 +403,8 @@ Pool pods are created before allocation. The lifecycle API therefore rejects `ne
 ::: tip Shared storage in Pool mode
 Static shared storage follows the same rule: pre-create a PVC (normally with a
 `ReadWriteMany`-capable storage class) and mount it in the Pool pod template as
-shown in the complete example linked below. The lifecycle API preserves this
-template when creating a Pool.
+shown in the complete example linked below. The Kubernetes controller preserves
+these static mounts when it creates warm pods from the Pool template.
 Per-sandbox `volumes` cannot be combined with `extensions.poolRef`, because an
 allocated warm pod cannot gain new volumes. See the
 [Kubernetes PVC guide](/examples/kubernetes-pvc-volume-mount#pool-mode-pre-mount-a-shared-pvc).

--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -371,13 +371,6 @@ spec:
         image: nginx:latest
         ports:
         - containerPort: 80
-        volumeMounts:
-        - name: shared-workspace
-          mountPath: /workspace
-      volumes:
-      - name: shared-workspace
-        persistentVolumeClaim:
-          claimName: shared-workspace-pvc
   capacitySpec:
     bufferMax: 10
     bufferMin: 2
@@ -410,7 +403,8 @@ Pool pods are created before allocation. The lifecycle API therefore rejects `ne
 ::: tip Shared storage in Pool mode
 Static shared storage follows the same rule: pre-create a PVC (normally with a
 `ReadWriteMany`-capable storage class) and mount it in the Pool pod template as
-shown above. The lifecycle API preserves this template when creating a Pool.
+shown in the complete example linked below. The lifecycle API preserves this
+template when creating a Pool.
 Per-sandbox `volumes` cannot be combined with `extensions.poolRef`, because an
 allocated warm pod cannot gain new volumes. See the
 [Kubernetes PVC guide](/examples/kubernetes-pvc-volume-mount#pool-mode-pre-mount-a-shared-pvc).

--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -371,6 +371,13 @@ spec:
         image: nginx:latest
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: shared-workspace
+          mountPath: /workspace
+      volumes:
+      - name: shared-workspace
+        persistentVolumeClaim:
+          claimName: shared-workspace-pvc
   capacitySpec:
     bufferMax: 10
     bufferMin: 2
@@ -398,6 +405,15 @@ spec:
 
 ::: warning Per-request network policies
 Pool pods are created before allocation. The lifecycle API therefore rejects `networkPolicy` together with `extensions.poolRef`; it cannot inject an egress sidecar into an existing pool pod. Configure required network controls in the Pool pod template before pods are created, or use a non-pooled sandbox for per-request policies.
+:::
+
+::: tip Shared storage in Pool mode
+Static shared storage follows the same rule: pre-create a PVC (normally with a
+`ReadWriteMany`-capable storage class) and mount it in the Pool pod template as
+shown above. The lifecycle API preserves this template when creating a Pool.
+Per-sandbox `volumes` cannot be combined with `extensions.poolRef`, because an
+allocated warm pod cannot gain new volumes. See the
+[Kubernetes PVC guide](/examples/kubernetes-pvc-volume-mount#pool-mode-pre-mount-a-shared-pvc).
 :::
 
 #### Pooled Sandbox with Heterogeneous Tasks

--- a/kubernetes/internal/controller/pool_static_volume_test.go
+++ b/kubernetes/internal/controller/pool_static_volume_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+	controllerutils "github.com/alibaba/OpenSandbox/sandbox-k8s/internal/utils/controller"
 )
 
 func TestCreatePoolPodPreservesStaticPVC(t *testing.T) {
@@ -83,7 +84,7 @@ func TestCreatePoolPodPreservesStaticPVC(t *testing.T) {
 			},
 		},
 	}
-	defer PoolScaleExpectations.DeleteExpectations("opensandbox/shared-workspace-pool")
+	defer PoolScaleExpectations.DeleteExpectations(controllerutils.GetControllerKey(pool))
 
 	r := &PoolReconciler{
 		Client:   fakeClient,

--- a/kubernetes/internal/controller/pool_static_volume_test.go
+++ b/kubernetes/internal/controller/pool_static_volume_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	sandboxv1alpha1 "github.com/alibaba/OpenSandbox/sandbox-k8s/apis/sandbox/v1alpha1"
+)
+
+func TestCreatePoolPodPreservesStaticPVC(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, sandboxv1alpha1.AddToScheme(scheme))
+
+	var createdPod *corev1.Pod
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				pod, ok := obj.(*corev1.Pod)
+				require.True(t, ok)
+				pod.Name = "shared-workspace-pool-test"
+				createdPod = pod.DeepCopy()
+				return nil
+			},
+		}).
+		Build()
+
+	pool := &sandboxv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-workspace-pool",
+			Namespace: "opensandbox",
+			UID:       types.UID("pool-uid"),
+		},
+		Spec: sandboxv1alpha1.PoolSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "sandbox-container",
+							Image: "python:3.11",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "shared-workspace", MountPath: "/workspace"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "shared-workspace",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "shared-workspace-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	defer PoolScaleExpectations.DeleteExpectations("opensandbox/shared-workspace-pool")
+
+	r := &PoolReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	require.NoError(t, r.createPoolPod(context.Background(), pool, "revision-1"))
+	require.NotNil(t, createdPod)
+	require.Len(t, createdPod.Spec.Volumes, 1)
+	require.NotNil(t, createdPod.Spec.Volumes[0].PersistentVolumeClaim)
+	assert.Equal(t, "shared-workspace-pvc", createdPod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+	require.Len(t, createdPod.Spec.Containers, 1)
+	assert.Contains(t, createdPod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "shared-workspace",
+		MountPath: "/workspace",
+	})
+}

--- a/server/tests/k8s/test_pool_service.py
+++ b/server/tests/k8s/test_pool_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from copy import deepcopy
 from unittest.mock import MagicMock
 from kubernetes.client import ApiException
 
@@ -196,11 +197,14 @@ class TestCreatePool:
             template=template,
             capacitySpec=_capacity_spec(),
         )
+        expected_template = deepcopy(request.template)
 
         svc.create_pool(request)
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
-        assert body["spec"]["template"] == template
+        assert body["spec"]["template"] == expected_template
+        assert request.template == expected_template
+        assert template == expected_template
 
     def test_create_pool_returns_pool_response(self):
         svc, mock_api = _make_pool_service()

--- a/server/tests/k8s/test_pool_service.py
+++ b/server/tests/k8s/test_pool_service.py
@@ -161,6 +161,47 @@ class TestCreatePool:
 
         assert result.name == "ci-pool"
 
+    def test_create_pool_preserves_static_pvc_template(self):
+        svc, mock_api = _make_pool_service(namespace="opensandbox")
+        mock_api.create_namespaced_custom_object.return_value = _make_raw_pool(
+            name="shared-workspace-pool",
+            namespace="opensandbox",
+        )
+        template = {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "sandbox-container",
+                        "image": "python:3.11",
+                        "volumeMounts": [
+                            {
+                                "name": "shared-workspace",
+                                "mountPath": "/workspace",
+                            }
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "shared-workspace",
+                        "persistentVolumeClaim": {
+                            "claimName": "shared-workspace-pvc",
+                        },
+                    }
+                ],
+            }
+        }
+        request = CreatePoolRequest(
+            name="shared-workspace-pool",
+            template=template,
+            capacitySpec=_capacity_spec(),
+        )
+
+        svc.create_pool(request)
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        assert body["spec"]["template"] == template
+
     def test_create_pool_returns_pool_response(self):
         svc, mock_api = _make_pool_service()
         raw = _make_raw_pool()


### PR DESCRIPTION
## Summary

- document the existing static shared-PVC path for pre-warmed Kubernetes Pools
- show a pre-created RWX PVC mounted through `Pool.spec.template`
- clarify that per-sandbox `volumes` still cannot be combined with `extensions.poolRef`
- add regression coverage from the server Pool manifest through controller warm-Pod creation

## Why

Pool templates already use a full Kubernetes `PodTemplateSpec`, and both the lifecycle server and controller preserve its `volumes` and `volumeMounts`. The PVC guide currently says Pool mode does not support volumes at all, which hides this supported static configuration and conflates it with unsupported per-allocation volume mutation.

This change does not alter CRDs, scheduling semantics, or production behavior. It documents and locks in the existing boundary: preconfigure shared storage in the Pool template; do not attach new volumes when allocating an already-created warm Pod.

Closes #961.

## Validation

- `cd server && uv run pytest tests/k8s/test_pool_service.py -q` (30 passed)
- `cd server && uv run ruff check tests/k8s/test_pool_service.py`
- `cd server && uv run ruff format --check tests/k8s/test_pool_service.py`
- `cd kubernetes && go test ./internal/controller -run '^TestCreatePoolPodPreservesStaticPVC$' -count=1 -v`
- `cd kubernetes && go test -race ./internal/controller -run '^TestCreatePoolPodPreservesStaticPVC$' -count=1`
- `cd kubernetes && go vet ./internal/controller`
- `cd docs && corepack pnpm docs:build`
- `git diff --check`

No live cluster is required for these manifest and Pod-construction regression tests.