### PR TITLE
docs(kubernetes): explain pooled entrypoint injection

### DIFF
--- a/docs/examples/code-interpreter.md
+++ b/docs/examples/code-interpreter.md
@@ -183,14 +183,18 @@ kubectl exec <pool-pod> -n <namespace> -- \
 # Check the executor health endpoint from a second terminal while this runs.
 kubectl port-forward pod/<pool-pod> -n <namespace> 5758:5758
 curl http://127.0.0.1:5758/health
+curl http://127.0.0.1:5758/getTasks
 
-# Check controller-reported task state and the latest task error.
-kubectl get batchsandbox <sandbox-name> -n <namespace> \
-  -o jsonpath='{.status.taskFailed}{"\t"}{.status.taskLastErrorMessage}{"\n"}'
+# The lifecycle server uses <sandbox-name>-0 as the task name. Check the task's
+# captured output (adjust the path if task-executor uses a custom data directory).
+kubectl exec <pool-pod> -n <namespace> -- \
+  sh -c 'tail -n 100 /var/lib/sandbox/tasks/<sandbox-name>-0/stdout.log; tail -n 100 /var/lib/sandbox/tasks/<sandbox-name>-0/stderr.log'
+
+# Check controller logs for delivery failures between the controller and port 5758.
 kubectl logs -n opensandbox-system -l control-plane=controller-manager --tail=100
 ```
 
-If `taskTemplate` exists but the health check cannot reach port `5758`, verify that task-executor is installed and remains running. If the task reaches `Failed`, use `taskLastErrorMessage` and the executor log to distinguish a missing `/opt/opensandbox/bootstrap.sh` from a failure inside the requested entrypoint.
+If `taskTemplate` exists but the health check cannot reach port `5758`, verify that task-executor is installed and remains running. The generated task intentionally starts `bootstrap.sh` in the background, so its wrapper can report success even when `bootstrap.sh` is missing or the requested entrypoint later fails. Do not rely on `taskFailed` or `taskLastErrorMessage` alone for these failures; inspect the task's captured `stderr.log` and `stdout.log`, then verify the execd or application process directly.
 
 Start the k8s OpenSandbox server:
 

--- a/docs/examples/code-interpreter.md
+++ b/docs/examples/code-interpreter.md
@@ -152,6 +152,46 @@ spec:
     poolMin: 0
 ```
 
+#### How Pool entrypoint injection works
+
+The lifecycle API allocates an already-running Pod from the Pool, so it does not replace that Pod's `command`, `args`, or `env`. When a create request supplies an `entrypoint` or environment variables, the server records them in `BatchSandbox.spec.taskTemplate`. The controller then sends the task to the allocated Pod's IP on port `5758`.
+
+The Pool template must provide all parts of that execution path:
+
+- Install and run task-executor, listening on `0.0.0.0:5758`.
+- Install execd and `bootstrap.sh` into the shared volume before the Pod starts.
+- Keep `bootstrap.sh` at `/opt/opensandbox/bootstrap.sh`. The server-generated task invokes that exact path. The execd binary can use another path only when the task-executor environment sets `EXECD` accordingly.
+- Start execd through `bootstrap.sh` after allocation so request-specific values such as `EXECD_ACCESS_TOKEN` are available. The example above leaves task-executor as the warm Pod's foreground process for this reason.
+
+The Pod YAML continuing to show the Pool template is therefore expected. Inspect the `BatchSandbox` resource and task-executor instead:
+
+```shell
+# Confirm that the server injected the requested process and environment.
+kubectl get batchsandbox <sandbox-name> -n <namespace> \
+  -o jsonpath='{.spec.taskTemplate}{"\n"}'
+
+# Find the allocated Pod. The annotation value contains a JSON `pods` array.
+kubectl get batchsandbox <sandbox-name> -n <namespace> \
+  -o jsonpath='{.metadata.annotations.sandbox\.opensandbox\.io/alloc-status}{"\n"}'
+
+# Replace <pool-pod> with the first Pod name from that array.
+kubectl exec <pool-pod> -n <namespace> -- \
+  sh -c 'test -x /opt/opensandbox/task-executor && test -x /opt/opensandbox/bootstrap.sh'
+kubectl exec <pool-pod> -n <namespace> -- \
+  tail -n 100 /tmp/task-executor.log
+
+# Check the executor health endpoint from a second terminal while this runs.
+kubectl port-forward pod/<pool-pod> -n <namespace> 5758:5758
+curl http://127.0.0.1:5758/health
+
+# Check controller-reported task state and the latest task error.
+kubectl get batchsandbox <sandbox-name> -n <namespace> \
+  -o jsonpath='{.status.taskFailed}{"\t"}{.status.taskLastErrorMessage}{"\n"}'
+kubectl logs -n opensandbox-system -l control-plane=controller-manager --tail=100
+```
+
+If `taskTemplate` exists but the health check cannot reach port `5758`, verify that task-executor is installed and remains running. If the task reaches `Failed`, use `taskLastErrorMessage` and the executor log to distinguish a missing `/opt/opensandbox/bootstrap.sh` from a failure inside the requested entrypoint.
+
 Start the k8s OpenSandbox server:
 
 ```shell

--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -400,6 +400,12 @@ spec:
 Pool pods are created before allocation. The lifecycle API therefore rejects `networkPolicy` together with `extensions.poolRef`; it cannot inject an egress sidecar into an existing pool pod. Configure required network controls in the Pool pod template before pods are created, or use a non-pooled sandbox for per-request policies.
 :::
 
+::: tip Entrypoint and environment injection
+Pool pods are also created before a lifecycle request supplies its `entrypoint` or environment variables. The server does not rewrite the allocated Pod's `command`, `args`, or `env`; seeing the original Pool template in the Pod YAML is expected. Instead, it writes the request-specific process to `BatchSandbox.spec.taskTemplate`, and the controller sends that task to an in-pod task-executor on port `5758`.
+
+A Pool used through the lifecycle API with a custom entrypoint or environment must therefore run task-executor and provide an executable `/opt/opensandbox/bootstrap.sh`. See the [Code Interpreter Pool example](/examples/code-interpreter#how-pool-entrypoint-injection-works) for a complete template and troubleshooting commands.
+:::
+
 #### Pooled Sandbox with Heterogeneous Tasks
 Create a batch of sandboxes with process-based heterogeneous tasks. For task execution to work properly, the task-executor must be deployed as a sidecar container in the pool template and share the process namespace with the sandbox container:
 


### PR DESCRIPTION
## Summary

- explain why an allocated warm Pool Pod retains its original command, args, and environment
- document the taskTemplate -> controller -> task-executor execution path
- list the required port and bootstrap path plus concrete troubleshooting commands

## Verification

- `corepack pnpm docs:build`
- `uv run pytest tests/k8s/test_batchsandbox_provider.py -k "poolref_allows_entrypoint_and_env or build_task_template" -q`
- `git diff --check`

Closes #970
