### PR TITLE
fix(server): release aborted proxy responses

### DIFF
--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -27,6 +27,7 @@ import websockets
 from fastapi import APIRouter, Request, WebSocket, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import StreamingResponse
+from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 from websockets.asyncio.client import ClientConnection
 from websockets.typing import Origin
@@ -213,19 +214,43 @@ async def _authenticate_websocket_tenant(websocket: WebSocket) -> bool:
     return True
 
 
-async def _stream_backend_response(resp: httpx.Response) -> AsyncIterator[bytes]:
-    """
-    Yield backend body chunks without httpx content decoding and always close the response.
-
-    httpx requires ``await resp.aclose()`` for ``stream=True`` responses so connections
-    return to the pool; Starlette's StreamingResponse does not do this automatically.
-    Use ``aiter_raw`` so forwarded ``content-encoding`` headers still match the body bytes.
-    """
-    try:
-        async for chunk in resp.aiter_raw():
-            yield chunk
-    finally:
+async def _close_backend_response(resp: httpx.Response) -> None:
+    """Return a streamed backend response to httpx's pool, even during cancellation."""
+    with anyio.CancelScope(shield=True):
         await resp.aclose()
+
+
+async def _stream_backend_response(resp: httpx.Response) -> AsyncIterator[bytes]:
+    """Yield raw backend chunks so content-encoding still matches the body bytes."""
+    async for chunk in resp.aiter_raw():
+        yield chunk
+
+
+class _ProxyStreamingResponse(StreamingResponse):
+    """Streaming response that owns and always releases its httpx response."""
+
+    def __init__(
+        self,
+        resp: httpx.Response,
+        *,
+        status_code: int,
+        headers: Mapping[str, str],
+    ) -> None:
+        self._backend_response = resp
+        super().__init__(
+            content=_stream_backend_response(resp),
+            status_code=status_code,
+            headers=headers,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            # The body iterator may never start if the downstream disconnects
+            # while Starlette sends response headers. Keep ownership here so
+            # that connection is still returned to the shared httpx pool.
+            await _close_backend_response(self._backend_response)
 
 
 def _verify_secure_access(endpoint: Endpoint, caller_headers: Mapping[str, str]) -> None:
@@ -301,26 +326,32 @@ async def _proxy_http_request(
 
         resp = await client.send(req, stream=True)
 
-        hop_by_hop = set(HOP_BY_HOP_HEADERS)
-        connection_header = resp.headers.get("connection")
-        if connection_header:
-            hop_by_hop.update(
-                header.strip().lower()
-                for header in connection_header.split(",")
-                if header.strip()
-            )
-        response_header_exclusions = hop_by_hop | SERVER_GENERATED_RESPONSE_HEADERS
-        response_headers = {
-            key: value
-            for key, value in resp.headers.items()
-            if key.lower() not in response_header_exclusions
-        }
+        try:
+            hop_by_hop = set(HOP_BY_HOP_HEADERS)
+            connection_header = resp.headers.get("connection")
+            if connection_header:
+                hop_by_hop.update(
+                    header.strip().lower()
+                    for header in connection_header.split(",")
+                    if header.strip()
+                )
+            response_header_exclusions = hop_by_hop | SERVER_GENERATED_RESPONSE_HEADERS
+            response_headers = {
+                key: value
+                for key, value in resp.headers.items()
+                if key.lower() not in response_header_exclusions
+            }
 
-        return StreamingResponse(
-            content=_stream_backend_response(resp),
-            status_code=resp.status_code,
-            headers=response_headers,
-        )
+            return _ProxyStreamingResponse(
+                resp,
+                status_code=resp.status_code,
+                headers=response_headers,
+            )
+        except BaseException:
+            # Until ownership passes to _ProxyStreamingResponse, any failure
+            # after client.send() must release the acquired pool connection.
+            await _close_backend_response(resp)
+            raise
     except httpx.ConnectError as e:
         raise HTTPException(
             status_code=502,

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -18,6 +18,8 @@ from typing import Any, cast
 
 import httpx
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
+from starlette.types import Message
 from websockets.typing import Origin
 
 import opensandbox_server.api.proxy as proxy_api
@@ -55,7 +57,19 @@ class _FakeStreamingResponse:
             yield chunk
 
     async def aclose(self):
+        await asyncio.sleep(0)
         self.aclose_called = True
+
+
+class _BlockingStreamingResponse(_FakeStreamingResponse):
+    def __init__(self) -> None:
+        super().__init__()
+        self.body_started = asyncio.Event()
+
+    async def aiter_raw(self):
+        self.body_started.set()
+        await asyncio.Future()
+        yield b"unreachable"
 
 
 class _FakeAsyncClient:
@@ -395,6 +409,7 @@ def test_proxy_allows_valid_secure_access_header(
     )
 
     assert response.status_code == 200
+    assert fake_client.built is not None
     lowered_headers = {
         key.lower(): value for key, value in fake_client.built["headers"].items()
     }
@@ -564,6 +579,79 @@ def test_proxy_streams_raw_body_for_content_encoded_response(
     assert fake_client.response.aiter_raw_called is True
     assert fake_client.response.aiter_bytes_called is False
     assert fake_client.response.aclose_called is True
+
+
+def test_proxy_closes_backend_response_when_downstream_rejects_headers() -> None:
+    """A disconnect before body iteration must not retain the backend connection."""
+
+    async def run() -> None:
+        backend_response = _FakeStreamingResponse()
+        response = proxy_api._ProxyStreamingResponse(
+            cast(httpx.Response, backend_response),
+            status_code=200,
+            headers={},
+        )
+
+        async def receive() -> Message:
+            return {"type": "http.disconnect"}
+
+        async def reject_response_start(message: Message) -> None:
+            assert message["type"] == "http.response.start"
+            raise ConnectionError("downstream disconnected")
+
+        try:
+            await response(
+                {"type": "http", "asgi": {"spec_version": "2.4"}},
+                receive,
+                reject_response_start,
+            )
+        except ClientDisconnect:
+            pass
+        else:
+            raise AssertionError("expected the downstream send to fail")
+
+        assert backend_response.aclose_called is True
+
+    asyncio.run(run())
+
+
+def test_proxy_closes_backend_response_when_stream_is_cancelled() -> None:
+    """Task cancellation must not interrupt returning the backend connection."""
+
+    async def run() -> None:
+        backend_response = _BlockingStreamingResponse()
+        response = proxy_api._ProxyStreamingResponse(
+            cast(httpx.Response, backend_response),
+            status_code=200,
+            headers={},
+        )
+
+        async def send(message: Message) -> None:
+            return None
+
+        async def receive() -> Message:
+            return {"type": "http.disconnect"}
+
+        task = asyncio.create_task(
+            response(
+                {"type": "http", "asgi": {"spec_version": "2.4"}},
+                receive,
+                send,
+            )
+        )
+        await backend_response.body_started.wait()
+        task.cancel()
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("expected stream task cancellation")
+
+        assert backend_response.aclose_called is True
+
+    asyncio.run(run())
 
 
 def test_proxy_rejects_websocket_upgrade(


### PR DESCRIPTION
## Summary

Fixes a server-proxy connection leak that can gradually exhaust the shared httpx pool when downstream clients disconnect before Starlette begins iterating the backend response body.

The previous cleanup lived inside the body async generator. If sending `http.response.start` failed first, the generator never started and `resp.aclose()` never ran, leaving the backend connection acquired. Repeated aborted requests can eventually surface as `httpcore.PoolTimeout`, matching #1386.

## Changes

- make a proxy-specific `StreamingResponse` own the backend httpx response for the complete ASGI response lifecycle
- shield `resp.aclose()` so task cancellation cannot interrupt pool release
- release the response if setup fails after `client.send(..., stream=True)` but before ownership is transferred
- add regressions for disconnect-before-body and stream cancellation cleanup

## Validation

- Windows: `cd server && uv run pytest -q` — 1334 passed, 1 skipped
- Ubuntu 24.04 / Python 3.12.3: full server suite — 1335 passed
- `cd server && uv run ruff check` — passed
- `cd server && uv run pyright opensandbox_server/api/proxy.py tests/test_routes_proxy.py` — 0 errors
- `git diff --check` — passed

### Ubuntu real-socket stress test

Ran Uvicorn proxy/backend apps on loopback with a four-connection httpx pool and real TCP RST disconnects at the response-start boundary:

- pre-fix ownership model: four disconnects left all four backend responses open; the next request raised `PoolTimeout`
- fixed implementation: 1,000 disconnects closed 1,000/1,000 backend responses
- ten health probes during the run all succeeded with zero `PoolTimeout`
- zero active backend streams remained; the pool retained one healthy keep-alive connection (limit: four)

Closes #1386
