### PR TITLE
docs(kubernetes): align task-executor log path

### DIFF
--- a/docs/examples/code-interpreter.md
+++ b/docs/examples/code-interpreter.md
@@ -130,7 +130,9 @@ spec:
           - "/bin/sh"
           - "-c"
           - |
-            /opt/opensandbox/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
+            /opt/opensandbox/task-executor \
+              -listen-addr=0.0.0.0:5758 \
+              -log-dir=/tmp
           env:
           - name: SANDBOX_MAIN_CONTAINER
             value: main
@@ -158,7 +160,9 @@ The lifecycle API allocates an already-running Pod from the Pool, so it does not
 
 The Pool template must provide all parts of that execution path:
 
-- Install and run task-executor, listening on `0.0.0.0:5758`.
+- Install and run task-executor, listening on `0.0.0.0:5758`. Set its
+  `-log-dir` explicitly so the troubleshooting path is deterministic; the
+  example writes `/tmp/task-executor.log`.
 - Install execd and `bootstrap.sh` into the shared volume before the Pod starts.
 - Keep `bootstrap.sh` at `/opt/opensandbox/bootstrap.sh`. The server-generated task invokes that exact path. The execd binary can use another path only when the task-executor environment sets `EXECD` accordingly.
 - Start execd through `bootstrap.sh` after allocation so request-specific values such as `EXECD_ACCESS_TOKEN` are available. The example above leaves task-executor as the warm Pod's foreground process for this reason.

--- a/kubernetes/config/samples/sandbox_v1alpha1_pool.yaml
+++ b/kubernetes/config/samples/sandbox_v1alpha1_pool.yaml
@@ -49,7 +49,9 @@ spec:
           - "/bin/sh"
           - "-c"
           - |
-            /opt/opensandbox/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
+            /opt/opensandbox/task-executor \
+              -listen-addr=0.0.0.0:5758 \
+              -log-dir=/tmp
           env:
           - name: SANDBOX_MAIN_CONTAINER
             value: main

--- a/kubernetes/config/samples/sandbox_v1alpha1_pool_restart.yaml
+++ b/kubernetes/config/samples/sandbox_v1alpha1_pool_restart.yaml
@@ -24,7 +24,9 @@ spec:
             - /bin/sh
             - -c
             - |
-              exec /opt/opensandbox/task-executor -listen-addr=0.0.0.0:5758 >/tmp/task-executor.log 2>&1
+              exec /opt/opensandbox/task-executor \
+                -listen-addr=0.0.0.0:5758 \
+                -log-dir=/tmp
           env:
             - name: SANDBOX_MAIN_CONTAINER
               value: main


### PR DESCRIPTION
## Summary

Follow-up to #1478. Pool examples now configure task-executor's own log destination explicitly, so the documented `/tmp/task-executor.log` troubleshooting command reads the file that klog actually writes.

## Changes

- pass `-log-dir=/tmp` in the Code Interpreter Pool example
- apply the same configuration to both Kubernetes Pool sample manifests
- remove stdout/stderr redirects that do not capture task-executor's klog output
- explain why the log directory is configured explicitly

## Validation

- `cd docs && corepack pnpm docs:build`
- offline `sigs.k8s.io/yaml` decode of both updated sample manifests
- `cd kubernetes && go test ./internal/task-executor/config -count=1`
- `git diff --check`

Addresses post-merge review feedback on #1478.