### PR TITLE
feat(pool): gate DIRECT_CREATE fallback with the shared warmup quota

### DIFF
--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/exceptions/SandboxException.kt
@@ -301,6 +301,20 @@ class PoolDestroyedException(
     )
 
 /**
+ * Thrown when an acquire falls through to direct create but the pool's
+ * in-flight create quota ([PoolConfig.warmupConcurrency], shared with warmups)
+ * stayed exhausted for the bounded wait.
+ */
+class PoolCapacityExceededException(
+    message: String? = "Pool in-flight create capacity exhausted",
+    cause: Throwable? = null,
+) : SandboxException(
+        message = message,
+        cause = cause,
+        error = SandboxError(SandboxError.POOL_CAPACITY_EXCEEDED, message),
+    )
+
+/**
  * Thrown when a pool destroy operation has started but did not complete. The pool namespace
  * remains fenced in DESTROYING state so callers can retry destroy instead of silently resuming
  * a partially-cleaned pool.
@@ -360,5 +374,8 @@ data class SandboxError(
 
         /** Pool destroy started but did not complete. */
         const val POOL_DESTROY_INCOMPLETE = "POOL_DESTROY_INCOMPLETE"
+
+        /** Pool-specific: direct-create quota exhausted and the bounded wait expired. */
+        const val POOL_CAPACITY_EXCEEDED = "POOL_CAPACITY_EXCEEDED"
     }
 }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPool.kt
@@ -20,6 +20,7 @@ import com.alibaba.opensandbox.sandbox.Sandbox
 import com.alibaba.opensandbox.sandbox.SandboxManager
 import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolAcquireFailedException
+import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolCapacityExceededException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolDestroyedException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolEmptyException
 import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolNotRunningException
@@ -1308,6 +1309,23 @@ class SandboxPool internal constructor(
         // instead of surfacing the outage. See ensurePoolNamespaceActiveForAcquire for
         // the full rationale.
         ensurePoolNamespaceActiveForAcquire(policy)
+        val run = currentRun ?: throw PoolNotRunningException("Cannot acquire without an active pool run")
+        // Direct creates share the warmup quota (warmingCount): total in-flight
+        // creates (warmups + direct creates) never exceeds warmupConcurrency.
+        // Under over-demand this bounds the synchronous-create burst instead of
+        // letting every waiting caller create concurrently (see #1520).
+        waitForDirectCreateSlot(run)
+        try {
+            return directCreateInternal(sandboxTimeout, policy)
+        } finally {
+            run.warmingCount.decrementAndGet()
+        }
+    }
+
+    private fun directCreateInternal(
+        sandboxTimeout: Duration?,
+        policy: AcquirePolicy,
+    ): Sandbox {
         sandboxCreator?.let {
             val sandbox =
                 buildSandboxFromCreator(
@@ -1354,6 +1372,41 @@ class SandboxPool internal constructor(
         // has already killed and closed the sandbox.
         ensurePoolNamespaceActiveOrDispose(sandbox, policy)
         return sandbox
+    }
+
+    /**
+     * Waits until an in-flight create slot is available, bounded by
+     * [PoolConfig.acquireReadyTimeout] (the acquire's overall duration knob).
+     * The wait is interruptible and re-validates pool state on every iteration,
+     * so a stopping/destroyed pool fails fast with the usual exceptions.
+     *
+     * @throws PoolCapacityExceededException when the quota stayed exhausted for
+     * the whole budget.
+     */
+    private fun waitForDirectCreateSlot(run: RunContext) {
+        val deadlineNanos = System.nanoTime() + config.acquireReadyTimeout.toNanos()
+        while (true) {
+            ensureAcquireRunActive(run)
+            val current = run.warmingCount.get()
+            if (current < config.warmupConcurrency &&
+                run.warmingCount.compareAndSet(current, current + 1)
+            ) {
+                return
+            }
+            if (System.nanoTime() >= deadlineNanos) {
+                throw PoolCapacityExceededException(
+                    "Pool in-flight create capacity exhausted " +
+                        "(warmupConcurrency=${config.warmupConcurrency}): " +
+                        "all slots are held by warmups and/or direct creates",
+                )
+            }
+            try {
+                Thread.sleep(DIRECT_CREATE_SLOT_POLL_MS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw e
+            }
+        }
     }
 
     private fun ensurePoolNamespaceActive() {
@@ -1751,6 +1804,9 @@ class SandboxPool internal constructor(
     companion object {
         /** Minimum spacing between completion-driven reconcile ticks (see [requestReconcile]). */
         private const val COMPLETION_RECONCILE_MIN_INTERVAL_MS = 500L
+
+        /** Poll interval while waiting for a direct-create quota slot. */
+        private const val DIRECT_CREATE_SLOT_POLL_MS = 50L
 
         @JvmStatic
         fun builder(): Builder = Builder()

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolDirectCreateGateTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/pool/SandboxPoolDirectCreateGateTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.opensandbox.sandbox.pool
+
+import com.alibaba.opensandbox.sandbox.config.ConnectionConfig
+import com.alibaba.opensandbox.sandbox.domain.exceptions.PoolCapacityExceededException
+import com.alibaba.opensandbox.sandbox.domain.pool.AcquirePolicy
+import com.alibaba.opensandbox.sandbox.domain.pool.PoolCreationSpec
+import com.alibaba.opensandbox.sandbox.infrastructure.pool.InMemoryPoolStateStore
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Verifies the DIRECT_CREATE concurrency gate: direct creates share the
+ * warmupConcurrency quota, concurrent fallback creates are bounded, and a
+ * quota-exhausted acquire waits (bounded) then fails with
+ * [PoolCapacityExceededException] instead of creating unboundedly.
+ */
+class SandboxPoolDirectCreateGateTest {
+    private lateinit var lifecycle: MockWebServer
+    private lateinit var execd: MockWebServer
+    private val sandboxSeq = AtomicLong()
+
+    @BeforeEach
+    fun setUp() {
+        lifecycle = MockWebServer()
+        execd = MockWebServer()
+        lifecycle.start()
+        execd.start()
+        execd.dispatcher =
+            object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse =
+                    MockResponse().setResponseCode(200).setBody("""{"status":"ok"}""")
+            }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        lifecycle.shutdown()
+        execd.shutdown()
+    }
+
+    private fun installLifecycleDispatcher(createAction: () -> Unit) {
+        lifecycle.dispatcher =
+            object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    val path = request.path.orEmpty()
+                    return when {
+                        request.method == "POST" && path == "/v1/sandboxes" -> {
+                            createAction()
+                            MockResponse().setResponseCode(201).setBody(
+                                """{"id":"sbx-${sandboxSeq.incrementAndGet()}","status":{"state":"Running"},""" +
+                                    """"createdAt":"2026-01-01T00:00:00Z","entrypoint":["tail"]}""",
+                            )
+                        }
+                        request.method == "GET" && path.contains("/endpoints/") ->
+                            MockResponse().setResponseCode(200).setBody(
+                                """{"endpoint":"${execd.hostName}:${execd.port}","headers":{"X-EXECD-ACCESS-TOKEN":"t"}}""",
+                            )
+                        request.method == "POST" && path.endsWith("/renew-expiration") ->
+                            MockResponse().setResponseCode(200).setBody("""{"expiresAt":"2026-12-31T00:00:00Z"}""")
+                        request.method == "DELETE" -> MockResponse().setResponseCode(204)
+                        else -> MockResponse().setResponseCode(404)
+                    }
+                }
+            }
+    }
+
+    private fun buildPool(
+        maxIdle: Int,
+        warmupConcurrency: Int,
+        acquireReadyTimeout: Duration = Duration.ofSeconds(30),
+    ): SandboxPool =
+        SandboxPool.builder()
+            .poolName("direct-gate-test")
+            .ownerId("owner")
+            .maxIdle(maxIdle)
+            .warmupConcurrency(warmupConcurrency)
+            .stateStore(InMemoryPoolStateStore())
+            .connectionConfig(
+                ConnectionConfig.builder()
+                    .domain(lifecycle.hostName + ":" + lifecycle.port)
+                    .protocol("http")
+                    .requestTimeout(Duration.ofSeconds(10))
+                    .disableMetrics()
+                    .build(),
+            )
+            .creationSpec(
+                PoolCreationSpec.builder()
+                    .image("test:latest")
+                    .entrypoint("tail", "-f", "/dev/null")
+                    .build(),
+            )
+            .reconcileInterval(Duration.ofMillis(100))
+            .idleTimeout(Duration.ofMinutes(30))
+            .acquireReadyTimeout(acquireReadyTimeout)
+            .acquireSkipHealthCheck(false)
+            .build()
+
+    @Test
+    fun `concurrent direct creates are bounded by warmupConcurrency`() {
+        val concurrent = AtomicInteger()
+        val maxConcurrent = AtomicInteger()
+        installLifecycleDispatcher {
+            val now = concurrent.incrementAndGet()
+            maxConcurrent.updateAndGet { maxOf(it, now) }
+            try {
+                Thread.sleep(300)
+            } finally {
+                concurrent.decrementAndGet()
+            }
+        }
+
+        val pool = buildPool(maxIdle = 0, warmupConcurrency = 2)
+        pool.start()
+        try {
+            val workers = 6
+            val threads = Executors.newFixedThreadPool(workers)
+            val done = CountDownLatch(workers)
+            val sandboxes = java.util.concurrent.ConcurrentLinkedQueue<com.alibaba.opensandbox.sandbox.Sandbox>()
+            repeat(workers) {
+                threads.submit {
+                    try {
+                        sandboxes.add(pool.acquire(Duration.ofMinutes(10), AcquirePolicy.DIRECT_CREATE))
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            assertTrue(done.await(30, TimeUnit.SECONDS), "acquires did not complete")
+            threads.shutdown()
+            sandboxes.forEach { it.kill() }
+            // 6 concurrent callers, gate = 2: server must never see more than 2
+            // in-flight creates at once.
+            assertTrue(
+                maxConcurrent.get() <= 2,
+                "expected direct creates bounded by warmupConcurrency=2, saw ${maxConcurrent.get()} concurrent",
+            )
+        } finally {
+            pool.shutdown(graceful = false)
+        }
+    }
+
+    @Test
+    fun `quota exhausted acquire waits then fails with PoolCapacityExceededException`() {
+        // The single warmup holds the only in-flight create slot until the
+        // test releases it, so any acquire fallback must wait and then fail.
+        val warmupRelease = CountDownLatch(1)
+        installLifecycleDispatcher { warmupRelease.await(60, TimeUnit.SECONDS) }
+        val pool =
+            buildPool(
+                maxIdle = 2,
+                warmupConcurrency = 1,
+                acquireReadyTimeout = Duration.ofSeconds(2),
+            )
+        pool.start()
+        try {
+            // Let the warmup occupy the single slot.
+            val deadline = System.currentTimeMillis() + 5000
+            while (lifecycle.requestCount < 1 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50)
+            }
+            assertTrue(lifecycle.requestCount >= 1, "warmup create never reached the server")
+
+            val start = System.currentTimeMillis()
+            val failure =
+                assertThrows(PoolCapacityExceededException::class.java) {
+                    pool.acquire(Duration.ofMinutes(10), AcquirePolicy.DIRECT_CREATE)
+                }
+            val elapsed = System.currentTimeMillis() - start
+            assertTrue(elapsed >= 1500, "expected bounded wait before failing, elapsed=${elapsed}ms")
+            assertTrue(failure.message!!.contains("warmupConcurrency=1"))
+        } finally {
+            warmupRelease.countDown()
+            pool.shutdown(graceful = false)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1520

## Problem

`DIRECT_CREATE` (the acquire fallback when the idle buffer is empty) has no concurrency gate — its parallelism is bounded only by the number of concurrent callers. Under demand above replenish capacity, every waiting caller creates synchronously (measured: ~1100 concurrent creates), causing connection-level failures and a 41% acquire failure rate (benchmark over-demand scenario, `steady-start-immediately` at 2x warmupConcurrency).

## Change

- `directCreate()` now acquires a slot by CAS-incrementing `run.warmingCount`, shared with warmup tasks — total in-flight creates never exceed `warmupConcurrency`.
- When the quota is exhausted, the acquire waits (bounded by `acquireReadyTimeout`, interruptible, re-validating pool state on each poll) and then fails with a new `PoolCapacityExceededException` (`POOL_CAPACITY_EXCEEDED`) instead of a network-level error.
- `WarmupPlan`/reconciler unchanged: it already reads `warmingCount`, so warmup submissions automatically yield to direct creates.
- Additive API: new exception type only; no existing signatures touched.

## Tests

- Concurrent direct creates (6 callers, gate=2) — server-side peak concurrent creates <= 2.
- Quota-exhausted acquire (warmup holds the single slot) — waits the bounded budget, then throws `PoolCapacityExceededException`.
- Full `:sandbox:test` suite green (one pre-existing timing-sensitive test flaked once and passed on rerun).

## Verification note

The bounded wait defaults to `acquireReadyTimeout` (the existing acquire-duration knob), so no new configuration is introduced. Behavior under over-demand: smooth burst instead of failure storm; callers eventually get a clear, catchable capacity signal.