### PR TITLE
fix(server): preserve proxy path in root-relative redirects

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -160,7 +160,7 @@ Header-routed ingress endpoints include `OpenSandbox-Ingress-To` in their endpoi
 When the endpoint is rewritten to a server-proxied URL, the server removes only this
 ingress routing header and preserves other required endpoint headers.
 
-The server proxy supports HTTP and WebSocket traffic and is also integrated with optional renew-on-access behavior. For HTTP responses, it strips hop-by-hop headers and the backend `Server` header while preserving an origin `Date`; the server adds a current `Date` only when the response does not already contain one.
+The server proxy supports HTTP and WebSocket traffic and is also integrated with optional renew-on-access behavior. For HTTP responses, it strips hop-by-hop headers and the backend `Server` header while preserving an origin `Date`; the server adds a current `Date` only when the response does not already contain one. A root-relative `Location` value that starts with a single `/` is rebased under the same sandbox proxy route, while absolute URLs, network-path references (`//host/path`), and ordinary path-relative values are forwarded unchanged.
 
 ## 4. Runtime Backends
 

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -170,6 +170,24 @@ def _set_forwarded_headers(
         headers["X-Forwarded-For"] = request.client.host
 
 
+def _rewrite_proxy_location(
+    location: str,
+    request: Request,
+    sandbox_id: str,
+    port: int,
+) -> str:
+    """Keep root-relative redirects inside the current sandbox proxy route."""
+    if not location.startswith("/") or location.startswith("//"):
+        return location
+
+    proxy_suffix = f"/sandboxes/{sandbox_id}/proxy/{port}"
+    proxy_start = request.url.path.find(proxy_suffix)
+    if proxy_start < 0:
+        return location
+    proxy_path = request.url.path[: proxy_start + len(proxy_suffix)]
+    return f"{proxy_path}{location}"
+
+
 def _schedule_proxy_renew(request: Request | WebSocket, sandbox_id: str) -> None:
     proxy_renew = getattr(request.app.state, "proxy_renew_coordinator", None)
     if proxy_renew is not None:
@@ -337,7 +355,11 @@ async def _proxy_http_request(
                 )
             response_header_exclusions = hop_by_hop | SERVER_GENERATED_RESPONSE_HEADERS
             response_headers = {
-                key: value
+                key: (
+                    _rewrite_proxy_location(value, request, sandbox_id, port)
+                    if key.lower() == "location"
+                    else value
+                )
                 for key, value in resp.headers.items()
                 if key.lower() not in response_header_exclusions
             }

--- a/server/opensandbox_server/api/proxy.py
+++ b/server/opensandbox_server/api/proxy.py
@@ -20,6 +20,7 @@ import hmac
 import logging
 from collections.abc import AsyncIterator, Mapping
 from typing import Optional
+from urllib.parse import urlsplit
 
 import anyio
 import httpx
@@ -181,6 +182,12 @@ def _rewrite_proxy_location(
         return location
 
     proxy_suffix = f"/sandboxes/{sandbox_id}/proxy/{port}"
+    eip = (lifecycle.get_config().server.eip or "").strip().rstrip("/")
+    if eip:
+        external_url = eip if "://" in eip else f"//{eip}"
+        external_prefix = urlsplit(external_url).path.rstrip("/")
+        return f"{external_prefix}{proxy_suffix}{location}"
+
     proxy_start = request.url.path.find(proxy_suffix)
     if proxy_start < 0:
         return location

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -17,6 +17,7 @@ import gzip
 from typing import Any, cast
 
 import httpx
+import pytest
 from fastapi.testclient import TestClient
 from starlette.requests import ClientDisconnect
 from starlette.types import Message
@@ -258,6 +259,73 @@ def test_proxy_preserves_origin_date_and_filters_server_header(
     assert response.headers.get("x-backend") == "yes"
     assert response.headers.get("date") == origin_date
     assert "server" not in response.headers
+
+
+@pytest.mark.parametrize(
+    ("request_path", "location", "expected_location"),
+    [
+        (
+            "/v1/sandboxes/sbx-123/proxy/44772/",
+            "/login?next=%2F",
+            "/v1/sandboxes/sbx-123/proxy/44772/login?next=%2F",
+        ),
+        (
+            "/sandboxes/sbx-123/proxy/44772/",
+            "/login?next=%2F",
+            "/sandboxes/sbx-123/proxy/44772/login?next=%2F",
+        ),
+        (
+            "/v1/sandboxes/sbx-123/proxy/44772/nested/page",
+            "/login?next=%2F",
+            "/v1/sandboxes/sbx-123/proxy/44772/login?next=%2F",
+        ),
+        ("/v1/sandboxes/sbx-123/proxy/44772/", "login?next=%2F", "login?next=%2F"),
+        (
+            "/v1/sandboxes/sbx-123/proxy/44772/",
+            "https://example.com/login",
+            "https://example.com/login",
+        ),
+        (
+            "/v1/sandboxes/sbx-123/proxy/44772/",
+            "//example.com/login",
+            "//example.com/login",
+        ),
+        ("/v1/sandboxes/sbx-123/proxy/44772/", "?next=%2F", "?next=%2F"),
+    ],
+)
+def test_proxy_rewrites_only_root_relative_redirects(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+    request_path: str,
+    location: str,
+    expected_location: str,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert sandbox_id == "sbx-123"
+            assert port == 44772
+            assert resolve_internal is True
+            return Endpoint(endpoint="backend.example:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(
+        status_code=302,
+        headers={"Location": location},
+    )
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        request_path,
+        headers=auth_headers,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == expected_location
 
 
 def test_proxy_root_path_forwards_endpoint_headers_and_query(

--- a/server/tests/test_routes_proxy.py
+++ b/server/tests/test_routes_proxy.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import gzip
+from types import SimpleNamespace
 from typing import Any, cast
 
 import httpx
@@ -326,6 +327,48 @@ def test_proxy_rewrites_only_root_relative_redirects(
 
     assert response.status_code == 302
     assert response.headers["location"] == expected_location
+
+
+def test_proxy_rewrites_root_relative_redirect_with_server_eip_path(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_endpoint(sandbox_id: str, port: int, resolve_internal: bool = False) -> Endpoint:
+            assert sandbox_id == "sbx-123"
+            assert port == 44772
+            assert resolve_internal is True
+            return Endpoint(endpoint="backend.example:40109")
+
+    monkeypatch.setattr(lifecycle, "sandbox_service", StubService())
+    monkeypatch.setattr(
+        lifecycle,
+        "get_config",
+        lambda: SimpleNamespace(
+            server=SimpleNamespace(eip="sandbox.example.com/opensandbox/")
+        ),
+    )
+
+    fake_client = _FakeAsyncClient()
+    fake_client.response = _FakeStreamingResponse(
+        status_code=302,
+        headers={"Location": "/login?next=%2F"},
+    )
+    _set_http_client(client, fake_client)
+
+    response = client.get(
+        "/v1/sandboxes/sbx-123/proxy/44772/",
+        headers=auth_headers,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == "/opensandbox/sandboxes/sbx-123/proxy/44772/login?next=%2F"
+    )
 
 
 def test_proxy_root_path_forwards_endpoint_headers_and_query(


### PR DESCRIPTION
# Summary

Fixes #1515.

## Problem

When a proxied backend returns an HTTP redirect such as `Location: /login`, the server forwards that value unchanged. A client then resolves it against the OpenSandbox server origin and leaves `/v1/sandboxes/{sandbox_id}/proxy/{port}`, so the redirect no longer reaches the sandbox service.

## Minimal reproduction

1. Have a sandbox endpoint return `302` with `Location: /login?next=%2F`.
2. Request it through `/v1/sandboxes/sbx-123/proxy/44772/`.
3. Before this change, the server returns `Location: /login?next=%2F`.
4. The expected value is `/v1/sandboxes/sbx-123/proxy/44772/login?next=%2F`.

The regression test was added first and failed with the unprefixed value before the implementation changed.

## Root cause

The HTTP proxy filters response headers but otherwise copied the backend `Location` header verbatim. Root-relative references therefore became relative to the OpenSandbox server root rather than the current sandbox proxy route.

## Change

- Rebase `Location` values beginning with a single `/` under the proxy route taken from the actual request path.
- Preserve both `/v1` and unversioned proxy aliases, including redirects returned from nested proxied paths.
- Leave absolute URLs, network-path references such as `//example.com/login`, ordinary path-relative references, and query-only references unchanged.
- Document the redirect behavior in the architecture guide.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run locally:

- `uv run --frozen pytest tests/test_routes_proxy.py -q --no-cov` - 27 passed
- `uv run --frozen pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80 -q` - 1354 passed, 82.16% coverage
- `uv run --frozen ruff check` - passed
- `uv run --frozen pyright opensandbox_server/api/proxy.py tests/test_routes_proxy.py` - 0 errors
- `./scripts/verify-license.sh` - passed
- `pnpm docs:build` - passed

The repository-wide `uv run --frozen pyright` currently reports 1366 errors across existing, untouched files; the two changed Python files pass when checked directly. Docker host/bridge smoke tests were not run locally and are left to the pull-request CI matrix.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

## Compatibility and security impact

This is a response-header compatibility fix and does not change the public API schema, authentication, cookies, request forwarding, or cross-origin policy. Only single-slash root-relative redirect targets are rebased. Absolute and network-path targets remain unchanged, avoiding any relaxation of redirect-origin behavior.

## Existing Issue

- #1515

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
