### PR TITLE
Adds --use-server-proxy param to the MCP server

### DIFF
--- a/sdks/mcp/sandbox/python/README.md
+++ b/sdks/mcp/sandbox/python/README.md
@@ -42,6 +42,7 @@ Config fields:
 - `protocol`: `http` or `https` for API requests.
 - `request_timeout_seconds`: HTTP request timeout in seconds.
 - `transport`: `stdio` by default, or `streamable-http`.
+- `use-server-proxy`: when present, forces the SDK client to use server proxy mode.
 
 ### Streamable HTTP
 

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
@@ -54,6 +54,12 @@ def main() -> None:
         default=30,
         help="HTTP request timeout in seconds.",
     )
+    parser.add_argument(
+        "--use-server-proxy",
+        action="store_true",
+        default=False,
+        help="Route sandbox traffic through the OpenSandbox server proxy (use when direct port access is blocked).",
+    )
 
     args = parser.parse_args()
     config_values = {}
@@ -67,6 +73,11 @@ def main() -> None:
         config_values["request_timeout"] = timedelta(
             seconds=args.request_timeout_seconds
         )
+    if args.use_server_proxy:
+        config_values["use_server_proxy"] = True
+
+     connection_config = ConnectionConfig(**config_values) if config_values else None
+     mcp = create_server(connection_config=connection_config)
     connection_config = ConnectionConfig(**config_values) if config_values else None
     mcp = create_server(connection_config=connection_config)
 

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
@@ -78,8 +78,6 @@ def main() -> None:
 
     connection_config = ConnectionConfig(**config_values) if config_values else None
     mcp = create_server(connection_config=connection_config)
-    connection_config = ConnectionConfig(**config_values) if config_values else None
-    mcp = create_server(connection_config=connection_config)
 
     if args.transport == "streamable-http":
         mcp.run(

--- a/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
+++ b/sdks/mcp/sandbox/python/src/opensandbox_mcp/__main__.py
@@ -76,8 +76,8 @@ def main() -> None:
     if args.use_server_proxy:
         config_values["use_server_proxy"] = True
 
-     connection_config = ConnectionConfig(**config_values) if config_values else None
-     mcp = create_server(connection_config=connection_config)
+    connection_config = ConnectionConfig(**config_values) if config_values else None
+    mcp = create_server(connection_config=connection_config)
     connection_config = ConnectionConfig(**config_values) if config_values else None
     mcp = create_server(connection_config=connection_config)
 


### PR DESCRIPTION
# Summary

Adds `--use-server-proxy` param to the MCP parameters list. The MCP, unlike the CLI, was missing the parameter and thus was unable to function when sandbox ports are unreachable through direct domain/IP address (i.e. behind Cloudflare)

# Testing
- manual verification

# Breaking Changes
- None

# Checklist
- Added/updated docs
- Backward compatibility considered
