### PR TITLE
fix(kotlin): replenish pool after cleanup

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -811,7 +811,10 @@ class SandboxPool internal constructor(
 
         private fun complete() {
             if (completed.compareAndSet(false, true)) {
-                run?.let { endOperation(it) }
+                run?.let {
+                    endOperation(it)
+                    requestReconcile(it)
+                }
             }
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -1090,11 +1090,12 @@ class SandboxPoolTest {
     @Test
     fun `acquire with RETRY_NEXT_IDLE and all stale idle drains up to maxAcquireRetries and throws`() {
         val store = InMemoryPoolStateStore()
+        val connectAttempts = AtomicInteger(0)
         // maxIdle=0 keeps the reconcile loop from creating fresh sandboxes against the (missing)
         // server; we drive idle membership manually via putIdle so the test only exercises the
         // acquire retry loop.
-        val pool =
-            SandboxPool.builder()
+        val config =
+            PoolConfig.builder()
                 .poolName("test-pool")
                 .ownerId("test-owner")
                 .maxIdle(0)
@@ -1105,7 +1106,21 @@ class SandboxPoolTest {
                 .reconcileInterval(Duration.ofSeconds(30))
                 .maxAcquireRetries(3)
                 .build()
-        // 5 stale IDs in idle; retry policy should try 3, leave 2 behind.
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { cfg ->
+                    SandboxManager.builder().connectionConfig(cfg).build()
+                },
+                idleSandboxConnector = { sandboxId ->
+                    connectAttempts.incrementAndGet()
+                    throw RuntimeException("stale sandbox $sandboxId")
+                },
+            )
+        // 5 stale IDs in idle; retry policy should try exactly 3. The leftover two are excess
+        // under maxIdle=0 and the completion-driven reconcile may remove them before the
+        // assertion, so the retry budget is verified via connector attempts instead of the
+        // residual idle count.
         repeat(5) { store.putIdle("test-pool", "stale-id-$it") }
 
         pool.start()
@@ -1113,7 +1128,7 @@ class SandboxPoolTest {
             assertThrows(PoolAcquireFailedException::class.java) {
                 pool.acquire(policy = AcquirePolicy.RETRY_NEXT_IDLE)
             }
-            assertEquals(2, store.snapshotCounters("test-pool").idleCount)
+            assertEquals(3, connectAttempts.get())
         } finally {
             pool.shutdown(graceful = false)
         }

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolTest.kt
@@ -1018,6 +1018,61 @@ class SandboxPoolTest {
     }
 
     @Test
+    fun `stale acquire cleanup triggers replenish before periodic reconcile`() {
+        val store = CountingPoolStateStore()
+        val manager = mockk<SandboxManager>(relaxed = true)
+        val created = AtomicInteger(0)
+        val killed = CountDownLatch(1)
+        every { manager.killSandbox("warmup-1") } answers { killed.countDown() }
+
+        val config =
+            PoolConfig.builder()
+                .poolName("cleanup-reconcile-pool")
+                .ownerId("cleanup-reconcile-owner")
+                .maxIdle(1)
+                .warmupConcurrency(1)
+                .stateStore(store)
+                .connectionConfig(ConnectionConfig.builder().build())
+                .creationSpec(PoolCreationSpec.builder().image("ubuntu:22.04").build())
+                .sandboxCreator(
+                    PooledSandboxCreator {
+                        val index = created.incrementAndGet()
+                        mockk<Sandbox>(relaxed = true).also { sandbox ->
+                            every { sandbox.id } returns "warmup-$index"
+                        }
+                    },
+                ).warmupSkipHealthCheck()
+                .reconcileInterval(Duration.ofSeconds(30))
+                .drainTimeout(Duration.ofSeconds(2))
+                .build()
+        val pool =
+            SandboxPool(
+                config = config,
+                sandboxManagerFactory = { manager },
+                idleSandboxConnector = { throw RuntimeException("stale sandbox") },
+            )
+
+        pool.start()
+        try {
+            awaitCondition {
+                store.snapshotCounters("cleanup-reconcile-pool").idleCount == 1 &&
+                    store.reconcileTicks.get() >= 2
+            }
+
+            assertThrows(PoolAcquireFailedException::class.java) {
+                pool.acquire(policy = AcquirePolicy.FAIL_FAST)
+            }
+
+            assertTrue(killed.await(5, TimeUnit.SECONDS))
+            awaitCondition {
+                created.get() == 2 && store.snapshotCounters("cleanup-reconcile-pool").idleCount == 1
+            }
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
     fun `acquire with RETRY_NEXT_IDLE and empty idle throws PoolEmptyException`() {
         val pool = buildPool()
         pool.start()


### PR DESCRIPTION
# Summary
- trigger the existing coalesced reconcile path after a tracked stale-sandbox cleanup completes
- replenish the idle slot promptly instead of waiting up to the periodic `reconcileInterval`
- add a regression test that drains the initial completion tick, fails an idle connection, waits for cleanup, and verifies the pool refills before the 30-second periodic tick

Closes #1513

# Testing
- [x] Not run (the local Gradle wrapper could not download `gradle-9.2.1-all.zip` because the distribution host timed out; the focused test command was attempted with Temurin JDK 17)
- [ ] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification
- `git show --check` passed

# Breaking Changes
- [x] None
- [ ] Yes (describe impact and migration path)

# Checklist
- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (not needed; internal latency behavior only)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered