### PR TITLE
fix(server): expire informer cache when the watch stops delivering

### DIFF
--- a/server/opensandbox_server/services/k8s/informer.py
+++ b/server/opensandbox_server/services/k8s/informer.py
@@ -25,6 +25,11 @@ from kubernetes.client import ApiException
 
 logger = logging.getLogger(__name__)
 
+# An idle watch sends nothing until the server closes the stream at
+# ``timeout_seconds``, so the client read timeout must sit above it.
+_WATCH_READ_TIMEOUT_BUFFER_SECONDS = 10
+_WATCH_CONNECT_TIMEOUT_SECONDS = 10
+
 
 class WorkloadInformer:
     """Maintain an in-memory cache of a namespaced custom resource via watch."""
@@ -58,13 +63,27 @@ class WorkloadInformer:
         self._lock = threading.RLock()
         self._resource_version: Optional[str] = None
         self._has_synced = False
+        self._last_contact_at: Optional[float] = None
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
     @property
     def has_synced(self) -> bool:
-        """Return True once an initial list has completed."""
-        return self._has_synced
+        """Return True while the cache is populated and still being maintained.
+
+        A watch can stop delivering without raising — a dead connection leaves the
+        reader parked forever — so a "listed once" latch would keep readers on a
+        frozen cache.  Going stale makes them fall back to a live request.
+        """
+        with self._lock:
+            if not self._has_synced or self._last_contact_at is None:
+                return False
+            return time.monotonic() - self._last_contact_at <= self._staleness_limit_seconds
+
+    @property
+    def _staleness_limit_seconds(self) -> float:
+        """One resync period, by which the cache should have been rebuilt, plus a watch cycle."""
+        return self.resync_period_seconds + self.watch_timeout_seconds
 
     def start(self) -> None:
         """Start the background watch thread if not already running."""
@@ -201,6 +220,7 @@ class WorkloadInformer:
             self._cache = new_cache
             self._advance_resource_version(resource_version)
             self._has_synced = True
+            self._last_contact_at = time.monotonic()
 
     def _run_watch_loop(self, timeout_seconds: int) -> None:
         """Stream watch events to keep the cache fresh."""
@@ -210,12 +230,21 @@ class WorkloadInformer:
                 self.list_fn,
                 resource_version=self._resource_version,
                 timeout_seconds=timeout_seconds,
+                # Without this a half-open connection parks the thread forever.
+                _request_timeout=(
+                    _WATCH_CONNECT_TIMEOUT_SECONDS,
+                    timeout_seconds + _WATCH_READ_TIMEOUT_BUFFER_SECONDS,
+                ),
             ):
                 if self._stop_event.is_set():
                     break
                 self._handle_event(event)
         finally:
             w.stop()
+
+        # The stream ran to completion, so the API server is still reachable.
+        with self._lock:
+            self._last_contact_at = time.monotonic()
 
     def _handle_event(self, event: Dict[str, Any]) -> None:
         obj = event.get("object")
@@ -228,12 +257,21 @@ class WorkloadInformer:
             except Exception:
                 return
 
+        event_type = event.get("type")
+        if event_type == "ERROR":
+            # A Status, not a workload — usually 410 Gone. It carries no name, so
+            # force a fresh list instead of resuming from a dead cursor.
+            logger.warning(f"Informer watch error event, forcing resync: {obj.get('message')}")
+            with self._lock:
+                self._resource_version = None
+                self._has_synced = False
+            return
+
         metadata = obj.get("metadata", {})
         name = metadata.get("name")
         if not name:
             return
 
-        event_type = event.get("type")
         with self._lock:
             if event_type == "DELETED":
                 self._cache.pop(name, None)

--- a/server/opensandbox_server/services/k8s/informer.py
+++ b/server/opensandbox_server/services/k8s/informer.py
@@ -75,6 +75,9 @@ class WorkloadInformer:
         reader parked forever — so a "listed once" latch would keep readers on a
         frozen cache.  Going stale makes them fall back to a live request.
         """
+        if self._stop_event.is_set():
+            # Stopped: nothing will refresh the cache again, however recent it is.
+            return False
         with self._lock:
             if not self._has_synced or self._last_contact_at is None:
                 return False

--- a/server/opensandbox_server/services/k8s/informer.py
+++ b/server/opensandbox_server/services/k8s/informer.py
@@ -74,6 +74,9 @@ class WorkloadInformer:
         A watch can stop delivering without raising — a dead connection leaves the
         reader parked forever — so a "listed once" latch would keep readers on a
         frozen cache.  Going stale makes them fall back to a live request.
+
+        A stopped informer is likewise considered not synced, however recent its
+        last contact, since nothing will refresh the cache again.
         """
         if self._stop_event.is_set():
             # Stopped: nothing will refresh the cache again, however recent it is.
@@ -260,21 +263,12 @@ class WorkloadInformer:
             except Exception:
                 return
 
-        event_type = event.get("type")
-        if event_type == "ERROR":
-            # A Status, not a workload — usually 410 Gone. It carries no name, so
-            # force a fresh list instead of resuming from a dead cursor.
-            logger.warning(f"Informer watch error event, forcing resync: {obj.get('message')}")
-            with self._lock:
-                self._resource_version = None
-                self._has_synced = False
-            return
-
         metadata = obj.get("metadata", {})
         name = metadata.get("name")
         if not name:
             return
 
+        event_type = event.get("type")
         with self._lock:
             if event_type == "DELETED":
                 self._cache.pop(name, None)

--- a/server/tests/k8s/test_informer.py
+++ b/server/tests/k8s/test_informer.py
@@ -15,6 +15,9 @@
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+from kubernetes.client import ApiException
+
 from opensandbox_server.services.k8s.informer import WorkloadInformer
 
 
@@ -262,7 +265,7 @@ class TestWorkloadInformerStaleness:
 
 
 class TestWorkloadInformerWatchResilience:
-    """The watch stream cannot silently park or resume from a dead cursor."""
+    """The watch stream cannot silently park the informer thread."""
 
     def test_watch_stream_sets_client_side_request_timeout(self):
         """A client read timeout is passed, above the server-side watch timeout."""
@@ -281,21 +284,31 @@ class TestWorkloadInformerWatchResilience:
         assert connect_timeout > 0
         assert read_timeout > kwargs["timeout_seconds"]
 
-    def test_error_event_forces_a_fresh_list(self):
-        """A 410 Gone Status carries no name, so it must clear the cursor explicitly."""
-        informer = _make_informer()
-        informer._resource_version = "12345"
-        informer._has_synced = True
+    def test_raising_watch_stream_does_not_refresh_contact(self):
+        """A stream that raises proves nothing about reachability.
 
-        informer._handle_event(
-            {
-                "type": "ERROR",
-                "object": {"kind": "Status", "code": 410, "message": "too old resource version"},
-            }
+        This is the live error path: the client raises ApiException(410) rather
+        than yielding an ERROR event, and _run's handler then forces a relist.
+        """
+        informer = _make_informer(
+            list_fn=MagicMock(return_value=_list_response("x")),
+            resync_period_seconds=300,
+            watch_timeout_seconds=60,
         )
+        informer._full_resync()
+        informer._last_contact_at -= informer._staleness_limit_seconds + 1
 
-        assert informer._resource_version is None
-        assert informer._has_synced is False
+        fake_watch = MagicMock()
+        fake_watch.stream.side_effect = ApiException(status=410)
+
+        with patch(
+            "opensandbox_server.services.k8s.informer.watch.Watch",
+            return_value=fake_watch,
+        ):
+            with pytest.raises(ApiException):
+                informer._run_watch_loop(60)
+
+        assert informer.has_synced is False
 
 
 class TestWorkloadInformerStartStop:

--- a/server/tests/k8s/test_informer.py
+++ b/server/tests/k8s/test_informer.py
@@ -213,6 +213,85 @@ class TestWorkloadInformerHandleEvent:
         assert informer._resource_version == "200"
 
 
+class TestWorkloadInformerStaleness:
+    """has_synced reflects whether the cache is still being maintained."""
+
+    def _synced_informer(self) -> WorkloadInformer:
+        informer = _make_informer(
+            list_fn=MagicMock(return_value=_list_response("x")),
+            resync_period_seconds=300,
+            watch_timeout_seconds=60,
+        )
+        informer._full_resync()
+        return informer
+
+    def test_has_synced_false_once_contact_goes_stale(self):
+        """A watch that stalls without raising must not leave readers on a frozen cache."""
+        informer = self._synced_informer()
+        assert informer.has_synced is True
+
+        informer._last_contact_at -= informer._staleness_limit_seconds + 1
+        assert informer.has_synced is False
+
+    def test_has_synced_true_within_staleness_limit(self):
+        """Recent contact keeps the cache usable."""
+        informer = self._synced_informer()
+        informer._last_contact_at -= informer._staleness_limit_seconds - 1
+        assert informer.has_synced is True
+
+    def test_completed_watch_stream_refreshes_contact(self):
+        """An idle watch that closes cleanly still proves the API server is reachable."""
+        informer = self._synced_informer()
+        informer._last_contact_at -= informer._staleness_limit_seconds + 1
+
+        fake_watch = MagicMock()
+        fake_watch.stream.return_value = iter(())
+        with patch(
+            "opensandbox_server.services.k8s.informer.watch.Watch",
+            return_value=fake_watch,
+        ):
+            informer._run_watch_loop(60)
+
+        assert informer.has_synced is True
+
+
+class TestWorkloadInformerWatchResilience:
+    """The watch stream cannot silently park or resume from a dead cursor."""
+
+    def test_watch_stream_sets_client_side_request_timeout(self):
+        """A client read timeout is passed, above the server-side watch timeout."""
+        informer = _make_informer()
+        fake_watch = MagicMock()
+        fake_watch.stream.return_value = iter(())
+
+        with patch(
+            "opensandbox_server.services.k8s.informer.watch.Watch",
+            return_value=fake_watch,
+        ):
+            informer._run_watch_loop(60)
+
+        kwargs = fake_watch.stream.call_args.kwargs
+        connect_timeout, read_timeout = kwargs["_request_timeout"]
+        assert connect_timeout > 0
+        assert read_timeout > kwargs["timeout_seconds"]
+
+    def test_error_event_forces_a_fresh_list(self):
+        """A 410 Gone Status carries no name, so it must clear the cursor explicitly."""
+        informer = _make_informer()
+        informer._resource_version = "12345"
+        informer._has_synced = True
+
+        informer._handle_event(
+            {
+                "type": "ERROR",
+                "object": {"kind": "Status", "code": 410, "message": "too old resource version"},
+            }
+        )
+
+        assert informer._resource_version is None
+        assert informer._has_synced is False
+
+
 class TestWorkloadInformerStartStop:
     """start/stop thread lifecycle."""
 

--- a/server/tests/k8s/test_informer.py
+++ b/server/tests/k8s/test_informer.py
@@ -239,6 +239,12 @@ class TestWorkloadInformerStaleness:
         informer._last_contact_at -= informer._staleness_limit_seconds - 1
         assert informer.has_synced is True
 
+    def test_has_synced_false_after_stop(self):
+        """A stopped informer will never refresh again, however recent its last contact."""
+        informer = self._synced_informer()
+        informer.stop()
+        assert informer.has_synced is False
+
     def test_completed_watch_stream_refreshes_contact(self):
         """An idle watch that closes cleanly still proves the API server is reachable."""
         informer = self._synced_informer()


### PR DESCRIPTION
# Summary

- Fixes #1533. Follow-up to #1322.

#1322 added the periodic relist to `WorkloadInformer`. That relist only runs when the watch loop *returns* — so when `w.stream()` blocks instead of returning, it never fires, `has_synced` stays `True` forever, and `get_custom_object()` keeps serving a frozen cache entry rather than falling through to the live API it already knows how to call.

`w.stream()` was passed only `timeout_seconds`, which is a **server-side** watch parameter, not a socket timeout. When the API server goes away abruptly the client socket blocks on `read()` with no data and no FIN, and the informer thread parks there permanently — no events, no resync, no exception to back off from, nothing logged.

For a sandbox created after that point the cached entry is the create response seeded by `create_custom_object`, which has no `status` yet. `get_status` maps a missing `Ready` condition to `Pending`, so `_wait_for_sandbox_ready` polls the same status-less object once a second until it gives up: every creation 504s with `KUBERNETES::POD_READY_TIMEOUT` and the healthy sandbox is then deleted by the cleanup path. We saw 100% failure for 6+ hours after a GKE control-plane upgrade, with zero restarts and zero log lines.

Three changes:

1. **`has_synced` now means "the cache is currently live"**, not "an initial list finished once". It tracks the last proven contact with the API server — a completed full resync, or a watch stream that closed cleanly — and goes `False` once that is stale. This is the load-bearing one: it turns *any* informer stall, whatever the cause, from "permanently serves wrong data" into "degrades to direct API reads". The staleness bound is derived from the existing knobs as `resync_period_seconds + watch_timeout_seconds` — one period by which the cache should have been rebuilt, plus one watch cycle of slack — so no new configuration is introduced. Happy to promote it to a config field if you would rather it be tunable.
2. **`_request_timeout` on `w.stream()`**, with the read timeout above the server-side `timeout_seconds` so an idle-but-healthy watch is not torn down every cycle, while a half-open connection raises into `_run`'s existing backoff and resync handling.
3. **`has_synced` is also `False` once the informer is stopped**, however recent its last contact, since nothing will refresh the cache again.

An earlier revision also handled `ERROR` watch events. That was dropped: `Watch.stream` never yields them — on a 410 it either breaks to retry or raises `ApiException` (`kubernetes/watch/watch.py:195-208`), and passing `timeout_seconds` sets `disable_retries`, so the raise is always taken. `_run`'s existing `except ApiException` already clears the cursor and forces a relist. Thanks @Pangjiping for catching it.

# Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Six tests added, one per behaviour: the cache goes stale when contact stops, stays usable while contact is recent, an idle watch still counts as contact, a raising stream does not, the request timeout is set above the watch timeout, and a stopped informer reports itself unsynced.

All fail against current `main` and pass with the fix. Full server suite: 1362 passed, coverage 82.20% (gate 80%), `informer.py` at 85%. `ruff check` clean; pre-commit hooks clean.

The original failure was also reproduced end-to-end against a live affected server before and after diagnosis — a sandbox reaching `Ready` in 3s while the server reported `Pending` for the full 600s, then 504'd and deleted it. Details in #1533.

# Breaking Changes

- [x] None

`has_synced` becomes stricter: it now returns `False` for an informer whose watch has stalled, and for one that has been stopped. That is the intent — callers fall back to the live API path that already exists in `get_custom_object`, trading a little extra API traffic for never serving a cache nothing is maintaining. Behaviour for a healthy, running informer is unchanged.

# Checklist

- [x] Linked Issue or clearly described motivation
- [ ] Added/updated docs (if needed) — no user-facing config or API change
- [x] Added/updated tests (if needed)
- [x] Security impact considered — none; no change to auth, tenancy, or data exposure. Strictly reduces the window in which stale state is served.
- [x] Backward compatibility considered — no config or API surface change; see Breaking Changes above.
