### PR TITLE
docs(kubernetes): clarify BatchSandbox status semantics

### DIFF
--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -475,6 +475,54 @@ kubectl describe pool example-pool
 kubectl describe batchsandbox example-batch-sandbox
 ```
 
+#### Understand BatchSandbox status
+
+A `BatchSandbox` reports sandbox availability and optional task execution separately. Use `status.phase`, `status.conditions`, and the replica counters for the sandbox runtime. Use the `status.task*` counters for task progress and completion.
+
+::: warning `Succeed` is not task completion
+`status.phase: Succeed` is the steady running phase. The controller sets it after observing at least one non-deleting Pod that is Running and Ready. It is non-terminal and does not mean that a task, Pod, or Kubernetes Job completed successfully.
+
+For a BatchSandbox with multiple replicas, `Succeed` also does not mean that every desired replica is Ready.
+:::
+
+| `status.phase` | Meaning |
+|---|---|
+| `Pending` | The controller has not observed a Running and Ready sandbox Pod yet. |
+| `Succeed` | At least one sandbox Pod is Running and Ready; the sandbox is available. |
+| `Pausing` | A pause operation is in progress. |
+| `Paused` | The sandbox is paused and its runtime resources have been released. |
+| `Resuming` | The controller is restoring runtime resources after a pause. |
+| `Failed` | The controller detected a sandbox runtime failure. Inspect conditions and Pod events for details. |
+
+The controller records active conditions with `status: "True"`:
+
+| Condition | Meaning when `True` |
+|---|---|
+| `Ready` | The phase is `Succeed`; reason `PodsReady` means the sandbox is running. |
+| `Progressing` | The sandbox is being created, paused, or resumed. |
+| `Paused` | The sandbox is fully paused. |
+| `PauseFailed`, `ResumeFailed`, `PodFailed` | The corresponding operation or runtime failed; inspect `reason` and `message`. |
+
+Treat a condition as satisfied only when the matching entry exists with `status: "True"`. Check `status.observedGeneration` against `metadata.generation` before acting on status after a spec update.
+
+Inspect runtime and task status together:
+
+```sh
+kubectl get batchsandbox example-batch-sandbox \
+  -o custom-columns='NAME:.metadata.name,GEN:.metadata.generation,OBSERVED:.status.observedGeneration,PHASE:.status.phase,READY:.status.ready,DESIRED:.spec.replicas,TASK_RUNNING:.status.taskRunning,TASK_SUCCEED:.status.taskSucceed,TASK_FAILED:.status.taskFailed'
+
+kubectl get batchsandbox example-batch-sandbox \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+```
+
+Choose monitoring fields based on the question you need to answer:
+
+| Monitoring goal | Fields to evaluate |
+|---|---|
+| At least one sandbox is available | A `Ready=True` condition, normally with `status.phase=Succeed` |
+| All desired replicas are Ready | A fresh status where `status.ready == spec.replicas` |
+| Tasks have completed | `taskPending`, `taskRunning`, `taskSucceed`, `taskFailed`, and `taskUnknown`, according to the workload's completion policy |
+
 ## Performance
 
 When both use resource pools, the total time comparison for delivering 100 Sandboxes:


### PR DESCRIPTION
# Problem

`BatchSandbox.status.phase=Succeed` can be mistaken for task completion. The controller actually uses `Succeed` as a non-terminal steady running phase after observing at least one non-deleting Pod that is Running and Ready. Optional task progress is reported separately through the `status.task*` counters.

The Kubernetes guide previously listed only basic `kubectl` commands and did not document the BatchSandbox phase, condition, replica, and task-status boundaries. This can produce incorrect availability and completion alerts, especially for multi-replica BatchSandboxes.

# Minimal observation

Inspect the runtime and task fields of a BatchSandbox with a Ready Pod and no completed task:

```bash
kubectl get batchsandbox <name> -n <namespace> \
  -o custom-columns='PHASE:.status.phase,READY:.status.ready,DESIRED:.spec.replicas,TASK_RUNNING:.status.taskRunning,TASK_SUCCEED:.status.taskSucceed,TASK_FAILED:.status.taskFailed'
```

A valid result can contain `PHASE=Succeed` while `TASK_SUCCEED=0`. For multiple replicas, `PHASE=Succeed` is also possible before every desired replica is Ready.

# Root cause

`applySteadyRuntimePhase` sets `BatchSandboxPhaseSucceed` when `status.Ready > 0`, while task scheduling updates `taskPending`, `taskRunning`, `taskSucceed`, `taskFailed`, and `taskUnknown` independently. The public Kubernetes guide did not explain this existing contract.

# Change

- add a BatchSandbox phase table and state explicitly that `Succeed` is non-terminal
- document active `Ready`, `Progressing`, `Paused`, and failure conditions
- distinguish at-least-one availability from full desired replica readiness
- direct task completion monitoring to the independent task counters
- add compact `kubectl` examples for runtime, replica, condition, and task status

This changes documentation only. It does not change the CRD schema, phase values, controller behavior, generated manifests, or APIs.

# Tests

- [ ] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Documentation verification:

- pre-change acceptance check for the `Succeed`/task-completion clarification returned exit 1 as expected; the same check finds the new warning and monitoring guidance after the change
- `cd docs && corepack pnpm docs:build` — passed
- `./scripts/verify-license.sh` — passed
- `git diff --check` — passed
- sensitive diff scan — no internal hosts, credentials, registry secrets, or cookies found

Unit, integration, and e2e tests were not run because the change is documentation-only and does not modify executable behavior.

# Compatibility and security impact

- no public API, CRD, configuration, authentication, or authorization changes
- no runtime or task scheduling behavior changes
- no security boundary changes

# Existing Issue

Closes #1510.

Related but distinct status-convergence reports are #1450 and #1497; they concern restart/failure transitions rather than the meaning of `Succeed` versus task counters.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed) — documentation build and acceptance checks cover this docs-only change
- [x] Security impact considered
- [x] Backward compatibility considered
