### PR TITLE
docs(egress): document vault state across resume

### DIFF
--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -61,6 +61,26 @@ The active vault used by the MITM process is served over a local Unix domain
 socket inside the sidecar. The sandbox workload cannot fetch this active state
 over the normal server proxy path.
 
+## Persistence Across Pause and Resume
+
+::: warning In-memory state
+Credential Vault entries are process-local memory in the egress sidecar; they
+are not part of the sandbox root filesystem or the `BatchSandbox` Pod template.
+Kubernetes pause deletes the Pod after snapshotting, so the fresh egress
+sidecar created by resume starts with an empty vault. Credential injection does
+not resume until a trusted client creates the credentials and bindings again.
+
+Keep the original vault request or an equivalent secret-manager reference in a
+trusted control plane outside the sandbox. After the sandbox returns to
+`Running`, call the Credential Vault create API again before allowing work that
+depends on those credentials. Do not persist real credential values in sandbox
+metadata, environment variables, snapshots, or logs.
+
+Docker pause/unpause retains the existing container processes, but any egress
+sidecar replacement or restart also creates a new in-memory vault and requires
+the same re-injection procedure.
+:::
+
 ## Service Mesh Compatibility
 
 Credential Vault depends on the egress sidecar's transparent redirect and MITM path. If the sandbox pod is also injected with a transparent service-mesh sidecar such as Istio/Envoy, both layers will try to intercept outbound traffic in the same network namespace. OpenSandbox does not currently support that combination for Credential Vault.

--- a/docs/guides/pause-resume.md
+++ b/docs/guides/pause-resume.md
@@ -75,8 +75,12 @@ The Lifecycle API exposes only the coarse-grained sandbox states above. For deta
 | Environment variables | ✅ Yes — from BatchSandbox template |
 | Running processes / memory | ❌ No — process state is not checkpointed |
 | Explicit volume mounts | Depends on volume type |
+| Credential Vault entries | No - stored only in egress sidecar memory; re-inject from a trusted control plane after resume |
 
 Pause/resume is currently single-replica only. The internal pause snapshot records one source Pod's container images and does not store per-replica state, so the Kubernetes controller rejects pause requests unless `BatchSandbox.spec.replicas=1`.
+
+See [Credential Vault](/guides/credential-vault#persistence-across-pause-and-resume)
+for the required post-resume credential re-injection procedure.
 
 ---
 


### PR DESCRIPTION
## Summary

- document that Credential Vault entries are egress-sidecar process memory and are not included in Kubernetes pause snapshots
- explain that the resumed sidecar starts with an empty vault and credential-dependent work must wait for trusted re-injection
- provide safe handling guidance that keeps secret values outside sandbox metadata, environment variables, snapshots, and logs
- link the limitation from the pause/resume preservation matrix

## Testing

- `cd docs && corepack pnpm docs:build`
- `git diff --check`

Refs #1366.