### PR TITLE
fix(server): use supported PVC strategic merge request

### DIFF
--- a/server/opensandbox_server/services/k8s/client.py
+++ b/server/opensandbox_server/services/k8s/client.py
@@ -365,16 +365,30 @@ class K8sClient:
 
         The pinned kubernetes-client picks ``application/json-patch+json`` by
         default (first entry in the generated content-type list) which would
-        reject our merge-shaped body. Force strategic-merge so list fields
-        like ``ownerReferences`` merge by key.
+        reject our merge-shaped body. Its generated high-level method does not
+        accept a content-type override, so use the underlying ``ApiClient`` to
+        preserve strategic-merge semantics for list fields like
+        ``ownerReferences``.
         """
         if self._write_limiter:
             self._write_limiter.acquire()
-        return self.get_core_v1_api().patch_namespaced_persistent_volume_claim(
-            name=name,
-            namespace=namespace,
+        api_client = self.get_core_v1_api().api_client
+        return api_client.call_api(
+            "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}",
+            "PATCH",
+            path_params={"namespace": namespace, "name": name},
+            query_params=[],
+            header_params={
+                "Accept": "application/json",
+                "Content-Type": "application/strategic-merge-patch+json",
+            },
             body=body,
-            _content_type="application/strategic-merge-patch+json",
+            post_params=[],
+            files={},
+            response_type="V1PersistentVolumeClaim",
+            auth_settings=["BearerToken"],
+            _return_http_data_only=True,
+            collection_formats={},
         )
 
     # ------------------------------------------------------------------

--- a/server/tests/k8s/test_k8s_client.py
+++ b/server/tests/k8s/test_k8s_client.py
@@ -15,7 +15,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from kubernetes.client import ApiException
+from kubernetes.client import ApiClient, ApiException, CoreV1Api
 
 from opensandbox_server.config import KubernetesRuntimeConfig
 from opensandbox_server.services.k8s.client import K8sClient
@@ -390,20 +390,36 @@ class TestK8sClient:
             name="foo-1", body=body
         )
 
-    def test_patch_pvc_uses_strategic_merge_content_type(self, k8s_runtime_config):
-        """patch_pvc must pin strategic-merge content type so a merge-shaped
-        body (e.g. ``{"metadata": {"ownerReferences": [...]}}``) is accepted.
-        The generated kubernetes client defaults to ``application/json-patch+json``
-        which would reject the body as malformed JSON Patch ops."""
+    def test_patch_pvc_uses_supported_strategic_merge_request(
+        self, k8s_runtime_config
+    ):
+        """patch_pvc sends a strategic-merge request accepted by ApiClient."""
         c = self._make_client(k8s_runtime_config)
+        api_client = ApiClient()
+        c._core_v1_api = CoreV1Api(api_client)
         body = {"metadata": {"ownerReferences": [{"name": "x"}]}}
-        c.patch_pvc("ns", "pvc-a", body)
-        c._core_v1_api.patch_namespaced_persistent_volume_claim.assert_called_once_with(
-            name="pvc-a",
-            namespace="ns",
-            body=body,
-            _content_type="application/strategic-merge-patch+json",
-        )
+        try:
+            with patch.object(
+                api_client, "call_api", return_value="patched"
+            ) as mock_call_api:
+                result = c.patch_pvc("ns", "pvc-a", body)
+
+            assert result == "patched"
+            mock_call_api.assert_called_once()
+            args, kwargs = mock_call_api.call_args
+            assert args == (
+                "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}",
+                "PATCH",
+            )
+            assert kwargs["path_params"] == {"namespace": "ns", "name": "pvc-a"}
+            assert kwargs["header_params"]["Content-Type"] == (
+                "application/strategic-merge-patch+json"
+            )
+            assert kwargs["body"] == body
+            assert kwargs["auth_settings"] == ["BearerToken"]
+            assert kwargs["_return_http_data_only"] is True
+        finally:
+            api_client.close()
 
     def test_create_secret_delegates_to_api(self, k8s_runtime_config):
         """create_secret forwards to CoreV1Api.create_namespaced_secret."""


### PR DESCRIPTION
# Summary

- Fix PVC owner-reference patching by sending the strategic-merge request through the supported `ApiClient.call_api` path.
- Replace the MagicMock-only assertion with a regression test that exercises the real generated `CoreV1Api` parameter validation.

## Problem

Auto-created PVCs do not receive the workload owner reference. The failure is caught by the best-effort cleanup path, so TTL or manual workload deletion can leave PVCs behind.

## Minimal reproduction

Call `CoreV1Api.patch_namespaced_persistent_volume_claim` with the current `_content_type="application/strategic-merge-patch+json"` override. Kubernetes Python client 35.0.0 raises `ApiTypeError` before making any network request.

## Root cause

The generated high-level PVC patch method does not accept `_content_type`. Omitting the override is also incorrect because that method selects `application/json-patch+json` while OpenSandbox sends a merge-shaped object.

## Change

Use the same CoreV1 API client and endpoint through `ApiClient.call_api`, explicitly setting `application/strategic-merge-patch+json`. This keeps merge-by-key behavior for `ownerReferences` without mutating shared client headers.

The regression test installs a real generated `CoreV1Api` over a mocked transport boundary, so the unsupported keyword fails before the fix and the request contract is verified after it.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
- [ ] Integration tests
- [ ] e2e / manual verification

Commands run:

- `uv run --frozen pytest -q tests/k8s/test_k8s_client.py -k patch_pvc_uses_supported_strategic_merge_request`
- `uv run --frozen pytest -q tests/k8s` — 563 passed
- `uv run --frozen pytest -q` — 1358 passed
- `uv run --frozen pytest --cov=opensandbox_server --cov-report=term --cov-fail-under=80` — 1358 passed, 82.18% coverage
- `uv run --frozen ruff check`
- `./scripts/verify-license.sh`

Live-cluster e2e was not run because the change is covered at the generated client request boundary and no test cluster mutation is required for this draft.

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

## Compatibility and security impact

No public API, spec, SDK, CRD, configuration, authentication, or authorization behavior changes. The request still uses the existing Kubernetes BearerToken authentication setting and preserves the intended strategic-merge semantics.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed) — no documentation change needed for this internal bug fix
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered

## Existing Issue

Fixes #1199