### PR TITLE
docs(execd): fix dead OSEP-0018 link breaking docs pages build

### DIFF
--- a/docs/components/execd.md
+++ b/docs/components/execd.md
@@ -347,7 +347,7 @@ OTLP metrics export is enabled when either endpoint is set:
 
 ## Init mode
 
-[OSEP-0018](../../oseps/0018-execd-as-sandbox-init.md) makes execd the sandbox
+[OSEP-0018](https://github.com/opensandbox-group/OpenSandbox/blob/main/oseps/0018-execd-as-sandbox-init.md) makes execd the sandbox
 init: it becomes the parent of the user entrypoint, reaps every child through
 a single reaper, forwards application signals, and propagates the entrypoint
 exit code to the container runtime.


### PR DESCRIPTION
Fixes the GitHub Pages build failure on main (https://github.com/opensandbox-group/OpenSandbox/actions/runs/32081162558).

**Root cause**: docs/components/execd.md linked to `../../oseps/0018-execd-as-sandbox-init.md`, which is outside the docs srcDir. VitePress treats it as a dead link and fails the build.

**Fix**: use the full GitHub URL for OSEP-0018 per docs conventions. Verified with `pnpm docs:build` (passes).