### PR TITLE
Limit vault path checks to matching bindings

### DIFF
--- a/components/egress/mitmscripts/system.py
+++ b/components/egress/mitmscripts/system.py
@@ -642,12 +642,18 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     if vault is None:
         return
 
-    # Reject ambiguous paths before injecting credentials: dot-segments or
-    # encoded separators on the wire are not produced by legit clients and
-    # could redirect credentials to a scope the canonical path does not match.
-    # A single-layer ``%2f`` is tolerated here (npm scoped packages send
-    # ``/@scope%2fname``); the next check rejects it if it crosses a binding
-    # boundary.
+    # Requests outside credential binding scope are ordinary egress traffic.
+    # Leave them untouched, including paths whose encoding would be ambiguous
+    # for credential injection, because no secret is at risk.
+    binding = _select_binding(flow, vault)
+    if not binding:
+        return
+
+    # Reject ambiguous paths only for requests that would receive credentials:
+    # dot-segments or encoded separators could redirect credentials to a scope
+    # the canonical path does not match. A single-layer ``%2f`` is tolerated
+    # here (npm scoped packages send ``/@scope%2fname``); the next check rejects
+    # it if it crosses a binding boundary.
     raw_path = flow.request.path or "/"
     if _path_is_ambiguous(raw_path, allow_single_encoded_slash=True):
         _reject_request(flow, b"request path contains ambiguous segments\n")
@@ -669,9 +675,6 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         )
         return
 
-    binding = _select_binding(flow, vault)
-    if not binding:
-        return
     flow.metadata[FLOW_BINDING_KEY] = binding
     # Persist the redactions of the matched revision: body substitutions run
     # later in the request hook, and reloading the vault there could return a

--- a/components/egress/tests/test_mitmproxy_runtime.py
+++ b/components/egress/tests/test_mitmproxy_runtime.py
@@ -55,7 +55,7 @@ VAULT_PAYLOAD = json.dumps(
                     "schemes": ["http"],
                     "hosts": ["code.example.com"],
                     "methods": ["POST"],
-                    "paths": ["/v1/chat/completions"],
+                    "paths": ["/v1/chat/*"],
                 },
                 "headers": [{"name": "x-api-key", "value": "secret-api-key"}],
             }

--- a/components/egress/tests/test_mitmscripts_system.py
+++ b/components/egress/tests/test_mitmscripts_system.py
@@ -611,7 +611,7 @@ class SystemAddonPathTraversalTest(unittest.TestCase):
         """%2f encoded path separator must be rejected."""
         system = self._make_system_with_vault()
         flow = _Flow()
-        flow.request.path = "/api/v8/projects/123%2f..%2f456/variables"
+        flow.request.path = "/api/v8/projects/123/%2f..%2f456/variables"
 
         system.requestheaders(flow)
 
@@ -650,6 +650,35 @@ class SystemAddonPathTraversalTest(unittest.TestCase):
 
         self.assertNotIn("Private-Token", flow.request.headers._values)
 
+    def test_double_encoded_path_outside_binding_scope_is_allowed(self) -> None:
+        """Ambiguous paths pass through when no credential binding matches."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.pretty_host = "packages.example.com"
+        flow.request.host = "packages.example.com"
+        flow.request.path = (
+            "/1/pypi/simple/pyyaml/"
+            "%252Fcentral-pypi-proxy%252Fpackages%252F8b%252F9d/wheel.whl"
+        )
+
+        system.requestheaders(flow)
+
+        self.assertFalse(flow.killed)
+        self.assertNotEqual(403, getattr(flow.response, "status_code", None))
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
+    def test_ambiguous_path_on_bound_host_outside_path_scope_is_allowed(self) -> None:
+        """A host match alone does not put a request in credential scope."""
+        system = self._make_system_with_vault()
+        flow = _Flow()
+        flow.request.path = "/downloads/%252Fartifacts%252Fwheel.whl"
+
+        system.requestheaders(flow)
+
+        self.assertFalse(flow.killed)
+        self.assertNotEqual(403, getattr(flow.response, "status_code", None))
+        self.assertNotIn("Private-Token", flow.request.headers._values)
+
     def test_dot_dot_substring_not_rejected(self) -> None:
         """'..' not as a complete segment (e.g. '/.../') must NOT be blocked."""
         system = self._make_system_with_vault()
@@ -682,7 +711,7 @@ class SystemAddonPathTraversalTest(unittest.TestCase):
         """Raw backslash in path must be rejected."""
         system = self._make_system_with_vault()
         flow = _Flow()
-        flow.request.path = "/api/v8/projects/123\\..\\456/variables"
+        flow.request.path = "/api/v8/projects/123/\\..\\456/variables"
 
         system.requestheaders(flow)
 
@@ -887,7 +916,7 @@ class SystemAddonStreamingTest(unittest.TestCase):
                     "match": {
                         "hosts": ["code.example.com"],
                         "methods": ["POST"],
-                        "paths": ["/v1/chat/completions"],
+                        "paths": ["/v1/chat/*"],
                     },
                     "headers": [{"name": "x-api-key", "value": "secret-api-key"}],
                     "substitutions": [

--- a/docs/guides/credential-vault.md
+++ b/docs/guides/credential-vault.md
@@ -57,6 +57,10 @@ At a high level:
    substitutions.
 6. Secret values are redacted from vault responses and response headers.
 
+Requests that do not match any credential binding are forwarded unchanged.
+Credential path-safety checks apply only after a binding matches and the request
+would otherwise receive credentials.
+
 The active vault used by the MITM process is served over a local Unix domain
 socket inside the sidecar. The sandbox workload cannot fetch this active state
 over the normal server proxy path.


### PR DESCRIPTION
## Summary

- select a Credential Vault binding before applying ambiguous-path checks
- forward unmatched egress requests unchanged, including double-encoded package URLs
- preserve fail-closed behavior for requests that would receive credentials
- document the unmatched-request contract and add focused regressions

## Root cause

The credential proxy evaluated path ambiguity for every outbound request whenever an active vault existed. Because that check ran before binding selection, unrelated requests containing nested percent-encoded separators received a local 403 even though no credential could be injected.

## Validation

- `python3 -m unittest discover -v -s tests -p 'test_*.py'` — 54 discovered, 50 passed, 4 skipped because `mitmdump` is not installed locally
- `pnpm docs:build`
- `git diff --check`
