### PR TITLE
fix(server): omit ingress header from proxy endpoints

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -156,6 +156,10 @@ The lifecycle endpoint API returns the reachable address for a service port insi
 - A Kubernetes ingress gateway endpoint.
 - A server-proxied URL under `/sandboxes/{sandboxId}/proxy/{port}` when `use_server_proxy=true`.
 
+Header-routed ingress endpoints include `OpenSandbox-Ingress-To` in their endpoint metadata.
+When the endpoint is rewritten to a server-proxied URL, the server removes only this
+ingress routing header and preserves other required endpoint headers.
+
 The server proxy supports HTTP and WebSocket traffic and is also integrated with optional renew-on-access behavior. For HTTP responses, it strips hop-by-hop headers and the backend `Server` header while preserving an origin `Date`; the server adds a current `Date` only when the response does not already contain one.
 
 ## 4. Runtime Backends

--- a/server/opensandbox_server/api/lifecycle.py
+++ b/server/opensandbox_server/api/lifecycle.py
@@ -45,7 +45,10 @@ from opensandbox_server.api.schema import (
     Snapshot,
     SnapshotFilter,
 )
-from opensandbox_server.services.constants import SandboxErrorCodes
+from opensandbox_server.services.constants import (
+    OPEN_SANDBOX_INGRESS_HEADER,
+    SandboxErrorCodes,
+)
 from opensandbox_server.services.factory import create_sandbox_service
 from opensandbox_server.services.snapshot_service import create_snapshot_service
 
@@ -580,5 +583,11 @@ def get_sandbox_endpoint(
             base_url = str(request.base_url).rstrip("/") + mount_prefix
         base_url = base_url.replace("https://", "").replace("http://", "")
         endpoint.endpoint = f"{base_url}/sandboxes/{sandbox_id}/proxy/{port}"
+        if endpoint.headers:
+            endpoint.headers = {
+                key: value
+                for key, value in endpoint.headers.items()
+                if key.lower() != OPEN_SANDBOX_INGRESS_HEADER.lower()
+            } or None
 
     return endpoint

--- a/server/tests/test_routes_endpoint_behavior.py
+++ b/server/tests/test_routes_endpoint_behavior.py
@@ -18,6 +18,10 @@ from fastapi.testclient import TestClient
 
 from opensandbox_server.api import lifecycle
 from opensandbox_server.api.schema import Endpoint
+from opensandbox_server.services.constants import (
+    OPEN_SANDBOX_INGRESS_HEADER,
+    OPEN_SANDBOX_SECURE_ACCESS_HEADER,
+)
 
 
 def test_get_endpoint_returns_service_result(
@@ -45,6 +49,30 @@ def test_get_endpoint_returns_service_result(
     assert calls == [("sbx-001", 44772)]
 
 
+def test_get_endpoint_preserves_ingress_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, **kwargs) -> Endpoint:
+            return Endpoint(
+                endpoint="gateway.example.com",
+                headers={OPEN_SANDBOX_INGRESS_HEADER: "sbx-001-44772"},
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/endpoints/44772",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["headers"] == {OPEN_SANDBOX_INGRESS_HEADER: "sbx-001-44772"}
+
+
 def test_get_endpoint_use_server_proxy_rewrites_url(
     client: TestClient,
     auth_headers: dict,
@@ -68,6 +96,34 @@ def test_get_endpoint_use_server_proxy_rewrites_url(
     # proxy routes live under the same prefix, and on shared hosts the bare
     # root path belongs to a different backend.
     assert response.json()["endpoint"] == "testserver/v1/sandboxes/sbx-001/proxy/44772"
+
+
+def test_get_endpoint_use_server_proxy_omits_ingress_header(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, **kwargs) -> Endpoint:
+            return Endpoint(
+                endpoint="gateway.example.com",
+                headers={
+                    OPEN_SANDBOX_INGRESS_HEADER.lower(): "sbx-001-44772",
+                    OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token",
+                },
+            )
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/endpoints/44772",
+        params={"use_server_proxy": "true"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["headers"] == {OPEN_SANDBOX_SECURE_ACCESS_HEADER: "secure-token"}
 
 
 def test_get_endpoint_use_server_proxy_without_mount_prefix(


### PR DESCRIPTION
# Summary

- Fixes #1502.
- Server-proxied endpoint responses currently retain `OpenSandbox-Ingress-To` after their URL is rewritten away from the ingress gateway.
- Remove only that ingress routing header, case-insensitively, while preserving unrelated endpoint headers such as `OpenSandbox-Secure-Access`.
- Keep direct ingress endpoint responses unchanged and document the endpoint metadata behavior.

## Minimal reproduction

Have endpoint resolution return `gateway.example.com` with both `OpenSandbox-Ingress-To` and `OpenSandbox-Secure-Access`, then call:

```http
GET /v1/sandboxes/sbx-001/endpoints/44772?use_server_proxy=true
```

Before this change, the response URL points to the lifecycle server proxy but still includes the ingress-only routing header.

## Root cause

`get_sandbox_endpoint` rewrites only `endpoint.endpoint` for `use_server_proxy=true`; the original gateway routing metadata remains in `endpoint.headers`.

## Change

- Filter `OpenSandbox-Ingress-To` only for server-proxy endpoint responses.
- Match the header name case-insensitively.
- Preserve other required endpoint headers.
- Return no `headers` field when the ingress header was the only entry.
- Add regression coverage for server-proxy and direct-ingress behavior.
- Document the distinction in the architecture guide.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Passed locally:

- `uv run --frozen pytest tests/test_routes_endpoint_behavior.py -q` — 10 passed
- `uv run --frozen pytest tests/test_routes_endpoint_behavior.py tests/test_routes_proxy.py tests/test_endpoint_auth.py -q` — 34 passed
- `uv run --frozen pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80 -q` — 1339 passed, 82.17% coverage
- `uv run --frozen ruff check`
- `pnpm docs:build`
- `./scripts/verify-license.sh`

The final regression test fails before the production change because the lowercase ingress header remains in the response, and passes after the fix.

Docker/Kubernetes smoke and real E2E were not run locally; the PR workflows cover those environments. Full `uv run --frozen pyright` is not currently clean on `main` (1363 existing errors); checking the two touched Python files reports only the pre-existing `lifecycle.py:417` error.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

The endpoint schema, route, status code, and direct-ingress behavior are unchanged. The only response change is removal of a routing header that is not applicable to the returned server-proxy URL.

# Compatibility and security impact

- Backward compatible for direct endpoint and server-proxy consumers.
- Secure-access and other unrelated endpoint credentials remain present.
- Prevents clients from being instructed to send an ingress-only routing header to the lifecycle proxy and potentially onward to a sandbox backend.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
