### PR TITLE
fix(examples): support HTTPS noVNC embedding

### DIFF
--- a/docs/examples/desktop.md
+++ b/docs/examples/desktop.md
@@ -104,12 +104,13 @@ server {
 ::: warning
 Do not expose a direct `http://<sandbox-host>:<mapped-port>` URL in an HTTPS
 iframe. That endpoint has no TLS termination and the browser will reject it as
-mixed content. Keep `SANDBOX_USE_SERVER_PROXY=true` unless the direct sandbox
-endpoint has its own trusted HTTPS gateway. Server proxy mode handles HTTP and
-WebSocket traffic, not the raw TCP protocol used by native VNC clients, so the
-example omits the native VNC endpoint in this mode. When server proxy mode is
-disabled, the example always generates an `http://` noVNC URL for the direct
-websockify endpoint, even if the management API itself uses HTTPS.
+mixed content. This SDK configuration uses one protocol for the management API
+and sandbox service requests, so the example requires
+`SANDBOX_USE_SERVER_PROXY=true` whenever the management API uses HTTPS. This
+keeps lifecycle, execd, noVNC page, and WebSocket traffic on the HTTPS server
+origin instead of incorrectly sending HTTPS to a direct sandbox endpoint.
+Server proxy mode does not support the raw TCP protocol used by native VNC
+clients, so the example omits the native VNC endpoint in this mode.
 :::
 
 ![Desktop shell](../public/images/desktop-screenshot-shell.jpg)
@@ -123,7 +124,7 @@ websockify endpoint, even if the management API itself uses HTTPS.
 |----------|---------|-------------|
 | `SANDBOX_DOMAIN` | `localhost:8080` | Sandbox service address; may include an `http://` or `https://` scheme |
 | `SANDBOX_PROTOCOL` | Domain scheme, otherwise `http` | Protocol used when `SANDBOX_DOMAIN` has no scheme (`http` or `https`) |
-| `SANDBOX_USE_SERVER_PROXY` | `false` | Route noVNC HTTP and WebSocket traffic through the OpenSandbox server |
+| `SANDBOX_USE_SERVER_PROXY` | `false` | Route sandbox service, noVNC HTTP, and WebSocket traffic through the OpenSandbox server; required with HTTPS |
 | `SANDBOX_API_KEY` | _(optional for local)_ | API key if your server requires authentication |
 | `SANDBOX_IMAGE` | `opensandbox/desktop:latest` | Sandbox image to use |
 | `VNC_PASSWORD` | `opensandbox` | Password for VNC access |

--- a/docs/examples/desktop.md
+++ b/docs/examples/desktop.md
@@ -48,10 +48,67 @@ uv run python examples/desktop/main.py
 ```
 
 The script starts the desktop stack (Xvfb + XFCE + x11vnc) and also launches noVNC/websockify. It prints:
-- VNC endpoint (`endpoint.endpoint`) for native VNC clients, password from `VNC_PASSWORD` (default: `opensandbox`)
+- VNC endpoint (`endpoint.endpoint`) for native VNC clients when direct endpoint mode is enabled, password from `VNC_PASSWORD` (default: `opensandbox`)
 - noVNC URL for browsers (`/vnc.html?host=...&port=...&path=...`)
 
 The sandbox stays alive for 5 minutes by default; interrupt sooner with Ctrl+C. Uses the prebuilt desktop image by default.
+
+### Embed noVNC in an HTTPS page
+
+Browsers block an `http://` noVNC iframe inside an HTTPS page. Terminate TLS at
+a reverse proxy in front of the OpenSandbox server, then make the example use
+that HTTPS origin and the server proxy:
+
+```shell
+export SANDBOX_DOMAIN=sandbox.example.com
+export SANDBOX_PROTOCOL=https
+export SANDBOX_USE_SERVER_PROXY=true
+export VNC_PASSWORD=opensandbox
+
+uv run python examples/desktop/main.py
+```
+
+The generated URL uses the same HTTPS origin for both the noVNC page and its
+WebSocket, for example:
+
+```text
+https://sandbox.example.com/v1/sandboxes/<sandbox-id>/proxy/6080/vnc.html?host=sandbox.example.com&port=443&path=v1/sandboxes/<sandbox-id>/proxy/6080
+```
+
+The TLS reverse proxy must forward normal HTTP requests and WebSocket upgrades
+to the OpenSandbox server. For Nginx, the relevant settings are:
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name sandbox.example.com;
+    # Configure ssl_certificate and ssl_certificate_key here.
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+```
+
+::: warning
+Do not expose a direct `http://<sandbox-host>:<mapped-port>` URL in an HTTPS
+iframe. That endpoint has no TLS termination and the browser will reject it as
+mixed content. Keep `SANDBOX_USE_SERVER_PROXY=true` unless the direct sandbox
+endpoint has its own trusted HTTPS gateway. Server proxy mode handles HTTP and
+WebSocket traffic, not the raw TCP protocol used by native VNC clients, so the
+example omits the native VNC endpoint in this mode.
+:::
 
 ![Desktop shell](../public/images/desktop-screenshot-shell.jpg)
 ![noVNC connect](../public/images/desktop-screenshot-connect.jpg)
@@ -62,7 +119,9 @@ The sandbox stays alive for 5 minutes by default; interrupt sooner with Ctrl+C. 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SANDBOX_DOMAIN` | `localhost:8080` | Sandbox service address |
+| `SANDBOX_DOMAIN` | `localhost:8080` | Sandbox service address; may include an `http://` or `https://` scheme |
+| `SANDBOX_PROTOCOL` | Domain scheme, otherwise `http` | Protocol used when `SANDBOX_DOMAIN` has no scheme (`http` or `https`) |
+| `SANDBOX_USE_SERVER_PROXY` | `false` | Route noVNC HTTP and WebSocket traffic through the OpenSandbox server |
 | `SANDBOX_API_KEY` | _(optional for local)_ | API key if your server requires authentication |
 | `SANDBOX_IMAGE` | `opensandbox/desktop:latest` | Sandbox image to use |
 | `VNC_PASSWORD` | `opensandbox` | Password for VNC access |

--- a/docs/examples/desktop.md
+++ b/docs/examples/desktop.md
@@ -107,7 +107,9 @@ iframe. That endpoint has no TLS termination and the browser will reject it as
 mixed content. Keep `SANDBOX_USE_SERVER_PROXY=true` unless the direct sandbox
 endpoint has its own trusted HTTPS gateway. Server proxy mode handles HTTP and
 WebSocket traffic, not the raw TCP protocol used by native VNC clients, so the
-example omits the native VNC endpoint in this mode.
+example omits the native VNC endpoint in this mode. When server proxy mode is
+disabled, the example always generates an `http://` noVNC URL for the direct
+websockify endpoint, even if the management API itself uses HTTPS.
 :::
 
 ![Desktop shell](../public/images/desktop-screenshot-shell.jpg)

--- a/docs/examples/desktop.md
+++ b/docs/examples/desktop.md
@@ -101,6 +101,20 @@ server {
 }
 ```
 
+This direct browser URL works when the OpenSandbox proxy route does not require
+browser-supplied authentication headers, including the default single-tenant
+mode. In multi-tenant mode, the proxy route requires
+`OPEN-SANDBOX-API-KEY` on both the initial noVNC HTTP request and the WebSocket
+upgrade. The SDK adds this header to its own requests, but a browser navigation
+or WebSocket cannot add it.
+
+For multi-tenant browser access, put a trusted, browser-authenticated reverse
+proxy in front of OpenSandbox. It must authorize access to the requested
+sandbox, map the browser identity to the correct tenant, and inject that
+tenant's `OPEN-SANDBOX-API-KEY` header for both HTTP and WebSocket traffic. Do
+not put the API key in the noVNC URL or expose a reverse proxy that adds one
+shared key to unauthenticated traffic.
+
 ::: warning
 Do not expose a direct `http://<sandbox-host>:<mapped-port>` URL in an HTTPS
 iframe. That endpoint has no TLS termination and the browser will reject it as

--- a/examples/desktop/main.py
+++ b/examples/desktop/main.py
@@ -20,12 +20,26 @@ from opensandbox import Sandbox
 from opensandbox.config import ConnectionConfig
 from opensandbox.models.execd import RunCommandOpts
 
+from novnc_url import build_novnc_url, resolve_protocol
+
 
 def _required_env(name: str) -> str:
     value = os.getenv(name)
     if not value:
         raise RuntimeError(f"{name} is required")
     return value
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(f"{name} must be true or false")
 
 
 async def _print_logs(label: str, execution) -> None:
@@ -39,6 +53,8 @@ async def _print_logs(label: str, execution) -> None:
 
 async def main() -> None:
     domain = os.getenv("SANDBOX_DOMAIN", "localhost:8080")
+    protocol = resolve_protocol(domain, os.getenv("SANDBOX_PROTOCOL"))
+    use_server_proxy = _bool_env("SANDBOX_USE_SERVER_PROXY")
     api_key = os.getenv("SANDBOX_API_KEY")
     image = os.getenv(
         "SANDBOX_IMAGE",
@@ -49,8 +65,10 @@ async def main() -> None:
 
     config = ConnectionConfig(
         domain=domain,
+        protocol=protocol,
         api_key=api_key,
         request_timeout=timedelta(seconds=60),
+        use_server_proxy=use_server_proxy,
     )
 
     sandbox = await Sandbox.create(
@@ -79,9 +97,7 @@ async def main() -> None:
         await _print_logs("xfce", xfce_exec)
 
         vnc_exec = await sandbox.commands.run(
-            "x11vnc -display :0 "
-            "-passwd \"$VNC_PASSWORD\" "
-            "-forever -shared -rfbport 5900",
+            'x11vnc -display :0 -passwd "$VNC_PASSWORD" -forever -shared -rfbport 5900',
             opts=RunCommandOpts(background=True),
         )
         await _print_logs("x11vnc", vnc_exec)
@@ -93,20 +109,17 @@ async def main() -> None:
         )
         await _print_logs("novnc", novnc_exec)
 
-        endpoint_vnc = await sandbox.get_endpoint(5900)
         endpoint_novnc = await sandbox.get_endpoint(6080)
 
-        # Build noVNC URL with host/port/path for routed endpoint, e.g., host:port/proxy/6080
-        novnc_host_port, novnc_path = endpoint_novnc.endpoint.split("/", 1)
-        novnc_host, novnc_port = novnc_host_port.split(":")
-        novnc_url = (
-            f"http://{endpoint_novnc.endpoint}/vnc.html"
-            f"?host={novnc_host}&port={novnc_port}&path={novnc_path}"
-        )
+        # noVNC uses the page's scheme to select ws:// or wss://. In HTTPS
+        # deployments, server proxy mode keeps both requests on the TLS origin.
+        novnc_url = build_novnc_url(endpoint_novnc.endpoint, config.protocol)
 
-        print("\nVNC endpoint (native clients):")
-        print(f"  {endpoint_vnc.endpoint}")
-        print(f"Password: {vnc_password}")
+        if not use_server_proxy:
+            endpoint_vnc = await sandbox.get_endpoint(5900)
+            print("\nVNC endpoint (native clients):")
+            print(f"  {endpoint_vnc.endpoint}")
+            print(f"Password: {vnc_password}")
 
         print("\nnoVNC (browser):")
         print(f"  {novnc_url}")

--- a/examples/desktop/main.py
+++ b/examples/desktop/main.py
@@ -21,6 +21,7 @@ from opensandbox.config import ConnectionConfig
 from opensandbox.models.execd import RunCommandOpts
 
 from novnc_url import (
+    browser_proxy_auth_warning,
     build_novnc_url,
     normalize_domain,
     parse_bool,
@@ -119,6 +120,7 @@ async def main() -> None:
         # websockify endpoints do not terminate TLS.
         novnc_protocol = resolve_novnc_protocol(config.protocol, use_server_proxy)
         novnc_url = build_novnc_url(endpoint_novnc.endpoint, novnc_protocol)
+        auth_warning = browser_proxy_auth_warning(use_server_proxy, api_key)
 
         if not use_server_proxy:
             endpoint_vnc = await sandbox.get_endpoint(5900)
@@ -129,6 +131,8 @@ async def main() -> None:
         print("\nnoVNC (browser):")
         print(f"  {novnc_url}")
         print(f"Password: {vnc_password}")
+        if auth_warning:
+            print(f"Authentication note: {auth_warning}")
 
         print("\nKeeping sandbox alive for 5 minutes. Press Ctrl+C to exit sooner.")
         try:

--- a/examples/desktop/main.py
+++ b/examples/desktop/main.py
@@ -20,7 +20,13 @@ from opensandbox import Sandbox
 from opensandbox.config import ConnectionConfig
 from opensandbox.models.execd import RunCommandOpts
 
-from novnc_url import build_novnc_url, resolve_protocol
+from novnc_url import (
+    build_novnc_url,
+    normalize_domain,
+    parse_bool,
+    resolve_novnc_protocol,
+    resolve_protocol,
+)
 
 
 def _required_env(name: str) -> str:
@@ -34,12 +40,7 @@ def _bool_env(name: str, default: bool = False) -> bool:
     value = os.getenv(name)
     if value is None:
         return default
-    normalized = value.strip().lower()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-    raise RuntimeError(f"{name} must be true or false")
+    return parse_bool(value, name)
 
 
 async def _print_logs(label: str, execution) -> None:
@@ -52,7 +53,7 @@ async def _print_logs(label: str, execution) -> None:
 
 
 async def main() -> None:
-    domain = os.getenv("SANDBOX_DOMAIN", "localhost:8080")
+    domain = normalize_domain(os.getenv("SANDBOX_DOMAIN", "localhost:8080"))
     protocol = resolve_protocol(domain, os.getenv("SANDBOX_PROTOCOL"))
     use_server_proxy = _bool_env("SANDBOX_USE_SERVER_PROXY")
     api_key = os.getenv("SANDBOX_API_KEY")
@@ -111,9 +112,11 @@ async def main() -> None:
 
         endpoint_novnc = await sandbox.get_endpoint(6080)
 
-        # noVNC uses the page's scheme to select ws:// or wss://. In HTTPS
-        # deployments, server proxy mode keeps both requests on the TLS origin.
-        novnc_url = build_novnc_url(endpoint_novnc.endpoint, config.protocol)
+        # noVNC uses the page's scheme to select ws:// or wss://. Only server
+        # proxy endpoints inherit the management API's TLS origin; direct
+        # websockify endpoints do not terminate TLS.
+        novnc_protocol = resolve_novnc_protocol(config.protocol, use_server_proxy)
+        novnc_url = build_novnc_url(endpoint_novnc.endpoint, novnc_protocol)
 
         if not use_server_proxy:
             endpoint_vnc = await sandbox.get_endpoint(5900)

--- a/examples/desktop/main.py
+++ b/examples/desktop/main.py
@@ -26,6 +26,7 @@ from novnc_url import (
     parse_bool,
     resolve_novnc_protocol,
     resolve_protocol,
+    validate_connection_mode,
 )
 
 
@@ -56,6 +57,7 @@ async def main() -> None:
     domain = normalize_domain(os.getenv("SANDBOX_DOMAIN", "localhost:8080"))
     protocol = resolve_protocol(domain, os.getenv("SANDBOX_PROTOCOL"))
     use_server_proxy = _bool_env("SANDBOX_USE_SERVER_PROXY")
+    validate_connection_mode(protocol, use_server_proxy)
     api_key = os.getenv("SANDBOX_API_KEY")
     image = os.getenv(
         "SANDBOX_IMAGE",

--- a/examples/desktop/novnc_url.py
+++ b/examples/desktop/novnc_url.py
@@ -12,19 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helpers for building browser-ready noVNC URLs."""
+"""Helpers for configuring and building browser-ready noVNC URLs."""
 
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 
+def normalize_domain(domain: str) -> str:
+    """Normalize whitespace and a case-insensitive HTTP scheme prefix."""
+    normalized = domain.strip()
+    lowered = normalized.lower()
+    if lowered.startswith("https://"):
+        return f"https://{normalized[len('https://') :]}"
+    if lowered.startswith("http://"):
+        return f"http://{normalized[len('http://') :]}"
+    return normalized
+
+
 def resolve_protocol(domain: str, configured_protocol: str | None) -> str:
     """Resolve the URL protocol, honoring a scheme embedded in the domain."""
-    lowered_domain = domain.lower()
+    lowered_domain = normalize_domain(domain).lower()
     if lowered_domain.startswith("https://"):
         return "https"
     if lowered_domain.startswith("http://"):
         return "http"
     return configured_protocol.lower() if configured_protocol else "http"
+
+
+def parse_bool(value: str, name: str) -> bool:
+    """Parse an environment-style boolean value."""
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(f"{name} must be one of: 1, true, yes, on, 0, false, no, off")
+
+
+def resolve_novnc_protocol(management_protocol: str, use_server_proxy: bool) -> str:
+    """Use the management scheme only when noVNC shares the server origin."""
+    return management_protocol if use_server_proxy else "http"
 
 
 def build_novnc_url(endpoint: str, protocol: str) -> str:

--- a/examples/desktop/novnc_url.py
+++ b/examples/desktop/novnc_url.py
@@ -62,6 +62,22 @@ def resolve_novnc_protocol(management_protocol: str, use_server_proxy: bool) -> 
     return management_protocol if use_server_proxy else "http"
 
 
+def browser_proxy_auth_warning(
+    use_server_proxy: bool,
+    api_key: str | None,
+) -> str | None:
+    """Warn when browser traffic may need authentication headers."""
+    if not use_server_proxy or not api_key:
+        return None
+
+    return (
+        "SANDBOX_API_KEY authenticates SDK requests only. Browsers cannot attach "
+        "OPEN-SANDBOX-API-KEY to noVNC HTTP or WebSocket requests. If the server "
+        "is multi-tenant, use a trusted authenticated reverse proxy that injects "
+        "the tenant key for both request types."
+    )
+
+
 def build_novnc_url(endpoint: str, protocol: str) -> str:
     """Build a noVNC page URL whose WebSocket targets the same endpoint."""
     scheme = protocol.lower()

--- a/examples/desktop/novnc_url.py
+++ b/examples/desktop/novnc_url.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for building browser-ready noVNC URLs."""
+
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+
+def resolve_protocol(domain: str, configured_protocol: str | None) -> str:
+    """Resolve the URL protocol, honoring a scheme embedded in the domain."""
+    lowered_domain = domain.lower()
+    if lowered_domain.startswith("https://"):
+        return "https"
+    if lowered_domain.startswith("http://"):
+        return "http"
+    return configured_protocol.lower() if configured_protocol else "http"
+
+
+def build_novnc_url(endpoint: str, protocol: str) -> str:
+    """Build a noVNC page URL whose WebSocket targets the same endpoint."""
+    scheme = protocol.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("protocol must be 'http' or 'https'")
+
+    parsed = urlsplit(f"{scheme}://{endpoint}")
+    if not parsed.hostname:
+        raise ValueError("endpoint must contain a hostname")
+
+    port = parsed.port or (443 if scheme == "https" else 80)
+    proxy_path = parsed.path.strip("/")
+    page_path = f"{parsed.path.rstrip('/')}/vnc.html"
+    if not page_path.startswith("/"):
+        page_path = f"/{page_path}"
+
+    query = urlencode(
+        {"host": parsed.hostname, "port": port, "path": proxy_path},
+        safe="/",
+    )
+    return urlunsplit((scheme, parsed.netloc, page_path, query, ""))

--- a/examples/desktop/novnc_url.py
+++ b/examples/desktop/novnc_url.py
@@ -48,6 +48,15 @@ def parse_bool(value: str, name: str) -> bool:
     raise RuntimeError(f"{name} must be one of: 1, true, yes, on, 0, false, no, off")
 
 
+def validate_connection_mode(management_protocol: str, use_server_proxy: bool) -> None:
+    """Require proxy mode when the management API uses HTTPS."""
+    if management_protocol == "https" and not use_server_proxy:
+        raise RuntimeError(
+            "SANDBOX_USE_SERVER_PROXY must be true when the management API uses HTTPS; "
+            "direct sandbox endpoints do not terminate TLS"
+        )
+
+
 def resolve_novnc_protocol(management_protocol: str, use_server_proxy: bool) -> str:
     """Use the management scheme only when noVNC shares the server origin."""
     return management_protocol if use_server_proxy else "http"

--- a/examples/desktop/test_novnc_url.py
+++ b/examples/desktop/test_novnc_url.py
@@ -15,6 +15,7 @@
 import unittest
 
 from novnc_url import (
+    browser_proxy_auth_warning,
     build_novnc_url,
     normalize_domain,
     parse_bool,
@@ -101,6 +102,19 @@ class EnvironmentTest(unittest.TestCase):
 
     def test_http_management_api_accepts_direct_endpoints(self) -> None:
         validate_connection_mode("http", False)
+
+    def test_server_proxy_with_api_key_warns_about_browser_auth(self) -> None:
+        warning = browser_proxy_auth_warning(True, "secret")
+
+        self.assertIsNotNone(warning)
+        self.assertIn("OPEN-SANDBOX-API-KEY", warning)
+        self.assertIn("HTTP or WebSocket", warning)
+
+    def test_direct_endpoint_does_not_warn_about_proxy_auth(self) -> None:
+        self.assertIsNone(browser_proxy_auth_warning(False, "secret"))
+
+    def test_server_proxy_without_api_key_does_not_warn(self) -> None:
+        self.assertIsNone(browser_proxy_auth_warning(True, None))
 
 
 if __name__ == "__main__":

--- a/examples/desktop/test_novnc_url.py
+++ b/examples/desktop/test_novnc_url.py
@@ -14,7 +14,13 @@
 
 import unittest
 
-from novnc_url import build_novnc_url, resolve_protocol
+from novnc_url import (
+    build_novnc_url,
+    normalize_domain,
+    parse_bool,
+    resolve_novnc_protocol,
+    resolve_protocol,
+)
 
 
 class BuildNoVNCURLTest(unittest.TestCase):
@@ -24,6 +30,18 @@ class BuildNoVNCURLTest(unittest.TestCase):
     def test_domain_url_scheme_overrides_explicit_protocol(self) -> None:
         self.assertEqual(
             resolve_protocol("https://sandbox.example.com", "HTTP"),
+            "https",
+        )
+
+    def test_normalizes_uppercase_domain_scheme_and_whitespace(self) -> None:
+        self.assertEqual(
+            normalize_domain("  HTTPS://sandbox.example.com  "),
+            "https://sandbox.example.com",
+        )
+
+    def test_resolves_uppercase_domain_scheme(self) -> None:
+        self.assertEqual(
+            resolve_protocol("HTTPS://sandbox.example.com", None),
             "https",
         )
 
@@ -54,6 +72,21 @@ class BuildNoVNCURLTest(unittest.TestCase):
     def test_rejects_unknown_protocol(self) -> None:
         with self.assertRaisesRegex(ValueError, "protocol"):
             build_novnc_url("sandbox.example.com/proxy/6080", "ftp")
+
+
+class EnvironmentTest(unittest.TestCase):
+    def test_bool_error_lists_accepted_values(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "1, true, yes, on, 0, false, no, off",
+        ):
+            parse_bool("maybe", "SANDBOX_USE_SERVER_PROXY")
+
+    def test_direct_novnc_stays_http_with_https_management_api(self) -> None:
+        self.assertEqual(resolve_novnc_protocol("https", False), "http")
+
+    def test_server_proxy_novnc_inherits_management_protocol(self) -> None:
+        self.assertEqual(resolve_novnc_protocol("https", True), "https")
 
 
 if __name__ == "__main__":

--- a/examples/desktop/test_novnc_url.py
+++ b/examples/desktop/test_novnc_url.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from novnc_url import build_novnc_url, resolve_protocol
+
+
+class BuildNoVNCURLTest(unittest.TestCase):
+    def test_resolves_protocol_from_domain_url(self) -> None:
+        self.assertEqual(resolve_protocol("https://sandbox.example.com", None), "https")
+
+    def test_domain_url_scheme_overrides_explicit_protocol(self) -> None:
+        self.assertEqual(
+            resolve_protocol("https://sandbox.example.com", "HTTP"),
+            "https",
+        )
+
+    def test_direct_http_endpoint(self) -> None:
+        self.assertEqual(
+            build_novnc_url("192.168.0.104:41618/proxy/6080", "http"),
+            "http://192.168.0.104:41618/proxy/6080/vnc.html"
+            "?host=192.168.0.104&port=41618&path=proxy/6080",
+        )
+
+    def test_https_server_proxy_uses_default_tls_port(self) -> None:
+        self.assertEqual(
+            build_novnc_url("sandbox.example.com/v1/sandboxes/sbx-123/proxy/6080", "https"),
+            "https://sandbox.example.com/v1/sandboxes/sbx-123/proxy/6080/vnc.html"
+            "?host=sandbox.example.com&port=443"
+            "&path=v1/sandboxes/sbx-123/proxy/6080",
+        )
+
+    def test_https_server_proxy_preserves_explicit_port(self) -> None:
+        self.assertIn(
+            "host=sandbox.example.com&port=8443",
+            build_novnc_url(
+                "sandbox.example.com:8443/v1/sandboxes/sbx-123/proxy/6080",
+                "https",
+            ),
+        )
+
+    def test_rejects_unknown_protocol(self) -> None:
+        with self.assertRaisesRegex(ValueError, "protocol"):
+            build_novnc_url("sandbox.example.com/proxy/6080", "ftp")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/desktop/test_novnc_url.py
+++ b/examples/desktop/test_novnc_url.py
@@ -20,6 +20,7 @@ from novnc_url import (
     parse_bool,
     resolve_novnc_protocol,
     resolve_protocol,
+    validate_connection_mode,
 )
 
 
@@ -87,6 +88,19 @@ class EnvironmentTest(unittest.TestCase):
 
     def test_server_proxy_novnc_inherits_management_protocol(self) -> None:
         self.assertEqual(resolve_novnc_protocol("https", True), "https")
+
+    def test_https_management_api_requires_server_proxy(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SANDBOX_USE_SERVER_PROXY must be true",
+        ):
+            validate_connection_mode("https", False)
+
+    def test_https_management_api_accepts_server_proxy(self) -> None:
+        validate_connection_mode("https", True)
+
+    def test_http_management_api_accepts_direct_endpoints(self) -> None:
+        validate_connection_mode("http", False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary  - make the desktop example derive noVNC URLs from the configured HTTP/HTTPS protocol instead of hard-coding `http://` - support HTTPS noVNC page and WebSocket traffic through `use_server_proxy` - document TLS termination and WebSocket upgrade settings for Nginx - add focused URL tests for direct HTTP, HTTPS default/custom ports, and domain scheme handling - avoid presenting the HTTP server-proxy path as a native VNC TCP endpoint  ## Validation  - `python -m unittest discover -s examples/desktop -p 'test_*.py' -v` (17 passed) - `uv run ruff check ../examples/desktop/main.py ../examples/desktop/novnc_url.py ../examples/desktop/test_novnc_url.py` - `uv run ruff format --check ../examples/desktop/main.py ../examples/desktop/novnc_url.py ../examples/desktop/test_novnc_url.py` - `python -m compileall -q examples/desktop` - `cd server && uv run pytest tests/test_routes_endpoint_behavior.py tests/test_routes_proxy.py -q` (25 passed) - `cd docs && corepack pnpm docs:build` - `git diff --check`  Closes #684