### PR TITLE
feat(kubernetes): initialize missing PVC subpaths

### DIFF
--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -66,6 +66,10 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/execd ./main.go
 
+RUN CGO_ENABLED=0 go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none" \
+    -o /build/opensandbox-subpath-initializer ./cmd/subpath-initializer
+
 RUN CGO_ENABLED=0 GOOS=windows go build ${GOFLAGS} -trimpath -buildvcs=false \
     -ldflags "${LDFLAGS} -buildid= -B none \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
@@ -99,6 +103,7 @@ COPY --from=bwrap-builder /build/bwrap/bwrap /usr/local/bin/bwrap
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /usr/local/libexec/opensandbox-session-gate
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-gate /opt/opensandbox/opensandbox-session-gate
 COPY --from=builder /build/execd .
+COPY --from=builder /build/opensandbox-subpath-initializer ./opensandbox-subpath-initializer
 COPY --from=builder /build/execd.exe ./execd.exe
 COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor
 COPY components/execd/bootstrap.sh ./bootstrap.sh

--- a/components/execd/cmd/subpath-initializer/main.go
+++ b/components/execd/cmd/subpath-initializer/main.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/alibaba/opensandbox/execd/pkg/subpathinitializer"
+)
+
+func main() {
+	planJSON := flag.String("plan-json", "", "trusted subpath initialization plan")
+	flag.Parse()
+	if *planJSON == "" || flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: opensandbox-subpath-initializer --plan-json <json>")
+		os.Exit(2)
+	}
+	plan, err := subpathinitializer.ParsePlan(*planJSON)
+	if err == nil {
+		err = subpathinitializer.Apply(plan)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/components/execd/pkg/subpathinitializer/securetree_linux.go
+++ b/components/execd/pkg/subpathinitializer/securetree_linux.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+// Package subpathinitializer creates planned directories without following links.
+package subpathinitializer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// PlanEntry names one trusted PVC root mount and the relative paths to create beneath it.
+type PlanEntry struct {
+	MountPath string   `json:"mountPath"`
+	SubPaths  []string `json:"subPaths"`
+}
+
+// ParsePlan accepts exactly the renderer's JSON plan shape.
+func ParsePlan(raw string) ([]PlanEntry, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var plan []PlanEntry
+	if err := decoder.Decode(&plan); err != nil {
+		return nil, fmt.Errorf("decode plan: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("decode plan: trailing data")
+	}
+	if len(plan) == 0 {
+		return nil, fmt.Errorf("plan must contain at least one entry")
+	}
+
+	mounts := make(map[string]struct{}, len(plan))
+	for index, entry := range plan {
+		if err := validateMountPath(entry.MountPath); err != nil {
+			return nil, fmt.Errorf("plan entry %d: %w", index, err)
+		}
+		if _, exists := mounts[entry.MountPath]; exists {
+			return nil, fmt.Errorf("plan entry %d: duplicate mountPath", index)
+		}
+		mounts[entry.MountPath] = struct{}{}
+		if len(entry.SubPaths) == 0 {
+			return nil, fmt.Errorf("plan entry %d: subPaths must not be empty", index)
+		}
+		paths := make(map[string]struct{}, len(entry.SubPaths))
+		for _, subPath := range entry.SubPaths {
+			if err := validateSubPath(subPath); err != nil {
+				return nil, fmt.Errorf("plan entry %d: %w", index, err)
+			}
+			if _, exists := paths[subPath]; exists {
+				return nil, fmt.Errorf("plan entry %d: duplicate subPath", index)
+			}
+			paths[subPath] = struct{}{}
+		}
+	}
+	return plan, nil
+}
+
+// Apply creates every planned directory relative to an O_NOFOLLOW root descriptor.
+func Apply(plan []PlanEntry) error {
+	if len(plan) == 0 {
+		return fmt.Errorf("plan must contain at least one entry")
+	}
+	for _, entry := range plan {
+		if err := validateMountPath(entry.MountPath); err != nil {
+			return err
+		}
+		if len(entry.SubPaths) == 0 {
+			return fmt.Errorf("subPaths must not be empty")
+		}
+		rootFD, err := unix.Open(entry.MountPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return fmt.Errorf("open root %q: %w", entry.MountPath, err)
+		}
+		for _, subPath := range entry.SubPaths {
+			if err := validateSubPath(subPath); err != nil {
+				unix.Close(rootFD)
+				return err
+			}
+			if err := mkdirAt(rootFD, subPath); err != nil {
+				unix.Close(rootFD)
+				return fmt.Errorf("create %q beneath %q: %w", subPath, entry.MountPath, err)
+			}
+		}
+		if err := unix.Close(rootFD); err != nil {
+			return fmt.Errorf("close root %q: %w", entry.MountPath, err)
+		}
+	}
+	return nil
+}
+
+func mkdirAt(rootFD int, subPath string) error {
+	currentFD := rootFD
+	for _, segment := range strings.Split(subPath, "/") {
+		if err := unix.Mkdirat(currentFD, segment, 0755); err != nil && err != unix.EEXIST {
+			if currentFD != rootFD {
+				unix.Close(currentFD)
+			}
+			return err
+		}
+		nextFD, err := unix.Openat(currentFD, segment, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if currentFD != rootFD {
+			unix.Close(currentFD)
+		}
+		if err != nil {
+			return err
+		}
+		currentFD = nextFD
+	}
+	if currentFD != rootFD {
+		return unix.Close(currentFD)
+	}
+	return nil
+}
+
+func validateMountPath(path string) error {
+	if path == "" || strings.IndexByte(path, 0) >= 0 || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return fmt.Errorf("mountPath must be a normalized absolute path")
+	}
+	return nil
+}
+
+func validateSubPath(path string) error {
+	if path == "" || strings.IndexByte(path, 0) >= 0 || strings.HasPrefix(path, "/") || strings.Contains(path, "\\") {
+		return fmt.Errorf("subPath must be a non-empty normalized relative path")
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("subPath must not contain empty, '.' or '..' segments")
+		}
+	}
+	return nil
+}

--- a/components/execd/pkg/subpathinitializer/securetree_linux_test.go
+++ b/components/execd/pkg/subpathinitializer/securetree_linux_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package subpathinitializer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePlanRejectsUnsafeAndMalformedInput(t *testing.T) {
+	tests := []string{
+		`[]`,
+		`[{"mountPath":"/root","subPaths":[]}]`,
+		`[{"mountPath":"/root","subPaths":["a/../b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a//b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a"]},{"mountPath":"/root","subPaths":["b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a"],"unknown":true}]`,
+		`[{"mountPath":"/root","subPaths":["a"]}] garbage`,
+	}
+	for _, raw := range tests {
+		if _, err := ParsePlan(raw); err == nil {
+			t.Fatalf("ParsePlan(%q) succeeded", raw)
+		}
+	}
+}
+
+func TestApplyCreatesDirectoriesWithoutFollowingSymlinks(t *testing.T) {
+	root := t.TempDir()
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"jobs/a", "jobs/b"}}}); err != nil {
+		t.Fatalf("Apply(): %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(root, "jobs", "a")); err != nil || !info.IsDir() {
+		t.Fatalf("created directory: info=%v err=%v", info, err)
+	}
+
+	if err := os.Symlink(t.TempDir(), filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"link/escape"}}}); err == nil {
+		t.Fatal("Apply followed a symlink")
+	}
+}

--- a/components/execd/pkg/subpathinitializer/securetree_unsupported.go
+++ b/components/execd/pkg/subpathinitializer/securetree_unsupported.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+// Package subpathinitializer creates planned directories without following links.
+package subpathinitializer
+
+import "fmt"
+
+// PlanEntry names one trusted PVC root mount and the relative paths to create beneath it.
+type PlanEntry struct {
+	MountPath string   `json:"mountPath"`
+	SubPaths  []string `json:"subPaths"`
+}
+
+// ParsePlan fails closed because secure fd-relative directory creation is Linux-only.
+func ParsePlan(string) ([]PlanEntry, error) {
+	return nil, fmt.Errorf("subpath initialization is supported only on linux")
+}
+
+// Apply fails closed because secure fd-relative directory creation is Linux-only.
+func Apply([]PlanEntry) error {
+	return fmt.Errorf("subpath initialization is supported only on linux")
+}

--- a/docs/guides/remote-kubernetes-subpath-poc.zh.md
+++ b/docs/guides/remote-kubernetes-subpath-poc.zh.md
@@ -1,0 +1,172 @@
+---
+title: 远程 Kubernetes subPath 初始化 POC
+description: 使用隔离随机命名空间，通过 OpenSandbox 生命周期 API 验证 ensureSubPathDirectory 的安全演练手册。
+---
+
+# 远程 Kubernetes `ensureSubPathDirectory` POC
+
+本手册使用 [`scripts/remote-k8s-subpath-poc.sh`](https://github.com/opensandbox-group/OpenSandbox/blob/main/scripts/remote-k8s-subpath-poc.sh) 验证现有 `ensureSubPathDirectory` 功能。脚本默认只打印计划，只有显式确认后才会产生远程写操作。
+
+::: warning
+该脚本**不会**构建或推送镜像，不会读取 Secret 内容，不会使用 `kubectl apply`，也不会使用端口转发。新 sandbox 仅通过 OpenSandbox 生命周期 API `POST /v1/sandboxes` 创建；不会直接创建 BatchSandbox 或 Pod。
+:::
+
+## 覆盖范围和安全边界
+
+一次已确认的运行只处理下列对象：
+
+| 对象 | 名称或选择方式 | 创建方式 | 清理方式 |
+| --- | --- | --- | --- |
+| Namespace | `opensandbox-subpath-poc-<16 位小写十六进制>` | 父级编排在获批凭证下预置 | 本脚本绝不删除 |
+| ServiceAccount | `opensandbox-subpath-poc-sa-<同一随机值>` | 父级编排在获批凭证下预置 | 本脚本绝不删除 |
+| imagePullSecret | `opensandbox-subpath-poc-pull-<同一随机值>` | 父级编排在获批凭证下预置 | 本脚本只读取 metadata，绝不读取 data，也绝不删除 |
+| PVC | `opensandbox-subpath-poc-pvc-<同一随机值>` | 生命周期 API 请求中的 PVC 自动创建 | 按精确名称删除 |
+| BatchSandbox | 生命周期 API 返回的 UUID | 生命周期 API | 对该 UUID 调用生命周期 API 删除 |
+| Pod | 控制器生成；仅以 `opensandbox.io/id=<返回 UUID>` 查询 | BatchSandbox 控制器 | 随精确 Namespace 清理 |
+
+OpenSandbox 当前的生命周期 API 由服务端生成 UUID sandbox ID，因此 BatchSandbox/Pod 名称不能由客户端改为 POC 前缀。脚本不猜测或伪造该名称：它只接受 API 返回的精确 UUID，并且所有 Kubernetes 查询都局限在 POC Namespace。客户端明确命名的 Namespace、ServiceAccount、Secret、PVC、volume、subPath 和 metadata 均使用 POC 前缀。
+
+脚本拒绝：
+
+- `sandbox-tenant-a`；
+- 不符合精确随机格式的 Namespace；
+- 不存在的预置 Namespace、ServiceAccount、imagePullSecret，目标 PVC 已存在，或目标 Namespace 中已有 BatchSandbox；
+- `http(s)://...:18080` 与 `http(s)://...:18090`，即正式服务端口；
+- 非 loopback 的 lifecycle URL、未设置 `KUBECONFIG`，或者本地 Server 配置与 POC Namespace/BatchSandbox template mode/固定 digest 的 execd 镜像不一致。
+
+清理函数由 `EXIT` trap 调用，只会删除 API 返回的单个 sandbox 与本次精确 PVC；不使用 `--all`、宽泛 label 删除或 Namespace 删除。Namespace、ServiceAccount 和 imagePullSecret 的创建与最终回收均归父级编排所有，避免脚本删除预置依赖或超出自身所有权的资源。
+
+## 前置条件
+
+1. 操作人员持有一个**单文件** `KUBECONFIG`，它可读取精确 POC Namespace、ServiceAccount、Secret metadata、BatchSandbox、PVC 与 Pod，并可在 POC Pod 内 `exec`；还必须能够删除本次精确 PVC。脚本不读取任何 Secret data。
+2. 父级编排必须使用独立、已获批的凭证预置新的 POC Namespace、同随机值的 ServiceAccount 和 imagePullSecret。使用 [`scripts/remote-k8s-subpath-poc-provision.sh`](https://github.com/opensandbox-group/OpenSandbox/blob/main/scripts/remote-k8s-subpath-poc-provision.sh)；它只能创建这三个精确资源，不能创建 Role/RoleBinding/ClusterRole、控制器、CRD、PVC、BatchSandbox、Pod 或 Service。
+3. OpenSandbox Server 必须是**由操作人员外部提供的隔离本地进程**，仅针对该 POC Namespace 运行。`REMOTE_POC_BASE_URL` 只能指向 `127.0.0.1`、`localhost` 或 `::1`，且不能使用正式端口。脚本通过操作人员提供的 `REMOTE_POC_SERVER_CONFIG` 读取本地配置，确认 `[kubernetes].namespace` 精确等于 `POC_NAMESPACE`、`workload_provider = "batchsandbox"`、`runtime.type = "kubernetes"`、`runtime.execd_image` 是固定 `@sha256` digest，且 template 中仅配置一个匹配的 POC ServiceAccount。
+4. `runtime.execd_image` 必须已包含 `/opensandbox-subpath-initializer`；这是现有功能的运行时前提。脚本只能验证固定 digest，不能检查镜像内容、构建或推送镜像。
+5. 已准备一个目标集群可拉取的、含 `/bin/sh` 的测试镜像。该镜像由预置的 POC ServiceAccount 引用的 imagePullSecret 授权拉取。脚本只验证 Secret 的精确名称、类型 `kubernetes.io/dockerconfigjson` 和 ServiceAccount 的引用关系，绝不读取 Secret data。
+6. 必须显式设置 `REMOTE_POC_STORAGE_CLASS` 为目标集群中适用于 POC 的 StorageClass 名称。该变量仅写入生命周期请求中**自动创建的本次精确 POC PVC**的 `storageClass`，不会修改 Server 配置、既有 PVC 或任何其他集群资源。
+7. 对 JuiceFS 或其他共享存储，只能使用脚本生成的**新随机 subPath**。绝不复用、删除、修复或清空共享后端路径。显式执行前，操作人员必须确认删除本次 PVC 和 POC Namespace 不会影响任何共享数据，并显式设置 `REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1`；无法确认时不得执行。
+8. 必须显式设置 `REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS` 为 61 至 300 的整数，且至少应大于等于隔离 Server 的 `sandbox_create_timeout_seconds` 再加上必要余量。该变量只控制本地 `curl` 等待 `POST /v1/sandboxes` 响应的最长时间，不修改 Server、Kubernetes 或 sandbox 超时。
+9. 如本地 Server 启用了认证，将 API key 只注入当前终端的 `REMOTE_POC_API_KEY`；不要写入命令历史、脚本、文档或仓库。
+
+若隔离本地 Server、预置依赖或配置检查无法确认，必须停止。不要尝试直接创建 CR、修改共享服务配置、使用正式端口、或仅以环境标志让脚本猜测 Namespace 路由。
+
+## 生成随机 Namespace
+
+先生成并保留一个随机 Namespace；必须严格为 `opensandbox-subpath-poc-` 加 16 位小写十六进制。然后由父级编排以获批凭证完成预置，并启动使用该 Namespace 的隔离本地 Server：
+
+```bash
+export POC_NAMESPACE="opensandbox-subpath-poc-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+printf '%s\n' "$POC_NAMESPACE"
+```
+
+不要复用旧 Namespace。父级编排必须只为这个新 Namespace 预置以下资源：
+
+```text
+Namespace:       $POC_NAMESPACE
+ServiceAccount:  opensandbox-subpath-poc-sa-${POC_NAMESPACE#opensandbox-subpath-poc-}
+imagePullSecret: opensandbox-subpath-poc-pull-${POC_NAMESPACE#opensandbox-subpath-poc-}
+```
+
+ServiceAccount 必须通过 `imagePullSecrets` 引用该同名随机 Secret；Secret 类型必须为 `kubernetes.io/dockerconfigjson`。此预置属于父级编排职责。provisioner 仅从 `REMOTE_POC_DOCKER_AUTH_KEY` 指定的本地 Docker config 单一 `auths` 条目构造 Secret，绝不打印凭证、不读取任何既有 Kubernetes Secret，也不复制其他 registry auth；临时 credential 文件在 Secret 创建后用 `shred -u` 擦除。待 POC 完成且本地 Server 已停止后，父级编排可按下文的精确 cleanup 模式回收 Namespace。
+
+## 父级预置与精确 cleanup
+
+以下命令均以默认 dry-run 运行：不访问 Kubernetes API，也不读取本地 Docker credential。仅在父级已批准后才设置相应确认变量。
+
+```bash
+export KUBECONFIG=/absolute/path/to/poc-provisioner-kubeconfig
+export REMOTE_POC_SERVICE_ACCOUNT="opensandbox-subpath-poc-sa-${POC_NAMESPACE#opensandbox-subpath-poc-}"
+export REMOTE_POC_IMAGE_PULL_SECRET="opensandbox-subpath-poc-pull-${POC_NAMESPACE#opensandbox-subpath-poc-}"
+export REMOTE_POC_DOCKER_CONFIG=/absolute/path/to/local/docker/config.json
+export REMOTE_POC_DOCKER_AUTH_KEY=registry.example.internal
+
+# 默认：只打印三个精确计划资源；无远程调用、无本地 credential 读取。
+scripts/remote-k8s-subpath-poc-provision.sh
+
+# 经父级审批后：只创建精确 Namespace、Secret 和 ServiceAccount。
+export REMOTE_POC_PROVISION_CONFIRM=1
+scripts/remote-k8s-subpath-poc-provision.sh
+unset REMOTE_POC_PROVISION_CONFIRM
+```
+
+provisioner 在任何写入前检查 `get/create namespaces`、POC Namespace 内 `create secrets` 与 `create serviceaccounts` 权限，并拒绝已存在的 Namespace。它不会检查、读取或覆盖既有 Kubernetes Secret。
+
+POC runner 已通过 lifecycle API 删除其精确 sandbox/PVC、且本地 Server 已停止之后，父级才可请求删除 Namespace：
+
+```bash
+export REMOTE_POC_PROVISION_MODE=cleanup
+scripts/remote-k8s-subpath-poc-provision.sh
+
+export REMOTE_POC_CLEANUP_CONFIRM=1
+export REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1
+scripts/remote-k8s-subpath-poc-provision.sh
+unset REMOTE_POC_CLEANUP_CONFIRM REMOTE_POC_PROVISION_MODE REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM
+```
+
+cleanup 在删除 Namespace 前枚举所有可列出的 namespaced resource 类型。白名单仅包含 `serviceaccount/default`、精确 POC ServiceAccount、精确 POC imagePullSecret、旧版自动生成的 `secret/default-token-<5 位小写字母数字>` 与 `secret/<精确 POC ServiceAccount>-token-<5 位小写字母数字>`、`configmap/kube-root-ca.crt`、`configmap/tapp-env-config`，以及 `events` 和 `events.events.k8s.io` 两种 Event API 资源。Events 仅因这是精确的随机 POC Namespace 才允许；cleanup 不会按名称或内容放宽其他资源。它不会读取 Secret data，也不会变更或单独删除这两个 system-injected ConfigMap。只要仍有 PVC、BatchSandbox、Pod、Job、Role、Service、其他 Secret/ConfigMap/ServiceAccount 或任何其他对象，或因权限不足无法验证某个资源类型，cleanup 就会拒绝。只有所有 POC workload 资源已不存在且操作人员已确认 Namespace 删除不影响 JuiceFS 或其他共享数据时，才会执行唯一的 Namespace 删除调用：精确的 `kubectl delete namespace "$POC_NAMESPACE"`；不使用 `--all`。
+
+## 默认 dry-run
+
+在仓库根目录执行以下命令。该模式不向 Kubernetes API 或生命周期 API 发出请求；它会打印精确 Namespace、PVC、subPath 和生命周期请求体：
+
+```bash
+export KUBECONFIG=/absolute/path/to/poc-kubeconfig
+export REMOTE_POC_BASE_URL=http://127.0.0.1:18180
+export REMOTE_POC_SANDBOX_IMAGE=registry.example.internal/poc/shell-image:approved
+export REMOTE_POC_SERVER_CONFIG=/absolute/path/to/isolated-poc-server.toml
+export REMOTE_POC_LOCAL_SERVER_CONFIRM=1
+export REMOTE_POC_SERVICE_ACCOUNT="opensandbox-subpath-poc-sa-${POC_NAMESPACE#opensandbox-subpath-poc-}"
+export REMOTE_POC_IMAGE_PULL_SECRET="opensandbox-subpath-poc-pull-${POC_NAMESPACE#opensandbox-subpath-poc-}"
+export REMOTE_POC_STORAGE_CLASS=approved-poc-storage-class
+export REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS=90
+
+scripts/remote-k8s-subpath-poc.sh
+```
+
+若认证需要 API key，在运行前额外设置（不要回显该变量）：
+
+```bash
+export REMOTE_POC_API_KEY='由安全凭证系统在当前终端注入'
+```
+
+`REMOTE_POC_LOCAL_SERVER_CONFIRM=1` 不是 Namespace 绑定声明。它仅确认操作人员已经核实 loopback URL 对应的进程就是 `REMOTE_POC_SERVER_CONFIG` 指定的隔离本地 Server。脚本仍会解析该配置并验证精确 Namespace、BatchSandbox template mode、固定 execd digest 与 template 的 ServiceAccount；任何不匹配都会失败关闭。
+
+## 显式执行和验证
+
+仅当 dry-run 输出、服务端 Namespace 路由和测试镜像均已由操作人员审核后，再设置第二个确认开关：
+
+```bash
+export REMOTE_POC_CONFIRM=1
+export REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1
+scripts/remote-k8s-subpath-poc.sh
+```
+
+执行阶段依次：
+
+1. 在本地静态检查 Server 配置、Namespace 前缀、ServiceAccount/Secret 的精确 POC 名称和 loopback URL；dry-run 不执行远程读取；
+2. 显式执行时，读取预置的精确 Namespace、ServiceAccount 和 Secret metadata，确认 ServiceAccount 引用精确 imagePullSecret；不读取 Secret data；
+3. 确认精确 PVC 不存在且 POC Namespace 中没有 BatchSandbox；
+4. 调用 `POST /v1/sandboxes`，其中 volume 使用 PVC、可写的规范化相对 `subPath`，以及 `ensureSubPathDirectory: true`；
+5. 使用 API 返回的 sandbox UUID 读取同 Namespace 的 BatchSandbox，验证它引用精确 PVC、主容器使用精确 subPath，且存在 `volume-subpath-initializer`；
+6. 等待唯一带 `opensandbox.io/id=<UUID>` 的 Pod Ready，并在 `sandbox` 容器内写入、读回 subPath 下的 POC proof 文件；
+7. 无论成功或失败，`finally`/`EXIT` 仅删除本次精确 sandbox 和 PVC；前提是操作人员已确认该 PVC 的删除不会影响 JuiceFS 或其他共享数据。它绝不删除、修复或清空共享后端路径。Namespace、ServiceAccount、Secret 保留给父级 provisioner 的显式 cleanup 模式回收。
+
+成功时会显示：
+
+```text
+Verified exact PVC mount and volume-subpath-initializer in BatchSandbox.
+PASS: the initializer-created subPath is mounted read-write in the sandbox.
+```
+
+## 失败诊断
+
+| 现象 | 处理方式 |
+| --- | --- |
+| 脚本在 `REMOTE_POC_SERVER_CONFIG` 或 `REMOTE_POC_LOCAL_SERVER_CONFIRM` 处退出 | 停止执行。确认本地 loopback URL 的进程确实使用该配置，且配置中的 Namespace、BatchSandbox template mode、固定 execd digest 和 ServiceAccount 全部精确匹配。环境标志不能替代配置检查。 |
+| 缺少 ServiceAccount 或 imagePullSecret | 由父级编排使用获批凭证在**新的精确 POC Namespace**中预置；确认 ServiceAccount `imagePullSecrets` 引用同一随机值的 Secret。不要读取、复制或在脚本中写入 Secret data。 |
+| 创建返回非 202 | 查看 POC Server 的审计/应用日志，不要打印或读取 Secret。确认认证、Kubernetes runtime、BatchSandbox template mode 和 `runtime.execd_image`。 |
+| 找不到 `volume-subpath-initializer` | 目标 Server/execd 镜像没有部署该功能；停止 POC，不要直接修改 BatchSandbox。 |
+| Pod 未 Ready | 在**精确 POC Namespace**读取 BatchSandbox、Pod 状态和 Events；确认 PVC StorageClass、镜像可拉取性和控制器状态。 |
+| cleanup 警告 | 记录精确 Namespace、PVC 和 API 返回的 UUID，使用同一受限 KUBECONFIG 只检查这些精确名称；禁止 `kubectl delete --all`。在 runner cleanup 完成、Server 停止后，使用父级 provisioner 的显式 cleanup 模式；它会拒绝任何残留的非预置 POC 对象。 |
+
+脚本不会尝试弥补未知部署细节。服务端路由、初始化镜像或受限权限不满足时，应修复/确认这些前置条件后再重新生成新的随机 Namespace 执行。

--- a/scripts/poc-local-kind-subpath-initializer.sh
+++ b/scripts/poc-local-kind-subpath-initializer.sh
@@ -1,0 +1,669 @@
+#!/usr/bin/env bash
+# 仅用于永久 pytest 用例 test_01g_pvc_unseeded_subpath_initializer 的本地 Kind POC。
+# 默认只展示计划；只有显式确认后才会创建唯一的 Kind 集群及其集群内资源。
+
+set -euo pipefail
+
+readonly KIND_CLUSTER='opensandbox-subpath-poc-kind'
+readonly KIND_NODE="${KIND_CLUSTER}-control-plane"
+readonly LIFECYCLE_LOCAL_PORT='18081'
+readonly LOCAL_PROXY_URL='http://127.0.0.1:7897'
+readonly POC_RESOURCE_PREFIX='opensandbox-subpath-poc-kind'
+readonly TEST_NODE='tests/python/tests/test_sandbox_e2e_sync.py::TestSandboxE2ESync::test_01g_pvc_unseeded_subpath_initializer'
+KIND_CLUSTER_CREATION_STARTED=0
+
+SCRIPT_DIRECTORY="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIRECTORY
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIRECTORY}/.." && pwd -P)"
+readonly REPO_ROOT
+readonly POC_DIRECTORY="${REPO_ROOT}/poc/opensandbox-subpath-poc-f6d69fcf375c7ca1"
+readonly STATE_DIRECTORY="${POC_DIRECTORY}/.local-kind-state"
+readonly KUBECONFIG_PATH="${STATE_DIRECTORY}/kubeconfig"
+readonly SERVER_VALUES_FILE="${STATE_DIRECTORY}/server-values.yaml"
+readonly PORT_FORWARD_LOG="${STATE_DIRECTORY}/server-port-forward.log"
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+note() {
+  printf '%s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command is unavailable: $1"
+}
+
+clear_proxy_environment() {
+  unset http_proxy https_proxy all_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY no_proxy NO_PROXY
+}
+
+set_kubernetes_no_proxy() {
+  # Kind, Kubernetes, port-forward, and pytest must never inherit host proxy routing.
+  clear_proxy_environment
+  export no_proxy='*'
+  export NO_PROXY='*'
+}
+
+set_build_tools_proxy() {
+  # This short pre-Kind phase may use only the verified local host proxy to
+  # cache controller-gen. Docker daemon proxy configuration is not modified.
+  clear_proxy_environment
+  export http_proxy="$LOCAL_PROXY_URL"
+  export https_proxy="$LOCAL_PROXY_URL"
+  export HTTP_PROXY="$LOCAL_PROXY_URL"
+  export HTTPS_PROXY="$LOCAL_PROXY_URL"
+}
+
+remove_private_directory() {
+  local directory=$1
+  local expected_prefix=$2
+
+  [[ "$directory" == "${expected_prefix}"* && -d "$directory" && ! -L "$directory" ]] || die \
+    "Refusing to remove unexpected private directory: ${directory}"
+  rm -rf -- "$directory"
+}
+
+create_runtime_image_build_docker_wrapper() {
+  local wrapper_directory=$1
+
+  cat >"${wrapper_directory}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != 'build' ]]; then
+  exec "$POC_REAL_DOCKER" "$@"
+fi
+shift
+
+declare -a build_arguments=()
+build_context=''
+while (($#)); do
+  case "$1" in
+    -f|--file|-t|--tag|--build-arg)
+      (($# >= 2)) || { printf 'ERROR: docker build wrapper requires a value for %s\n' "$1" >&2; exit 64; }
+      build_arguments+=("$1" "$2")
+      shift 2
+      ;;
+    --file=*|--tag=*|--build-arg=*)
+      build_arguments+=("$1")
+      shift
+      ;;
+    --)
+      shift
+      (($# == 1 && -z "$build_context")) || { printf 'ERROR: docker build wrapper accepts exactly one build context\n' >&2; exit 64; }
+      build_context="$1"
+      shift
+      ;;
+    -*)
+      printf 'ERROR: refusing unsupported docker build flag: %s\n' "$1" >&2
+      exit 64
+      ;;
+    *)
+      [[ -z "$build_context" ]] || { printf 'ERROR: docker build wrapper accepts exactly one build context\n' >&2; exit 64; }
+      build_context="$1"
+      shift
+      ;;
+  esac
+done
+[[ -n "$build_context" ]] || { printf 'ERROR: docker build wrapper requires exactly one build context\n' >&2; exit 64; }
+
+exec "$POC_REAL_DOCKER" build --network=host \
+  --build-arg "http_proxy=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  --build-arg "https_proxy=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  --build-arg "HTTP_PROXY=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  --build-arg "HTTPS_PROXY=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  --build-arg "all_proxy=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  --build-arg "ALL_PROXY=${POC_RUNTIME_BUILD_PROXY_URL}" \
+  "${build_arguments[@]}" "$build_context"
+EOF
+  chmod 700 -- "${wrapper_directory}/docker"
+}
+
+run_runtime_image_builds_with_local_proxy() {
+  local wrapper_directory
+  local real_docker
+  local original_path=$PATH
+  local build_status=0
+
+  real_docker="$(type -P docker)"
+  [[ -n "$real_docker" && -x "$real_docker" ]] || die \
+    'Unable to resolve the real Docker client for the runtime image build wrapper.'
+  wrapper_directory="$(mktemp -d "${STATE_DIRECTORY}/runtime-image-docker-wrapper.XXXXXX")" || die \
+    'Unable to create private runtime image build wrapper directory.'
+  if ! chmod 700 -- "$wrapper_directory"; then
+    remove_private_directory "$wrapper_directory" "${STATE_DIRECTORY}/runtime-image-docker-wrapper."
+    die 'Unable to protect private runtime image build wrapper directory.'
+  fi
+  create_runtime_image_build_docker_wrapper "$wrapper_directory"
+
+  # Only the helper's docker build calls are rewritten. Its docker pull calls
+  # remain direct and continue using the Docker daemon's existing proxy.
+  export POC_REAL_DOCKER="$real_docker"
+  export POC_RUNTIME_BUILD_PROXY_URL="$LOCAL_PROXY_URL"
+  export PATH="${wrapper_directory}:${original_path}"
+  if ! k8s_e2e_build_runtime_images; then
+    build_status=1
+  fi
+  export PATH="$original_path"
+  unset POC_REAL_DOCKER POC_RUNTIME_BUILD_PROXY_URL
+  set_kubernetes_no_proxy
+  remove_private_directory "$wrapper_directory" "${STATE_DIRECTORY}/runtime-image-docker-wrapper."
+  ((build_status == 0)) || die 'Runtime image build/pull helper phase failed.'
+}
+
+load_runtime_images_into_poc_kind() {
+  local nodes
+  local image
+  local expected_reference
+  local first_component
+  local references
+  local reference
+  local reference_found=0
+  local -a runtime_images=("$SERVER_IMG" "$EXECD_IMG" "$EGRESS_IMG" "$SANDBOX_TEST_IMAGE")
+
+  # Kind's docker-image loader currently imports with ctr --all-platforms,
+  # which can fail with Docker 29 OCI manifest indexes (Kind #4224/#4066).
+  # This POC owns exactly one verified node, so import each exact local image
+  # directly without --all-platforms; never target another Kind cluster/node.
+  nodes="$(kind get nodes --name "$KIND_CLUSTER")" || die \
+    "Unable to resolve nodes for owned POC Kind cluster: ${KIND_CLUSTER}"
+  [[ "$nodes" == "$KIND_NODE" ]] || die \
+    "Expected exactly one owned POC Kind node ${KIND_NODE}; received: ${nodes}"
+
+  for image in "${runtime_images[@]}"; do
+    docker image inspect "$image" >/dev/null 2>&1 || die \
+      "Required local runtime image is unavailable for POC Kind import: ${image}"
+    if ! docker save "$image" | docker exec --privileged -i "$KIND_NODE" \
+      ctr --namespace=k8s.io images import --digests --snapshotter=overlayfs -; then
+      die "Unable to import exact runtime image into owned POC Kind node: ${image}"
+    fi
+    # ctr interprets a reference argument containing slashes as a filter. List
+    # only this exact POC node's references without a filter and compare in the
+    # runner. Docker Hub imports gain docker.io/ (and bare names gain library/).
+    if [[ "$image" != */* ]]; then
+      expected_reference="docker.io/library/${image}"
+    else
+      first_component="${image%%/*}"
+      if [[ "$first_component" == *.* || "$first_component" == *:* || "$first_component" == 'localhost' ]]; then
+        expected_reference="$image"
+      else
+        expected_reference="docker.io/${image}"
+      fi
+    fi
+    references="$(docker exec "$KIND_NODE" ctr --namespace=k8s.io images ls --quiet)" || die \
+      "Unable to verify imported runtime image on owned POC Kind node: ${image}"
+    reference_found=0
+    while IFS= read -r reference; do
+      [[ "$reference" == "$expected_reference" ]] && reference_found=1
+    done <<< "$references"
+    ((reference_found)) || die \
+      "Owned POC Kind node lacks expected imported runtime image reference: ${expected_reference}"
+  done
+}
+
+apply_poc_pvc_and_seed() {
+  local seed_pod_name="${POC_RESOURCE_PREFIX}-pvc-seed"
+
+  # The shared helper hard-codes alpine:3.20, whose Docker 29 OCI archive
+  # cannot be imported into this Kind POC. This runner-owned fixture keeps the
+  # same PV/PVC and seed data semantics, but uses the already loaded Ubuntu
+  # SANDBOX_TEST_IMAGE. It does not create any business sandbox workload.
+  kubectl get namespace "$E2E_NAMESPACE" >/dev/null 2>&1 || \
+    kubectl create namespace "$E2E_NAMESPACE"
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ${PV_NAME}
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /tmp/${PV_NAME}
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: ${E2E_NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: ${PV_NAME}
+EOF
+
+  kubectl wait --for=jsonpath='{.status.phase}'=Bound --timeout=120s \
+    "pvc/${PVC_NAME}" -n "$E2E_NAMESPACE"
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${seed_pod_name}
+  namespace: ${E2E_NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: seed
+      image: ${SANDBOX_TEST_IMAGE}
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -eux
+          mkdir -p /data/datasets/train
+          echo 'pvc-marker-data' > /data/marker.txt
+          echo 'pvc-subpath-marker' > /data/datasets/train/marker.txt
+      volumeMounts:
+        - name: pvc
+          mountPath: /data
+  volumes:
+    - name: pvc
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME}
+EOF
+
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=120s \
+    "pod/${seed_pod_name}" -n "$E2E_NAMESPACE"
+  kubectl delete pod "$seed_pod_name" -n "$E2E_NAMESPACE" --ignore-not-found=true
+}
+
+ensure_make_tool_cache() {
+  local tool_path=$1
+  local tool_version=$2
+  local tool_directory=$3
+  local tool_module=$4
+  local marker_path="${tool_path}-${tool_version}"
+  local temporary_gobin
+  local temporary_tool_path
+  local tool_name
+  local version_ready=0
+  local invalid_poc_marker=0
+  local resolved_tool_path
+
+  # kubernetes/Makefile's go-install-tool expects an executable versioned file
+  # and then runs ln -sf $(target)-$(version) $(target). Keep this exact layout
+  # project-local and never follow symlinks for the versioned executable.
+  [[ "$marker_path" == "${tool_directory}/"* ]] || die \
+    "Refusing Make tool version path outside the Kubernetes tool directory: ${marker_path}"
+  if [[ -e "$marker_path" || -L "$marker_path" ]]; then
+    [[ ! -L "$marker_path" ]] || die \
+      "Kubernetes Make tool version path must not be a symlink: ${marker_path}"
+    if [[ -f "$marker_path" && -x "$marker_path" ]]; then
+      version_ready=1
+    elif [[ -f "$marker_path" && ! -s "$marker_path" ]]; then
+      # Only the prior POC implementation created empty exact version paths.
+      invalid_poc_marker=1
+    else
+      die "Kubernetes Make tool version path is not an executable regular file: ${marker_path}"
+    fi
+  fi
+
+  if ((version_ready)); then
+    [[ -L "$tool_path" ]] || die \
+      "Kubernetes Make active tool must be a symlink to its versioned executable: ${tool_path}"
+    resolved_tool_path="$(readlink -f -- "$tool_path")" || die \
+      "Unable to resolve Kubernetes Make active tool symlink: ${tool_path}"
+    [[ "$resolved_tool_path" == "$marker_path" ]] || die \
+      "Kubernetes Make active tool resolves to an unexpected path: ${tool_path}"
+    return
+  fi
+
+  if ((invalid_poc_marker)); then
+    # Repair only the exact empty marker created by this POC. Its active path
+    # must either point to it (controller-gen) or be an executable regular file
+    # beside it (kustomize); any other layout is refused as potentially foreign.
+    if [[ -L "$tool_path" ]]; then
+      resolved_tool_path="$(readlink -f -- "$tool_path")" || die \
+        "Unable to resolve invalid Kubernetes Make active tool symlink: ${tool_path}"
+      [[ "$resolved_tool_path" == "$marker_path" ]] || die \
+        "Refusing to replace active tool with an unexpected symlink target: ${tool_path}"
+    else
+      [[ -f "$tool_path" && ! -L "$tool_path" && -x "$tool_path" ]] || die \
+        "Refusing to replace unexpected invalid Kubernetes Make active tool: ${tool_path}"
+    fi
+    rm -f -- "$tool_path" "$marker_path"
+  elif [[ -e "$tool_path" || -L "$tool_path" ]]; then
+    die "Kubernetes Make active tool exists without a valid versioned executable: ${tool_path}"
+  fi
+
+  tool_name="${tool_path##*/}"
+  temporary_gobin="$(mktemp -d "${STATE_DIRECTORY}/go-tool-cache.XXXXXX")" || die \
+    "Unable to create private Go tool cache directory for ${tool_name}."
+  if ! chmod 700 -- "$temporary_gobin"; then
+    remove_private_directory "$temporary_gobin" "${STATE_DIRECTORY}/go-tool-cache."
+    die "Unable to protect private Go tool cache directory for ${tool_name}."
+  fi
+  set_build_tools_proxy
+  if ! GOBIN="$temporary_gobin" go install "${tool_module}@${tool_version}"; then
+    set_kubernetes_no_proxy
+    remove_private_directory "$temporary_gobin" "${STATE_DIRECTORY}/go-tool-cache."
+    die "Unable to cache required ${tool_name} ${tool_version} before Kind creation."
+  fi
+  set_kubernetes_no_proxy
+  temporary_tool_path="${temporary_gobin}/${tool_name}"
+  [[ -f "$temporary_tool_path" && ! -L "$temporary_tool_path" && -x "$temporary_tool_path" ]] || {
+    remove_private_directory "$temporary_gobin" "${STATE_DIRECTORY}/go-tool-cache."
+    die "Downloaded ${tool_name} is not an executable regular file."
+  }
+  # A hard link publishes without replacement atomically. Both paths are under
+  # this worktree, so the private GOBIN and target remain on the same filesystem.
+  if ! ln -- "$temporary_tool_path" "$marker_path"; then
+    remove_private_directory "$temporary_gobin" "${STATE_DIRECTORY}/go-tool-cache."
+    die "Refusing to overwrite Kubernetes Make tool version path: ${marker_path}"
+  fi
+  rm -f -- "$temporary_tool_path"
+  remove_private_directory "$temporary_gobin" "${STATE_DIRECTORY}/go-tool-cache."
+  [[ -f "$marker_path" && ! -L "$marker_path" && -x "$marker_path" ]] || die \
+    "Kubernetes Make tool version executable was not safely published: ${marker_path}"
+
+  # ln creates the active symlink without replacing a concurrently created or
+  # pre-existing tool path.
+  ln -s -- "$marker_path" "$tool_path" || die \
+    "Refusing to overwrite Kubernetes Make active tool: ${tool_path}"
+  [[ -L "$tool_path" && "$(readlink -f -- "$tool_path")" == "$marker_path" ]] || die \
+    "Kubernetes Make active tool link was not safely published: ${tool_path}"
+}
+
+preflight_docker_resolver() {
+  local preflight_directory
+  local preflight_id
+  local preflight_image
+  local build_status=0
+
+  # Exercise the Docker daemon's normal BuildKit resolver path before Kind is
+  # created. Its globally configured proxy is external to this runner.
+  preflight_directory="$(mktemp -d "${STATE_DIRECTORY}/buildx-proxy-preflight.XXXXXX")" || die \
+    'Unable to create private Docker resolver preflight directory.'
+  if ! chmod 700 -- "$preflight_directory"; then
+    remove_private_directory "$preflight_directory" "${STATE_DIRECTORY}/buildx-proxy-preflight."
+    die 'Unable to protect private Docker resolver preflight directory.'
+  fi
+  preflight_id="$(openssl rand -hex 16)" || {
+    remove_private_directory "$preflight_directory" "${STATE_DIRECTORY}/buildx-proxy-preflight."
+    die 'Unable to generate a unique Docker resolver preflight image tag.'
+  }
+  preflight_image="opensandbox/poc-docker-resolver-preflight:${preflight_id}"
+  if docker image inspect "$preflight_image" >/dev/null 2>&1; then
+    remove_private_directory "$preflight_directory" "${STATE_DIRECTORY}/buildx-proxy-preflight."
+    die 'Generated Docker resolver preflight image tag already exists; refusing to replace it.'
+  fi
+  if ! printf '%s\n' 'FROM golang:1.25.12-alpine' >"${preflight_directory}/Dockerfile"; then
+    remove_private_directory "$preflight_directory" "${STATE_DIRECTORY}/buildx-proxy-preflight."
+    die 'Unable to write private Docker resolver preflight Dockerfile.'
+  fi
+
+  if ! docker build --pull=false --tag "$preflight_image" "$preflight_directory"; then
+    build_status=1
+  fi
+  if docker image inspect "$preflight_image" >/dev/null 2>&1; then
+    docker image rm --force "$preflight_image" >/dev/null || die \
+      "Unable to remove only the generated Docker resolver preflight image: ${preflight_image}"
+  fi
+  remove_private_directory "$preflight_directory" "${STATE_DIRECTORY}/buildx-proxy-preflight."
+  ((build_status == 0)) || die \
+    'Docker resolver preflight failed for golang:1.25.12-alpine; refusing to create a Kind cluster.'
+}
+
+cache_controller_gen() {
+  local kubernetes_directory="${REPO_ROOT}/kubernetes"
+  local kubernetes_bin_directory="${kubernetes_directory}/bin"
+  local controller_gen_path="${kubernetes_bin_directory}/controller-gen"
+  local make_metadata
+  local make_controller_gen_path
+  local controller_tools_version
+
+  # Ask the Kubernetes Makefile for its expanded target and version rather
+  # than duplicating either value in this runner.
+  make_metadata="$(make -s --no-print-directory -C "$kubernetes_directory" \
+    --eval 'print-poc-controller-gen: ; @printf "%s|%s\\n" "$(CONTROLLER_GEN)" "$(CONTROLLER_TOOLS_VERSION)"' \
+    print-poc-controller-gen)" || die \
+    'Unable to read controller-gen target and version from kubernetes/Makefile.'
+  IFS='|' read -r make_controller_gen_path controller_tools_version <<< "$make_metadata"
+  [[ "$make_controller_gen_path" == "$controller_gen_path" && "$controller_tools_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die \
+    'Kubernetes Makefile controller-gen target or version is not safe for this POC cache.'
+  [[ -d "$kubernetes_directory" && ! -L "$kubernetes_directory" ]] || die \
+    "Kubernetes directory must be a non-symlink directory: ${kubernetes_directory}"
+  if [[ -e "$kubernetes_bin_directory" || -L "$kubernetes_bin_directory" ]]; then
+    [[ -d "$kubernetes_bin_directory" && ! -L "$kubernetes_bin_directory" ]] || die \
+      "Kubernetes tool directory must be a non-symlink directory: ${kubernetes_bin_directory}"
+  else
+    mkdir -p -- "$kubernetes_bin_directory"
+    chmod 700 -- "$kubernetes_bin_directory"
+  fi
+  ensure_make_tool_cache "$controller_gen_path" "$controller_tools_version" \
+    "$kubernetes_bin_directory" 'sigs.k8s.io/controller-tools/cmd/controller-gen'
+}
+
+cache_kustomize() {
+  local kubernetes_directory="${REPO_ROOT}/kubernetes"
+  local kubernetes_bin_directory="${kubernetes_directory}/bin"
+  local kustomize_path="${kubernetes_bin_directory}/kustomize"
+  local make_metadata
+  local make_kustomize_path
+  local kustomize_version
+
+  # Ask the Kubernetes Makefile for its expanded target and version rather
+  # than duplicating either value in this runner.
+  make_metadata="$(make -s --no-print-directory -C "$kubernetes_directory" \
+    --eval 'print-poc-kustomize: ; @printf "%s|%s\\n" "$(KUSTOMIZE)" "$(KUSTOMIZE_VERSION)"' \
+    print-poc-kustomize)" || die \
+    'Unable to read kustomize target and version from kubernetes/Makefile.'
+  IFS='|' read -r make_kustomize_path kustomize_version <<< "$make_metadata"
+  [[ "$make_kustomize_path" == "$kustomize_path" && "$kustomize_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die \
+    'Kubernetes Makefile kustomize target or version is not safe for this POC cache.'
+  [[ -d "$kubernetes_directory" && ! -L "$kubernetes_directory" ]] || die \
+    "Kubernetes directory must be a non-symlink directory: ${kubernetes_directory}"
+  if [[ -e "$kubernetes_bin_directory" || -L "$kubernetes_bin_directory" ]]; then
+    [[ -d "$kubernetes_bin_directory" && ! -L "$kubernetes_bin_directory" ]] || die \
+      "Kubernetes tool directory must be a non-symlink directory: ${kubernetes_bin_directory}"
+  else
+    mkdir -p -- "$kubernetes_bin_directory"
+    chmod 700 -- "$kubernetes_bin_directory"
+  fi
+  ensure_make_tool_cache "$kustomize_path" "$kustomize_version" \
+    "$kubernetes_bin_directory" 'sigs.k8s.io/kustomize/kustomize/v5'
+}
+
+cache_kubernetes_go_modules() {
+  local kubernetes_directory="${REPO_ROOT}/kubernetes"
+  local go_mod_path="${kubernetes_directory}/go.mod"
+  local go_sum_path="${kubernetes_directory}/go.sum"
+
+  # controller-gen can load packages whose module dependencies are not needed
+  # by its own installation. Cache only the existing module graph; do not run
+  # Make targets or generate source before the isolated Kind phase.
+  for path in "$go_mod_path" "$go_sum_path"; do
+    [[ -f "$path" && ! -L "$path" && -r "$path" ]] || die \
+      "Kubernetes Go module file must be a readable non-symlink regular file: ${path}"
+  done
+  set_build_tools_proxy
+  if ! (cd "$kubernetes_directory" && go mod download); then
+    set_kubernetes_no_proxy
+    die 'Unable to cache Kubernetes Go module dependencies before Kind creation.'
+  fi
+  set_kubernetes_no_proxy
+}
+
+validate_fixed_paths() {
+  [[ -d "$POC_DIRECTORY" && ! -L "$POC_DIRECTORY" ]] || die \
+    "POC directory must be a non-symlink directory: ${POC_DIRECTORY}"
+  if [[ -e "$STATE_DIRECTORY" || -L "$STATE_DIRECTORY" ]]; then
+    [[ -d "$STATE_DIRECTORY" && ! -L "$STATE_DIRECTORY" ]] || die \
+      "POC state directory must be a non-symlink directory: ${STATE_DIRECTORY}"
+  fi
+  for path in "$KUBECONFIG_PATH" "$SERVER_VALUES_FILE" "$PORT_FORWARD_LOG"; do
+    [[ ! -L "$path" ]] || die "Refusing symlinked POC state file: ${path}"
+  done
+}
+
+print_plan() {
+  note 'OpenSandbox 本地 Kind ensureSubPathDirectory POC（默认 dry-run）'
+  note "唯一受管 Kind 集群: ${KIND_CLUSTER}"
+  note "固定本地生命周期端口: 127.0.0.1:${LIFECYCLE_LOCAL_PORT}（不使用 18080/18090）"
+  note "POC 状态目录: ${STATE_DIRECTORY}"
+  note "固定 pytest 节点: ${TEST_NODE}"
+  note '确认执行后将按以下既有公共 helper 流程运行：'
+  note '  1. scripts/common/kubernetes-e2e.sh:k8s_e2e_setup_kind_and_controller'
+  note '  2. scripts/common/kubernetes-e2e.sh:k8s_e2e_build_runtime_images'
+  note '  3. scripts/common/kubernetes-e2e.sh:k8s_e2e_kind_load_runtime_images'
+  note '  4. scripts/common/kubernetes-e2e.sh:k8s_e2e_apply_pvc_and_seed'
+  note '  5. scripts/common/kubernetes-e2e.sh:k8s_e2e_write_server_helm_values / k8s_e2e_helm_install_server'
+  note "  6. uv run pytest -q ${TEST_NODE}"
+  note '创建 Kind 前会先通过本机 127.0.0.1:7897 代理缓存 Makefile 指定的 controller-gen/kustomize，并写入可执行版本文件及其兼容的活动符号链接，再清除进程代理并设置 no_proxy=*。'
+  note '同一预备阶段会执行 kubernetes/go.mod 的 go mod download，仅填充 Go module cache，不执行生成或 Make 目标。'
+  note '随后通过 Docker daemon 的默认 BuildKit 以临时 golang:1.25.12-alpine Dockerfile 执行 docker build --pull=false 验证镜像解析；失败则不创建集群。'
+  note '仅运行时镜像 helper 期间，临时包装 docker build 为保持 Docker 本地镜像格式的 docker build --network=host，并传入本机 127.0.0.1:7897 代理 build args；docker pull 保持直连 Docker daemon。'
+  note '运行时镜像（包括 Ubuntu seed fixture 镜像）只会导入唯一受管节点 opensandbox-subpath-poc-kind-control-plane；为规避 Docker 29 OCI manifest index 的 Kind --all-platforms 导入兼容性问题，使用 docker save | ctr images import（不带 --all-platforms）。'
+  note 'PVC fixture 使用 runner 专属的 Ubuntu seed Pod 写入既有 datasets/train 与 marker 数据，不调用硬编码 alpine:3.20 的公共 helper。'
+  note 'Kind、Kubernetes、port-forward 和 pytest 阶段均设置 no_proxy=*；不会修改 Docker daemon 的外部代理配置。'
+  note '测试通过 OpenSandbox 生命周期 API 创建 sandbox；本脚本不直接创建 BatchSandbox 或业务 Pod。'
+  note '公共 PVC helper 会写入其既有基线标记；目标用例使用随机、此前未种子化的 subPath。'
+  note '退出时仅删除本次创建的固定 Kind 集群。'
+}
+
+validate_dependencies() {
+  local command
+  for command in kind docker kubectl helm make go uv curl openssl python3 ss; do
+    require_command "$command"
+  done
+}
+
+assert_cluster_absent() {
+  local cluster
+  while IFS= read -r cluster; do
+    [[ "$cluster" != "$KIND_CLUSTER" ]] || die \
+      "Refusing to use existing Kind cluster ${KIND_CLUSTER}; it may not be owned by this POC run."
+  done < <(kind get clusters)
+}
+
+assert_lifecycle_port_free() {
+  local listeners
+  listeners="$(ss -H -ltn "sport = :${LIFECYCLE_LOCAL_PORT}")" || die \
+    "Unable to inspect fixed lifecycle port ${LIFECYCLE_LOCAL_PORT}."
+  [[ -z "$listeners" ]] || die \
+    "Fixed lifecycle port 127.0.0.1:${LIFECYCLE_LOCAL_PORT} is already in use; refusing to touch its listener."
+}
+
+prepare_state_directory() {
+  validate_fixed_paths
+  mkdir -p -- "$STATE_DIRECTORY"
+  chmod 700 -- "$STATE_DIRECTORY"
+  validate_fixed_paths
+}
+
+cleanup_poc_resources() {
+  local status=$?
+  local cluster
+
+  trap - EXIT
+  if ((KIND_CLUSTER_CREATION_STARTED)); then
+    while IFS= read -r cluster; do
+      if [[ "$cluster" == "$KIND_CLUSTER" ]]; then
+        # The name is constant and was absent before this run began.
+        kind delete cluster --name "$KIND_CLUSTER" || \
+          printf 'WARN: unable to delete only owned Kind cluster %s\n' "$KIND_CLUSTER" >&2
+        break
+      fi
+    done < <(kind get clusters 2>/dev/null || true)
+  fi
+  exit "$status"
+}
+
+run_confirmed_poc() {
+  validate_dependencies
+  assert_cluster_absent
+  assert_lifecycle_port_free
+  prepare_state_directory
+
+  # 禁止代理影响 Kind、Kubernetes API、kubectl port-forward 或本地生命周期 API。
+  set_kubernetes_no_proxy
+  export DOCKER_BUILDKIT=1
+
+  export KIND_CLUSTER
+  export KIND_K8S_VERSION="${KIND_K8S_VERSION:-v1.30.4}"
+  export KUBECONFIG_PATH
+  export E2E_NAMESPACE="${POC_RESOURCE_PREFIX}-e2e"
+  export SERVER_NAMESPACE="${POC_RESOURCE_PREFIX}-system"
+  export PV_NAME="${POC_RESOURCE_PREFIX}-pv"
+  export PVC_NAME="${POC_RESOURCE_PREFIX}-pvc"
+  export CONTROLLER_IMG="opensandbox/controller:subpath-poc-kind"
+  export SERVER_IMG="opensandbox/server:subpath-poc-kind"
+  export EXECD_IMG="opensandbox/execd:subpath-poc-kind"
+  export EGRESS_IMG="opensandbox/egress:subpath-poc-kind"
+  export SERVER_RELEASE="${POC_RESOURCE_PREFIX}-server"
+  export SERVER_VALUES_FILE
+  export PORT_FORWARD_LOG
+  export SANDBOX_TEST_IMAGE="${SANDBOX_TEST_IMAGE:-ubuntu:latest}"
+  export LIFECYCLE_LOCAL_PORT
+  export SERVER_IMG_REPOSITORY="${SERVER_IMG%:*}"
+  export SERVER_IMG_TAG="${SERVER_IMG##*:}"
+
+  # shellcheck source=common/kubernetes-e2e.sh
+  source "${SCRIPT_DIRECTORY}/common/kubernetes-e2e.sh"
+
+  trap cleanup_poc_resources EXIT
+  # Fetch the Makefile-required local tool in a tightly scoped pre-Kind proxy
+  # phase. It restores no_proxy=* before any Kind or Kubernetes command.
+  cache_controller_gen
+  cache_kustomize
+  cache_kubernetes_go_modules
+  # The normal Docker BuildKit resolver must succeed before Kind can create
+  # anything. The daemon proxy is external and is not changed by this runner.
+  preflight_docker_resolver
+
+  k8s_e2e_export_kubeconfig
+  KIND_CLUSTER_CREATION_STARTED=1
+  k8s_e2e_setup_kind_and_controller
+  run_runtime_image_builds_with_local_proxy
+  load_runtime_images_into_poc_kind
+  apply_poc_pvc_and_seed
+  k8s_e2e_write_server_helm_values
+  # The shared helper does not set the chart namespace override; append this
+  # runner-owned value so all server chart resources stay in the isolated POC namespace.
+  printf '\nnamespaceOverride: "%s"\n' "$SERVER_NAMESPACE" >> "$SERVER_VALUES_FILE"
+  k8s_e2e_helm_install_server
+
+  kubectl port-forward -n "$SERVER_NAMESPACE" svc/opensandbox-server \
+    "${LIFECYCLE_LOCAL_PORT}:80" >"$PORT_FORWARD_LOG" 2>&1 &
+  k8s_e2e_wait_http_ok "http://127.0.0.1:${LIFECYCLE_LOCAL_PORT}/health"
+
+  export OPENSANDBOX_TEST_DOMAIN="localhost:${LIFECYCLE_LOCAL_PORT}"
+  export OPENSANDBOX_TEST_PROTOCOL='http'
+  export OPENSANDBOX_TEST_API_KEY='kubernetes-e2e'
+  export OPENSANDBOX_SANDBOX_DEFAULT_IMAGE="$SANDBOX_TEST_IMAGE"
+  export OPENSANDBOX_E2E_RUNTIME='kubernetes'
+  export OPENSANDBOX_TEST_USE_SERVER_PROXY='true'
+  export OPENSANDBOX_TEST_PVC_NAME="$PVC_NAME"
+  k8s_e2e_export_sandbox_resource_env
+
+  cd "${REPO_ROOT}/tests/python"
+  uv sync --all-extras --refresh
+  uv run pytest -q \
+    'tests/test_sandbox_e2e_sync.py::TestSandboxE2ESync::test_01g_pvc_unseeded_subpath_initializer'
+}
+
+[[ "$#" -eq 0 ]] || die 'This POC runner accepts no arguments; cluster, paths, port, and pytest node are fixed.'
+validate_fixed_paths
+print_plan
+
+if [[ "${LOCAL_KIND_POC_CONFIRM:-}" != '1' ]]; then
+  note 'Dry run only: no docker, kind, kubectl, Helm, build, port-forward, or pytest command was executed.'
+  note 'To run only this isolated POC, set LOCAL_KIND_POC_CONFIRM=1.'
+  exit 0
+fi
+
+run_confirmed_poc

--- a/scripts/remote-k8s-subpath-poc-provision.sh
+++ b/scripts/remote-k8s-subpath-poc-provision.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Parent-owned prerequisite provisioning and exact namespace cleanup for the
+# ensureSubPathDirectory remote Kubernetes POC.
+
+set -euo pipefail
+
+readonly POC_PREFIX='opensandbox-subpath-poc-'
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+note() {
+  printf '%s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command is unavailable: $1"
+}
+
+validate_namespace() {
+  [[ "$POC_NAMESPACE" =~ ^opensandbox-subpath-poc-[a-f0-9]{16}$ ]] || die \
+    "POC_NAMESPACE must be exactly ${POC_PREFIX}<16 lowercase hex characters>."
+  [[ "$POC_NAMESPACE" != 'sandbox-tenant-a' ]] || die 'sandbox-tenant-a is never an allowed POC namespace.'
+}
+
+validate_names() {
+  [[ "$POC_SERVICE_ACCOUNT" == "${POC_PREFIX}sa-${POC_TOKEN}" ]] || die \
+    "POC ServiceAccount must exactly be ${POC_PREFIX}sa-${POC_TOKEN}."
+  [[ "$POC_IMAGE_PULL_SECRET" == "${POC_PREFIX}pull-${POC_TOKEN}" ]] || die \
+    "POC imagePullSecret must exactly be ${POC_PREFIX}pull-${POC_TOKEN}."
+}
+
+secure_remove() {
+  local path="$1"
+  [[ -e "$path" ]] || return 0
+  shred -u -- "$path" || {
+    printf 'ERROR: unable to securely erase temporary credential material: %s\n' "$path" >&2
+    exit 1
+  }
+}
+
+credential_file=''
+cleanup_local_credentials() {
+  local status=$?
+  trap - EXIT
+  if [[ -n "$credential_file" ]]; then
+    secure_remove "$credential_file"
+  fi
+  exit "$status"
+}
+
+write_registry_docker_config() {
+  credential_file="$(mktemp "${TMPDIR:-/tmp}/opensandbox-subpath-poc-dockerconfig.XXXXXX")"
+  chmod 600 "$credential_file"
+  REMOTE_POC_DOCKER_CONFIG="$REMOTE_POC_DOCKER_CONFIG" \
+    REMOTE_POC_DOCKER_AUTH_KEY="$REMOTE_POC_DOCKER_AUTH_KEY" python3 - "$credential_file" <<'PY'
+import json
+import os
+import sys
+
+source_path = os.environ["REMOTE_POC_DOCKER_CONFIG"]
+auth_key = os.environ["REMOTE_POC_DOCKER_AUTH_KEY"]
+target_path = sys.argv[1]
+with open(source_path, encoding="utf-8") as source_file:
+    source = json.load(source_file)
+auths = source.get("auths")
+if not isinstance(auths, dict):
+    raise SystemExit("Local Docker config has no auths object.")
+registry_auth = auths.get(auth_key)
+if not isinstance(registry_auth, dict) or not registry_auth:
+    raise SystemExit("Local Docker config has no auth entry for REMOTE_POC_DOCKER_AUTH_KEY.")
+with open(target_path, "w", encoding="utf-8") as target_file:
+    json.dump({"auths": {auth_key: registry_auth}}, target_file, separators=(",", ":"))
+PY
+}
+
+check_provision_permissions() {
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i get namespaces | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot determine whether the exact POC Namespace exists.'
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i create namespaces | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot create the exact POC Namespace.'
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i create secrets -n "$POC_NAMESPACE" | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot create the exact POC imagePullSecret.'
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i create serviceaccounts -n "$POC_NAMESPACE" | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot create the exact POC ServiceAccount.'
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i patch serviceaccounts -n "$POC_NAMESPACE" | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot add the exact imagePullSecret reference to the POC ServiceAccount.'
+}
+
+check_cleanup_permissions() {
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i get namespaces | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot inspect the exact POC Namespace.'
+  kubectl --kubeconfig "$KUBECONFIG" auth can-i delete namespaces | grep -qx yes || die \
+    'The supplied KUBECONFIG cannot delete the exact POC Namespace.'
+}
+
+assert_cleanup_namespace_is_exactly_prerequisites() {
+  local resource object
+  while IFS= read -r resource; do
+    [[ -n "$resource" ]] || continue
+    kubectl --kubeconfig "$KUBECONFIG" auth can-i list "$resource" -n "$POC_NAMESPACE" | grep -qx yes || die \
+      "Cannot list ${resource} in ${POC_NAMESPACE}; refusing namespace cleanup."
+    object="$(kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+      get "$resource" -o name)" || die \
+      "Cannot list ${resource} in ${POC_NAMESPACE}; refusing namespace cleanup."
+    [[ -n "$object" ]] || continue
+
+    case "$resource" in
+      events|events.events.k8s.io)
+        # The exact, random POC Namespace may contain ordinary runner Events.
+        ;;
+      serviceaccounts)
+        while IFS= read -r object; do
+          [[ -z "$object" ]] && continue
+          [[ "$object" == 'serviceaccount/default' || "$object" == "serviceaccount/${POC_SERVICE_ACCOUNT}" ]] || die \
+            "Unexpected resource ${object}; refusing namespace cleanup."
+        done <<<"$object"
+        ;;
+      secrets)
+        while IFS= read -r object; do
+          [[ -z "$object" ]] && continue
+          [[ "$object" == "secret/${POC_IMAGE_PULL_SECRET}" \
+            || "$object" =~ ^secret/default-token-[a-z0-9]{5}$ \
+            || "$object" =~ ^secret/"${POC_SERVICE_ACCOUNT}"-token-[a-z0-9]{5}$ ]] || die \
+            "Unexpected resource ${object}; refusing namespace cleanup."
+        done <<<"$object"
+        ;;
+      configmaps)
+        while IFS= read -r object; do
+          [[ -z "$object" ]] && continue
+          [[ "$object" == 'configmap/kube-root-ca.crt' || "$object" == 'configmap/tapp-env-config' ]] || die \
+            "Unexpected resource ${object}; refusing namespace cleanup."
+        done <<<"$object"
+        ;;
+      *)
+        die "Unexpected POC Namespace content (${resource}: ${object}); refusing namespace cleanup."
+        ;;
+    esac
+  done < <(kubectl --kubeconfig "$KUBECONFIG" api-resources --namespaced=true --verbs=list -o name)
+}
+
+require_command kubectl
+require_command python3
+require_command mktemp
+require_command chmod
+require_command shred
+
+[[ -n "${KUBECONFIG:-}" ]] || die 'KUBECONFIG must be explicitly set to one readable kubeconfig file.'
+[[ -f "$KUBECONFIG" && -r "$KUBECONFIG" ]] || die 'KUBECONFIG must name one readable regular file.'
+[[ -n "${POC_NAMESPACE:-}" ]] || die \
+  'POC_NAMESPACE must be explicitly set to a newly generated random POC Namespace.'
+
+POC_TOKEN="${POC_NAMESPACE#"$POC_PREFIX"}"
+POC_SERVICE_ACCOUNT="${REMOTE_POC_SERVICE_ACCOUNT:-${POC_PREFIX}sa-${POC_TOKEN}}"
+POC_IMAGE_PULL_SECRET="${REMOTE_POC_IMAGE_PULL_SECRET:-${POC_PREFIX}pull-${POC_TOKEN}}"
+validate_namespace
+validate_names
+
+mode="${REMOTE_POC_PROVISION_MODE:-provision}"
+case "$mode" in
+  provision)
+    note 'OpenSandbox remote Kubernetes POC prerequisite provisioning'
+    note "Target Namespace:       ${POC_NAMESPACE}"
+    note "Target ServiceAccount:  ${POC_SERVICE_ACCOUNT}"
+    note "Target imagePullSecret: ${POC_IMAGE_PULL_SECRET}"
+    note 'Planned writes: exact Namespace, exact dockerconfigjson Secret, exact ServiceAccount only.'
+    note 'The Secret is derived only from the configured local Docker config auth entry and is never printed.'
+    if [[ "${REMOTE_POC_PROVISION_CONFIRM:-}" != '1' ]]; then
+      note 'Dry run only: no Kubernetes API request and no local Docker credential read was made.'
+      note 'To provision, set REMOTE_POC_PROVISION_CONFIRM=1 after parent approval.'
+      exit 0
+    fi
+    [[ -n "${REMOTE_POC_DOCKER_CONFIG:-}" ]] || die \
+      'REMOTE_POC_DOCKER_CONFIG must name the local Docker config containing the selected registry auth.'
+    [[ -f "$REMOTE_POC_DOCKER_CONFIG" && -r "$REMOTE_POC_DOCKER_CONFIG" ]] || die \
+      'REMOTE_POC_DOCKER_CONFIG must name one readable regular file.'
+    [[ -n "${REMOTE_POC_DOCKER_AUTH_KEY:-}" ]] || die \
+      'REMOTE_POC_DOCKER_AUTH_KEY must name the exact auths key to copy from the local Docker config.'
+    check_provision_permissions
+    if kubectl --kubeconfig "$KUBECONFIG" get namespace "$POC_NAMESPACE" >/dev/null 2>&1; then
+      die "Refusing to provision an existing Namespace: ${POC_NAMESPACE}"
+    fi
+    trap cleanup_local_credentials EXIT
+    write_registry_docker_config
+    kubectl --kubeconfig "$KUBECONFIG" create namespace "$POC_NAMESPACE"
+    kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" create secret generic "$POC_IMAGE_PULL_SECRET" \
+      --type=kubernetes.io/dockerconfigjson \
+      --from-file=.dockerconfigjson="$credential_file"
+    secure_remove "$credential_file"
+    credential_file=''
+    kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" create serviceaccount "$POC_SERVICE_ACCOUNT"
+    kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" patch serviceaccount "$POC_SERVICE_ACCOUNT" \
+      --type=merge \
+      -p "{\"imagePullSecrets\":[{\"name\":\"${POC_IMAGE_PULL_SECRET}\"}]}"
+    note 'Provisioning completed. Parent owns the Namespace and prerequisite cleanup.'
+    ;;
+  cleanup)
+    note 'OpenSandbox remote Kubernetes POC parent cleanup'
+    note "Target Namespace: ${POC_NAMESPACE}"
+    note 'Cleanup permits only default ServiceAccount, exact POC ServiceAccount, exact POC imagePullSecret, generated default and POC ServiceAccount token Secrets, configmap/kube-root-ca.crt, configmap/tapp-env-config, and Events only because this is the exact random POC Namespace.'
+    note 'It refuses cleanup if any PVC, BatchSandbox, Pod, or other namespaced object remains.'
+    if [[ "${REMOTE_POC_CLEANUP_CONFIRM:-}" != '1' ]]; then
+      note 'Dry run only: no Kubernetes API request was made.'
+      note 'To clean up, set REMOTE_POC_CLEANUP_CONFIRM=1 after the runner has removed its sandbox and PVC and shared-storage impact is confirmed.'
+      exit 0
+    fi
+    [[ "${REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM:-}" == '1' ]] || die \
+      'Set REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1 only after confirming Namespace deletion cannot affect shared backing data.'
+    check_cleanup_permissions
+    kubectl --kubeconfig "$KUBECONFIG" get namespace "$POC_NAMESPACE" >/dev/null || die \
+      "Required POC Namespace is absent: ${POC_NAMESPACE}"
+    assert_cleanup_namespace_is_exactly_prerequisites
+    kubectl --kubeconfig "$KUBECONFIG" delete namespace "$POC_NAMESPACE" --wait=false
+    note "Requested deletion of exact POC Namespace: ${POC_NAMESPACE}"
+    ;;
+  *)
+    die 'REMOTE_POC_PROVISION_MODE must be provision (default) or cleanup.'
+    ;;
+esac

--- a/scripts/remote-k8s-subpath-poc.sh
+++ b/scripts/remote-k8s-subpath-poc.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# Safe remote Kubernetes POC for ensureSubPathDirectory.
+#
+# This runner is deliberately dry-run by default. It creates workloads only
+# through the OpenSandbox lifecycle API and uses kubectl only for approved
+# prerequisite inspection, observation, terminal verification, and cleanup of
+# the exact sandbox/PVC created by this runner's lifecycle request.
+
+set -euo pipefail
+
+readonly POC_PREFIX='opensandbox-subpath-poc-'
+readonly POC_LABEL_KEY='opensandbox.io/id'
+readonly POC_MOUNT_PATH='/mnt/opensandbox-subpath-poc'
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+note() {
+  printf '%s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command is unavailable: $1"
+}
+
+validate_namespace() {
+  [[ "$POC_NAMESPACE" =~ ^opensandbox-subpath-poc-[a-f0-9]{16}$ ]] || die \
+    "POC_NAMESPACE must be a random namespace in the exact form ${POC_PREFIX}<16 lowercase hex characters>."
+  [[ "$POC_NAMESPACE" != 'sandbox-tenant-a' ]] || die 'sandbox-tenant-a is never an allowed POC namespace.'
+}
+
+validate_base_url() {
+  python3 - "$REMOTE_POC_BASE_URL" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+value = sys.argv[1]
+parsed = urlparse(value)
+if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+    raise SystemExit("REMOTE_POC_BASE_URL must be an absolute http(s) URL.")
+if parsed.username or parsed.password or parsed.query or parsed.fragment:
+    raise SystemExit("REMOTE_POC_BASE_URL must not embed credentials, a query, or a fragment.")
+if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+    raise SystemExit("REMOTE_POC_BASE_URL must target an isolated local OpenSandbox Server on a loopback host.")
+try:
+    port = parsed.port
+except ValueError as exc:
+    raise SystemExit(f"REMOTE_POC_BASE_URL has an invalid port: {exc}")
+if port in {18080, 18090}:
+    raise SystemExit("REMOTE_POC_BASE_URL must not use formal service ports 18080 or 18090.")
+PY
+}
+
+validate_storage_class() {
+  python3 - "$REMOTE_POC_STORAGE_CLASS" <<'PY'
+import re
+import sys
+
+storage_class = sys.argv[1]
+dns1123_subdomain = re.compile(
+    r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*"
+)
+if len(storage_class) > 253 or not dns1123_subdomain.fullmatch(storage_class):
+    raise SystemExit(
+        "REMOTE_POC_STORAGE_CLASS must be a nonempty Kubernetes DNS-1123 subdomain suitable for storageClassName."
+    )
+PY
+}
+
+validate_create_request_timeout() {
+  [[ "$REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || die \
+    'REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS must be an integer from 61 through 300.'
+  (( 10#$REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS >= 61 && 10#$REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS <= 300 )) || die \
+    'REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS must be an integer from 61 through 300.'
+}
+
+validate_local_server_config() {
+  python3 - "$REMOTE_POC_SERVER_CONFIG" "$POC_NAMESPACE" "$REMOTE_POC_SERVICE_ACCOUNT" <<'PY'
+import os
+import re
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError as exc:
+    raise SystemExit("python3 >= 3.11 with tomllib is required to validate REMOTE_POC_SERVER_CONFIG.") from exc
+
+config_path, namespace, service_account = sys.argv[1:]
+with open(config_path, "rb") as config_file:
+    config = tomllib.load(config_file)
+
+runtime = config.get("runtime", {})
+kubernetes = config.get("kubernetes", {})
+if runtime.get("type") != "kubernetes":
+    raise SystemExit("REMOTE_POC_SERVER_CONFIG must set [runtime].type to kubernetes.")
+if kubernetes.get("namespace") != namespace:
+    raise SystemExit("REMOTE_POC_SERVER_CONFIG [kubernetes].namespace must exactly match POC_NAMESPACE.")
+if kubernetes.get("workload_provider") != "batchsandbox":
+    raise SystemExit("REMOTE_POC_SERVER_CONFIG [kubernetes].workload_provider must be batchsandbox.")
+execd_image = runtime.get("execd_image", "")
+if not isinstance(execd_image, str) or not re.search(r"@sha256:[0-9a-f]{64}$", execd_image):
+    raise SystemExit("REMOTE_POC_SERVER_CONFIG [runtime].execd_image must use a pinned @sha256 digest.")
+template_path = kubernetes.get("batchsandbox_template_file")
+if not isinstance(template_path, str) or not template_path.strip():
+    raise SystemExit("REMOTE_POC_SERVER_CONFIG must set [kubernetes].batchsandbox_template_file.")
+template_path = os.path.expanduser(template_path)
+if not os.path.isfile(template_path) or not os.access(template_path, os.R_OK):
+    raise SystemExit("Configured BatchSandbox template is not a readable regular file.")
+with open(template_path, encoding="utf-8") as template_file:
+    template = template_file.read()
+matches = re.findall(r"(?m)^\s*serviceAccountName:\s*['\"]?([^\s'\"#]+)", template)
+if matches != [service_account]:
+    raise SystemExit("Configured BatchSandbox template must contain exactly one matching serviceAccountName.")
+PY
+}
+
+validate_poc_resource_names() {
+  [[ "$REMOTE_POC_SERVICE_ACCOUNT" == "${POC_PREFIX}sa-${POC_TOKEN}" ]] || die \
+    "REMOTE_POC_SERVICE_ACCOUNT must exactly be ${POC_PREFIX}sa-${POC_TOKEN}."
+  [[ "$REMOTE_POC_IMAGE_PULL_SECRET" == "${POC_PREFIX}pull-${POC_TOKEN}" ]] || die \
+    "REMOTE_POC_IMAGE_PULL_SECRET must exactly be ${POC_PREFIX}pull-${POC_TOKEN}."
+}
+
+api_headers=()
+api_headers=(-H 'Accept: application/json')
+if [[ -n "${REMOTE_POC_API_KEY:-}" ]]; then
+  # Deliberately do not print this environment value.
+  api_headers+=(-H "OPEN-SANDBOX-API-KEY: ${REMOTE_POC_API_KEY}")
+fi
+
+sandbox_id=''
+
+api_delete_sandbox() {
+  local sandbox_id="$1"
+  curl -sS --connect-timeout 10 --max-time 60 \
+    -X DELETE \
+    "${api_headers[@]}" \
+    -o /dev/null \
+    -w '%{http_code}' \
+    "${REMOTE_POC_BASE_URL}/v1/sandboxes/${sandbox_id}" || true
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+
+  if [[ "${REMOTE_POC_CONFIRM:-}" == '1' ]]; then
+    note "Cleanup: only the exact lifecycle sandbox and its exact POC PVC will be removed."
+    if [[ -n "$sandbox_id" ]]; then
+      local delete_status
+      delete_status="$(api_delete_sandbox "$sandbox_id")"
+      if [[ "$delete_status" != '200' && "$delete_status" != '202' && "$delete_status" != '204' && "$delete_status" != '404' ]]; then
+        printf 'WARN: lifecycle deletion for exact sandbox %s returned HTTP %s.\n' \
+          "$sandbox_id" "$delete_status" >&2
+      fi
+    fi
+
+    kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+      delete pvc "$POC_PVC_NAME" --ignore-not-found --wait=false >/dev/null 2>&1 || \
+      printf 'WARN: exact PVC cleanup failed: %s/%s\n' "$POC_NAMESPACE" "$POC_PVC_NAME" >&2
+  fi
+
+  exit "$status"
+}
+
+require_command kubectl
+require_command curl
+require_command python3
+
+[[ -n "${KUBECONFIG:-}" ]] || die 'KUBECONFIG must be explicitly set to one readable kubeconfig file.'
+[[ -f "$KUBECONFIG" && -r "$KUBECONFIG" ]] || die 'KUBECONFIG must name one readable regular file.'
+[[ -n "${REMOTE_POC_BASE_URL:-}" ]] || die 'REMOTE_POC_BASE_URL is required.'
+[[ -n "${REMOTE_POC_SANDBOX_IMAGE:-}" ]] || die \
+  'REMOTE_POC_SANDBOX_IMAGE is required; supply an image already reachable by the target cluster.'
+[[ -n "${REMOTE_POC_SERVER_CONFIG:-}" ]] || die \
+  'REMOTE_POC_SERVER_CONFIG must name the isolated local OpenSandbox Server configuration file.'
+[[ -f "$REMOTE_POC_SERVER_CONFIG" && -r "$REMOTE_POC_SERVER_CONFIG" ]] || die \
+  'REMOTE_POC_SERVER_CONFIG must name one readable regular file.'
+[[ "${REMOTE_POC_LOCAL_SERVER_CONFIRM:-}" == '1' ]] || die \
+  'Set REMOTE_POC_LOCAL_SERVER_CONFIRM=1 only after confirming the loopback URL is the isolated local process using REMOTE_POC_SERVER_CONFIG.'
+[[ -n "${REMOTE_POC_SERVICE_ACCOUNT:-}" ]] || die 'REMOTE_POC_SERVICE_ACCOUNT is required.'
+[[ -n "${REMOTE_POC_IMAGE_PULL_SECRET:-}" ]] || die 'REMOTE_POC_IMAGE_PULL_SECRET is required.'
+[[ -n "${REMOTE_POC_STORAGE_CLASS:-}" ]] || die 'REMOTE_POC_STORAGE_CLASS is required.'
+[[ -n "${REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS:-}" ]] || die \
+  'REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS is required.'
+
+[[ -n "${POC_NAMESPACE:-}" ]] || die \
+  'POC_NAMESPACE must be explicitly set to a newly generated random POC namespace.'
+POC_TOKEN="${POC_NAMESPACE#"$POC_PREFIX"}"
+POC_PVC_NAME="${POC_PREFIX}pvc-${POC_TOKEN}"
+POC_SUBPATH="${POC_PREFIX}data-${POC_TOKEN}"
+validate_namespace
+validate_base_url
+validate_storage_class
+validate_create_request_timeout
+validate_poc_resource_names
+validate_local_server_config
+
+request_body="$(POC_NAMESPACE="$POC_NAMESPACE" POC_PVC_NAME="$POC_PVC_NAME" POC_SUBPATH="$POC_SUBPATH" \
+  REMOTE_POC_SANDBOX_IMAGE="$REMOTE_POC_SANDBOX_IMAGE" REMOTE_POC_STORAGE_CLASS="$REMOTE_POC_STORAGE_CLASS" \
+  python3 - "$POC_MOUNT_PATH" <<'PY'
+import json
+import os
+import sys
+
+mount_path = sys.argv[1]
+print(json.dumps({
+    "image": {"uri": os.environ["REMOTE_POC_SANDBOX_IMAGE"]},
+    "entrypoint": ["/bin/sh", "-c", "sleep 300"],
+    "resourceLimits": {"cpu": "250m", "memory": "256Mi"},
+    "timeout": 300,
+    "metadata": {
+        "poc": "opensandbox-subpath-poc",
+        "pocNamespace": os.environ["POC_NAMESPACE"],
+    },
+    "volumes": [{
+        "name": "opensandbox-subpath-poc-volume",
+        "pvc": {
+            "claimName": os.environ["POC_PVC_NAME"],
+            "storageClass": os.environ["REMOTE_POC_STORAGE_CLASS"],
+            "createIfNotExists": True,
+            "deleteOnSandboxTermination": True,
+        },
+        "mountPath": mount_path,
+        "readOnly": False,
+        "subPath": os.environ["POC_SUBPATH"],
+        "ensureSubPathDirectory": True,
+    }],
+}, separators=(",", ":")))
+PY
+)"
+
+note 'OpenSandbox ensureSubPathDirectory remote Kubernetes POC'
+note "Target namespace: ${POC_NAMESPACE}"
+note "Target PVC:       ${POC_PVC_NAME}"
+note "StorageClass:     ${REMOTE_POC_STORAGE_CLASS}"
+note "Create wait:      ${REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS}s (local curl only)"
+note "Target subPath:   ${POC_SUBPATH}"
+note "Lifecycle URL:    ${REMOTE_POC_BASE_URL}"
+note 'The generated subPath is new and random. This POC never deletes, repairs, or empties a shared backing path.'
+note 'Formal service ports 18080 and 18090 are refused. No port-forward is used.'
+note 'Exact planned remote resources/actions:'
+note "  - Namespace/${POC_NAMESPACE} (pre-provisioned and owned by the parent orchestration; never deleted here)"
+note "  - ServiceAccount/${REMOTE_POC_SERVICE_ACCOUNT} and Secret/${REMOTE_POC_IMAGE_PULL_SECRET} in ${POC_NAMESPACE} (pre-provisioned; metadata inspected only)"
+note "  - PersistentVolumeClaim/${POC_PVC_NAME} in ${POC_NAMESPACE} (created by the lifecycle request with StorageClass/${REMOTE_POC_STORAGE_CLASS})"
+note "  - BatchSandbox/<server-generated UUID> in ${POC_NAMESPACE} (created/deleted only through /v1/sandboxes)"
+note "  - Pod/<controller-generated name> in ${POC_NAMESPACE}, selected only by ${POC_LABEL_KEY}=<returned UUID>"
+note "  - POST ${REMOTE_POC_BASE_URL}/v1/sandboxes with the following body:"
+note "$request_body"
+
+if [[ "${REMOTE_POC_CONFIRM:-}" != '1' ]]; then
+  note 'Dry run only: no Kubernetes API or lifecycle API request was sent.'
+  note 'To execute, set REMOTE_POC_CONFIRM=1 and REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1 after completing the runbook prerequisites.'
+  exit 0
+fi
+
+[[ "${REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM:-}" == '1' ]] || die \
+  'Set REMOTE_POC_SHARED_STORAGE_DELETE_CONFIRM=1 only after confirming POC PVC deletion cannot affect shared backing data.'
+
+trap cleanup EXIT
+
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get namespaces | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot read the exact POC namespace.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get serviceaccounts -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot inspect the exact POC ServiceAccount.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get secrets -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot inspect exact POC Secret metadata.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get persistentvolumeclaims -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot verify the exact POC PVC is absent.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i delete persistentvolumeclaims -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot clean up the exact POC PVC.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get batchsandboxes.sandbox.opensandbox.io -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot inspect BatchSandbox resources in the POC namespace.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i get pods -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot inspect the exact POC sandbox Pod.'
+kubectl --kubeconfig "$KUBECONFIG" auth can-i create pods/exec -n "$POC_NAMESPACE" | grep -qx yes || die \
+  'The supplied KUBECONFIG cannot perform the exact POC Pod exec verification.'
+
+kubectl --kubeconfig "$KUBECONFIG" get namespace "$POC_NAMESPACE" >/dev/null || die \
+  "Required pre-provisioned POC namespace is absent: ${POC_NAMESPACE}"
+service_account_pull_secrets="$(kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+  get serviceaccount "$REMOTE_POC_SERVICE_ACCOUNT" \
+  -o jsonpath='{.imagePullSecrets[*].name}')" || die \
+  "Required pre-provisioned POC ServiceAccount is absent: ${POC_NAMESPACE}/${REMOTE_POC_SERVICE_ACCOUNT}"
+python3 - "$REMOTE_POC_IMAGE_PULL_SECRET" "$service_account_pull_secrets" <<'PY'
+import sys
+
+if sys.argv[1] not in sys.argv[2].split():
+    raise SystemExit("Required POC ServiceAccount does not reference REMOTE_POC_IMAGE_PULL_SECRET.")
+PY
+secret_metadata="$(kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+  get secret "$REMOTE_POC_IMAGE_PULL_SECRET" \
+  -o jsonpath='{.metadata.name}:{.type}')" || die \
+  "Required pre-provisioned POC image pull Secret is absent: ${POC_NAMESPACE}/${REMOTE_POC_IMAGE_PULL_SECRET}"
+[[ "$secret_metadata" == "${REMOTE_POC_IMAGE_PULL_SECRET}:kubernetes.io/dockerconfigjson" ]] || die \
+  'Required POC image pull Secret must have the exact name and type kubernetes.io/dockerconfigjson; Secret data is not read.'
+
+if kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" get pvc "$POC_PVC_NAME" >/dev/null 2>&1; then
+  die "Refusing to use existing target PVC: ${POC_NAMESPACE}/${POC_PVC_NAME}"
+fi
+if kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+  get batchsandboxes.sandbox.opensandbox.io >/dev/null 2>&1; then
+  [[ "$(kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+    get batchsandboxes.sandbox.opensandbox.io -o name)" == '' ]] || die \
+    "Refusing a non-empty target namespace: ${POC_NAMESPACE}"
+else
+  die 'The supplied KUBECONFIG cannot read BatchSandbox resources in the target namespace.'
+fi
+
+create_response="$(curl -sS --connect-timeout 10 --max-time "$REMOTE_POC_CREATE_REQUEST_TIMEOUT_SECONDS" \
+  -w $'\n%{http_code}' \
+  -X POST \
+  "${api_headers[@]}" \
+  -H 'Content-Type: application/json' \
+  --data "$request_body" \
+  "${REMOTE_POC_BASE_URL}/v1/sandboxes")" || die 'Lifecycle API create request failed.'
+http_status="${create_response##*$'\n'}"
+create_body="${create_response%$'\n'*}"
+[[ "$http_status" == '202' ]] || die "Lifecycle API create returned HTTP ${http_status}; no response body is printed."
+sandbox_id="$(python3 - "$create_body" <<'PY'
+import json
+import sys
+
+value = json.loads(sys.argv[1]).get("id", "")
+if not isinstance(value, str) or not value:
+    raise SystemExit("Lifecycle create response has no sandbox id.")
+print(value)
+PY
+)"
+
+note "Lifecycle created exact sandbox ID: ${sandbox_id}"
+note "Observed BatchSandbox: ${POC_NAMESPACE}/${sandbox_id}"
+kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+  get batchsandboxes.sandbox.opensandbox.io "$sandbox_id" -o json | \
+  POC_PVC_NAME="$POC_PVC_NAME" POC_SUBPATH="$POC_SUBPATH" EXPECTED_POC_MOUNT_PATH="$POC_MOUNT_PATH" python3 -c '
+import json
+import os
+import sys
+
+pod_spec = json.load(sys.stdin)["spec"]["template"]["spec"]
+expected_pvc = os.environ["POC_PVC_NAME"]
+expected_subpath = os.environ["POC_SUBPATH"]
+expected_mount = os.environ["EXPECTED_POC_MOUNT_PATH"]
+volumes = pod_spec.get("volumes", [])
+if not any(v.get("persistentVolumeClaim", {}).get("claimName") == expected_pvc for v in volumes):
+    raise SystemExit("BatchSandbox does not reference the exact POC PVC.")
+main = next((c for c in pod_spec.get("containers", []) if c.get("name") == "sandbox"), None)
+if main is None or not any(
+    m.get("mountPath") == expected_mount and m.get("subPath") == expected_subpath
+    for m in main.get("volumeMounts", [])
+):
+    raise SystemExit("BatchSandbox main container lacks the exact POC subPath mount.")
+initializer = next((c for c in pod_spec.get("initContainers", []) if c.get("name") == "volume-subpath-initializer"), None)
+if initializer is None or initializer.get("command") != ["/opensandbox-subpath-initializer"]:
+    raise SystemExit("BatchSandbox lacks the expected subPath initializer command.")
+print("Verified exact PVC mount and volume-subpath-initializer in BatchSandbox.")
+'
+
+kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" wait \
+  --for=condition=Ready pod -l "${POC_LABEL_KEY}=${sandbox_id}" --timeout=120s
+pod_name="$(kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" \
+  get pods -l "${POC_LABEL_KEY}=${sandbox_id}" -o json | python3 -c '
+import json
+import sys
+items = json.load(sys.stdin).get("items", [])
+if len(items) != 1:
+    raise SystemExit(f"Expected exactly one sandbox pod, found {len(items)}.")
+print(items[0]["metadata"]["name"])
+')"
+note "Observed exact pod: ${POC_NAMESPACE}/${pod_name}"
+kubectl --kubeconfig "$KUBECONFIG" -n "$POC_NAMESPACE" exec "$pod_name" -c sandbox -- \
+  /bin/sh -ceu "test -d '${POC_MOUNT_PATH}' && printf '%s\\n' 'ensure-subpath-poc' > '${POC_MOUNT_PATH}/opensandbox-subpath-poc-proof.txt' && test \"\$(cat '${POC_MOUNT_PATH}/opensandbox-subpath-poc-proof.txt')\" = ensure-subpath-poc"
+note 'PASS: the initializer-created subPath is mounted read-write in the sandbox.'

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -164,6 +164,7 @@ class SandboxModelConverter:
             pvc=api_pvc,
             ossfs=api_ossfs,
             sub_path=api_sub_path,
+            ensure_sub_path_directory=volume.ensure_sub_path_directory,
         )
 
     @staticmethod

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/volume.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/volume.py
@@ -37,7 +37,7 @@ class Volume:
     """Storage mount definition for a sandbox. Each volume entry contains:
     - A unique name identifier
     - Exactly one backend struct (host, pvc, ossfs, etc.) with backend-specific fields
-    - Common mount settings (mountPath, readOnly, subPath)
+    - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
 
         Attributes:
             name (str): Unique identifier for the volume within the sandbox.
@@ -67,6 +67,13 @@ class Volume:
             sub_path (str | Unset): Optional subdirectory under the backend path to mount.
                 For `ossfs` backend, this field is used as the bucket prefix.
                 Must be a relative path without '..' components.
+            ensure_sub_path_directory (bool | Unset): When true, Kubernetes BatchSandbox template-mode creation ensures that
+                `subPath` exists before the main container starts using the fixed trusted
+                initializer bundled with the configured execd image. It supports only
+                writable PVC mounts with a non-empty normalized relative `subPath`; it is
+                not supported for host or ossfs backends, read-only mounts, Docker, other
+                Kubernetes providers, or pool mode.
+                 Default: False.
     """
 
     name: str
@@ -76,6 +83,7 @@ class Volume:
     ossfs: OSSFS | Unset = UNSET
     read_only: bool | Unset = False
     sub_path: str | Unset = UNSET
+    ensure_sub_path_directory: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -98,6 +106,8 @@ class Volume:
 
         sub_path = self.sub_path
 
+        ensure_sub_path_directory = self.ensure_sub_path_directory
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -116,6 +126,8 @@ class Volume:
             field_dict["readOnly"] = read_only
         if sub_path is not UNSET:
             field_dict["subPath"] = sub_path
+        if ensure_sub_path_directory is not UNSET:
+            field_dict["ensureSubPathDirectory"] = ensure_sub_path_directory
 
         return field_dict
 
@@ -155,6 +167,8 @@ class Volume:
 
         sub_path = d.pop("subPath", UNSET)
 
+        ensure_sub_path_directory = d.pop("ensureSubPathDirectory", UNSET)
+
         volume = cls(
             name=name,
             mount_path=mount_path,
@@ -163,6 +177,7 @@ class Volume:
             ossfs=ossfs,
             read_only=read_only,
             sub_path=sub_path,
+            ensure_sub_path_directory=ensure_sub_path_directory,
         )
 
         return volume

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -480,7 +480,7 @@ class Volume(BaseModel):
     Each volume entry contains:
     - A unique name identifier
     - Exactly one backend (host, pvc, ossfs) with backend-specific fields
-    - Common mount settings (mount_path, read_only, sub_path)
+    - Common mount settings (mount_path, read_only, sub_path, ensure_sub_path_directory)
 
     Usage:
         # Host path mount (read-write by default)
@@ -527,6 +527,14 @@ class Volume(BaseModel):
         default=None,
         description="Optional subdirectory under the backend path to mount.",
         alias="subPath",
+    )
+    ensure_sub_path_directory: bool = Field(
+        default=False,
+        description=(
+            "Ensure a writable PVC subPath exists before a Kubernetes BatchSandbox "
+            "template-mode sandbox starts."
+        ),
+        alias="ensureSubPathDirectory",
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -48,11 +48,13 @@ from opensandbox.exceptions import (
 )
 from opensandbox.models.execd import RunCommandOpts
 from opensandbox.models.sandboxes import (
+    PVC,
     CredentialProxyConfig,
     NetworkPolicy,
     NetworkRule,
     PlatformSpec,
     SandboxImageSpec,
+    Volume,
 )
 
 
@@ -512,6 +514,21 @@ def test_sandbox_model_converter_to_api_create_request_and_renew_tz() -> None:
 
     renew = SandboxModelConverter.to_api_renew_request(datetime(2025, 1, 1))
     assert renew.expires_at.tzinfo is timezone.utc
+
+
+def test_sandbox_model_converter_forwards_ensure_subpath_directory() -> None:
+    volume = Volume(
+        name="workspace",
+        pvc=PVC(claimName="workspace-pvc"),
+        mountPath="/workspace",
+        subPath="unseeded",
+        ensureSubPathDirectory=True,
+    )
+
+    converted = SandboxModelConverter.to_api_volume(volume)
+
+    assert converted.ensure_sub_path_directory is True
+    assert converted.to_dict()["ensureSubPathDirectory"] is True
 
 
 def test_platform_spec_accepts_windows() -> None:

--- a/sdks/sandbox/python/tests/test_models_stability.py
+++ b/sdks/sandbox/python/tests/test_models_stability.py
@@ -301,6 +301,21 @@ def test_volume_with_pvc_backend() -> None:
     assert vol.sub_path == "v1"
 
 
+def test_volume_ensure_subpath_directory_serializes_with_alias() -> None:
+    vol = Volume(
+        name="workspace",
+        pvc=PVC(claimName="shared-workspace"),
+        mountPath="/workspace",
+        subPath="unseeded",
+        ensureSubPathDirectory=True,
+    )
+
+    dumped = vol.model_dump(by_alias=True, mode="json")
+
+    assert vol.ensure_sub_path_directory is True
+    assert dumped["ensureSubPathDirectory"] is True
+
+
 def test_volume_rejects_blank_name() -> None:
     with pytest.raises(ValueError, match="blank"):
         Volume(

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -338,6 +338,14 @@ class Volume(BaseModel):
         alias="subPath",
         description="Optional subdirectory under the backend path to mount.",
     )
+    ensure_sub_path_directory: bool = Field(
+        False,
+        alias="ensureSubPathDirectory",
+        description=(
+            "Ensure a PVC subPath directory exists before the sandbox starts. "
+            "Supported only for writable Kubernetes BatchSandbox template-mode PVC mounts."
+        ),
+    )
 
     class Config:
         populate_by_name = True
@@ -351,6 +359,24 @@ class Volume(BaseModel):
             raise ValueError("Exactly one backend (host, pvc, ossfs) must be specified, but none was provided.")
         if len(specified) > 1:
             raise ValueError("Exactly one backend (host, pvc, ossfs) must be specified, but multiple were provided.")
+
+        if self.ensure_sub_path_directory:
+            if self.pvc is None:
+                raise ValueError("ensureSubPathDirectory is supported only for PVC volumes.")
+            if self.read_only:
+                raise ValueError("ensureSubPathDirectory cannot be used with readOnly=true.")
+            if not self.sub_path or not self.sub_path.strip():
+                raise ValueError("ensureSubPathDirectory requires a non-empty subPath.")
+            if (
+                self.sub_path.startswith("/")
+                or "\\" in self.sub_path
+                or "\x00" in self.sub_path
+                or any(segment in {"", ".", ".."} for segment in self.sub_path.split("/"))
+            ):
+                raise ValueError(
+                    "ensureSubPathDirectory requires a normalized relative subPath "
+                    "without empty, '.', or '..' segments."
+                )
         return self
 
 

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -644,6 +644,17 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     "message": "poolRef is not supported by the Docker provider. Use Kubernetes BatchSandbox provider instead.",
                 },
             )
+        if any(volume.ensure_sub_path_directory for volume in request.volumes or []):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": SandboxErrorCodes.INVALID_PARAMETER,
+                    "message": (
+                        "ensureSubPathDirectory is supported only by the Kubernetes "
+                        "BatchSandbox provider in template mode."
+                    ),
+                },
+            )
         request = resolve_sandbox_image_from_request(request)
         ensure_entrypoint(request.entrypoint or [])
         ensure_metadata_labels(request.metadata)

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -144,6 +144,11 @@ class AgentSandboxProvider(WorkloadProvider):
         egress_env: Optional[Dict[str, Optional[str]]] = None,
     ) -> Dict[str, Any]:
         """Create an agent-sandbox Sandbox CRD workload."""
+        if any(volume.ensure_sub_path_directory for volume in volumes or []):
+            raise ValueError(
+                "ensureSubPathDirectory is supported only by the Kubernetes "
+                "BatchSandbox provider in template mode."
+            )
         if is_windows_profile(platform):
             raise ValueError("agent-sandbox does not support platform.os=windows.")
 

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -54,7 +54,11 @@ from opensandbox_server.services.k8s.windows_profile import (
     is_windows_profile,
     validate_windows_profile_resource_limits,
 )
-from opensandbox_server.services.k8s.volume_helper import apply_volumes_to_pod_spec
+from opensandbox_server.services.k8s.volume_helper import (
+    SUBPATH_INITIALIZER_NAME,
+    add_subpath_initializer_to_pod_spec,
+    apply_volumes_to_pod_spec,
+)
 from opensandbox_server.services.k8s.workload_provider import WorkloadProvider
 from opensandbox_server.services.runtime_resolver import SecureRuntimeResolver
 
@@ -63,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 class BatchSandboxProvider(WorkloadProvider):
     """Workload provider for BatchSandbox CRDs."""
-    
+
     def __init__(
         self,
         k8s_client: K8sClient,
@@ -98,6 +102,10 @@ class BatchSandboxProvider(WorkloadProvider):
 
     def supports_image_auth(self) -> bool:
         """BatchSandbox supports per-request image pull auth."""
+        return True
+
+    def supports_ensure_sub_path_directory(self) -> bool:
+        """BatchSandbox template mode runs the trusted execd initializer."""
         return True
 
     def create_workload(
@@ -177,11 +185,10 @@ class BatchSandboxProvider(WorkloadProvider):
             self.execd_init_resources,
             disable_ipv6_for_egress=disable_ipv6_for_egress,
         )
-        
+
         main_env = dict(env)
         if credential_proxy_enabled:
             main_env[OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT] = "true"
-
         main_container = _build_main_container(
             image_spec=image_spec,
             entrypoint=entrypoint,
@@ -192,7 +199,7 @@ class BatchSandboxProvider(WorkloadProvider):
             image_pull_policy=self.image_pull_policy,
             resource_requests=resource_requests or None,
         )
-        
+
         containers = [_container_to_dict(main_container)]
         pod_volumes = [
             {
@@ -287,6 +294,13 @@ class BatchSandboxProvider(WorkloadProvider):
             batchsandbox["spec"]["expireTime"] = expires_at.isoformat()
         self._merge_pod_spec_extras(batchsandbox, extra_volumes, extra_mounts)
         merged_pod_spec = batchsandbox.get("spec", {}).get("template", {}).get("spec", {})
+        if volumes and any(volume.ensure_sub_path_directory for volume in volumes):
+            self._reject_template_subpath_initializer_collision()
+            add_subpath_initializer_to_pod_spec(
+                merged_pod_spec,
+                volumes,
+                execd_image,
+            )
         ensure_egress_runtime_compatible(
             network_policy,
             effective_runtime_class=merged_pod_spec.get("runtimeClassName"),
@@ -398,7 +412,7 @@ class BatchSandboxProvider(WorkloadProvider):
             plural=self.plural,
             body=runtime_manifest,
         )
-        
+
         return {
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
@@ -430,6 +444,23 @@ class BatchSandboxProvider(WorkloadProvider):
         if not isinstance(extra_mounts, list):
             extra_mounts = []
         return extra_volumes, extra_mounts
+
+    def _reject_template_subpath_initializer_collision(self) -> None:
+        """Reject templates that try to define the server-reserved initializer."""
+        template = self.template_manager.get_base_template()
+        template_spec = (
+            template.get("spec", {}).get("template", {}).get("spec", {})
+            if isinstance(template, dict)
+            else {}
+        )
+        init_containers = template_spec.get("initContainers", [])
+        if isinstance(init_containers, list) and any(
+            isinstance(container, dict) and container.get("name") == SUBPATH_INITIALIZER_NAME
+            for container in init_containers
+        ):
+            raise ValueError(
+                f"Pod template cannot define reserved init container '{SUBPATH_INITIALIZER_NAME}'."
+            )
 
     def _merge_pod_spec_extras(
         self,
@@ -481,9 +512,7 @@ class BatchSandboxProvider(WorkloadProvider):
         """Build pool taskTemplate with shell-escaped bootstrap command."""
         escaped_entrypoint = ' '.join(shlex.quote(arg) for arg in entrypoint)
         user_process_cmd = f"/opt/opensandbox/bootstrap.sh {escaped_entrypoint} &"
-        
         wrapped_command = ["/bin/sh", "-c", user_process_cmd]
-
         env_list = [{"name": k, "value": v} for k, v in env.items()] if env else []
 
         return {
@@ -494,7 +523,6 @@ class BatchSandboxProvider(WorkloadProvider):
                 }
             }
         }
-
 
     def get_workload(self, sandbox_id: str, namespace: str) -> Optional[Dict[str, Any]]:
         """Get BatchSandbox by sandbox ID."""
@@ -519,7 +547,7 @@ class BatchSandboxProvider(WorkloadProvider):
             )
 
         return None
-    
+
     def delete_workload(self, sandbox_id: str, namespace: str) -> None:
         """Delete BatchSandbox workload."""
         batchsandbox = self.get_workload(sandbox_id, namespace)
@@ -709,22 +737,20 @@ class BatchSandboxProvider(WorkloadProvider):
             raise ValueError(f"Cannot resume: sandbox is being created (phase={phase})")
         else:
             raise ValueError(f"Cannot resume sandbox in phase {phase}, expected Paused")
-
         if resume_failed:
             self._patch_pause_with_retry_bridge(sandbox_id, namespace, False)
             logger.info("Patched BatchSandbox %s retry bridge spec.pause=nil->false", sandbox_id)
         else:
             self.patch_workload(sandbox_id, namespace, {"spec": {"pause": False}})
             logger.info("Patched BatchSandbox %s spec.pause=false", sandbox_id)
-
     def get_expiration(self, workload: Dict[str, Any]) -> Optional[datetime]:
         """Parse expiration timestamp from `spec.expireTime`."""
         spec = workload.get("spec", {})
         expire_time_str = spec.get("expireTime")
-        
+
         if not expire_time_str:
             return None
-        
+
         try:
             return datetime.fromisoformat(expire_time_str.replace('Z', '+00:00'))
         except (ValueError, TypeError) as e:
@@ -765,7 +791,6 @@ class BatchSandboxProvider(WorkloadProvider):
             )
         except Exception:
             return None
-
         for pod in pods:
             message = _extract_platform_unschedulable_message_from_pod(
                 pod,
@@ -841,7 +866,7 @@ class BatchSandboxProvider(WorkloadProvider):
             "message": message,
             "last_transition_at": creation_timestamp,
         }
-    
+
     def get_internal_endpoint(
         self, workload: Dict[str, Any], port: int, sandbox_id: str
     ) -> Optional[Endpoint]:

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -389,6 +389,23 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             },
         )
 
+    def _ensure_sub_path_initializer_support(self, request: CreateSandboxRequest) -> None:
+        """Reject directory initialization unless the active provider implements it."""
+        if not any(volume.ensure_sub_path_directory for volume in request.volumes or []):
+            return
+        if self.workload_provider.supports_ensure_sub_path_directory():
+            return
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "ensureSubPathDirectory is supported only by the Kubernetes "
+                    "BatchSandbox provider in template mode."
+                ),
+            },
+        )
+
     def _ensure_secure_access_support(self, request: CreateSandboxRequest) -> None:
         """Validate that secure access can be enforced for the configured exposure mode."""
         if not request.secure_access:
@@ -832,6 +849,8 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                         ),
                     },
                 )
+
+            self._ensure_sub_path_initializer_support(request)
 
             if has_pool_ref and pool_ref != POOL_AUTO_ASSIGN_REF:
                 await asyncio.to_thread(self._ensure_pool_ref_exists, pool_ref)

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -16,12 +16,16 @@
 Volume helper utilities for Kubernetes pod specs.
 """
 
+import json
 import logging
 from typing import Any, Dict, List
 
 from opensandbox_server.api.schema import Volume
 
 logger = logging.getLogger(__name__)
+
+SUBPATH_INITIALIZER_NAME = "volume-subpath-initializer"
+_SUBPATH_INITIALIZER_ROOT = "/opensandbox-subpath-pvcs"
 
 
 def _get_pvc_source_read_only_policies(volumes: List[Volume]) -> Dict[str, bool]:
@@ -125,3 +129,73 @@ def apply_volumes_to_pod_spec(
 
     pod_spec["volumes"] = pod_volumes
     main_container["volumeMounts"] = mounts
+
+
+def add_subpath_initializer_to_pod_spec(
+    pod_spec: Dict[str, Any],
+    volumes: List[Volume],
+    initializer_image: str,
+) -> None:
+    """Append the fixed PVC subPath initializer when a request requires it."""
+    requested_volumes = [volume for volume in volumes if volume.ensure_sub_path_directory]
+    if not requested_volumes:
+        return
+
+    if not initializer_image or not initializer_image.strip():
+        raise ValueError(
+            "runtime.execd_image must be set when ensureSubPathDirectory=true."
+        )
+
+    init_containers = pod_spec.get("initContainers", [])
+    if not isinstance(init_containers, list):
+        raise ValueError("Pod spec initContainers must be a list.")
+    if any(
+        isinstance(container, dict) and container.get("name") == SUBPATH_INITIALIZER_NAME
+        for container in init_containers
+    ):
+        raise ValueError(
+            f"Pod template cannot define reserved init container '{SUBPATH_INITIALIZER_NAME}'."
+        )
+
+    pvc_volume_names: Dict[str, str] = {}
+    for pod_volume in pod_spec.get("volumes", []):
+        if not isinstance(pod_volume, dict):
+            continue
+        pvc = pod_volume.get("persistentVolumeClaim")
+        if isinstance(pvc, dict) and isinstance(pvc.get("claimName"), str):
+            pvc_volume_names[pvc["claimName"]] = pod_volume["name"]
+
+    plans_by_claim: Dict[str, Dict[str, Any]] = {}
+    for volume in requested_volumes:
+        # Volume schema validation guarantees pvc and sub_path are present here.
+        assert volume.pvc is not None
+        assert volume.sub_path is not None
+        claim_name = volume.pvc.claim_name
+        if claim_name not in pvc_volume_names:
+            raise ValueError(f"PVC '{claim_name}' is missing from the generated pod volumes.")
+        plan = plans_by_claim.setdefault(claim_name, {"subPaths": []})
+        if volume.sub_path not in plan["subPaths"]:
+            plan["subPaths"].append(volume.sub_path)
+
+    plan_entries = []
+    root_mounts = []
+    for index, (claim_name, plan) in enumerate(plans_by_claim.items()):
+        root_mount_path = f"{_SUBPATH_INITIALIZER_ROOT}/{index}"
+        plan_entries.append({"mountPath": root_mount_path, "subPaths": plan["subPaths"]})
+        root_mounts.append(
+            {
+                "name": pvc_volume_names[claim_name],
+                "mountPath": root_mount_path,
+            }
+        )
+
+    init_containers.append(
+        {
+            "name": SUBPATH_INITIALIZER_NAME,
+            "image": initializer_image.strip(),
+            "command": ["/opensandbox-subpath-initializer"],
+            "args": ["--plan-json", json.dumps(plan_entries, separators=(",", ":"))],
+            "volumeMounts": root_mounts,
+        }
+    )
+    pod_spec["initContainers"] = init_containers

--- a/server/opensandbox_server/services/k8s/workload_provider.py
+++ b/server/opensandbox_server/services/k8s/workload_provider.py
@@ -243,6 +243,10 @@ class WorkloadProvider(ABC):
         """
         return False
 
+    def supports_ensure_sub_path_directory(self) -> bool:
+        """Whether the provider safely initializes requested PVC subpaths."""
+        return False
+
     def legacy_resource_name(self, sandbox_id: str) -> str:
         """
         Convert a sandbox_id to the legacy resource name with prefix.

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -140,9 +140,9 @@ class TestBatchSandboxProvider:
             expires_at=expires_at,
             execd_image="execd:latest",
         )
-        
+
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
@@ -880,7 +880,7 @@ spec:
         )
 
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-    
+
     # ===== Workload List Tests =====
 
     def test_list_workloads_returns_items(self, mock_k8s_client, mock_batchsandbox_list_response):
@@ -1335,7 +1335,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1367,7 +1367,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1435,9 +1435,9 @@ spec:
             execd_image="execd:latest",
             extensions={"poolRef": "my-pool"},
         )
-        
+
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -2796,6 +2796,107 @@ spec:
         data_mount = next((m for m in mounts if m["name"] == "data-volume"), None)
         assert data_mount is not None
         assert data_mount.get("subPath") == "task-001"
+        assert [container["name"] for container in pod_spec["initContainers"]] == [
+            "execd-installer"
+        ]
+
+    def test_create_workload_initializes_multiple_subpaths_for_one_pvc(self, mock_k8s_client):
+        """The initializer receives one root PVC mount and a safe JSON plan."""
+        from opensandbox_server.api.schema import PVC, Volume
+        import json
+
+        provider = BatchSandboxProvider(mock_k8s_client)
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+        volumes = [
+            Volume(
+                name="workspace-a",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace/a",
+                sub_path="jobs/a",
+                ensure_sub_path_directory=True,
+            ),
+            Volume(
+                name="workspace-b",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace/b",
+                sub_path="jobs/b",
+                ensure_sub_path_directory=True,
+            ),
+        ]
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            volumes=volumes,
+        )
+
+        pod_spec = mock_k8s_client.create_custom_object.call_args.kwargs["body"]["spec"][
+            "template"
+        ]["spec"]
+        assert [container["name"] for container in pod_spec["initContainers"]] == [
+            "execd-installer",
+            "volume-subpath-initializer",
+        ]
+        initializer = pod_spec["initContainers"][1]
+        assert initializer["image"] == "execd:latest"
+        assert initializer["command"] == ["/opensandbox-subpath-initializer"]
+        assert initializer["volumeMounts"] == [
+            {"name": "workspace-a", "mountPath": "/opensandbox-subpath-pvcs/0"}
+        ]
+        assert json.loads(initializer["args"][1]) == [
+            {"mountPath": "/opensandbox-subpath-pvcs/0", "subPaths": ["jobs/a", "jobs/b"]}
+        ]
+        main_mounts = pod_spec["containers"][0]["volumeMounts"]
+        assert {mount["subPath"] for mount in main_mounts if mount["name"] == "workspace-a"} == {
+            "jobs/a",
+            "jobs/b",
+        }
+
+    def test_create_workload_rejects_template_initializer_name_collision(
+        self, mock_k8s_client, tmp_path
+    ):
+        from opensandbox_server.api.schema import PVC, Volume
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            "spec:\n  template:\n    spec:\n      initContainers:\n        - name: volume-subpath-initializer\n"
+        )
+        config = _app_config_with_template(str(template_file))
+        provider = BatchSandboxProvider(mock_k8s_client, config)
+        volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+
+        with pytest.raises(ValueError, match="reserved init container"):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+                volumes=volumes,
+            )
+
+        mock_k8s_client.create_custom_object.assert_not_called()
 
     def test_create_workload_with_host_volume(self, mock_k8s_client):
         """

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -35,6 +35,8 @@ from opensandbox_server.api.schema import (
     ListSandboxesRequest,
     NetworkPolicy,
     PlatformSpec,
+    PVC,
+    Volume,
 )
 from opensandbox_server.config import (
     EGRESS_MODE_DNS,
@@ -89,6 +91,41 @@ class TestKubernetesSandboxServiceInit:
             assert exc_info.value.detail["code"] == SandboxErrorCodes.K8S_INITIALIZATION_ERROR
 
 class TestKubernetesSandboxServiceCreate:
+
+    def test_ensure_subpath_directory_rejects_non_batchsandbox_provider(
+        self, k8s_service, create_sandbox_request
+    ):
+        create_sandbox_request.volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+        k8s_service.workload_provider.supports_ensure_sub_path_directory.return_value = False
+
+        with pytest.raises(HTTPException, match="BatchSandbox provider") as exc_info:
+            k8s_service._ensure_sub_path_initializer_support(create_sandbox_request)
+
+        assert exc_info.value.status_code == 400
+
+    def test_ensure_subpath_directory_allows_batchsandbox_provider(
+        self, k8s_service, create_sandbox_request
+    ):
+        create_sandbox_request.volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+        k8s_service.workload_provider.supports_ensure_sub_path_directory.return_value = True
+
+        k8s_service._ensure_sub_path_initializer_support(create_sandbox_request)
 
     def test_credential_proxy_requires_dns_nft_mode(
         self, k8s_service, create_sandbox_request

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -3445,6 +3445,33 @@ class TestDockerVolumeValidation:
         assert response.status.state == "Running"
 
     @pytest.mark.asyncio
+    async def test_ensure_subpath_directory_is_rejected_before_docker_side_effects(self, mock_docker):
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        service = DockerSandboxService(config=_app_config())
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            timeout=120,
+            resourceLimits=ResourceLimits(root={}),
+            entrypoint=["python"],
+            volumes=[
+                Volume(
+                    name="workspace",
+                    pvc=PVC(claim_name="workspace-pvc"),
+                    mount_path="/workspace",
+                    sub_path="jobs/123",
+                    ensure_sub_path_directory=True,
+                )
+            ],
+        )
+
+        with pytest.raises(HTTPException, match="BatchSandbox provider") as exc_info:
+            await service.create_sandbox(request)
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        mock_client.api.inspect_volume.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_host_volume_binds_passed_to_docker(self, mock_docker):
         """Host volume binds should be passed to Docker host config."""
         mock_client = MagicMock()

--- a/server/tests/test_schema.py
+++ b/server/tests/test_schema.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from opensandbox_server.api.schema import (
@@ -37,7 +38,6 @@ from opensandbox_server.api.schema import (
 
 
 class TestHost:
-
     def test_valid_path(self):
         backend = Host(path="/data/opensandbox")
         assert backend.path == "/data/opensandbox"
@@ -171,6 +171,67 @@ class TestVolume:
         assert volume.read_only is True
         assert volume.host is None
 
+    def test_ensure_subpath_directory_defaults_to_false_and_serializes(self):
+        volume = Volume(
+            name="workspace",
+            pvc=PVC(claim_name="workspace-pvc"),
+            mount_path="/workspace",
+            sub_path="jobs/123",
+        )
+
+        assert volume.ensure_sub_path_directory is False
+        assert volume.model_dump(by_alias=True)["ensureSubPathDirectory"] is False
+        assert (
+            Volume.model_json_schema(by_alias=True)["properties"]["ensureSubPathDirectory"][
+                "default"
+            ]
+            is False
+        )
+
+    def test_ensure_subpath_directory_rejects_unsupported_combinations(self):
+        with pytest.raises(ValidationError, match="readOnly=true"):
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                read_only=True,
+                ensure_sub_path_directory=True,
+            )
+
+        with pytest.raises(ValidationError, match="only for PVC"):
+            Volume(
+                name="workspace",
+                host=Host(path="/data/workspace"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+
+    @pytest.mark.parametrize(
+        "sub_path",
+        ["", "   ", "/absolute", ".", "..", "a//b", "a/./b", "a/../b", "a\x00b"],
+    )
+    def test_ensure_subpath_directory_rejects_invalid_subpaths(self, sub_path):
+        with pytest.raises(ValidationError, match="non-empty subPath|normalized relative subPath"):
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path=sub_path,
+                ensure_sub_path_directory=True,
+            )
+
+    def test_lifecycle_spec_exposes_ensure_subpath_directory(self):
+        from pathlib import Path
+
+        spec_path = Path(__file__).resolve().parents[2] / "specs" / "sandbox-lifecycle.yml"
+        spec = yaml.safe_load(spec_path.read_text())
+        field = spec["components"]["schemas"]["Volume"]["properties"]["ensureSubPathDirectory"]
+
+        assert field["type"] == "boolean"
+        assert field["default"] is False
+
     def test_valid_volume_with_subpath(self):
         volume = Volume(
             name="workdir",
@@ -234,6 +295,7 @@ class TestVolume:
             "mountPath": "/mnt/work",
             "readOnly": False,
             "subPath": "task-001",
+            "ensureSubPathDirectory": False,
         }
 
     def test_serialization_pvc_volume(self):
@@ -253,6 +315,7 @@ class TestVolume:
             },
             "mountPath": "/mnt/models",
             "readOnly": True,
+            "ensureSubPathDirectory": False,
         }
 
     def test_deserialization_host_volume(self):

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1551,7 +1551,7 @@ components:
         Storage mount definition for a sandbox. Each volume entry contains:
         - A unique name identifier
         - Exactly one backend struct (host, pvc, ossfs, etc.) with backend-specific fields
-        - Common mount settings (mountPath, readOnly, subPath)
+        - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
       required: [name, mountPath]
       properties:
         name:
@@ -1584,6 +1584,16 @@ components:
             Optional subdirectory under the backend path to mount.
             For `ossfs` backend, this field is used as the bucket prefix.
             Must be a relative path without '..' components.
+        ensureSubPathDirectory:
+          type: boolean
+          default: false
+          description: |
+            When true, Kubernetes BatchSandbox template-mode creation ensures that
+            `subPath` exists before the main container starts using the fixed trusted
+            initializer bundled with the configured execd image. It supports only
+            writable PVC mounts with a non-empty normalized relative `subPath`; it is
+            not supported for host or ossfs backends, read-only mounts, Docker, other
+            Kubernetes providers, or pool mode.
       additionalProperties: false
 
     Host:

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -21,6 +21,7 @@ This mirrors `test_sandbox_e2e.py` but uses the synchronous SDK.
 
 import logging
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from io import BytesIO
@@ -778,6 +779,70 @@ class TestSandboxE2ESync:
                 pass
 
         logger.info("TEST 1f PASSED: PVC subPath named volume mount test completed successfully")
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.order(1)
+    def test_01g_pvc_unseeded_subpath_initializer(self) -> None:
+        """Create and use a previously unseeded PVC subPath through the lifecycle API."""
+        if not is_kubernetes_runtime():
+            pytest.skip("ensureSubPathDirectory is covered only in the Kubernetes runtime suite")
+
+        logger.info("=" * 80)
+        logger.info("TEST 1g: Creating sandbox with an unseeded PVC subPath initializer")
+        logger.info("=" * 80)
+
+        pvc_volume_name = get_test_pvc_name()
+        container_mount_path = "/mnt/ensure-subpath"
+        unseeded_sub_path = f"ensure-subpath-initializer-{uuid.uuid4().hex}"
+        cfg = create_connection_config_sync()
+        sandbox = SandboxSync.create(
+            image=SandboxImageSpec(get_sandbox_image()),
+            resource=get_e2e_sandbox_resource(),
+            connection_config=cfg,
+            timeout=timedelta(minutes=5),
+            ready_timeout=timedelta(seconds=30),
+            volumes=[
+                Volume(
+                    name="test-pvc-unseeded-subpath",
+                    pvc=PVC(claimName=pvc_volume_name),
+                    mountPath=container_mount_path,
+                    readOnly=False,
+                    subPath=unseeded_sub_path,
+                    ensureSubPathDirectory=True,
+                ),
+            ],
+        )
+        try:
+            info = sandbox.get_info()
+            assert info.status.state == "Running"
+
+            result = sandbox.commands.run(
+                f"test -d {container_mount_path} && "
+                f"test ! -e {container_mount_path}/marker.txt && "
+                f"test ! -e {container_mount_path}/datasets"
+            )
+            assert result.error is None, "business container did not receive only the exact subPath"
+
+            result = sandbox.commands.run(
+                f"printf '%s\\n' 'ensure-subpath-write-test' > "
+                f"{container_mount_path}/output.txt && "
+                f"cat {container_mount_path}/output.txt"
+            )
+            assert result.error is None, f"Failed to write initialized subPath: {result.error}"
+            assert len(result.logs.stdout) == 1
+            assert result.logs.stdout[0].text == "ensure-subpath-write-test"
+        finally:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass
+            sandbox.close()
+            try:
+                cfg.transport.close()
+            except Exception:
+                pass
+
+        logger.info("TEST 1g PASSED: Unseeded PVC subPath initializer test completed successfully")
 
     @pytest.mark.timeout(120)
     @pytest.mark.order(2)

--- a/tests/python/uv.lock
+++ b/tests/python/uv.lock
@@ -123,6 +123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +164,7 @@ source = { editable = "../../sdks/sandbox/python" }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
@@ -163,6 +173,7 @@ dependencies = [
 requires-dist = [
     { name = "attrs", specifier = ">=21.3.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
+    { name = "httpx-sse", specifier = ">=0.4.3,<0.5" },
     { name = "pydantic", specifier = ">=2.4.2,<3.0" },
     { name = "pyjwt", marker = "extra == 'pool-redis'", specifier = ">=2.13.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0" },


### PR DESCRIPTION
## Summary
- add the additive `ensureSubPathDirectory` lifecycle volume field for writable PVC subpaths
- inject a trusted, symlink-safe init container only for Kubernetes BatchSandbox template mode
- keep unsupported Docker, AgentSandbox, and pool paths fail-closed; align Python SDK, OpenAPI, tests, and safe remote POC tooling

## Validation
- `go test ./pkg/subpathinitializer ./cmd/subpath-initializer`
- `GOOS=darwin GOARCH=amd64 go test ./pkg/subpathinitializer ./cmd/subpath-initializer`
- `GOOS=windows GOARCH=amd64 go test ./pkg/subpathinitializer ./cmd/subpath-initializer`
- `go vet ./pkg/subpathinitializer ./cmd/subpath-initializer`
- `uv run pytest tests/k8s` (566 passed)
- focused server regression suite (428 passed)
- Python SDK tests (78 passed) and Ruff
- `pnpm docs:build`
- final commit isolated Kind E2E: `test_01g_pvc_unseeded_subpath_initializer` (1 passed)
- isolated Product Kubernetes lifecycle E2E: verified init container injection, Pod Ready, and random PVC subPath read/write; all POC namespaces cleaned