### PR TITLE
perf(sdk): resolve execd and egress endpoints in parallel

### DIFF
--- a/sdks/sandbox/python/src/opensandbox/sandbox.py
+++ b/sdks/sandbox/python/src/opensandbox/sandbox.py
@@ -590,11 +590,13 @@ class Sandbox:
             )
             sandbox_id = response.id
 
-            execd_endpoint = await sandbox_service.get_sandbox_endpoint(
-                response.id, DEFAULT_EXECD_PORT, config.use_server_proxy
-            )
-            egress_endpoint = await sandbox_service.get_sandbox_endpoint(
-                response.id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+            execd_endpoint, egress_endpoint = await asyncio.gather(
+                sandbox_service.get_sandbox_endpoint(
+                    response.id, DEFAULT_EXECD_PORT, config.use_server_proxy
+                ),
+                sandbox_service.get_sandbox_endpoint(
+                    response.id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+                ),
             )
 
             sandbox = cls(
@@ -702,11 +704,13 @@ class Sandbox:
 
         try:
             sandbox_service = factory.create_sandbox_service()
-            execd_endpoint = await sandbox_service.get_sandbox_endpoint(
-                sandbox_id, DEFAULT_EXECD_PORT, config.use_server_proxy
-            )
-            egress_endpoint = await sandbox_service.get_sandbox_endpoint(
-                sandbox_id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+            execd_endpoint, egress_endpoint = await asyncio.gather(
+                sandbox_service.get_sandbox_endpoint(
+                    sandbox_id, DEFAULT_EXECD_PORT, config.use_server_proxy
+                ),
+                sandbox_service.get_sandbox_endpoint(
+                    sandbox_id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+                ),
             )
 
             sandbox = cls(
@@ -782,11 +786,13 @@ class Sandbox:
             sandbox_service = factory.create_sandbox_service()
             await sandbox_service.resume_sandbox(sandbox_id)
 
-            execd_endpoint = await sandbox_service.get_sandbox_endpoint(
-                sandbox_id, DEFAULT_EXECD_PORT, config.use_server_proxy
-            )
-            egress_endpoint = await sandbox_service.get_sandbox_endpoint(
-                sandbox_id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+            execd_endpoint, egress_endpoint = await asyncio.gather(
+                sandbox_service.get_sandbox_endpoint(
+                    sandbox_id, DEFAULT_EXECD_PORT, config.use_server_proxy
+                ),
+                sandbox_service.get_sandbox_endpoint(
+                    sandbox_id, DEFAULT_EGRESS_PORT, config.use_server_proxy
+                ),
             )
 
             sandbox = cls(

--- a/sdks/sandbox/python/tests/test_sandbox_business_logic.py
+++ b/sdks/sandbox/python/tests/test_sandbox_business_logic.py
@@ -23,7 +23,10 @@ import pytest
 
 from opensandbox.config import ConnectionConfig
 from opensandbox.constants import DEFAULT_EGRESS_PORT, DEFAULT_EXECD_PORT
-from opensandbox.exceptions import SandboxReadyTimeoutException
+from opensandbox.exceptions import (
+    SandboxInternalException,
+    SandboxReadyTimeoutException,
+)
 from opensandbox.models.diagnostics import DiagnosticContent
 from opensandbox.models.sandboxes import NetworkPolicy, NetworkRule, SandboxEndpoint
 from opensandbox.sandbox import Sandbox
@@ -348,6 +351,200 @@ async def test_create_resolves_egress_endpoint_and_builds_service(
             headers={"X-Port": str(DEFAULT_EGRESS_PORT)},
         )
     ]
+
+
+class _GatedEndpointServiceStub:
+    """get_sandbox_endpoint that blocks the execd request until released.
+
+    Detects serial endpoint resolution: when the two endpoint requests are
+    awaited sequentially, the egress request cannot start while the execd
+    request is still blocked.
+    """
+
+    def __init__(self) -> None:
+        self.execd_entered = asyncio.Event()
+        self.egress_entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def get_sandbox_endpoint(
+        self, _sandbox_id, port: int, _use_server_proxy: bool = False
+    ) -> SandboxEndpoint:
+        if port == DEFAULT_EXECD_PORT:
+            self.execd_entered.set()
+            await self.release.wait()
+        else:
+            self.egress_entered.set()
+        return SandboxEndpoint(endpoint=f"sbx.internal:{port}")
+
+
+async def _assert_parallel_endpoint_resolution(
+    gate: _GatedEndpointServiceStub, op
+) -> None:
+    task = asyncio.create_task(op())
+    await asyncio.wait_for(gate.execd_entered.wait(), timeout=1)
+    try:
+        # Fails if the egress endpoint is requested only after the execd
+        # endpoint request has completed.
+        await asyncio.wait_for(gate.egress_entered.wait(), timeout=1)
+    finally:
+        gate.release.set()
+        await task
+
+
+@pytest.mark.parametrize("flow", ["create", "connect", "resume"])
+@pytest.mark.asyncio
+async def test_sandbox_resolves_endpoints_in_parallel(
+    monkeypatch: pytest.MonkeyPatch, flow: str
+) -> None:
+    gate = _GatedEndpointServiceStub()
+
+    class _CreateResponse:
+        id = "sbx-1"
+
+    class _SandboxServiceStub:
+        async def create_sandbox(self, *_args, **_kwargs):
+            return _CreateResponse()
+
+        async def resume_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+        async def kill_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+        async def get_sandbox_endpoint(
+            self, sandbox_id, port: int, use_server_proxy: bool = False
+        ) -> SandboxEndpoint:
+            return await gate.get_sandbox_endpoint(sandbox_id, port, use_server_proxy)
+
+    class _FactoryStub:
+        def __init__(self, _connection_config: ConnectionConfig) -> None:
+            pass
+
+        def create_sandbox_service(self):
+            return sandbox_service
+
+        def create_filesystem_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_command_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_health_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_metrics_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_egress_service(self, _endpoint: SandboxEndpoint):
+            return _EgressServiceStub()
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
+        def create_isolated_session_service(self, endpoint: SandboxEndpoint):
+            return _Noop()
+
+    sandbox_service = _SandboxServiceStub()
+    monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
+
+    async def _op() -> Sandbox:
+        if flow == "create":
+            return await Sandbox.create(
+                "python:3.11",
+                skip_health_check=True,
+                connection_config=ConnectionConfig(),
+            )
+        if flow == "connect":
+            return await Sandbox.connect(
+                "sbx-1",
+                skip_health_check=True,
+                connection_config=ConnectionConfig(),
+            )
+        return await Sandbox.resume(
+            "sbx-1",
+            skip_health_check=True,
+            connection_config=ConnectionConfig(),
+        )
+
+    await _assert_parallel_endpoint_resolution(gate, _op)
+
+
+@pytest.mark.parametrize("flow", ["create", "connect", "resume"])
+@pytest.mark.parametrize("failing_port", [DEFAULT_EXECD_PORT, DEFAULT_EGRESS_PORT])
+@pytest.mark.asyncio
+async def test_sandbox_errors_when_either_endpoint_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch, flow: str, failing_port: int
+) -> None:
+    class _CreateResponse:
+        id = "sbx-1"
+
+    class _SandboxServiceStub:
+        async def create_sandbox(self, *_args, **_kwargs):
+            return _CreateResponse()
+
+        async def resume_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+        async def kill_sandbox(self, _sandbox_id: str) -> None:
+            return None
+
+        async def get_sandbox_endpoint(
+            self, _sandbox_id, port: int, _use_server_proxy: bool = False
+        ) -> SandboxEndpoint:
+            if port == failing_port:
+                raise RuntimeError(f"endpoint resolution failed for port {port}")
+            return SandboxEndpoint(endpoint=f"sbx.internal:{port}")
+
+    class _FactoryStub:
+        def __init__(self, _connection_config: ConnectionConfig) -> None:
+            pass
+
+        def create_sandbox_service(self):
+            return sandbox_service
+
+        def create_filesystem_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_command_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_health_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_metrics_service(self, _endpoint: SandboxEndpoint):
+            return _Noop()
+
+        def create_egress_service(self, _endpoint: SandboxEndpoint):
+            return _EgressServiceStub()
+
+        def create_diagnostics_service(self):
+            return _DiagnosticsServiceStub()
+
+        def create_isolated_session_service(self, endpoint: SandboxEndpoint):
+            return _Noop()
+
+    sandbox_service = _SandboxServiceStub()
+    monkeypatch.setattr("opensandbox.sandbox.AdapterFactory", _FactoryStub)
+
+    with pytest.raises(SandboxInternalException):
+        if flow == "create":
+            await Sandbox.create(
+                "python:3.11",
+                skip_health_check=True,
+                connection_config=ConnectionConfig(),
+            )
+        elif flow == "connect":
+            await Sandbox.connect(
+                "sbx-1",
+                skip_health_check=True,
+                connection_config=ConnectionConfig(),
+            )
+        else:
+            await Sandbox.resume(
+                "sbx-1",
+                skip_health_check=True,
+                connection_config=ConnectionConfig(),
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`Sandbox.create` / `connect` / `resume` resolve the execd and egress endpoints with two sequential round trips to the management API. This change awaits both requests concurrently via `asyncio.gather`, roughly halving endpoint-resolution latency on sandbox startup.

## Behavior

- Any endpoint failure still raises: gather defaults to `return_exceptions=False`, so a failure in either request propagates (the first failure chronologically is raised; the other request keeps running in the background, bounded by the existing `request_timeout`, default 30s).
- No changes to error wrapping or the zombie-cleanup path in `create`.

## Tests

- 3 new cases verifying concurrent resolution for create/connect/resume (a gated stub asserts the egress request starts before the execd request completes).
- 6 new cases verifying error propagation when either endpoint resolution fails.

## Verification

- `uv run pytest tests/test_sandbox_business_logic.py` — 23 passed
- `uv run ruff check src tests` — clean
- `uv run pyright` — 0 errors
- Full suite: 28 failures + 36 errors in adapter lifecycle / isolation tests are pre-existing on `main` in this environment (missing optional `socksio` dependency etc.), identical with and without this change.
