### PR TITLE
fix(cli): report pause request acceptance

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -166,6 +166,17 @@ osb sandbox metrics <sandbox-id>
 osb sandbox metrics <sandbox-id> --watch -o raw
 ```
 
+### Pause a sandbox
+
+Pause is asynchronous. `Pause request accepted` confirms that the server accepted
+the request, not that the sandbox has reached the `Paused` state. Poll the sandbox
+until the transition finishes:
+
+```bash
+osb sandbox pause <sandbox-id>
+osb sandbox get <sandbox-id> -o json
+```
+
 ### Expose a service
 
 ```bash

--- a/cli/src/opensandbox_cli/commands/sandbox.py
+++ b/cli/src/opensandbox_cli/commands/sandbox.py
@@ -371,7 +371,7 @@ def sandbox_pause(obj: ClientContext, sandbox_id: str, output_format: str | None
     mgr = obj.get_manager()
     with obj.output.spinner("Pausing sandbox..."):
         mgr.pause_sandbox(sandbox_id)
-    obj.output.success(f"Sandbox paused: {sandbox_id}")
+    obj.output.success(f"Pause request accepted: {sandbox_id}")
 
 
 # ---- resume ---------------------------------------------------------------

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-lifecycle.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-lifecycle.md
@@ -226,6 +226,7 @@ Rules:
 - `sandbox list --state` accepts known lifecycle states case-insensitively
 - use `renew` before long-running work instead of waiting for expiry
 - use `pause` only when the workload can tolerate suspension
+- treat the pause result as request acceptance and poll `sandbox get` until the state is `Paused` or `Failed`
 - use `kill` when cleanup is the real goal; do not leave orphaned sandboxes behind
 
 ## Runtime Notes
@@ -233,6 +234,7 @@ Rules:
 - `renew` resets the expiration to approximately `now + timeout`; treat it as a fresh TTL, not a simple additive extension to the old timestamp
 - `create --timeout none` means no automatic expiration; cleanup becomes an explicit `kill` responsibility
 - `create` without `--timeout` does not mean manual cleanup; it uses `defaults.timeout` first and otherwise leaves TTL selection to the SDK/server default
+- `pause` is asynchronous; `Pause request accepted` does not mean the sandbox is already paused
 - `pause` and `resume` may depend on the underlying runtime; if the runtime does not support them, avoid promising they will work
 - host-path volumes depend on server-side allowed host path configuration
 - if creation fails or the sandbox never becomes healthy, switch to `sandbox-troubleshooting` instead of adding more create flags blindly

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -569,12 +569,12 @@ class TestSandboxKill:
 
 
 class TestSandboxPause:
-    def test_pause_calls_manager(self, runner: CliRunner) -> None:
+    def test_pause_reports_request_accepted(self, runner: CliRunner) -> None:
         mock_mgr = MagicMock()
         result = _invoke(runner, ["sandbox", "pause", "sb-123"], manager=mock_mgr)
         assert result.exit_code == 0
         mock_mgr.pause_sandbox.assert_called_once_with("sb-123")
-        assert "Sandbox paused: sb-123" in result.output
+        assert "Pause request accepted: sb-123" in result.output
 
 
 class TestSandboxResume:


### PR DESCRIPTION
# Summary

- report a successful pause call as `Pause request accepted` instead of claiming that the sandbox is already paused
- document that callers must poll the sandbox until it reaches `Paused` or `Failed`
- update the bundled lifecycle skill and regression test to use the same asynchronous semantics

## Problem

`osb sandbox pause <sandbox-id>` currently prints `Sandbox paused` immediately after the SDK method returns. The lifecycle API only guarantees `202 Accepted`; Kubernetes snapshot processing continues asynchronously and can still fail after that response.

## Minimal reproduction

1. Invoke `osb sandbox pause <sandbox-id>` for a running Kubernetes-backed sandbox.
2. Allow the API request to be accepted while the later snapshot operation fails.
3. Observe that the CLI has already reported `Sandbox paused`, even though polling the sandbox never reaches `Paused`.

The regression test reproduces the same contract mismatch with a mocked manager: the method returns no final sandbox state, but the old command reports completion.

## Root cause

The pause command treats a successful return from `SandboxManager.pause_sandbox` as completion and emits a past-tense success message. That SDK method only confirms the accepted lifecycle request and does not return or wait for the final state.

## Change

The command now prints:

```text
Pause request accepted: <sandbox-id>
```

This PR intentionally does not add a `--wait` option or change lifecycle polling, timeout, controller, SDK, or API behavior.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:

```text
cd cli
uv sync
uv run ruff check
uv run pyright
uv run pytest tests/ -q  # 205 passed
./scripts/verify-license.sh
```

The focused regression assertion failed against the old implementation with `OK: Sandbox paused: sb-123` and passes after the wording change. Integration and e2e tests were not run because this change does not alter the SDK call or lifecycle API behavior.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

## Compatibility and security impact

The only compatibility impact is the corrected human-readable CLI message. Automation should use structured state responses rather than parse completion from this text. No API, SDK, configuration, authentication, authorization, credential forwarding, or network behavior changes.

## Existing Issue

Fixes #1536

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
