### PR TITLE
docs: fix empty allowed_host_paths semantics in config examples

### DIFF
--- a/docs/examples/host-volume-mount.md
+++ b/docs/examples/host-volume-mount.md
@@ -34,12 +34,12 @@ For security, the server restricts which host paths can be mounted. Add a `[stor
 [storage]
 # Allowlist of host path prefixes permitted for bind mounts.
 # Only paths under these prefixes can be mounted into sandboxes.
-# If empty, all host paths are allowed (not recommended for production).
+# If empty, all host bind mounts are rejected (secure by default).
 allowed_host_paths = ["/tmp/opensandbox-data", "/data/shared"]
 ```
 
 ::: warning Security note
-In production, always set explicit `allowed_host_paths` to prevent sandboxes from accessing sensitive host directories. An empty list allows all paths, which is convenient for local development but not safe for shared environments.
+In production, always set explicit `allowed_host_paths` to prevent sandboxes from accessing sensitive host directories. The default is an empty list, which rejects every host bind mount, so this section must be configured before host volumes can be used at all.
 :::
 
 ### 3. Create Host Directories

--- a/server/opensandbox_server/examples/example.config.k8s.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.toml
@@ -36,7 +36,7 @@ execd_image = "opensandbox/execd:v1.0.22"
 
 [storage]
 # Allowlist of host path prefixes permitted for bind mounts.
-# If empty, all host paths are allowed (not recommended for production).
+# If empty (the default), all host bind mounts are rejected (secure by default).
 # Example: allowed_host_paths = ["/data/opensandbox", "/tmp/sandbox"]
 allowed_host_paths = []
 

--- a/server/opensandbox_server/examples/example.config.k8s.zh.toml
+++ b/server/opensandbox_server/examples/example.config.k8s.zh.toml
@@ -36,7 +36,7 @@ execd_image = "sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/execd
 
 [storage]
 # 允许进行 bind mount 的宿主机路径前缀白名单。
-# 如果为空，则允许所有路径（不建议在生产环境使用）。
+# 如果为空（默认值），则拒绝所有宿主机 bind mount（默认安全）。
 # 示例：allowed_host_paths = ["/data/opensandbox", "/tmp/sandbox"]
 allowed_host_paths = []
 

--- a/server/opensandbox_server/examples/example.config.toml
+++ b/server/opensandbox_server/examples/example.config.toml
@@ -36,7 +36,7 @@ execd_image = "opensandbox/execd:v1.0.22"
 
 [storage]
 # Allowlist of host path prefixes permitted for bind mounts.
-# If empty, all host paths are allowed (not recommended for production).
+# If empty (the default), all host bind mounts are rejected (secure by default).
 # Example: allowed_host_paths = ["/data/opensandbox", "/tmp/sandbox"]
 allowed_host_paths = []
 

--- a/server/tests/test_validators.py
+++ b/server/tests/test_validators.py
@@ -371,6 +371,21 @@ class TestEnsureValidHostPath:
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail["code"] == SandboxErrorCodes.HOST_PATH_NOT_ALLOWED
 
+    def test_empty_allowlist_rejects_every_path(self):
+        """An empty allowlist is secure-by-default: it rejects every host path.
+
+        This is the ``storage.allowed_host_paths = []`` default, and it is
+        distinct from ``None`` (no allowlist configured) below.
+        """
+        with pytest.raises(HTTPException) as exc_info:
+            ensure_valid_host_path("/data/opensandbox", [])
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == SandboxErrorCodes.HOST_PATH_NOT_ALLOWED
+
+    def test_none_allowlist_skips_the_prefix_check(self):
+        """``None`` means no prefix check at all, unlike an empty list."""
+        assert ensure_valid_host_path("/data/opensandbox", None) is None
+
 class TestEnsureValidPvcName:
 
     def test_valid_simple_name(self):


### PR DESCRIPTION
# Summary

`storage.allowed_host_paths` is secure-by-default: an empty list rejects **every** host bind mount. Three example configs and the host-volume-mount guide say the opposite — that an empty list allows all paths — which reads as a permissive default and contradicts the project's own reference documentation.

The behaviour comes from `ensure_valid_host_path` in `server/opensandbox_server/services/validators.py`, where the allowlist branch is gated on `if allowed_prefixes is not None:`. An empty list is not `None`, so `any(...)` over zero prefixes is `False` and the path is rejected with `HOST_PATH_NOT_ALLOWED`. Both runtimes reach this through `ensure_volumes_valid` (`services/docker/volumes.py` and `services/k8s/kubernetes_service.py`), so the semantics are identical for Docker and Kubernetes.

Observed directly against `main`:

| `allowed_prefixes` | result for `/tmp/opensandbox-data` |
|---|---|
| `None` | allowed |
| `[]` | rejected — `VOLUME::HOST_PATH_NOT_ALLOWED` |
| `["/tmp"]` | allowed |
| `["/data"]` | rejected — `VOLUME::HOST_PATH_NOT_ALLOWED` |

Two places already describe this correctly and were used as the reference for the new wording, so nothing there changed:

- `server/configuration.md` — "If **empty**, all host bind mounts are rejected (secure-by-default)."
- `StorageConfig.allowed_host_paths` in `server/opensandbox_server/config.py` — "If empty, host bind mounts are rejected."

## Files corrected

- `server/opensandbox_server/examples/example.config.toml`
- `server/opensandbox_server/examples/example.config.k8s.toml`
- `server/opensandbox_server/examples/example.config.k8s.zh.toml`
- `docs/examples/host-volume-mount.md` (the inline comment and the security note)

`server/opensandbox_server/examples/example.config.zh.toml` has no comment on this key, so it needed no change.

## Tests

The empty-list case was not covered anywhere, so I added two tests to `TestEnsureValidHostPath` pinning both branches — `[]` rejects, `None` skips the prefix check.

To confirm they are not vacuous, I temporarily changed the guard to `if allowed_prefixes:` (the behaviour the old docs described) and re-ran the file: `test_empty_allowlist_rejects_every_path` was the only test that failed, so nothing else in the suite pins this. The source change was reverted before committing and is not part of this PR.

One note: `tests/test_validators.py` does not currently satisfy `ruff format`, on `main` as well as here. I matched the file's existing style rather than reformatting it, to keep this diff to the change being made. Happy to split a formatting pass into a separate PR if that would be useful.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

```
pytest tests/test_validators.py   ->  86 passed
ruff check tests/test_validators.py  ->  All checks passed
```

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Documentation and tests only. No runtime behaviour is changed.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered — the docs understated the safety of the default; the code was already correct, so this is a documentation correction rather than a fix to enforcement
- [x] Backward compatibility considered
