### PR TITLE
fix(examples): warn for SDK fallback API key

### DIFF
--- a/docs/examples/desktop.md
+++ b/docs/examples/desktop.md
@@ -139,7 +139,8 @@ clients, so the example omits the native VNC endpoint in this mode.
 | `SANDBOX_DOMAIN` | `localhost:8080` | Sandbox service address; may include an `http://` or `https://` scheme |
 | `SANDBOX_PROTOCOL` | Domain scheme, otherwise `http` | Protocol used when `SANDBOX_DOMAIN` has no scheme (`http` or `https`) |
 | `SANDBOX_USE_SERVER_PROXY` | `false` | Route sandbox service, noVNC HTTP, and WebSocket traffic through the OpenSandbox server; required with HTTPS |
-| `SANDBOX_API_KEY` | _(optional for local)_ | API key if your server requires authentication |
+| `SANDBOX_API_KEY` | _(optional for local)_ | Example-specific API key; takes precedence over `OPEN_SANDBOX_API_KEY` |
+| `OPEN_SANDBOX_API_KEY` | _(optional for local)_ | SDK-standard API key fallback when `SANDBOX_API_KEY` is unset |
 | `SANDBOX_IMAGE` | `opensandbox/desktop:latest` | Sandbox image to use |
 | `VNC_PASSWORD` | `opensandbox` | Password for VNC access |
 

--- a/examples/desktop/main.py
+++ b/examples/desktop/main.py
@@ -16,19 +16,19 @@ import asyncio
 import os
 from datetime import timedelta
 
-from opensandbox import Sandbox
-from opensandbox.config import ConnectionConfig
-from opensandbox.models.execd import RunCommandOpts
-
 from novnc_url import (
     browser_proxy_auth_warning,
     build_novnc_url,
     normalize_domain,
     parse_bool,
+    resolve_api_key,
     resolve_novnc_protocol,
     resolve_protocol,
     validate_connection_mode,
 )
+from opensandbox import Sandbox
+from opensandbox.config import ConnectionConfig
+from opensandbox.models.execd import RunCommandOpts
 
 
 def _required_env(name: str) -> str:
@@ -59,7 +59,10 @@ async def main() -> None:
     protocol = resolve_protocol(domain, os.getenv("SANDBOX_PROTOCOL"))
     use_server_proxy = _bool_env("SANDBOX_USE_SERVER_PROXY")
     validate_connection_mode(protocol, use_server_proxy)
-    api_key = os.getenv("SANDBOX_API_KEY")
+    api_key = resolve_api_key(
+        os.getenv("SANDBOX_API_KEY"),
+        os.getenv("OPEN_SANDBOX_API_KEY"),
+    )
     image = os.getenv(
         "SANDBOX_IMAGE",
         "opensandbox/desktop:latest",

--- a/examples/desktop/novnc_url.py
+++ b/examples/desktop/novnc_url.py
@@ -62,6 +62,14 @@ def resolve_novnc_protocol(management_protocol: str, use_server_proxy: bool) -> 
     return management_protocol if use_server_proxy else "http"
 
 
+def resolve_api_key(
+    example_api_key: str | None,
+    sdk_api_key: str | None,
+) -> str | None:
+    """Prefer the example override, then use the SDK-standard fallback."""
+    return example_api_key or sdk_api_key
+
+
 def browser_proxy_auth_warning(
     use_server_proxy: bool,
     api_key: str | None,
@@ -71,7 +79,7 @@ def browser_proxy_auth_warning(
         return None
 
     return (
-        "SANDBOX_API_KEY authenticates SDK requests only. Browsers cannot attach "
+        "The configured API key authenticates SDK requests only. Browsers cannot attach "
         "OPEN-SANDBOX-API-KEY to noVNC HTTP or WebSocket requests. If the server "
         "is multi-tenant, use a trusted authenticated reverse proxy that injects "
         "the tenant key for both request types."

--- a/examples/desktop/test_novnc_url.py
+++ b/examples/desktop/test_novnc_url.py
@@ -19,6 +19,7 @@ from novnc_url import (
     build_novnc_url,
     normalize_domain,
     parse_bool,
+    resolve_api_key,
     resolve_novnc_protocol,
     resolve_protocol,
     validate_connection_mode,
@@ -56,7 +57,9 @@ class BuildNoVNCURLTest(unittest.TestCase):
 
     def test_https_server_proxy_uses_default_tls_port(self) -> None:
         self.assertEqual(
-            build_novnc_url("sandbox.example.com/v1/sandboxes/sbx-123/proxy/6080", "https"),
+            build_novnc_url(
+                "sandbox.example.com/v1/sandboxes/sbx-123/proxy/6080", "https"
+            ),
             "https://sandbox.example.com/v1/sandboxes/sbx-123/proxy/6080/vnc.html"
             "?host=sandbox.example.com&port=443"
             "&path=v1/sandboxes/sbx-123/proxy/6080",
@@ -77,6 +80,20 @@ class BuildNoVNCURLTest(unittest.TestCase):
 
 
 class EnvironmentTest(unittest.TestCase):
+    def test_example_api_key_takes_precedence(self) -> None:
+        self.assertEqual(resolve_api_key("example-key", "sdk-key"), "example-key")
+
+    def test_sdk_api_key_is_used_as_fallback(self) -> None:
+        self.assertEqual(resolve_api_key(None, "sdk-key"), "sdk-key")
+
+    def test_server_proxy_with_sdk_fallback_api_key_warns(self) -> None:
+        warning = browser_proxy_auth_warning(
+            True,
+            resolve_api_key(None, "sdk-key"),
+        )
+
+        self.assertIsNotNone(warning)
+
     def test_bool_error_lists_accepted_values(self) -> None:
         with self.assertRaisesRegex(
             RuntimeError,


### PR DESCRIPTION
## Summary

Follow-up to #1477. The desktop example now honors the Python SDK's standard `OPEN_SANDBOX_API_KEY` fallback when `SANDBOX_API_KEY` is unset, so server-proxy mode still prints the browser authentication warning for authenticated servers.

## Changes

- resolve the example-specific key before the SDK-standard environment fallback
- document both supported environment variables and their precedence
- add regression tests for fallback resolution and warning behavior

## Validation

- `python examples/desktop/test_novnc_url.py` (20 tests)
- `python -m compileall -q examples/desktop`
- `uvx ruff check examples/desktop/main.py examples/desktop/novnc_url.py examples/desktop/test_novnc_url.py`
- `uvx ruff format --check examples/desktop/main.py examples/desktop/novnc_url.py examples/desktop/test_novnc_url.py`
- `cd docs && corepack pnpm docs:build`
- `git diff --check`

Addresses post-merge review feedback on #1477.