### PR TITLE
feat(examples): add Deep Agents + OpenSandbox example

### DIFF
--- a/docs/examples/deep-agents.md
+++ b/docs/examples/deep-agents.md
@@ -35,8 +35,8 @@ uv run python examples/deep-agents/main.py
 ```
 
 The agent writes a Python script into the sandbox, runs it, and reports the output — all file
-and shell operations happen inside the sandbox rather than on the host. The sandbox is killed
-on exit.
+and shell operations happen inside the sandbox rather than on the host. The sandbox is destroyed
+on exit (terminated and local resources closed).
 
 ## Environment Variables
 

--- a/docs/examples/deep-agents.md
+++ b/docs/examples/deep-agents.md
@@ -1,0 +1,54 @@
+---
+title: Deep Agents
+description: Run a Deep Agent with its file and shell tools executing inside an OpenSandbox sandbox.
+---
+
+# Deep Agents + OpenSandbox Example
+
+Run a [Deep Agent](https://github.com/langchain-ai/deepagents) whose file and shell tools
+execute inside an OpenSandbox sandbox. The
+[`langchain-sandbox-opensandbox`](https://pypi.org/project/langchain-sandbox-opensandbox/)
+backend adapts the OpenSandbox Python SDK to the Deep Agents `BaseSandbox` interface, so every
+`ls` / `read_file` / `write_file` / `glob` / `grep` / command the agent performs is sandboxed.
+
+The backend passes the full `langchain-tests` `SandboxIntegrationTests` conformance suite
+(86/86) against a live server.
+
+## Start OpenSandbox server [local]
+
+Start a local OpenSandbox server, logs will be visible in the terminal:
+
+```shell
+uv pip install opensandbox-server
+opensandbox-server init-config ~/.sandbox.toml --example docker
+opensandbox-server
+```
+
+## Run the example
+
+```shell
+# Install Deep Agents + the OpenSandbox backend
+uv pip install deepagents langchain-sandbox-opensandbox
+
+# Run the example (requires SANDBOX_DOMAIN / ANTHROPIC_API_KEY)
+uv run python examples/deep-agents/main.py
+```
+
+The agent writes a Python script into the sandbox, runs it, and reports the output — all file
+and shell operations happen inside the sandbox rather than on the host. The sandbox is killed
+on exit.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SANDBOX_DOMAIN` | `localhost:8080` | Sandbox service address (host and optional port) |
+| `SANDBOX_PROTOCOL` | `http` | Protocol used to reach the server (`http` or `https`) |
+| `SANDBOX_API_KEY` | _(optional for local)_ | API key if your server requires authentication |
+| `ANTHROPIC_API_KEY` | _(required)_ | Anthropic API key for the default Deep Agents model |
+
+## References
+
+- [Deep Agents](https://github.com/langchain-ai/deepagents) - Agent framework
+- [langchain-sandbox-opensandbox](https://pypi.org/project/langchain-sandbox-opensandbox/) - OpenSandbox backend for Deep Agents
+- [Source code on GitHub](https://github.com/opensandbox-group/OpenSandbox/tree/main/examples/deep-agents)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -23,6 +23,7 @@ Run coding CLIs and AI agent frameworks inside isolated sandboxes.
 | [Qwen Code](/examples/qwen-code) | Run Qwen Code CLI in a sandbox |
 | [Kimi CLI](/examples/kimi-cli) | Run Kimi CLI (Moonshot AI) in a sandbox |
 | [LangGraph](/examples/langgraph) | LangGraph state-machine workflow with sandbox |
+| [Deep Agents](/examples/deep-agents) | Deep Agents file/shell tools running in a sandbox |
 | [Google ADK](/examples/google-adk) | Google ADK agent using OpenSandbox tools |
 | [OpenClaw](/examples/openclaw) | OpenClaw Gateway inside a sandbox |
 | [NullClaw](/examples/nullclaw) | NullClaw Gateway sandbox integration |

--- a/examples/deep-agents/README.md
+++ b/examples/deep-agents/README.md
@@ -1,29 +1,5 @@
 # Deep Agents + OpenSandbox Example
 
-Run a [Deep Agent](https://github.com/langchain-ai/deepagents) whose file and
-shell tools execute inside an OpenSandbox sandbox.
+Run a [Deep Agent](https://github.com/langchain-ai/deepagents) whose file and shell tools execute inside an OpenSandbox sandbox, via the [`langchain-sandbox-opensandbox`](https://pypi.org/project/langchain-sandbox-opensandbox/) backend.
 
-This uses the
-[`langchain-sandbox-opensandbox`](https://pypi.org/project/langchain-sandbox-opensandbox/)
-backend, which adapts the OpenSandbox Python SDK to the Deep Agents
-`BaseSandbox` interface. Every `ls` / `read_file` / `write_file` / `glob` /
-`grep` / command the agent performs is sandboxed.
-
-## Install
-
-```bash
-pip install deepagents langchain-sandbox-opensandbox
-```
-
-## Run
-
-Point the SDK at a running OpenSandbox server and provide a model key:
-
-```bash
-export SANDBOX_DOMAIN=localhost:8080
-export SANDBOX_PROTOCOL=http
-# export SANDBOX_API_KEY=...        # if your server requires auth
-export ANTHROPIC_API_KEY=...        # for the default Deep Agents model
-
-python main.py
-```
+> **Full documentation**: [docs/examples/deep-agents.md](../../docs/examples/deep-agents.md)

--- a/examples/deep-agents/README.md
+++ b/examples/deep-agents/README.md
@@ -1,0 +1,29 @@
+# Deep Agents + OpenSandbox Example
+
+Run a [Deep Agent](https://github.com/langchain-ai/deepagents) whose file and
+shell tools execute inside an OpenSandbox sandbox.
+
+This uses the
+[`langchain-sandbox-opensandbox`](https://pypi.org/project/langchain-sandbox-opensandbox/)
+backend, which adapts the OpenSandbox Python SDK to the Deep Agents
+`BaseSandbox` interface. Every `ls` / `read_file` / `write_file` / `glob` /
+`grep` / command the agent performs is sandboxed.
+
+## Install
+
+```bash
+pip install deepagents langchain-sandbox-opensandbox
+```
+
+## Run
+
+Point the SDK at a running OpenSandbox server and provide a model key:
+
+```bash
+export SANDBOX_DOMAIN=localhost:8080
+export SANDBOX_PROTOCOL=http
+# export SANDBOX_API_KEY=...        # if your server requires auth
+export ANTHROPIC_API_KEY=...        # for the default Deep Agents model
+
+python main.py
+```

--- a/examples/deep-agents/main.py
+++ b/examples/deep-agents/main.py
@@ -74,7 +74,7 @@ def main() -> None:
 
         print(result["messages"][-1].content)
     finally:
-        sandbox.kill()
+        sandbox.destroy()
 
 
 if __name__ == "__main__":

--- a/examples/deep-agents/main.py
+++ b/examples/deep-agents/main.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deep Agents + OpenSandbox example.
+
+Runs a Deep Agent whose file and shell tools execute inside an OpenSandbox
+sandbox. The `langchain-sandbox-opensandbox` package adapts the OpenSandbox
+Python SDK to the Deep Agents `BaseSandbox` interface, so every file read/write
+and command the agent runs is sandboxed.
+
+Prerequisites:
+    pip install deepagents langchain-sandbox-opensandbox
+
+Environment:
+    SANDBOX_DOMAIN     Host (and optional port) of the OpenSandbox server.
+                       Defaults to "localhost:8080".
+    SANDBOX_PROTOCOL   "http" (default) or "https".
+    SANDBOX_API_KEY    API key, if the server requires authentication.
+    ANTHROPIC_API_KEY  Required by the default Deep Agents model.
+"""
+
+import os
+
+from deepagents import create_deep_agent
+from langchain_opensandbox import OpenSandboxBackend
+from opensandbox import SandboxSync
+from opensandbox.config.connection_sync import ConnectionConfigSync
+
+
+def main() -> None:
+    connection = ConnectionConfigSync(
+        domain=os.getenv("SANDBOX_DOMAIN", "localhost:8080"),
+        api_key=os.getenv("SANDBOX_API_KEY"),
+        protocol=os.getenv("SANDBOX_PROTOCOL", "http"),
+    )
+    sandbox = SandboxSync.create("python:3.12", connection_config=connection)
+    backend = OpenSandboxBackend(sandbox=sandbox, timeout=300)
+
+    try:
+        agent = create_deep_agent(
+            tools=[],
+            system_prompt=(
+                "You are a coding assistant. Use the sandbox to write and run "
+                "Python, and verify your work by executing it."
+            ),
+            backend=backend,
+        )
+
+        result = agent.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Write a script that prints the first 10 Fibonacci "
+                            "numbers, save it as fib.py, run it, and report the "
+                            "output."
+                        ),
+                    }
+                ]
+            }
+        )
+
+        print(result["messages"][-1].content)
+    finally:
+        sandbox.kill()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an `examples/deep-agents` example showing how to run a [Deep Agent](https://github.com/langchain-ai/deepagents) with its file and shell tools executing inside an OpenSandbox sandbox.

It uses the [`langchain-sandbox-opensandbox`](https://pypi.org/project/langchain-sandbox-opensandbox/) backend, which adapts the OpenSandbox Python SDK to the Deep Agents `BaseSandbox` interface and passes the full `langchain-tests` `SandboxIntegrationTests` conformance suite (86/86) against a live server.

Mirrors the structure of the existing `examples/langgraph` example.