### PR TITLE
docs(server): clarify sandbox failure recovery

### DIFF
--- a/docs/components/server.md
+++ b/docs/components/server.md
@@ -219,6 +219,39 @@ For Kubernetes-backed sandboxes, pause/resume is implemented via `BatchSandbox.s
      +------------+   +--------+
 ```
 
+### Failure recovery and `resume`
+
+`resume` is a pause-state operation, not a general restart operation. The API
+accepts it only for a sandbox in `Paused` and returns `409 Conflict` for a
+container or workload that has already exited into `Terminated` or `Failed`.
+It does not restart an externally stopped Docker container.
+
+Runtime restart behavior is configured below the Lifecycle API:
+
+- **Docker**: OpenSandbox does not set a Docker restart policy on sandbox
+  containers. If the entrypoint exits or an operator stops the container, the
+  sandbox becomes `Terminated` for exit code 0 or `Failed` for a non-zero exit.
+- **Kubernetes BatchSandbox**: container restart behavior follows the effective
+  Pod template's `restartPolicy`. The example Linux template uses `Never`, but
+  operators can supply a different template when its lifecycle and state-loss
+  tradeoffs are acceptable. OpenSandbox reports the resulting workload state;
+  it does not turn `resume` into a restart of a failed Pod.
+
+To continue after a terminal failure, create a replacement sandbox and update
+the caller to use its new sandbox ID. Ordinary recreation starts from the
+configured image and persistent volume contents; it does not recover process
+memory or unpersisted container filesystem changes. For an intentional
+state-preserving suspension, call `pause` while the sandbox is healthy and then
+`resume`. Kubernetes pause/resume keeps the same sandbox ID and restores the
+captured root filesystem, but not running processes or memory; see
+[Pause and Resume](/guides/pause-resume).
+
+TTL is an absolute expiration time. Runtime or server restarts do not reset it:
+the Docker server restores timers for managed containers after a server
+restart, and Kubernetes keeps `spec.expireTime` on the workload. A newly
+created replacement receives its own ID and expiration time from its new create
+request.
+
 ## Experimental Features
 
 Optional experimental behavior; off by default. See release notes before production.


### PR DESCRIPTION
## Summary

- clarify that `resume` only accepts a deliberately paused sandbox and is not a restart API for `Terminated` or `Failed` workloads
- document Docker and Kubernetes restart-policy boundaries without changing lifecycle behavior
- explain replacement sandbox IDs, persisted versus lost state, and absolute TTL behavior across restarts

## Testing

- `cd docs && corepack pnpm docs:build`
- `git diff --check`

Refs #1127.
Refs #1328.