### PR TITLE
feat(lifecycle): expose confirmed pool allocation

### DIFF
--- a/kubernetes/internal/controller/allocator.go
+++ b/kubernetes/internal/controller/allocator.go
@@ -651,7 +651,11 @@ func (allocator *defaultAllocator) SyncSandboxAllocation(ctx context.Context, sa
 	allocator.store.UpdateAllocation(ctx, sandbox.Namespace, poolRef, sandbox.Name, pods)
 
 	// Phase 2: persist to sandbox annotation.
-	allocation := &SandboxAllocation{Pods: pods}
+	allocation := &SandboxAllocation{
+		Pods:       pods,
+		PoolRef:    sandbox.Spec.PoolRef,
+		Generation: sandbox.Generation,
+	}
 	if err := allocator.syncer.SetAllocation(ctx, sandbox, allocation); err != nil {
 		// Rollback in-memory store to the previous state.
 		log.Error(err, "Rollback sandbox allocation", "sandbox", sandbox.Name, "pods", oldState.Pods)

--- a/kubernetes/internal/controller/allocator_test.go
+++ b/kubernetes/internal/controller/allocator_test.go
@@ -350,14 +350,25 @@ func newTestSyncer(sandbox *sandboxv1alpha1.BatchSandbox) (*annoAllocationSyncer
 
 func TestSetAllocation_AddsFinalizer(t *testing.T) {
 	sandbox := &sandboxv1alpha1.BatchSandbox{
-		ObjectMeta: metav1.ObjectMeta{Name: "sbx1", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx1", Namespace: "default", Generation: 7},
 		Spec:       sandboxv1alpha1.BatchSandboxSpec{PoolRef: "pool1"},
 	}
 	syncer, sbx := newTestSyncer(sandbox)
 
-	err := syncer.SetAllocation(context.Background(), sbx, &SandboxAllocation{Pods: []string{"pod1"}})
+	err := syncer.SetAllocation(context.Background(), sbx, &SandboxAllocation{
+		Pods:       []string{"pod1"},
+		PoolRef:    "pool1",
+		Generation: 7,
+	})
 	assert.NoError(t, err)
 	assert.Contains(t, sbx.Finalizers, FinalizerPoolAllocation)
+
+	var persisted SandboxAllocation
+	err = json.Unmarshal([]byte(sbx.Annotations[AnnoAllocStatusKey]), &persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"pod1"}, persisted.Pods)
+	assert.Equal(t, "pool1", persisted.PoolRef)
+	assert.EqualValues(t, 7, persisted.Generation)
 }
 
 func TestSetReleased_FinalizerBehavior(t *testing.T) {
@@ -444,7 +455,7 @@ func TestSyncSandboxAllocation_Success(t *testing.T) {
 
 	allocator, store, syncer := newTestAllocator(ctrl)
 	sandbox := &sandboxv1alpha1.BatchSandbox{
-		ObjectMeta: metav1.ObjectMeta{Name: "sbx1", Namespace: "ns1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx1", Namespace: "ns1", Generation: 11},
 		Spec:       sandboxv1alpha1.BatchSandboxSpec{PoolRef: "pool1"},
 	}
 	newPods := []string{"pod1", "pod2"}
@@ -456,6 +467,8 @@ func TestSyncSandboxAllocation_Success(t *testing.T) {
 	syncer.EXPECT().SetAllocation(gomock.Any(), sandbox, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, sbx *sandboxv1alpha1.BatchSandbox, alloc *SandboxAllocation) error {
 			assert.Equal(t, newPods, alloc.Pods)
+			assert.Equal(t, sandbox.Spec.PoolRef, alloc.PoolRef)
+			assert.Equal(t, sandbox.Generation, alloc.Generation)
 			return nil
 		}).Times(1)
 

--- a/kubernetes/internal/controller/apis.go
+++ b/kubernetes/internal/controller/apis.go
@@ -39,7 +39,9 @@ const (
 var AnnotationSandboxEndpoints = pkgutils.AnnotationEndpoints
 
 type SandboxAllocation struct {
-	Pods []string `json:"pods"`
+	Pods       []string `json:"pods"`
+	PoolRef    string   `json:"poolRef"`
+	Generation int64    `json:"generation"`
 }
 
 type AllocationRelease struct {

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/__init__.py
@@ -16,6 +16,9 @@
 
 """Contains all the data models used in inputs/outputs"""
 
+from .allocation_summary import AllocationSummary
+from .allocation_summary_mode import AllocationSummaryMode
+from .allocation_summary_state import AllocationSummaryState
 from .create_sandbox_request import CreateSandboxRequest
 from .create_sandbox_request_env import CreateSandboxRequestEnv
 from .create_sandbox_request_extensions import CreateSandboxRequestExtensions
@@ -59,6 +62,9 @@ from .snapshot_status import SnapshotStatus
 from .volume import Volume
 
 __all__ = (
+    "AllocationSummary",
+    "AllocationSummaryMode",
+    "AllocationSummaryState",
     "CreateSandboxRequest",
     "CreateSandboxRequestEnv",
     "CreateSandboxRequestExtensions",

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary.py
@@ -1,0 +1,82 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..models.allocation_summary_mode import AllocationSummaryMode
+from ..models.allocation_summary_state import AllocationSummaryState
+
+T = TypeVar("T", bound="AllocationSummary")
+
+
+@_attrs_define
+class AllocationSummary:
+    """Current runtime-confirmed Pool allocation summary for a sandbox. This field is
+    not a request echo, allocation history, lifecycle readiness signal, or generic
+    Kubernetes introspection. It is omitted unless the current Kubernetes workload
+    has a confirmed concrete Pool allocation.
+
+        Attributes:
+            mode (AllocationSummaryMode): Allocation mode. This initial contract supports only Pool allocation.
+            pool_ref (str): Effective concrete Pool reference confirmed by the current runtime allocation.
+            state (AllocationSummaryState): Current confirmed allocation state. This initial contract always returns
+                allocated.
+    """
+
+    mode: AllocationSummaryMode
+    pool_ref: str
+    state: AllocationSummaryState
+
+    def to_dict(self) -> dict[str, Any]:
+        mode = self.mode.value
+
+        pool_ref = self.pool_ref
+
+        state = self.state.value
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "mode": mode,
+                "poolRef": pool_ref,
+                "state": state,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        mode = AllocationSummaryMode(d.pop("mode"))
+
+        pool_ref = d.pop("poolRef")
+
+        state = AllocationSummaryState(d.pop("state"))
+
+        allocation_summary = cls(
+            mode=mode,
+            pool_ref=pool_ref,
+            state=state,
+        )
+
+        return allocation_summary

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary_mode.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary_mode.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class AllocationSummaryMode(str, Enum):
+    POOL = "pool"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary_state.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/allocation_summary_state.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from enum import Enum
+
+
+class AllocationSummaryState(str, Enum):
+    ALLOCATED = "allocated"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/sandbox.py
@@ -27,6 +27,7 @@ from dateutil.parser import isoparse
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.allocation_summary import AllocationSummary
     from ..models.image_spec import ImageSpec
     from ..models.platform_spec import PlatformSpec
     from ..models.sandbox_extensions import SandboxExtensions
@@ -67,6 +68,11 @@ class Sandbox:
               is injected unless provided by request or workload template.
             - If provided and cannot be satisfied by runtime/template/pool constraints,
               request must fail explicitly.
+        allocation (AllocationSummary | Unset): Current runtime-confirmed Pool allocation summary for a sandbox. This
+            field is
+            not a request echo, allocation history, lifecycle readiness signal, or generic
+            Kubernetes introspection. It is omitted unless the current Kubernetes workload
+            has a confirmed concrete Pool allocation.
         metadata (SandboxMetadata | Unset): Custom metadata from creation request
         extensions (SandboxExtensions | Unset): Opaque extension data restored from provider-specific storage
         expires_at (datetime.datetime | Unset): Timestamp when sandbox will auto-terminate. Omitted when manual cleanup
@@ -80,6 +86,7 @@ class Sandbox:
     image: ImageSpec | Unset = UNSET
     snapshot_id: str | Unset = UNSET
     platform: PlatformSpec | Unset = UNSET
+    allocation: AllocationSummary | Unset = UNSET
     metadata: SandboxMetadata | Unset = UNSET
     extensions: SandboxExtensions | Unset = UNSET
     expires_at: datetime.datetime | Unset = UNSET
@@ -103,6 +110,10 @@ class Sandbox:
         platform: dict[str, Any] | Unset = UNSET
         if not isinstance(self.platform, Unset):
             platform = self.platform.to_dict()
+
+        allocation: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.allocation, Unset):
+            allocation = self.allocation.to_dict()
 
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
@@ -132,6 +143,8 @@ class Sandbox:
             field_dict["snapshotId"] = snapshot_id
         if platform is not UNSET:
             field_dict["platform"] = platform
+        if allocation is not UNSET:
+            field_dict["allocation"] = allocation
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
         if extensions is not UNSET:
@@ -143,6 +156,7 @@ class Sandbox:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.allocation_summary import AllocationSummary
         from ..models.image_spec import ImageSpec
         from ..models.platform_spec import PlatformSpec
         from ..models.sandbox_extensions import SandboxExtensions
@@ -174,6 +188,13 @@ class Sandbox:
         else:
             platform = PlatformSpec.from_dict(_platform)
 
+        _allocation = d.pop("allocation", UNSET)
+        allocation: AllocationSummary | Unset
+        if isinstance(_allocation, Unset):
+            allocation = UNSET
+        else:
+            allocation = AllocationSummary.from_dict(_allocation)
+
         _metadata = d.pop("metadata", UNSET)
         metadata: SandboxMetadata | Unset
         if isinstance(_metadata, Unset):
@@ -203,6 +224,7 @@ class Sandbox:
             image=image,
             snapshot_id=snapshot_id,
             platform=platform,
+            allocation=allocation,
             metadata=metadata,
             extensions=extensions,
             expires_at=expires_at,

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -388,6 +388,27 @@ class SandboxStatus(BaseModel):
 # Sandbox Models
 # ============================================================================
 
+class AllocationSummary(BaseModel):
+    """Current runtime-confirmed allocation summary for a pooled sandbox."""
+
+    mode: Literal["pool"] = Field(
+        ...,
+        description="Allocation mode. This initial contract supports only pool allocation.",
+    )
+    pool_ref: str = Field(
+        ...,
+        alias="poolRef",
+        description="Effective concrete Pool reference confirmed by the current runtime allocation.",
+    )
+    state: Literal["allocated"] = Field(
+        ...,
+        description="Current confirmed allocation state. This initial contract always returns allocated.",
+    )
+
+    class Config:
+        populate_by_name = True
+
+
 class CreateSandboxRequest(BaseModel):
     """
     Request to create a new sandbox from either a container image or a snapshot.
@@ -584,6 +605,15 @@ class Sandbox(BaseModel):
         description=(
             "Platform constraint echoed from request or workload template. "
             "Null when no scheduling constraint is provided."
+        ),
+    )
+    allocation: Optional[AllocationSummary] = Field(
+        None,
+        description=(
+            "Current runtime-confirmed Pool allocation summary. Omitted unless the "
+            "Kubernetes workload has a confirmed concrete Pool allocation; this is "
+            "not a request echo, allocation history, lifecycle readiness, or generic "
+            "Kubernetes introspection."
         ),
     )
     status: SandboxStatus = Field(..., description="Current lifecycle status and detailed state information")

--- a/server/opensandbox_server/services/k8s/workload_mapper.py
+++ b/server/opensandbox_server/services/k8s/workload_mapper.py
@@ -14,15 +14,105 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Optional
 
-from opensandbox_server.api.schema import ImageSpec, PlatformSpec, Sandbox, SandboxStatus
+from opensandbox_server.api.schema import (
+    AllocationSummary,
+    ImageSpec,
+    PlatformSpec,
+    Sandbox,
+    SandboxStatus,
+)
 from opensandbox_server.extensions import extract_extensions_from_mapping
 from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SANDBOX_SNAPSHOT_ID_LABEL
 
 
+_ALLOCATION_STATUS_ANNOTATION = "sandbox.opensandbox.io/alloc-status"
+_POOL_ALLOCATION_FINALIZER = "pool.sandbox.opensandbox.io/pool-allocation"
+
+
 def _is_opensandbox_label(label_key: str) -> bool:
     return label_key.split("/", 1)[0] == "opensandbox.io"
+
+
+def _get_workload_value(value: Any, mapping_key: str, attribute_name: Optional[str] = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(mapping_key)
+    return getattr(value, attribute_name or mapping_key, None)
+
+
+def _extract_confirmed_pool_allocation(workload: Any) -> Optional[AllocationSummary]:
+    """Return a public allocation only when controller state confirms it is current."""
+    metadata = _get_workload_value(workload, "metadata")
+    spec = _get_workload_value(workload, "spec")
+    status = _get_workload_value(workload, "status")
+
+    pool_ref = _get_workload_value(spec, "poolRef", "pool_ref")
+    if (
+        not isinstance(pool_ref, str)
+        or not pool_ref.strip()
+        or pool_ref == "*"
+    ):
+        return None
+
+    if _get_workload_value(metadata, "deletionTimestamp", "deletion_timestamp") is not None:
+        return None
+
+    finalizers = _get_workload_value(metadata, "finalizers")
+    if not isinstance(finalizers, list) or _POOL_ALLOCATION_FINALIZER not in finalizers:
+        return None
+
+    annotations = _get_workload_value(metadata, "annotations")
+    if not isinstance(annotations, dict):
+        return None
+    allocation_raw = annotations.get(_ALLOCATION_STATUS_ANNOTATION)
+    if not isinstance(allocation_raw, str):
+        return None
+    try:
+        allocation_status = json.loads(allocation_raw)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(allocation_status, dict):
+        return None
+
+    allocation_pool_ref = allocation_status.get("poolRef")
+    allocation_generation = allocation_status.get("generation")
+    generation = _get_workload_value(metadata, "generation")
+    if (
+        not isinstance(allocation_pool_ref, str)
+        or allocation_pool_ref != pool_ref
+        or isinstance(allocation_generation, bool)
+        or not isinstance(allocation_generation, int)
+        or isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or allocation_generation != generation
+    ):
+        return None
+
+    pods = allocation_status.get("pods")
+    if (
+        not isinstance(pods, list)
+        or not pods
+        or any(not isinstance(pod, str) or not pod.strip() for pod in pods)
+        or len(set(pods)) != len(pods)
+    ):
+        return None
+
+    allocated = _get_workload_value(status, "allocated")
+    observed_generation = _get_workload_value(status, "observedGeneration", "observed_generation")
+    if (
+        isinstance(allocated, bool)
+        or not isinstance(allocated, int)
+        or allocated != len(pods)
+        or isinstance(observed_generation, bool)
+        or not isinstance(observed_generation, int)
+        or observed_generation != generation
+    ):
+        return None
+
+    return AllocationSummary(mode="pool", poolRef=pool_ref, state="allocated")
 
 
 def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandbox:
@@ -83,6 +173,7 @@ def _build_sandbox_from_workload(workload: Any, workload_provider: Any) -> Sandb
         snapshotId=snapshot_id,
         entrypoint=entrypoint,
         platform=platform_spec,
+        allocation=_extract_confirmed_pool_allocation(workload),
     )
 
 

--- a/server/tests/k8s/test_workload_mapper.py
+++ b/server/tests/k8s/test_workload_mapper.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
+import pytest
+
 from opensandbox_server.services.k8s.workload_mapper import (
     _build_sandbox_from_workload,
     _extract_platform_from_workload,
 )
-
 
 class _WorkloadProvider:
     @staticmethod
@@ -34,6 +37,27 @@ class _WorkloadProvider:
 
 
 class TestBuildSandboxFromWorkload:
+    @staticmethod
+    def _pool_workload(**overrides):
+        workload = {
+            "metadata": {
+                "labels": {"opensandbox.io/id": "sandbox-1"},
+                "annotations": {
+                    "sandbox.opensandbox.io/alloc-status": (
+                        '{"pods":["pool-pod-1"],"poolRef":"pool-runc","generation":3}'
+                    ),
+                },
+                "finalizers": ["pool.sandbox.opensandbox.io/pool-allocation"],
+                "generation": 3,
+                "creationTimestamp": "2026-06-22T00:00:00Z",
+            },
+            "spec": {"poolRef": "pool-runc"},
+            "status": {"allocated": 1, "observedGeneration": 3},
+        }
+        for section, values in overrides.items():
+            workload[section].update(values)
+        return workload
+
     def test_restores_extensions_from_annotations(self):
         workload = {
             "metadata": {
@@ -50,6 +74,68 @@ class TestBuildSandboxFromWorkload:
         sandbox = _build_sandbox_from_workload(workload, _WorkloadProvider())
 
         assert sandbox.extensions == {"opensandbox.extensions.custom-label": "中文数据"}
+
+    def test_returns_confirmed_pool_allocation(self):
+        sandbox = _build_sandbox_from_workload(self._pool_workload(), _WorkloadProvider())
+
+        assert sandbox.allocation is not None
+        assert sandbox.allocation.mode == "pool"
+        assert sandbox.allocation.pool_ref == "pool-runc"
+        assert sandbox.allocation.state == "allocated"
+
+    def test_returns_confirmed_pool_allocation_for_object_workload(self):
+        workload = self._pool_workload()
+        object_workload = SimpleNamespace(
+            metadata=SimpleNamespace(
+                labels=workload["metadata"]["labels"],
+                annotations=workload["metadata"]["annotations"],
+                finalizers=workload["metadata"]["finalizers"],
+                generation=workload["metadata"]["generation"],
+                creation_timestamp=workload["metadata"]["creationTimestamp"],
+            ),
+            spec=SimpleNamespace(pool_ref=workload["spec"]["poolRef"]),
+            status=SimpleNamespace(
+                allocated=workload["status"]["allocated"],
+                observed_generation=workload["status"]["observedGeneration"],
+            ),
+        )
+
+        sandbox = _build_sandbox_from_workload(object_workload, _WorkloadProvider())
+
+        assert sandbox.allocation is not None
+        assert sandbox.allocation.pool_ref == "pool-runc"
+
+    @pytest.mark.parametrize(
+        ("overrides", "description"),
+        [
+            ({"spec": {"poolRef": "   "}}, "blank pool reference"),
+            ({"spec": {"poolRef": "*"}}, "auto-assigned pool reference"),
+            ({"metadata": {"deletionTimestamp": "2026-06-23T00:00:00Z"}}, "deleting workload"),
+            ({"metadata": {"finalizers": []}}, "missing allocation finalizer"),
+            ({"metadata": {"annotations": {}}}, "missing allocation annotation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": "not-json"}}}, "invalid allocation annotation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1"]}'}}}, "legacy pods-only allocation annotation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1"],"poolRef":"pool-runc"}'}}}, "missing allocation generation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1"],"generation":3}'}}}, "missing allocation pool reference"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1"],"poolRef":"other-pool","generation":3}'}}}, "wrong allocation pool reference"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1"],"poolRef":"pool-runc","generation":2}'}}}, "wrong allocation generation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":[],"poolRef":"pool-runc","generation":3}'}}}, "empty allocation annotation"),
+            ({"metadata": {"annotations": {"sandbox.opensandbox.io/alloc-status": '{"pods":["pool-pod-1","pool-pod-1"],"poolRef":"pool-runc","generation":3}'}}}, "duplicate allocated pods"),
+            ({"status": {"allocated": 2}}, "allocated pod count mismatch"),
+            ({"status": {"observedGeneration": 2}}, "unobserved generation"),
+        ],
+    )
+    def test_omits_unconfirmed_pool_allocation(self, overrides, description):
+        sandbox = _build_sandbox_from_workload(self._pool_workload(**overrides), _WorkloadProvider())
+
+        assert sandbox.allocation is None, description
+
+    def test_omits_allocation_for_nonpool_workload(self):
+        workload = self._pool_workload(spec={"poolRef": None})
+
+        sandbox = _build_sandbox_from_workload(workload, _WorkloadProvider())
+
+        assert sandbox.allocation is None
 
 
 class TestExtractPlatformFromWorkload:

--- a/server/tests/test_routes_get_sandbox.py
+++ b/server/tests/test_routes_get_sandbox.py
@@ -18,7 +18,7 @@ from fastapi.exceptions import HTTPException
 from fastapi.testclient import TestClient
 
 from opensandbox_server.api import lifecycle
-from opensandbox_server.api.schema import ImageSpec, Sandbox, SandboxStatus
+from opensandbox_server.api.schema import AllocationSummary, ImageSpec, Sandbox, SandboxStatus
 
 
 def test_get_sandbox_returns_service_payload(
@@ -80,6 +80,37 @@ def test_get_sandbox_propagates_not_found(
     }
 
 
+def test_get_sandbox_serializes_pool_allocation(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    class StubService:
+        @staticmethod
+        def get_sandbox(sandbox_id: str) -> Sandbox:
+            return Sandbox(
+                id=sandbox_id,
+                image=ImageSpec(uri="python:3.11"),
+                status=SandboxStatus(state="Running"),
+                allocation=AllocationSummary(mode="pool", poolRef="pool-runc", state="allocated"),
+                entrypoint=["python", "-V"],
+                createdAt=now,
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get("/v1/sandboxes/sbx-pool", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["allocation"] == {
+        "mode": "pool",
+        "poolRef": "pool-runc",
+        "state": "allocated",
+    }
+
+
 def test_get_sandbox_omits_none_fields(
     client: TestClient,
     auth_headers: dict,
@@ -108,6 +139,7 @@ def test_get_sandbox_omits_none_fields(
     payload = response.json()
     assert "expiresAt" not in payload
     assert "metadata" not in payload
+    assert "allocation" not in payload
     assert "reason" not in payload["status"]
     assert "message" not in payload["status"]
     assert "lastTransitionAt" not in payload["status"]

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1035,6 +1035,28 @@ components:
       required: [state]
       additionalProperties: false
 
+    AllocationSummary:
+      type: object
+      description: |
+        Current runtime-confirmed Pool allocation summary for a sandbox. This field is
+        not a request echo, allocation history, lifecycle readiness signal, or generic
+        Kubernetes introspection. It is omitted unless the current Kubernetes workload
+        has a confirmed concrete Pool allocation.
+      properties:
+        mode:
+          type: string
+          enum: [pool]
+          description: Allocation mode. This initial contract supports only Pool allocation.
+        poolRef:
+          type: string
+          description: Effective concrete Pool reference confirmed by the current runtime allocation.
+        state:
+          type: string
+          enum: [allocated]
+          description: Current confirmed allocation state. This initial contract always returns allocated.
+      required: [mode, poolRef, state]
+      additionalProperties: false
+
     Sandbox:
       type: object
       description: Runtime execution environment provisioned from a container image or restored from a snapshot
@@ -1062,6 +1084,14 @@ components:
           description: |
             Platform constraint echoed from request or workload template.
             Null when no scheduling constraint is provided.
+
+        allocation:
+          $ref: '#/components/schemas/AllocationSummary'
+          description: |
+            Current runtime-confirmed Pool allocation summary. Omitted unless the
+            Kubernetes workload has a confirmed concrete Pool allocation; it is not a
+            request echo, allocation history, lifecycle readiness signal, or generic
+            Kubernetes introspection.
 
         status:
           $ref: '#/components/schemas/SandboxStatus'


### PR DESCRIPTION
## Summary

Adds an optional lifecycle `Sandbox.allocation` summary for a current, runtime-confirmed Kubernetes Pool allocation.

```json
{
  "allocation": {
    "mode": "pool",
    "poolRef": "example-pool",
    "state": "allocated"
  }
}
```

The field is omitted for direct or unsupported workloads and for every unconfirmed case. It is neither a request echo nor generic Kubernetes introspection.

## Evidence boundary

The controller persists the current `poolRef` and CR `generation` with allocated Pod names in its existing internal allocation annotation. The lifecycle mapper emits the public summary only when all of these match current controller state: concrete non-wildcard Pool ref, non-deleting workload, allocation finalizer, valid non-empty unique Pod list, matching allocation count, and matching allocation/status/current generations. Legacy pods-only annotations fail closed. No Pod names, namespace, node/IP/UID, raw annotations, finalizers, history, or generation are exposed publicly.

## Compatibility and scope

- Additive optional response field only; no Create response, endpoint, CRD, or controller scheduling behavior change.
- Updates lifecycle OpenAPI source, Server model/mapper/tests, controller internal evidence binding/tests, and generated Python lifecycle SDK models.
- Closes #1479.

## Verification

Passed after rebasing the change onto current upstream `main` (`fad3920b`):

- `go test ./internal/controller -run "Test(Schedule|SetAllocation|SyncSandboxAllocation)" -count=1`
- `uv run --no-sync pytest tests/k8s/test_workload_mapper.py tests/test_routes_get_sandbox.py` — 30 passed
- `uv run --no-sync ruff check opensandbox_server/api/schema.py opensandbox_server/services/k8s/workload_mapper.py tests/k8s/test_workload_mapper.py tests/test_routes_get_sandbox.py`
- `git diff --check`

The generated Python lifecycle SDK output was produced and previously passed focused model/adapter tests before the host restart. Those focused SDK tests could not be rerun afterward because the restarted local SDK environment uses system Python without the project dependencies. JavaScript/Kotlin SDK generators were not run because their local generator dependencies are unavailable; generated files were not hand-edited.