### PR TITLE
feat(kubernetes): initialize missing PVC subpaths

### DIFF
--- a/.github/workflows/kubernetes-nightly-build.yml
+++ b/.github/workflows/kubernetes-nightly-build.yml
@@ -34,12 +34,23 @@ jobs:
           - variant: direct
             script: scripts/python-k8s-e2e.sh
             e2e_gateway_route_mode: ""
+            e2e_batchsandbox_template_file: ""
+            e2e_pytest_target: ""
           - variant: ingress-header
             script: scripts/python-k8s-e2e-ingress.sh
             e2e_gateway_route_mode: ""
+            e2e_batchsandbox_template_file: ""
+            e2e_pytest_target: ""
           - variant: ingress-uri
             script: scripts/python-k8s-e2e-ingress.sh
             e2e_gateway_route_mode: uri
+            e2e_batchsandbox_template_file: ""
+            e2e_pytest_target: ""
+          - variant: direct-nonroot-subpath-initializer
+            script: scripts/python-k8s-e2e.sh
+            e2e_gateway_route_mode: ""
+            e2e_batchsandbox_template_file: /etc/opensandbox/e2e-subpath-nonroot.batchsandbox-template.yaml
+            e2e_pytest_target: tests/test_sandbox_e2e_sync.py::TestSandboxE2ESync::test_01g_pvc_unseeded_subpath_initializer_nonroot
     env:
       KIND_CLUSTER: opensandbox-e2e
       KIND_K8S_VERSION: v1.30.4
@@ -78,6 +89,8 @@ jobs:
       - name: Run Kubernetes runtime E2E
         env:
           E2E_GATEWAY_ROUTE_MODE: ${{ matrix.e2e_gateway_route_mode }}
+          E2E_BATCHSANDBOX_TEMPLATE_FILE: ${{ matrix.e2e_batchsandbox_template_file }}
+          E2E_PYTEST_TARGET: ${{ matrix.e2e_pytest_target }}
         run: bash "./${{ matrix.script }}"
 
       - name: Dump kind diagnostics

--- a/components/execd/Dockerfile
+++ b/components/execd/Dockerfile
@@ -66,6 +66,10 @@ RUN if [ -n "${CC}" ]; then export CC; fi; \
               -X 'github.com/alibaba/opensandbox/internal/version.GitCommit=${GIT_COMMIT}'" \
     -o /build/execd ./main.go
 
+RUN CGO_ENABLED=0 go build ${GOFLAGS} -trimpath -buildvcs=false \
+    -ldflags "${LDFLAGS} -buildid= -B none" \
+    -o /build/opensandbox-subpath-initializer ./cmd/subpath-initializer
+
 RUN CGO_ENABLED=0 GOOS=windows go build ${GOFLAGS} -trimpath -buildvcs=false \
     -ldflags "${LDFLAGS} -buildid= -B none \
               -X 'github.com/alibaba/opensandbox/internal/version.Version=${VERSION}' \
@@ -131,6 +135,7 @@ COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-session-ga
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-launcher /usr/local/libexec/opensandbox-launcher
 COPY --from=bwrap-builder --chown=0:0 --chmod=0555 /build/opensandbox-launcher /opt/opensandbox/opensandbox-launcher
 COPY --from=builder /build/execd .
+COPY --from=builder /build/opensandbox-subpath-initializer ./opensandbox-subpath-initializer
 COPY --from=builder /build/execd.exe ./execd.exe
 COPY --from=builder /build/opensandbox-supervisor ./opensandbox-supervisor
 COPY --from=ebpf-builder /build/execd-ebpf ./execd-ebpf

--- a/components/execd/cmd/subpath-initializer/main.go
+++ b/components/execd/cmd/subpath-initializer/main.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/alibaba/opensandbox/execd/pkg/subpathinitializer"
+)
+
+func main() {
+	planJSON := flag.String("plan-json", "", "trusted subpath initialization plan")
+	fsGroup := flag.String("fs-group", "", "trusted fsGroup applied to newly created directories")
+	flag.Parse()
+	if *planJSON == "" || flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: opensandbox-subpath-initializer --plan-json <json> [--fs-group <gid>]")
+		os.Exit(2)
+	}
+	group, err := parseFSGroup(*fsGroup)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	plan, err := subpathinitializer.ParsePlan(*planJSON)
+	if err == nil {
+		err = subpathinitializer.Apply(plan, group)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func parseFSGroup(raw string) (*int, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 1 {
+		return nil, fmt.Errorf("fs-group must be an integer between 1 and 2147483647")
+	}
+	fsGroup := int(parsed)
+	return &fsGroup, nil
+}

--- a/components/execd/cmd/subpath-initializer/main_test.go
+++ b/components/execd/cmd/subpath-initializer/main_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestParseFSGroup(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want *int
+	}{
+		{raw: ""},
+		{raw: "1", want: intPointer(1)},
+		{raw: "2147483647", want: intPointer(2147483647)},
+	}
+	for _, test := range tests {
+		got, err := parseFSGroup(test.raw)
+		if err != nil {
+			t.Errorf("parseFSGroup(%q): %v", test.raw, err)
+			continue
+		}
+		if (got == nil) != (test.want == nil) || got != nil && *got != *test.want {
+			t.Errorf("parseFSGroup(%q) = %v, want %v", test.raw, got, test.want)
+		}
+	}
+
+	for _, raw := range []string{"0", "-1", "2147483648", "invalid"} {
+		if _, err := parseFSGroup(raw); err == nil {
+			t.Errorf("parseFSGroup(%q) succeeded", raw)
+		}
+	}
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/components/execd/pkg/subpathinitializer/securetree_linux.go
+++ b/components/execd/pkg/subpathinitializer/securetree_linux.go
@@ -1,0 +1,174 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+// Package subpathinitializer creates planned directories without following links.
+package subpathinitializer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// PlanEntry names one trusted PVC root mount and the relative paths to create beneath it.
+type PlanEntry struct {
+	MountPath string   `json:"mountPath"`
+	SubPaths  []string `json:"subPaths"`
+}
+
+// ParsePlan accepts exactly the renderer's JSON plan shape.
+func ParsePlan(raw string) ([]PlanEntry, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var plan []PlanEntry
+	if err := decoder.Decode(&plan); err != nil {
+		return nil, fmt.Errorf("decode plan: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("decode plan: trailing data")
+	}
+	if len(plan) == 0 {
+		return nil, fmt.Errorf("plan must contain at least one entry")
+	}
+
+	mounts := make(map[string]struct{}, len(plan))
+	for index, entry := range plan {
+		if err := validateMountPath(entry.MountPath); err != nil {
+			return nil, fmt.Errorf("plan entry %d: %w", index, err)
+		}
+		if _, exists := mounts[entry.MountPath]; exists {
+			return nil, fmt.Errorf("plan entry %d: duplicate mountPath", index)
+		}
+		mounts[entry.MountPath] = struct{}{}
+		if len(entry.SubPaths) == 0 {
+			return nil, fmt.Errorf("plan entry %d: subPaths must not be empty", index)
+		}
+		paths := make(map[string]struct{}, len(entry.SubPaths))
+		for _, subPath := range entry.SubPaths {
+			if err := validateSubPath(subPath); err != nil {
+				return nil, fmt.Errorf("plan entry %d: %w", index, err)
+			}
+			if _, exists := paths[subPath]; exists {
+				return nil, fmt.Errorf("plan entry %d: duplicate subPath", index)
+			}
+			paths[subPath] = struct{}{}
+		}
+	}
+	return plan, nil
+}
+
+// Apply creates every planned directory relative to an O_NOFOLLOW root descriptor.
+func Apply(plan []PlanEntry, fsGroup *int) error {
+	if err := validateFSGroup(fsGroup); err != nil {
+		return err
+	}
+	if len(plan) == 0 {
+		return fmt.Errorf("plan must contain at least one entry")
+	}
+	for _, entry := range plan {
+		if err := validateMountPath(entry.MountPath); err != nil {
+			return err
+		}
+		if len(entry.SubPaths) == 0 {
+			return fmt.Errorf("subPaths must not be empty")
+		}
+		rootFD, err := unix.Open(entry.MountPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return fmt.Errorf("open root %q: %w", entry.MountPath, err)
+		}
+		for _, subPath := range entry.SubPaths {
+			if err := validateSubPath(subPath); err != nil {
+				unix.Close(rootFD)
+				return err
+			}
+			if err := mkdirAt(rootFD, subPath, fsGroup); err != nil {
+				unix.Close(rootFD)
+				return fmt.Errorf("create %q beneath %q: %w", subPath, entry.MountPath, err)
+			}
+		}
+		if err := unix.Close(rootFD); err != nil {
+			return fmt.Errorf("close root %q: %w", entry.MountPath, err)
+		}
+	}
+	return nil
+}
+
+func mkdirAt(rootFD int, subPath string, fsGroup *int) error {
+	currentFD := rootFD
+	for _, segment := range strings.Split(subPath, "/") {
+		created := false
+		if err := unix.Mkdirat(currentFD, segment, 0755); err == nil {
+			created = true
+		} else if err != unix.EEXIST {
+			if currentFD != rootFD {
+				unix.Close(currentFD)
+			}
+			return err
+		}
+		nextFD, err := unix.Openat(currentFD, segment, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if currentFD != rootFD {
+			unix.Close(currentFD)
+		}
+		if err != nil {
+			return err
+		}
+		if created && fsGroup != nil {
+			if err := unix.Fchown(nextFD, -1, *fsGroup); err != nil {
+				unix.Close(nextFD)
+				return err
+			}
+			if err := unix.Fchmod(nextFD, 02770); err != nil {
+				unix.Close(nextFD)
+				return err
+			}
+		}
+		currentFD = nextFD
+	}
+	if currentFD != rootFD {
+		return unix.Close(currentFD)
+	}
+	return nil
+}
+
+func validateFSGroup(fsGroup *int) error {
+	if fsGroup != nil && (*fsGroup < 1 || *fsGroup > 2147483647) {
+		return fmt.Errorf("fsGroup must be between 1 and 2147483647")
+	}
+	return nil
+}
+
+func validateMountPath(path string) error {
+	if path == "" || strings.IndexByte(path, 0) >= 0 || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return fmt.Errorf("mountPath must be a normalized absolute path")
+	}
+	return nil
+}
+
+func validateSubPath(path string) error {
+	if path == "" || strings.IndexByte(path, 0) >= 0 || strings.HasPrefix(path, "/") || strings.Contains(path, "\\") {
+		return fmt.Errorf("subPath must be a non-empty normalized relative path")
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("subPath must not contain empty, '.' or '..' segments")
+		}
+	}
+	return nil
+}

--- a/components/execd/pkg/subpathinitializer/securetree_linux_test.go
+++ b/components/execd/pkg/subpathinitializer/securetree_linux_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package subpathinitializer
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestParsePlanRejectsUnsafeAndMalformedInput(t *testing.T) {
+	tests := []string{
+		`[]`,
+		`[{"mountPath":"/root","subPaths":[]}]`,
+		`[{"mountPath":"/root","subPaths":["a/../b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a//b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a"]},{"mountPath":"/root","subPaths":["b"]}]`,
+		`[{"mountPath":"/root","subPaths":["a"],"unknown":true}]`,
+		`[{"mountPath":"/root","subPaths":["a"]}] garbage`,
+	}
+	for _, raw := range tests {
+		if _, err := ParsePlan(raw); err == nil {
+			t.Fatalf("ParsePlan(%q) succeeded", raw)
+		}
+	}
+}
+
+func TestApplyCreatesDirectoriesWithoutFollowingSymlinks(t *testing.T) {
+	root := t.TempDir()
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"jobs/a", "jobs/b"}}}, nil); err != nil {
+		t.Fatalf("Apply(): %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(root, "jobs", "a")); err != nil || !info.IsDir() {
+		t.Fatalf("created directory: info=%v err=%v", info, err)
+	}
+
+	if err := os.Symlink(t.TempDir(), filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"link/escape"}}}, nil); err == nil {
+		t.Fatal("Apply followed a symlink")
+	}
+}
+
+func TestApplyWithoutFSGroupUsesDefaultDirectoryMode(t *testing.T) {
+	root := t.TempDir()
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"jobs/a"}}}, nil); err != nil {
+		t.Fatalf("Apply(): %v", err)
+	}
+
+	for _, path := range []string{"jobs", "jobs/a"} {
+		info, err := os.Stat(filepath.Join(root, path))
+		if err != nil {
+			t.Fatalf("stat %q: %v", path, err)
+		}
+		if mode := info.Mode().Perm(); mode != 0755 {
+			t.Errorf("mode for %q = %#o, want 0755", path, mode)
+		}
+	}
+}
+
+func TestApplyFSGroupChangesOnlyCreatedDirectories(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "existing")
+	if err := os.Mkdir(existing, 0711); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(existing, 0711); err != nil {
+		t.Fatal(err)
+	}
+	before := stat(t, existing)
+
+	fsGroup := os.Getgid()
+	if fsGroup == 0 {
+		fsGroup = 1
+	}
+	if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"existing/new/nested"}}}, &fsGroup); err != nil {
+		t.Fatalf("Apply(): %v", err)
+	}
+
+	after := stat(t, existing)
+	if mode := after.Mode & 07777; mode != before.Mode&07777 {
+		t.Errorf("existing directory mode = %#o, want %#o", mode, before.Mode&07777)
+	}
+	if after.Gid != before.Gid {
+		t.Errorf("existing directory gid = %d, want %d", after.Gid, before.Gid)
+	}
+	for _, path := range []string{"existing/new", "existing/new/nested"} {
+		info := stat(t, filepath.Join(root, path))
+		if mode := info.Mode & 07777; mode != 02770 {
+			t.Errorf("mode for %q = %#o, want 02770", path, mode)
+		}
+		if info.Gid != uint32(fsGroup) {
+			t.Errorf("gid for %q = %d, want %d", path, info.Gid, fsGroup)
+		}
+	}
+}
+
+func TestApplyRejectsInvalidFSGroup(t *testing.T) {
+	root := t.TempDir()
+	zero := 0
+	negative := -1
+	invalidGroups := []*int{&zero, &negative}
+	if strconv.IntSize > 32 {
+		overflow := int(int64(2147483647) + 1)
+		invalidGroups = append(invalidGroups, &overflow)
+	}
+
+	for _, fsGroup := range invalidGroups {
+		if err := Apply([]PlanEntry{{MountPath: root, SubPaths: []string{"jobs"}}}, fsGroup); err == nil {
+			t.Errorf("Apply(fsGroup=%d) succeeded", *fsGroup)
+		}
+	}
+}
+
+func stat(t *testing.T, path string) *syscall.Stat_t {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	result, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat %q returned %T, want *syscall.Stat_t", path, info.Sys())
+	}
+	return result
+}

--- a/components/execd/pkg/subpathinitializer/securetree_unsupported.go
+++ b/components/execd/pkg/subpathinitializer/securetree_unsupported.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+// Package subpathinitializer creates planned directories without following links.
+package subpathinitializer
+
+import "fmt"
+
+// PlanEntry names one trusted PVC root mount and the relative paths to create beneath it.
+type PlanEntry struct {
+	MountPath string   `json:"mountPath"`
+	SubPaths  []string `json:"subPaths"`
+}
+
+// ParsePlan fails closed because secure fd-relative directory creation is Linux-only.
+func ParsePlan(string) ([]PlanEntry, error) {
+	return nil, fmt.Errorf("subpath initialization is supported only on linux")
+}
+
+// Apply fails closed because secure fd-relative directory creation is Linux-only.
+func Apply([]PlanEntry, *int) error {
+	return fmt.Errorf("subpath initialization is supported only on linux")
+}

--- a/docs/examples/kubernetes-pvc-volume-mount.md
+++ b/docs/examples/kubernetes-pvc-volume-mount.md
@@ -93,6 +93,61 @@ print("\n".join(msg.text for msg in result.logs.stdout))
 
 The PVC is never deleted by OpenSandbox: when the sandbox terminates, the claim stays bound and the data is available for the next sandbox that mounts it.
 
+## Create a PVC subpath when needed
+
+Set `ensure_sub_path_directory=True` only when mounting a writable PVC subpath
+through Kubernetes `BatchSandbox` template mode. The subpath must be non-empty,
+normalized, and relative. Docker, pool mode, `host`, `ossfs`, and read-only PVC
+mounts do not support this option.
+
+The existing BatchSandbox template main `sandbox` container must explicitly set
+`securityContext.runAsGroup` to an integer from `1` through `2147483647`. No Pod
+`fsGroup` is set or required. For example:
+
+```yaml
+apiVersion: sandbox.opensandbox.io/v1alpha1
+kind: BatchSandbox
+spec:
+  template:
+    spec:
+      containers:
+      - name: sandbox
+        image: python:3.11
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+```
+
+With this template setting, a request can create a missing directory before it
+mounts the subpath:
+
+```python
+sandbox = await Sandbox.create(
+    image="python:3.11",
+    volumes=[
+        Volume(
+            name="run-workspace",
+            pvc=PVC(claim_name="my-pvc", create_if_not_exists=False),
+            mount_path="/workspace",
+            read_only=False,
+            sub_path="runs/current",
+            ensure_sub_path_directory=True,
+        ),
+    ],
+)
+```
+
+The initializer assigns the template `runAsGroup` and mode `02770` only to newly
+created segments; it does not alter existing directories. When enabled, the
+server applies/merges the template `sandbox` container's selected identity fields
+(`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the generated sandbox so its
+effective group matches the initializer-created directory. It preserves
+runtime-required capabilities, seccomp, and AppArmor settings and does not
+otherwise replace the security context. Storage and mount behavior remains
+Kubernetes/CSI dependent; the initializer does not recursively alter existing
+paths. Configure a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
 ### Run the end-to-end example
 
 ```shell

--- a/docs/sdks/csharp.md
+++ b/docs/sdks/csharp.md
@@ -208,7 +208,55 @@ var url = await sandbox.GetEndpointUrlAsync(44772);
 Console.WriteLine(url); // e.g., "http://localhost:44772"
 ```
 
-### 6. Sandbox Management (Admin)
+### 6. Volume Mounts
+
+To create a missing directory before mounting a PVC subpath, set
+`EnsureSubPathDirectory = true`. The `SubPath` must be a non-empty normalized
+relative path, and the PVC mount must be writable:
+
+```csharp
+using OpenSandbox.Models;
+
+var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+{
+    ConnectionConfig = config,
+    Image = "ubuntu",
+    Volumes = new[]
+    {
+        new Volume
+        {
+            Name = "workspace",
+            Pvc = new PVC
+            {
+                ClaimName = "agent-workspace",
+                CreateIfNotExists = false,
+            },
+            MountPath = "/workspace",
+            ReadOnly = false,
+            SubPath = "runs/current",
+            EnsureSubPathDirectory = true,
+        },
+    },
+});
+```
+
+`EnsureSubPathDirectory` is supported only for Kubernetes `BatchSandbox`
+template mode. It is rejected for Docker, pool mode, `Host` and `Ossfs`
+volumes. The existing BatchSandbox template main `sandbox` container must
+explicitly set `securityContext.runAsGroup` to an integer from `1` through
+`2147483647`; no Pod `fsGroup` is set or required. Newly created segments are
+assigned that GID and mode `02770`; existing directories are not altered. When
+enabled, the server applies/merges the template `sandbox` container's selected
+identity fields (`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the
+generated sandbox so its effective group matches the initializer-created
+directory. It preserves runtime-required capabilities, seccomp, and AppArmor
+settings and does not otherwise replace the security context. Storage and mount
+behavior remains Kubernetes/CSI dependent; the initializer does not recursively
+alter existing paths. The JSON wire field is
+`ensureSubPathDirectory`. Use a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
+### 7. Sandbox Management (Admin)
 
 Use `SandboxManager` for administrative tasks and finding existing sandboxes.
 

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -73,6 +73,52 @@ func main() {
 }
 ```
 
+### Ensure a PVC subpath directory
+
+To create a missing directory before mounting a PVC subpath, set
+`EnsureSubPathDirectory`. The `SubPath` must be a non-empty normalized relative
+path, and the PVC mount must be writable:
+
+```go
+enabled := true
+createIfNotExists := false
+sandbox, err := opensandbox.CreateSandbox(ctx, config, opensandbox.SandboxCreateOptions{
+    Image: "ubuntu",
+    Volumes: []opensandbox.Volume{
+        {
+            Name: "workspace",
+            PVC: &opensandbox.PVC{
+                ClaimName:         "agent-workspace",
+                CreateIfNotExists: &createIfNotExists,
+            },
+            MountPath:              "/workspace",
+            ReadOnly:               false,
+            SubPath:                "runs/current",
+            EnsureSubPathDirectory: &enabled,
+        },
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+`EnsureSubPathDirectory` is supported only for Kubernetes `BatchSandbox`
+template mode. It is rejected for Docker, pool mode, `Host` and `OSSFS`
+volumes. The existing BatchSandbox template main `sandbox` container must
+explicitly set `securityContext.runAsGroup` to an integer from `1` through
+`2147483647`; no Pod `fsGroup` is set or required. Newly created segments are
+assigned that GID and mode `02770`; existing directories are not altered. When
+enabled, the server applies/merges the template `sandbox` container's selected
+identity fields (`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the
+generated sandbox so its effective group matches the initializer-created
+directory. It preserves runtime-required capabilities, seccomp, and AppArmor
+settings and does not otherwise replace the security context. Storage and mount
+behavior remains Kubernetes/CSI dependent; the initializer does not recursively
+alter existing paths. The JSON wire field is
+`ensureSubPathDirectory`. Use a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
 ### Run a command with streaming output
 
 ```go

--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -195,6 +195,46 @@ const sandbox = await Sandbox.create({
 });
 ```
 
+To create a missing directory before mounting a PVC subpath, set
+`ensureSubPathDirectory: true`. The `subPath` must be a non-empty normalized
+relative path, and the PVC mount must be writable:
+
+```ts
+const sandbox = await Sandbox.create({
+  connectionConfig: config,
+  image: "ubuntu",
+  volumes: [
+    {
+      name: "workspace",
+      pvc: {
+        claimName: "agent-workspace",
+        createIfNotExists: false,
+      },
+      mountPath: "/workspace",
+      readOnly: false,
+      subPath: "runs/current",
+      ensureSubPathDirectory: true,
+    },
+  ],
+});
+```
+
+`ensureSubPathDirectory` is supported only for Kubernetes `BatchSandbox`
+template mode. It is rejected for Docker, pool mode, `host` and `ossfs`
+volumes. The existing BatchSandbox template main `sandbox` container must
+explicitly set `securityContext.runAsGroup` to an integer from `1` through
+`2147483647`; no Pod `fsGroup` is set or required. Newly created segments are
+assigned that GID and mode `02770`; existing directories are not altered. When
+enabled, the server applies/merges the template `sandbox` container's selected
+identity fields (`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the
+generated sandbox so its effective group matches the initializer-created
+directory. It preserves runtime-required capabilities, seccomp, and AppArmor
+settings and does not otherwise replace the security context. Storage and mount
+behavior remains Kubernetes/CSI dependent; the initializer does not recursively
+alter existing paths. The JSON wire field is also
+`ensureSubPathDirectory`. Use a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
 ### 7. Sandbox Management (Admin)
 
 Use `SandboxManager` for administrative tasks and finding existing sandboxes.

--- a/docs/sdks/kotlin.md
+++ b/docs/sdks/kotlin.md
@@ -110,6 +110,51 @@ Sandbox manual = Sandbox.builder()
     .build();
 ```
 
+### Ensure a PVC subpath directory
+
+To create a missing directory before mounting a PVC subpath, set
+`ensureSubPathDirectory(true)`. The `subPath` must be a non-empty normalized
+relative path, and the PVC mount must be writable:
+
+```java
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PVC;
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume;
+import java.util.List;
+
+Sandbox sandbox = Sandbox.builder()
+    .connectionConfig(config)
+    .image("ubuntu")
+    .volumes(
+        List.of(
+            Volume.builder()
+                .name("workspace")
+                .pvc(PVC.of("agent-workspace"))
+                .mountPath("/workspace")
+                .readOnly(false)
+                .subPath("runs/current")
+                .ensureSubPathDirectory(true)
+                .build()
+        )
+    )
+    .build();
+```
+
+`ensureSubPathDirectory` is supported only for Kubernetes `BatchSandbox`
+template mode. It is rejected for Docker, pool mode, `host` and `ossfs`
+volumes. The existing BatchSandbox template main `sandbox` container must
+explicitly set `securityContext.runAsGroup` to an integer from `1` through
+`2147483647`; no Pod `fsGroup` is set or required. Newly created segments are
+assigned that GID and mode `02770`; existing directories are not altered. When
+enabled, the server applies/merges the template `sandbox` container's selected
+identity fields (`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the
+generated sandbox so its effective group matches the initializer-created
+directory. It preserves runtime-required capabilities, seccomp, and AppArmor
+settings and does not otherwise replace the security context. Storage and mount
+behavior remains Kubernetes/CSI dependent; the initializer does not recursively
+alter existing paths. The JSON wire field is
+`ensureSubPathDirectory`. Use a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
 ### 2. Custom Health Check
 
 Define custom logic to determine if the sandbox is healthy. This overrides the default ping check.

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -560,7 +560,48 @@ sandbox = await Sandbox.create(
 )
 ```
 
-### 4. Runtime Egress Policy Updates
+### 4. Ensure a PVC Subpath Directory
+
+To create a missing directory before mounting a PVC subpath, set
+`ensure_sub_path_directory=True`. The `sub_path` must be a non-empty normalized
+relative path, and the PVC mount must be writable:
+
+```python
+from opensandbox.models.sandboxes import PVC, Volume
+
+sandbox = await Sandbox.create(
+    "ubuntu",
+    connection_config=config,
+    volumes=[
+        Volume(
+            name="workspace",
+            pvc=PVC(claim_name="agent-workspace", create_if_not_exists=False),
+            mount_path="/workspace",
+            read_only=False,
+            sub_path="runs/current",
+            ensure_sub_path_directory=True,
+        ),
+    ],
+)
+```
+
+`ensure_sub_path_directory` is supported only for Kubernetes `BatchSandbox`
+template mode. It is rejected for Docker, pool mode, `host` and `ossfs`
+volumes. The existing BatchSandbox template main `sandbox` container must
+explicitly set `securityContext.runAsGroup` to an integer from `1` through
+`2147483647`; no Pod `fsGroup` is set or required. Newly created segments are
+assigned that GID and mode `02770`; existing directories are not altered. When
+enabled, the server applies/merges the template `sandbox` container's selected
+identity fields (`runAsUser`, `runAsGroup`, and `runAsNonRoot`) into the
+generated sandbox so its effective group matches the initializer-created
+directory. It preserves runtime-required capabilities, seccomp, and AppArmor
+settings and does not otherwise replace the security context. Storage and mount
+behavior remains Kubernetes/CSI dependent; the initializer does not recursively
+alter existing paths. The JSON wire field is
+`ensureSubPathDirectory`. Use a compatible published execd image that contains
+`/opensandbox-subpath-initializer`.
+
+### 5. Runtime Egress Policy Updates
 
 Runtime egress policy reads and patches are sent directly to the sandbox egress sidecar.
 The SDK first resolves the sandbox endpoint on port `18080`, then calls the sidecar `/policy` API.
@@ -582,7 +623,7 @@ await sandbox.patch_egress_rules(
 )
 ```
 
-### 5. Credential Vault
+### 6. Credential Vault
 
 Credential Vault injects outbound credentials from the egress sidecar while
 keeping real secrets out of sandbox environment variables, commands, files, and

--- a/scripts/common/kubernetes-e2e.sh
+++ b/scripts/common/kubernetes-e2e.sh
@@ -21,6 +21,8 @@
 # Optional:
 #   E2E_SERVER_GATEWAY_ENABLED=true — include server.gateway.* in Helm values (ingress-gateway path).
 #   E2E_GATEWAY_ROUTE_MODE — when gateway enabled: header | uri (default header). Matches chart server.gateway.gatewayRouteMode.
+#   E2E_BATCHSANDBOX_TEMPLATE_FILE — server-image template path for an opt-in E2E fixture.
+#   E2E_PYTEST_TARGET — run only this pytest node instead of the Kubernetes mini suite.
 
 k8s_e2e_export_kubeconfig() {
   export KUBECONFIG="${KUBECONFIG_PATH}"
@@ -132,7 +134,12 @@ EOF
 
 k8s_e2e_write_server_helm_values() {
   local signing_key
+  local batchsandbox_template_file
   signing_key=$(openssl rand -base64 32 | tr -d '\n')
+  batchsandbox_template_file="${E2E_BATCHSANDBOX_TEMPLATE_FILE:-/etc/opensandbox/e2e.batchsandbox-template.yaml}"
+  if [ -n "${E2E_BATCHSANDBOX_TEMPLATE_FILE:-}" ]; then
+    export E2E_BATCHSANDBOX_TEMPLATE_FILE
+  fi
 
   {
     cat <<EOF
@@ -199,7 +206,7 @@ configToml: |
   workload_provider = "batchsandbox"
   sandbox_create_timeout_seconds = 180
   sandbox_create_poll_interval_seconds = 1.0
-  batchsandbox_template_file = "/etc/opensandbox/e2e.batchsandbox-template.yaml"
+  batchsandbox_template_file = "${batchsandbox_template_file}"
 
   [storage]
   allowed_host_paths = []
@@ -294,5 +301,9 @@ k8s_e2e_generate_sdk_and_run_kubernetes_mini() {
   make generate-api
   cd "${REPO_ROOT}/tests/python"
   uv sync --all-extras --refresh
+  if [ -n "${E2E_PYTEST_TARGET:-}" ]; then
+    uv run pytest "${E2E_PYTEST_TARGET}"
+    return
+  fi
   make test-kubernetes-mini
 }

--- a/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
+++ b/sdks/sandbox/csharp/src/OpenSandbox/Models/Sandboxes.cs
@@ -686,6 +686,14 @@ public class Volume
     /// </summary>
     [JsonPropertyName("subPath")]
     public string? SubPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the Kubernetes BatchSandbox template runtime should create the subpath directory.
+    /// Supported only for writable PVC volume mounts with a normalized, nonempty subpath; rejected for Docker,
+    /// pool mode, and host or OSSFS volume mounts.
+    /// </summary>
+    [JsonPropertyName("ensureSubPathDirectory")]
+    public bool? EnsureSubPathDirectory { get; set; }
 }
 
 /// <summary>

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/ModelsTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using OpenSandbox.Models;
 using Xunit;
@@ -304,6 +305,42 @@ public class ModelsTests
         json.Should().Contain("\"accessKeySecret\":\"sk\"");
         json.Should().Contain("\"version\":\"2.0\"");
         json.Should().Contain("\"platform\":{\"os\":\"linux\",\"arch\":\"arm64\"}");
+
+        json.Should().NotContain("ensureSubPathDirectory");
+
+        var volumeWithoutEnsure = new Volume
+        {
+            Name = "data",
+            MountPath = "/mnt/data"
+        };
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        JsonSerializer.Serialize(volumeWithoutEnsure, options)
+            .Should().NotContain("ensureSubPathDirectory");
+    }
+
+    [Fact]
+    public void Volume_WithWritablePvcAndSubPath_ShouldSerializeEnsureSubPathDirectory()
+    {
+        var volume = new Volume
+        {
+            Name = "workspace",
+            Pvc = new PVC { ClaimName = "workspace-pvc" },
+            MountPath = "/workspace",
+            SubPath = "agent/run",
+            EnsureSubPathDirectory = true
+        };
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        var json = JsonSerializer.Serialize(volume, options);
+
+        json.Should().Contain("\"pvc\":{\"claimName\":\"workspace-pvc\"}");
+        json.Should().Contain("\"subPath\":\"agent/run\"");
+        json.Should().Contain("\"ensureSubPathDirectory\":true");
     }
 
     [Fact]

--- a/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
+++ b/sdks/sandbox/csharp/tests/OpenSandbox.Tests/SandboxEgressLifecycleTests.cs
@@ -142,6 +142,49 @@ public class SandboxEgressLifecycleTests
         sandboxes.LastCreateRequest!.Volumes.Should().NotBeNull();
         sandboxes.LastCreateRequest.Volumes!.Should().ContainSingle();
         sandboxes.LastCreateRequest.Volumes![0].Host!.Path.Should().Be("D:/sandbox-mnt/ReMe");
+        sandboxes.LastCreateRequest.Volumes[0].EnsureSubPathDirectory.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldMapEnsureSubPathDirectoryForWritablePvc()
+    {
+        var sandboxes = new StubSandboxes();
+        var adapterFactory = new StubAdapterFactory(sandboxes, new StubEgress());
+
+        await using var sandbox = await Sandbox.CreateAsync(new SandboxCreateOptions
+        {
+            Image = "python:3.12",
+            ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+            {
+                Domain = "127.0.0.1:8080",
+                Protocol = ConnectionProtocol.Http
+            }),
+            AdapterFactory = adapterFactory,
+            SkipHealthCheck = true,
+            Volumes =
+            [
+                new Volume
+                {
+                    Name = "workspace",
+                    Pvc = new PVC { ClaimName = "workspace-pvc" },
+                    MountPath = "/workspace",
+                    SubPath = "agent/run",
+                    EnsureSubPathDirectory = true
+                }
+            ],
+            Diagnostics = new SdkDiagnosticsOptions
+            {
+                LoggerFactory = NullLoggerFactory.Instance
+            }
+        });
+
+        sandboxes.LastCreateRequest.Should().NotBeNull();
+        sandboxes.LastCreateRequest!.Volumes.Should().ContainSingle();
+        var volume = sandboxes.LastCreateRequest.Volumes![0];
+        volume.Pvc!.ClaimName.Should().Be("workspace-pvc");
+        volume.ReadOnly.Should().NotBeTrue();
+        volume.SubPath.Should().Be("agent/run");
+        volume.EnsureSubPathDirectory.Should().BeTrue();
     }
 
     [Fact]

--- a/sdks/sandbox/go/opensandbox_test.go
+++ b/sdks/sandbox/go/opensandbox_test.go
@@ -2670,3 +2670,32 @@ func TestCreateSandbox_WithVolumes(t *testing.T) {
 	})
 	require.NoErrorf(t, err, "CreateSandbox with Volumes")
 }
+
+func TestVolumeEnsureSubPathDirectoryJSON(t *testing.T) {
+	withoutEnsure := Volume{
+		Name:      "data",
+		MountPath: "/mnt/data",
+	}
+	withoutEnsureJSON, err := json.Marshal(withoutEnsure)
+	require.NoErrorf(t, err, "marshal volume without EnsureSubPathDirectory")
+	if strings.Contains(string(withoutEnsureJSON), "ensureSubPathDirectory") {
+		assert.Fail(t, "EnsureSubPathDirectory should be omitted when nil")
+	}
+
+	enabled := true
+	volume := Volume{
+		Name:                   "data",
+		PVC:                    &PVC{ClaimName: "data-pvc"},
+		MountPath:              "/mnt/data",
+		SubPath:                "agent/run",
+		EnsureSubPathDirectory: &enabled,
+	}
+	data, err := json.Marshal(volume)
+	require.NoErrorf(t, err, "marshal volume with EnsureSubPathDirectory")
+
+	var payload map[string]any
+	require.NoErrorf(t, json.Unmarshal(data, &payload), "unmarshal volume JSON")
+	if got, ok := payload["ensureSubPathDirectory"].(bool); !ok || !got {
+		assert.Fail(t, fmt.Sprintf("ensureSubPathDirectory = %#v, want true", payload["ensureSubPathDirectory"]))
+	}
+}

--- a/sdks/sandbox/go/sandbox_test.go
+++ b/sdks/sandbox/go/sandbox_test.go
@@ -16,6 +16,7 @@ package opensandbox
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -106,6 +107,52 @@ func TestSandbox_Ping_OK(t *testing.T) {
 	}
 
 	require.NoError(t, sb.Ping(context.Background()))
+}
+
+func TestCreateSandboxMapsVolumeEnsureSubPathDirectory(t *testing.T) {
+	var createRequest CreateSandboxRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes":
+			if err := json.NewDecoder(r.Body).Decode(&createRequest); err != nil {
+				t.Fatalf("decode create request: %v", err)
+			}
+			jsonResponse(w, http.StatusCreated, SandboxInfo{
+				ID:        "sbx-volume",
+				Status:    SandboxStatus{State: StateRunning},
+				CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes/sbx-volume":
+			jsonResponse(w, http.StatusOK, SandboxInfo{
+				ID:        "sbx-volume",
+				Status:    SandboxStatus{State: StateRunning},
+				CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/endpoints/"):
+			jsonResponse(w, http.StatusOK, Endpoint{Endpoint: "http://127.0.0.1:18080"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	enabled := true
+	_, err := CreateSandbox(context.Background(), ConnectionConfig{Domain: srv.URL}, SandboxCreateOptions{
+		Image:           "python:3.12",
+		SkipHealthCheck: true,
+		Volumes: []Volume{{
+			Name:                   "workspace",
+			PVC:                    &PVC{ClaimName: "workspace-pvc"},
+			MountPath:              "/workspace",
+			SubPath:                "agent/run",
+			EnsureSubPathDirectory: &enabled,
+		}},
+	})
+	require.NoErrorf(t, err, "CreateSandbox")
+	require.Len(t, createRequest.Volumes, 1)
+	if createRequest.Volumes[0].EnsureSubPathDirectory == nil || !*createRequest.Volumes[0].EnsureSubPathDirectory {
+		assert.Fail(t, "EnsureSubPathDirectory should be mapped to the lifecycle create request")
+	}
 }
 
 func TestSandbox_IsHealthy_ExecdNil(t *testing.T) {

--- a/sdks/sandbox/go/types.go
+++ b/sdks/sandbox/go/types.go
@@ -95,13 +95,14 @@ type ResourceLimits map[string]string
 
 // Volume defines a storage mount for a sandbox.
 type Volume struct {
-	Name      string `json:"name"`
-	Host      *Host  `json:"host,omitempty"`
-	PVC       *PVC   `json:"pvc,omitempty"`
-	OSSFS     *OSSFS `json:"ossfs,omitempty"`
-	MountPath string `json:"mountPath"`
-	ReadOnly  bool   `json:"readOnly,omitempty"`
-	SubPath   string `json:"subPath,omitempty"`
+	Name                   string `json:"name"`
+	Host                   *Host  `json:"host,omitempty"`
+	PVC                    *PVC   `json:"pvc,omitempty"`
+	OSSFS                  *OSSFS `json:"ossfs,omitempty"`
+	MountPath              string `json:"mountPath"`
+	ReadOnly               bool   `json:"readOnly,omitempty"`
+	SubPath                string `json:"subPath,omitempty"`
+	EnsureSubPathDirectory *bool  `json:"ensureSubPathDirectory,omitempty"`
 }
 
 // Host represents a host path bind mount backend.

--- a/sdks/sandbox/javascript/scripts/generate-api.mjs
+++ b/sdks/sandbox/javascript/scripts/generate-api.mjs
@@ -143,8 +143,24 @@ function ensureExecdSessionNote(filePath) {
 
 ensureExecdSessionNote(outFiles.execd);
 
+function ensureOptionalEnsureSubPathDirectory(filePath) {
+  const body = readFileSync(filePath, "utf8");
+  const requiredProperty = "            ensureSubPathDirectory: boolean;";
+  if (!body.includes(requiredProperty)) {
+    return;
+  }
+  writeFileSync(
+    filePath,
+    body.replace(requiredProperty, "            ensureSubPathDirectory?: boolean;"),
+    "utf8",
+  );
+}
+
+// `default: false` causes openapi-typescript to mark this non-required field as
+// required. Preserve the OpenAPI required list for the public request type.
+ensureOptionalEnsureSubPathDirectory(outFiles.lifecycle);
+
 console.log("\n✅ API type generation completed:");
 console.log(`- ${path.relative(packageRoot, outFiles.execd)}`);
 console.log(`- ${path.relative(packageRoot, outFiles.egress)}`);
 console.log(`- ${path.relative(packageRoot, outFiles.lifecycle)}`);
-

--- a/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
+++ b/sdks/sandbox/javascript/src/adapters/sandboxesAdapter.ts
@@ -75,6 +75,18 @@ function encodeMetadataFilter(metadata: Record<string, string>): string {
   return parts.join("&");
 }
 
+function toApiCreateSandboxRequest(req: CreateSandboxRequest): ApiCreateSandboxRequest {
+  const volumes = req.volumes?.map(({ ensureSubPathDirectory, ...volume }) => ({
+    ...volume,
+    ...(ensureSubPathDirectory ? { ensureSubPathDirectory: true } : {}),
+  }));
+
+  return {
+    ...req,
+    ...(volumes ? { volumes } : {}),
+  } as unknown as ApiCreateSandboxRequest;
+}
+
 export class SandboxesAdapter implements Sandboxes {
   private readonly endpointCache: EndpointCache | null;
 
@@ -131,7 +143,7 @@ export class SandboxesAdapter implements Sandboxes {
 
   async createSandbox(req: CreateSandboxRequest): Promise<CreateSandboxResponse> {
     // Make the OpenAPI contract explicit so backend schema changes surface quickly.
-    const body: ApiCreateSandboxRequest = req as unknown as ApiCreateSandboxRequest;
+    const body = toApiCreateSandboxRequest(req);
     const { data, error, response } = await this.client.POST("/sandboxes", {
       body,
     });

--- a/sdks/sandbox/javascript/src/api/lifecycle.ts
+++ b/sdks/sandbox/javascript/src/api/lifecycle.ts
@@ -1338,7 +1338,7 @@ export interface components {
          * @description Storage mount definition for a sandbox. Each volume entry contains:
          *     - A unique name identifier
          *     - Exactly one backend struct (host, pvc, ossfs, etc.) with backend-specific fields
-         *     - Common mount settings (mountPath, readOnly, subPath)
+         *     - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
          */
         Volume: {
             /**
@@ -1365,6 +1365,28 @@ export interface components {
              *     Must be a relative path without '..' components.
              */
             subPath?: string;
+            /**
+             * @description When true, Kubernetes BatchSandbox template-mode creation ensures that
+             *     `subPath` exists before the main container starts using the fixed trusted
+             *     initializer bundled with a compatible published execd image that contains
+             *     `/opensandbox-subpath-initializer`. It supports only writable PVC mounts
+             *     with a non-empty normalized relative `subPath`. The existing BatchSandbox
+             *     template main `sandbox` container must explicitly set
+             *     `securityContext.runAsGroup` to an integer from `1` through `2147483647`.
+             *     No Pod `fsGroup` is set or required. The initializer assigns that GID and
+             *     mode `02770` only to newly created segments; it does not alter existing
+             *     directories. When enabled, the server applies/merges the template
+             *     `sandbox` container's selected identity fields (`runAsUser`, `runAsGroup`,
+             *     and `runAsNonRoot`) into the generated sandbox so its effective group
+             *     matches the initializer-created directory. It preserves runtime-required
+             *     capabilities, seccomp, and AppArmor settings and does not otherwise
+             *     replace the security context. Storage and mount behavior remains
+             *     Kubernetes/CSI dependent; the initializer does not recursively alter
+             *     existing paths. It is not supported for host or ossfs backends, read-only
+             *     mounts, Docker, other Kubernetes providers, or pool mode.
+             * @default false
+             */
+            ensureSubPathDirectory?: boolean;
         };
         /**
          * @description Host path bind mount backend. Maps a directory on the host filesystem

--- a/sdks/sandbox/javascript/src/models/sandboxes.ts
+++ b/sdks/sandbox/javascript/src/models/sandboxes.ts
@@ -376,7 +376,7 @@ export interface OSSFS extends Record<string, unknown> {
  * Each volume entry contains:
  * - A unique name identifier
  * - Exactly one backend (host, pvc, ossfs) with backend-specific fields
- * - Common mount settings (mountPath, readOnly, subPath)
+ * - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
  */
 export interface Volume extends Record<string, unknown> {
   /**
@@ -407,6 +407,12 @@ export interface Volume extends Record<string, unknown> {
    * Optional subdirectory under the backend path to mount.
    */
   subPath?: string;
+  /**
+   * When true, Kubernetes template-mode creation creates `subPath` before the
+   * main container starts. Supported only for writable PVC mounts with a
+   * non-empty relative subPath.
+   */
+  ensureSubPathDirectory?: boolean;
 }
 
 export type SandboxState =

--- a/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
+++ b/sdks/sandbox/javascript/tests/sandbox.create.test.mjs
@@ -8,6 +8,7 @@ import {
   DEFAULT_TIMEOUT_SECONDS,
   Sandbox,
 } from "../dist/index.js";
+import { SandboxesAdapter, createLifecycleClient } from "../dist/internal.js";
 
 function createAdapterFactory({ includeCredentialVault = true } = {}) {
   const recordedRequests = [];
@@ -325,6 +326,111 @@ test("Sandbox.create passes OSSFS volume to request", async () => {
   assert.equal(recordedRequests[0].volumes[0].name, "oss-data");
   assert.equal(recordedRequests[0].volumes[0].ossfs.bucket, "my-bucket");
   assert.equal(recordedRequests[0].volumes[0].ossfs.endpoint, "oss-cn-hangzhou.aliyuncs.com");
+});
+
+test("Sandbox.create serializes ensureSubPathDirectory in camelCase", async () => {
+  const { adapterFactory, recordedRequests } = createAdapterFactory();
+
+  await Sandbox.create({
+    adapterFactory,
+    connectionConfig: { domain: "http://127.0.0.1:8080" },
+    image: "python:3.12",
+    skipHealthCheck: true,
+    volumes: [
+      {
+        name: "workspace",
+        pvc: { claimName: "workspace-pvc" },
+        mountPath: "/workspace",
+        subPath: "projects/example",
+        ensureSubPathDirectory: true,
+      },
+    ],
+  });
+
+  const volume = recordedRequests[0].volumes[0];
+  assert.equal(volume.ensureSubPathDirectory, true);
+  assert.equal(Object.hasOwn(volume, "ensure_sub_path_directory"), false);
+});
+
+test("SandboxesAdapter sends ensureSubPathDirectory as camelCase JSON", async () => {
+  let requestBody;
+  const client = createLifecycleClient({
+    baseUrl: "https://opensandbox.invalid/v1",
+    fetch: async (request) => {
+      requestBody = await request.json();
+      return new Response(
+        JSON.stringify({
+          id: "sandbox-test-id",
+          createdAt: "2026-01-01T00:00:00Z",
+          expiresAt: null,
+        }),
+        { status: 202, headers: { "content-type": "application/json" } }
+      );
+    },
+  });
+  const adapter = new SandboxesAdapter(client);
+
+  await adapter.createSandbox({
+    image: { uri: "python:3.12" },
+    entrypoint: [],
+    resourceLimits: { cpu: 1, memory: 1 },
+    secureAccess: false,
+    volumes: [
+      {
+        name: "workspace",
+        pvc: { claimName: "workspace-pvc" },
+        mountPath: "/workspace",
+        subPath: "projects/example",
+        ensureSubPathDirectory: true,
+      },
+    ],
+  });
+
+  const volume = requestBody.volumes[0];
+  assert.equal(volume.ensureSubPathDirectory, true);
+  assert.equal(Object.hasOwn(volume, "ensure_sub_path_directory"), false);
+});
+
+test("SandboxesAdapter omits false and unset ensureSubPathDirectory from JSON", async () => {
+  const requestBodies = [];
+  const client = createLifecycleClient({
+    baseUrl: "https://opensandbox.invalid/v1",
+    fetch: async (request) => {
+      requestBodies.push(await request.json());
+      return new Response(
+        JSON.stringify({
+          id: "sandbox-test-id",
+          createdAt: "2026-01-01T00:00:00Z",
+          expiresAt: null,
+        }),
+        { status: 202, headers: { "content-type": "application/json" } }
+      );
+    },
+  });
+  const adapter = new SandboxesAdapter(client);
+  const createRequest = (ensureSubPathDirectory) => ({
+    image: { uri: "python:3.12" },
+    entrypoint: [],
+    resourceLimits: { cpu: 1, memory: 1 },
+    secureAccess: false,
+    volumes: [
+      {
+        name: "workspace",
+        pvc: { claimName: "workspace-pvc" },
+        mountPath: "/workspace",
+        subPath: "projects/example",
+        ...(ensureSubPathDirectory === undefined ? {} : { ensureSubPathDirectory }),
+      },
+    ],
+  });
+
+  await adapter.createSandbox(createRequest(false));
+  await adapter.createSandbox(createRequest(undefined));
+
+  for (const body of requestBodies) {
+    assert.equal(Object.hasOwn(body.volumes[0], "ensureSubPathDirectory"), false);
+    assert.equal(Object.hasOwn(body.volumes[0], "ensure_sub_path_directory"), false);
+  }
 });
 
 test("Sandbox.create rejects volume with no backend", async () => {

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/domain/models/sandboxes/SandboxModels.kt
@@ -585,7 +585,7 @@ class OSSFS private constructor(
  * Each volume entry contains:
  * - A unique name identifier
  * - Exactly one backend (host, pvc, ossfs) with backend-specific fields
- * - Common mount settings (mountPath, readOnly, subPath)
+ * - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
  *
  * Example usage:
  * ```kotlin
@@ -612,6 +612,8 @@ class OSSFS private constructor(
  * @property mountPath Absolute path inside the container where the volume is mounted
  * @property readOnly If true, the volume is mounted as read-only. Defaults to false (read-write).
  * @property subPath Optional subdirectory under the backend path to mount
+ * @property ensureSubPathDirectory If true, ensures a PVC subpath directory exists before mounting it.
+ * When unset, the field is omitted from lifecycle requests.
  */
 class Volume private constructor(
     val name: String,
@@ -621,6 +623,7 @@ class Volume private constructor(
     val mountPath: String,
     val readOnly: Boolean,
     val subPath: String?,
+    val ensureSubPathDirectory: Boolean?,
 ) {
     companion object {
         @JvmStatic
@@ -635,6 +638,7 @@ class Volume private constructor(
         private var mountPath: String? = null
         private var readOnly: Boolean = false
         private var subPath: String? = null
+        private var ensureSubPathDirectory: Boolean? = null
 
         fun name(name: String): Builder {
             require(name.isNotBlank()) { "Volume name cannot be blank" }
@@ -673,6 +677,11 @@ class Volume private constructor(
             return this
         }
 
+        fun ensureSubPathDirectory(ensureSubPathDirectory: Boolean?): Builder {
+            this.ensureSubPathDirectory = ensureSubPathDirectory
+            return this
+        }
+
         fun build(): Volume {
             val nameValue = name ?: throw IllegalArgumentException("Name must be specified")
             val mountPathValue = mountPath ?: throw IllegalArgumentException("Mount path must be specified")
@@ -698,6 +707,7 @@ class Volume private constructor(
                 mountPath = mountPathValue,
                 readOnly = readOnly,
                 subPath = subPath,
+                ensureSubPathDirectory = ensureSubPathDirectory,
             )
         }
     }

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/converter/SandboxModelConverter.kt
@@ -245,6 +245,7 @@ internal object SandboxModelConverter {
             pvc = this.pvc?.toApiPVC(),
             ossfs = this.ossfs?.toApiOSSFS(),
             subPath = this.subPath,
+            ensureSubPathDirectory = this.ensureSubPathDirectory,
         )
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/main/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapter.kt
@@ -20,6 +20,8 @@ import com.alibaba.opensandbox.sandbox.HttpClientProvider
 import com.alibaba.opensandbox.sandbox.api.SandboxesApi
 import com.alibaba.opensandbox.sandbox.api.SnapshotsApi
 import com.alibaba.opensandbox.sandbox.api.infrastructure.Serializer
+import com.alibaba.opensandbox.sandbox.api.models.CreateSandboxRequest
+import com.alibaba.opensandbox.sandbox.api.models.CreateSandboxResponse
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.CredentialProxyConfig
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PagedSandboxInfos
@@ -48,6 +50,11 @@ import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandb
 import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.toSandboxException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -149,7 +156,12 @@ internal class SandboxesAdapter(
                     snapshotId = snapshotId,
                     resourceRequests = resourceRequests,
                 )
-            val apiResponse = api.sandboxesPost(createRequest)
+            val apiResponse =
+                if (volumes?.any { it.ensureSubPathDirectory == null } == true) {
+                    createSandboxOmittingUnsetVolumeFields(createRequest, volumes)
+                } else {
+                    api.sandboxesPost(createRequest)
+                }
             val response = apiResponse.toSandboxCreateResponse()
 
             logger.info("Successfully created sandbox: {}", response.id)
@@ -157,6 +169,58 @@ internal class SandboxesAdapter(
             response
         } catch (e: Exception) {
             throw e.toSandboxException()
+        }
+    }
+
+    private fun createSandboxOmittingUnsetVolumeFields(
+        createRequest: CreateSandboxRequest,
+        volumes: List<Volume>,
+    ): CreateSandboxResponse {
+        val payload =
+            Serializer.kotlinxSerializationJson
+                .encodeToJsonElement(createRequest)
+                .jsonObject
+                .toMutableMap()
+        val serializedVolumes = payload["volumes"] as? JsonArray
+        if (serializedVolumes != null) {
+            payload["volumes"] =
+                JsonArray(
+                    serializedVolumes.mapIndexed { index, serializedVolume ->
+                        if (volumes[index].ensureSubPathDirectory == null) {
+                            buildJsonObject {
+                                serializedVolume.jsonObject.forEach { (key, value) ->
+                                    if (key != "ensureSubPathDirectory") put(key, value)
+                                }
+                            }
+                        } else {
+                            serializedVolume
+                        }
+                    },
+                )
+        }
+        val body =
+            Serializer.kotlinxSerializationJson
+                .encodeToString(payload)
+                .toRequestBody("application/json".toMediaType())
+        val url =
+            provider.config.getBaseUrl().toHttpUrl().newBuilder()
+                .addPathSegment("sandboxes")
+                .build()
+        val request =
+            Request.Builder()
+                .url(url)
+                .post(body)
+                .header("Accept", "application/json")
+                .build()
+
+        provider.authenticatedClient.newCall(request).execute().use { response ->
+            val responseBody = response.body?.string().orEmpty()
+            if (response.isSuccessful) {
+                return Serializer.kotlinxSerializationJson.decodeFromString(responseBody)
+            }
+            throw response.toSandboxApiException(responseBody) { statusCode, responseContent ->
+                "Failed to create sandbox. Status code: $statusCode, Body: $responseContent"
+            }
         }
     }
 

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/domain/models/VolumeModelsTest.kt
@@ -20,6 +20,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Host
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.OSSFS
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PVC
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
+import com.alibaba.opensandbox.sandbox.infrastructure.adapters.converter.SandboxModelConverter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -89,6 +90,7 @@ class VolumeModelsTest {
         assertEquals("/mnt/data", volume.mountPath)
         assertFalse(volume.readOnly) // default is read-write
         assertNull(volume.subPath)
+        assertNull(volume.ensureSubPathDirectory)
     }
 
     @Test
@@ -109,6 +111,23 @@ class VolumeModelsTest {
         assertEquals("/mnt/models", volume.mountPath)
         assertTrue(volume.readOnly)
         assertEquals("v1", volume.subPath)
+    }
+
+    @Test
+    fun `Volume should map ensureSubPathDirectory to lifecycle API`() {
+        val volume =
+            Volume.builder()
+                .name("models")
+                .pvc(PVC.of("shared-models"))
+                .mountPath("/mnt/models")
+                .subPath("v1")
+                .ensureSubPathDirectory(true)
+                .build()
+
+        val apiVolume = SandboxModelConverter.run { volume.toApiVolume() }
+
+        assertTrue(volume.ensureSubPathDirectory == true)
+        assertEquals(true, apiVolume.ensureSubPathDirectory)
     }
 
     @Test

--- a/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
+++ b/sdks/sandbox/kotlin/sandbox/src/test/kotlin/com/alibaba/opensandbox/sandbox/infrastructure/adapters/service/SandboxesAdapterTest.kt
@@ -23,6 +23,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.CredentialProxyCo
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkPolicy
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.NetworkRule
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.OSSFS
+import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PVC
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.PlatformSpec
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxFilter
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SandboxImageSpec
@@ -31,6 +32,7 @@ import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.SnapshotFilter
 import com.alibaba.opensandbox.sandbox.domain.models.sandboxes.Volume
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -39,6 +41,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -534,6 +537,91 @@ class SandboxesAdapterTest {
         assertEquals("sk", ossfs["accessKeySecret"]!!.jsonPrimitive.content)
         assertEquals("2.0", ossfs["version"]!!.jsonPrimitive.content)
         assertEquals("prefix", serializedVolume["subPath"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `createSandbox should omit unset ensureSubPathDirectory`() {
+        mockWebServer.enqueue(createSandboxResponse())
+
+        sandboxesAdapter.createSandbox(
+            spec = SandboxImageSpec.builder().image("ubuntu:latest").build(),
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = null,
+            resource = emptyMap(),
+            platform = null,
+            networkPolicy = null,
+            extensions = emptyMap(),
+            volumes =
+                listOf(
+                    Volume.builder()
+                        .name("workspace")
+                        .pvc(PVC.of("workspace-pvc"))
+                        .mountPath("/workspace")
+                        .subPath("unseeded")
+                        .build(),
+                ),
+            secureAccess = false,
+            snapshotId = null,
+            credentialProxy = null,
+        )
+
+        val payload = Json.parseToJsonElement(mockWebServer.takeRequest().body.readUtf8()).jsonObject
+        val serializedVolume = payload["volumes"]!!.jsonArray[0].jsonObject
+
+        assertNull(serializedVolume["ensureSubPathDirectory"])
+    }
+
+    @Test
+    fun `createSandbox should serialize enabled ensureSubPathDirectory with wire name`() {
+        mockWebServer.enqueue(createSandboxResponse())
+
+        sandboxesAdapter.createSandbox(
+            spec = SandboxImageSpec.builder().image("ubuntu:latest").build(),
+            entrypoint = listOf("bash"),
+            env = emptyMap(),
+            metadata = emptyMap(),
+            timeout = null,
+            resource = emptyMap(),
+            platform = null,
+            networkPolicy = null,
+            extensions = emptyMap(),
+            volumes =
+                listOf(
+                    Volume.builder()
+                        .name("workspace")
+                        .pvc(PVC.of("workspace-pvc"))
+                        .mountPath("/workspace")
+                        .subPath("unseeded")
+                        .ensureSubPathDirectory(true)
+                        .build(),
+                ),
+            secureAccess = false,
+            snapshotId = null,
+            credentialProxy = null,
+        )
+
+        val payload = Json.parseToJsonElement(mockWebServer.takeRequest().body.readUtf8()).jsonObject
+        val serializedVolume = payload["volumes"]!!.jsonArray[0].jsonObject
+
+        assertTrue(serializedVolume["ensureSubPathDirectory"]!!.jsonPrimitive.boolean)
+    }
+
+    private fun createSandboxResponse(): MockResponse {
+        return MockResponse()
+            .setResponseCode(201)
+            .setBody(
+                """
+                {
+                    "id": "sandbox-id",
+                    "status": { "state": "Running" },
+                    "expiresAt": null,
+                    "createdAt": "2023-01-01T10:00:00Z",
+                    "entrypoint": ["bash"]
+                }
+                """.trimIndent(),
+            )
     }
 
     @Test

--- a/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
+++ b/sdks/sandbox/python/src/opensandbox/adapters/converter/sandbox_model_converter.py
@@ -164,6 +164,11 @@ class SandboxModelConverter:
             pvc=api_pvc,
             ossfs=api_ossfs,
             sub_path=api_sub_path,
+            ensure_sub_path_directory=(
+                volume.ensure_sub_path_directory
+                if volume.ensure_sub_path_directory is not None
+                else UNSET
+            ),
         )
 
     @staticmethod

--- a/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/volume.py
+++ b/sdks/sandbox/python/src/opensandbox/api/lifecycle/models/volume.py
@@ -37,7 +37,7 @@ class Volume:
     """Storage mount definition for a sandbox. Each volume entry contains:
     - A unique name identifier
     - Exactly one backend struct (host, pvc, ossfs, etc.) with backend-specific fields
-    - Common mount settings (mountPath, readOnly, subPath)
+    - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
 
         Attributes:
             name (str): Unique identifier for the volume within the sandbox.
@@ -67,6 +67,25 @@ class Volume:
             sub_path (str | Unset): Optional subdirectory under the backend path to mount.
                 For `ossfs` backend, this field is used as the bucket prefix.
                 Must be a relative path without '..' components.
+            ensure_sub_path_directory (bool | Unset): When true, Kubernetes BatchSandbox template-mode creation ensures that
+                `subPath` exists before the main container starts using the fixed trusted
+                initializer bundled with a compatible published execd image that contains
+                `/opensandbox-subpath-initializer`. It supports only writable PVC mounts
+                with a non-empty normalized relative `subPath`. The existing BatchSandbox
+                template main `sandbox` container must explicitly set
+                `securityContext.runAsGroup` to an integer from `1` through `2147483647`.
+                No Pod `fsGroup` is set or required. The initializer assigns that GID and
+                mode `02770` only to newly created segments; it does not alter existing
+                directories. When enabled, the server applies/merges the template
+                `sandbox` container's selected identity fields (`runAsUser`, `runAsGroup`,
+                and `runAsNonRoot`) into the generated sandbox so its effective group
+                matches the initializer-created directory. It preserves runtime-required
+                capabilities, seccomp, and AppArmor settings and does not otherwise
+                replace the security context. Storage and mount behavior remains
+                Kubernetes/CSI dependent; the initializer does not recursively alter
+                existing paths. It is not supported for host or ossfs backends, read-only
+                mounts, Docker, other Kubernetes providers, or pool mode.
+                 Default: False.
     """
 
     name: str
@@ -76,6 +95,7 @@ class Volume:
     ossfs: OSSFS | Unset = UNSET
     read_only: bool | Unset = False
     sub_path: str | Unset = UNSET
+    ensure_sub_path_directory: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -98,6 +118,8 @@ class Volume:
 
         sub_path = self.sub_path
 
+        ensure_sub_path_directory = self.ensure_sub_path_directory
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -116,6 +138,8 @@ class Volume:
             field_dict["readOnly"] = read_only
         if sub_path is not UNSET:
             field_dict["subPath"] = sub_path
+        if ensure_sub_path_directory is not UNSET:
+            field_dict["ensureSubPathDirectory"] = ensure_sub_path_directory
 
         return field_dict
 
@@ -155,6 +179,8 @@ class Volume:
 
         sub_path = d.pop("subPath", UNSET)
 
+        ensure_sub_path_directory = d.pop("ensureSubPathDirectory", UNSET)
+
         volume = cls(
             name=name,
             mount_path=mount_path,
@@ -163,6 +189,7 @@ class Volume:
             ossfs=ossfs,
             read_only=read_only,
             sub_path=sub_path,
+            ensure_sub_path_directory=ensure_sub_path_directory,
         )
 
         return volume

--- a/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
+++ b/sdks/sandbox/python/src/opensandbox/models/sandboxes.py
@@ -480,7 +480,7 @@ class Volume(BaseModel):
     Each volume entry contains:
     - A unique name identifier
     - Exactly one backend (host, pvc, ossfs) with backend-specific fields
-    - Common mount settings (mount_path, read_only, sub_path)
+    - Common mount settings (mount_path, read_only, sub_path, ensure_sub_path_directory)
 
     Usage:
         # Host path mount (read-write by default)
@@ -527,6 +527,14 @@ class Volume(BaseModel):
         default=None,
         description="Optional subdirectory under the backend path to mount.",
         alias="subPath",
+    )
+    ensure_sub_path_directory: bool | None = Field(
+        default=None,
+        description=(
+            "Ensure a writable PVC subPath exists before a Kubernetes BatchSandbox "
+            "template-mode sandbox starts."
+        ),
+        alias="ensureSubPathDirectory",
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/sdks/sandbox/python/tests/test_converters_and_error_handling.py
+++ b/sdks/sandbox/python/tests/test_converters_and_error_handling.py
@@ -49,11 +49,13 @@ from opensandbox.exceptions import (
 )
 from opensandbox.models.execd import RunCommandOpts
 from opensandbox.models.sandboxes import (
+    PVC,
     CredentialProxyConfig,
     NetworkPolicy,
     NetworkRule,
     PlatformSpec,
     SandboxImageSpec,
+    Volume,
 )
 
 
@@ -572,6 +574,34 @@ def test_sandbox_model_converter_to_api_create_request_and_renew_tz() -> None:
 
     renew = SandboxModelConverter.to_api_renew_request(datetime(2025, 1, 1))
     assert renew.expires_at.tzinfo is timezone.utc
+
+
+def test_sandbox_model_converter_forwards_ensure_subpath_directory() -> None:
+    volume = Volume(
+        name="workspace",
+        pvc=PVC(claimName="workspace-pvc"),
+        mountPath="/workspace",
+        subPath="unseeded",
+        ensureSubPathDirectory=True,
+    )
+
+    converted = SandboxModelConverter.to_api_volume(volume)
+
+    assert converted.ensure_sub_path_directory is True
+    assert converted.to_dict()["ensureSubPathDirectory"] is True
+
+
+def test_sandbox_model_converter_omits_unset_ensure_subpath_directory() -> None:
+    volume = Volume(
+        name="workspace",
+        pvc=PVC(claimName="workspace-pvc"),
+        mountPath="/workspace",
+        subPath="unseeded",
+    )
+
+    converted = SandboxModelConverter.to_api_volume(volume)
+
+    assert "ensureSubPathDirectory" not in converted.to_dict()
 
 
 def test_platform_spec_accepts_windows() -> None:

--- a/sdks/sandbox/python/tests/test_models_stability.py
+++ b/sdks/sandbox/python/tests/test_models_stability.py
@@ -282,6 +282,7 @@ def test_volume_with_host_backend() -> None:
     assert vol.mount_path == "/mnt/data"
     assert vol.read_only is False  # default is read-write
     assert vol.sub_path is None
+    assert vol.ensure_sub_path_directory is None
 
 
 def test_volume_with_pvc_backend() -> None:
@@ -299,6 +300,33 @@ def test_volume_with_pvc_backend() -> None:
     assert vol.mount_path == "/mnt/models"
     assert vol.read_only is True
     assert vol.sub_path == "v1"
+
+
+def test_volume_ensure_subpath_directory_serializes_with_alias() -> None:
+    vol = Volume(
+        name="workspace",
+        pvc=PVC(claimName="shared-workspace"),
+        mountPath="/workspace",
+        subPath="unseeded",
+        ensureSubPathDirectory=True,
+    )
+
+    dumped = vol.model_dump(by_alias=True, mode="json")
+
+    assert vol.ensure_sub_path_directory is True
+    assert dumped["ensureSubPathDirectory"] is True
+
+
+def test_volume_ensure_subpath_directory_is_omitted_by_default() -> None:
+    vol = Volume(
+        name="workspace",
+        pvc=PVC(claimName="shared-workspace"),
+        mountPath="/workspace",
+    )
+
+    dumped = vol.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+    assert "ensureSubPathDirectory" not in dumped
 
 
 def test_volume_rejects_blank_name() -> None:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=builder /app/opensandbox_server/examples/example.config.k8s.toml /et
 COPY --from=builder /app/opensandbox_server/examples/example.config.k8s.zh.toml /etc/opensandbox/config.zh.toml
 COPY --from=builder /app/opensandbox_server/examples/example.batchsandbox-template.yaml /etc/opensandbox/example.batchsandbox-template.yaml
 COPY --from=builder /app/opensandbox_server/examples/e2e.batchsandbox-template.yaml /etc/opensandbox/e2e.batchsandbox-template.yaml
+COPY --from=builder /app/opensandbox_server/examples/e2e-subpath-nonroot.batchsandbox-template.yaml /etc/opensandbox/e2e-subpath-nonroot.batchsandbox-template.yaml
 
 EXPOSE 8080
 

--- a/server/opensandbox_server/api/schema.py
+++ b/server/opensandbox_server/api/schema.py
@@ -338,6 +338,25 @@ class Volume(BaseModel):
         alias="subPath",
         description="Optional subdirectory under the backend path to mount.",
     )
+    ensure_sub_path_directory: bool = Field(
+        False,
+        alias="ensureSubPathDirectory",
+        description=(
+            "When true, Kubernetes BatchSandbox template-mode creation ensures that "
+            "subPath exists before the main container starts using the fixed trusted "
+            "initializer bundled with a compatible published execd image that contains "
+            "/opensandbox-subpath-initializer. It supports only writable PVC mounts "
+            "with a non-empty normalized relative subPath. The existing BatchSandbox "
+            "template main sandbox container must explicitly set securityContext.runAsGroup "
+            "to an integer from 1 through 2147483647. No Pod fsGroup is set or required. "
+            "The initializer assigns that GID and mode 02770 only to newly created "
+            "segments; it does not alter existing directories, the business container "
+            "identity, or its security context. Storage and mount behavior remains "
+            "Kubernetes/CSI dependent; the initializer does not recursively alter "
+            "existing paths. It is not supported for host or ossfs backends, read-only "
+            "mounts, Docker, other Kubernetes providers, or pool mode."
+        ),
+    )
 
     class Config:
         populate_by_name = True
@@ -351,6 +370,24 @@ class Volume(BaseModel):
             raise ValueError("Exactly one backend (host, pvc, ossfs) must be specified, but none was provided.")
         if len(specified) > 1:
             raise ValueError("Exactly one backend (host, pvc, ossfs) must be specified, but multiple were provided.")
+
+        if self.ensure_sub_path_directory:
+            if self.pvc is None:
+                raise ValueError("ensureSubPathDirectory is supported only for PVC volumes.")
+            if self.read_only:
+                raise ValueError("ensureSubPathDirectory cannot be used with readOnly=true.")
+            if not self.sub_path or not self.sub_path.strip():
+                raise ValueError("ensureSubPathDirectory requires a non-empty subPath.")
+            if (
+                self.sub_path.startswith("/")
+                or "\\" in self.sub_path
+                or "\x00" in self.sub_path
+                or any(segment in {"", ".", ".."} for segment in self.sub_path.split("/"))
+            ):
+                raise ValueError(
+                    "ensureSubPathDirectory requires a normalized relative subPath "
+                    "without empty, '.', or '..' segments."
+                )
         return self
 
 

--- a/server/opensandbox_server/examples/e2e-subpath-nonroot.batchsandbox-template.yaml
+++ b/server/opensandbox_server/examples/e2e-subpath-nonroot.batchsandbox-template.yaml
@@ -1,0 +1,24 @@
+# E2E-only BatchSandbox template for PVC subPath initialization as a non-root user.
+# Select explicitly with E2E_BATCHSANDBOX_TEMPLATE_FILE; never used by production defaults.
+#
+# Faster Pod teardown in Kind/CI: skip the default 30s graceful termination window.
+# Do not use for real workloads where graceful shutdown matters.
+
+# Metadata template (will be merged with runtime-generated metadata)
+metadata:
+# Spec template
+spec:
+  replicas: 1
+  template:
+    spec:
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+      tolerations:
+        - operator: "Exists"
+      containers:
+        # "sandbox" is the generated primary runtime container name.
+        - name: sandbox
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 2000

--- a/server/opensandbox_server/services/docker/docker_service.py
+++ b/server/opensandbox_server/services/docker/docker_service.py
@@ -645,6 +645,17 @@ class DockerSandboxService(DockerDiagnosticsMixin, DockerRuntimeMixin, DockerVol
                     "message": "poolRef is not supported by the Docker provider. Use Kubernetes BatchSandbox provider instead.",
                 },
             )
+        if any(volume.ensure_sub_path_directory for volume in request.volumes or []):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": SandboxErrorCodes.INVALID_PARAMETER,
+                    "message": (
+                        "ensureSubPathDirectory is supported only by the Kubernetes "
+                        "BatchSandbox provider in template mode."
+                    ),
+                },
+            )
         request = resolve_sandbox_image_from_request(request)
         ensure_entrypoint(request.entrypoint or [])
         ensure_metadata_labels(request.metadata)

--- a/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/agent_sandbox_provider.py
@@ -145,6 +145,11 @@ class AgentSandboxProvider(WorkloadProvider):
         egress_env: Optional[Dict[str, Optional[str]]] = None,
     ) -> Dict[str, Any]:
         """Create an agent-sandbox Sandbox CRD workload."""
+        if any(volume.ensure_sub_path_directory for volume in volumes or []):
+            raise ValueError(
+                "ensureSubPathDirectory is supported only by the Kubernetes "
+                "BatchSandbox provider in template mode."
+            )
         if is_windows_profile(platform):
             raise ValueError("agent-sandbox does not support platform.os=windows.")
 

--- a/server/opensandbox_server/services/k8s/batchsandbox_provider.py
+++ b/server/opensandbox_server/services/k8s/batchsandbox_provider.py
@@ -54,7 +54,13 @@ from opensandbox_server.services.k8s.windows_profile import (
     is_windows_profile,
     validate_windows_profile_resource_limits,
 )
-from opensandbox_server.services.k8s.volume_helper import apply_volumes_to_pod_spec
+from opensandbox_server.services.k8s.volume_helper import (
+    SUBPATH_INITIALIZER_NAME,
+    add_subpath_initializer_to_pod_spec,
+    apply_volumes_to_pod_spec,
+    get_subpath_initializer_main_container_identity,
+    merge_subpath_initializer_main_container_identity,
+)
 from opensandbox_server.services.k8s.workload_provider import WorkloadProvider
 from opensandbox_server.services.runtime_resolver import SecureRuntimeResolver
 
@@ -63,7 +69,7 @@ logger = logging.getLogger(__name__)
 
 class BatchSandboxProvider(WorkloadProvider):
     """Workload provider for BatchSandbox CRDs."""
-    
+
     def __init__(
         self,
         k8s_client: K8sClient,
@@ -99,6 +105,10 @@ class BatchSandboxProvider(WorkloadProvider):
 
     def supports_image_auth(self) -> bool:
         """BatchSandbox supports per-request image pull auth."""
+        return True
+
+    def supports_ensure_sub_path_directory(self) -> bool:
+        """BatchSandbox template mode runs the trusted execd initializer."""
         return True
 
     def create_workload(
@@ -178,14 +188,13 @@ class BatchSandboxProvider(WorkloadProvider):
             self.execd_init_resources,
             disable_ipv6_for_egress=disable_ipv6_for_egress,
         )
-        
+
         main_env = dict(env)
         main_env["OPENSANDBOX_ID"] = sandbox_id
         if self.execd_run_as_init:
             main_env["EXECD_INIT"] = "1"
         if credential_proxy_enabled:
             main_env[OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT] = "true"
-
         main_container = _build_main_container(
             image_spec=image_spec,
             entrypoint=entrypoint,
@@ -196,7 +205,7 @@ class BatchSandboxProvider(WorkloadProvider):
             image_pull_policy=self.image_pull_policy,
             resource_requests=resource_requests or None,
         )
-        
+
         containers = [_container_to_dict(main_container)]
         pod_volumes = [
             {
@@ -291,6 +300,27 @@ class BatchSandboxProvider(WorkloadProvider):
             batchsandbox["spec"]["expireTime"] = expires_at.isoformat()
         self._merge_pod_spec_extras(batchsandbox, extra_volumes, extra_mounts)
         merged_pod_spec = batchsandbox.get("spec", {}).get("template", {}).get("spec", {})
+        if volumes and any(volume.ensure_sub_path_directory for volume in volumes):
+            self._reject_template_subpath_initializer_collision()
+            template = self.template_manager.get_base_template()
+            template_pod_spec = (
+                template.get("spec", {}).get("template", {}).get("spec", {})
+                if isinstance(template, dict)
+                else {}
+            )
+            identity = get_subpath_initializer_main_container_identity(
+                template_pod_spec
+            )
+            merge_subpath_initializer_main_container_identity(
+                merged_pod_spec,
+                identity,
+            )
+            add_subpath_initializer_to_pod_spec(
+                merged_pod_spec,
+                volumes,
+                execd_image,
+                identity["runAsGroup"],
+            )
         ensure_egress_runtime_compatible(
             network_policy,
             effective_runtime_class=merged_pod_spec.get("runtimeClassName"),
@@ -416,7 +446,7 @@ class BatchSandboxProvider(WorkloadProvider):
             plural=self.plural,
             body=runtime_manifest,
         )
-        
+
         return {
             "name": created["metadata"]["name"],
             "uid": created["metadata"]["uid"],
@@ -448,6 +478,23 @@ class BatchSandboxProvider(WorkloadProvider):
         if not isinstance(extra_mounts, list):
             extra_mounts = []
         return extra_volumes, extra_mounts
+
+    def _reject_template_subpath_initializer_collision(self) -> None:
+        """Reject templates that try to define the server-reserved initializer."""
+        template = self.template_manager.get_base_template()
+        template_spec = (
+            template.get("spec", {}).get("template", {}).get("spec", {})
+            if isinstance(template, dict)
+            else {}
+        )
+        init_containers = template_spec.get("initContainers", [])
+        if isinstance(init_containers, list) and any(
+            isinstance(container, dict) and container.get("name") == SUBPATH_INITIALIZER_NAME
+            for container in init_containers
+        ):
+            raise ValueError(
+                f"Pod template cannot define reserved init container '{SUBPATH_INITIALIZER_NAME}'."
+            )
 
     def _merge_pod_spec_extras(
         self,
@@ -530,7 +577,6 @@ class BatchSandboxProvider(WorkloadProvider):
             }
         }
 
-
     def get_workload(self, sandbox_id: str, namespace: str) -> Optional[Dict[str, Any]]:
         """Get BatchSandbox by sandbox ID."""
         workload = self.k8s_client.get_custom_object(
@@ -554,7 +600,7 @@ class BatchSandboxProvider(WorkloadProvider):
             )
 
         return None
-    
+
     def delete_workload(self, sandbox_id: str, namespace: str) -> None:
         """Delete BatchSandbox workload."""
         batchsandbox = self.get_workload(sandbox_id, namespace)
@@ -744,22 +790,20 @@ class BatchSandboxProvider(WorkloadProvider):
             raise ValueError(f"Cannot resume: sandbox is being created (phase={phase})")
         else:
             raise ValueError(f"Cannot resume sandbox in phase {phase}, expected Paused")
-
         if resume_failed:
             self._patch_pause_with_retry_bridge(sandbox_id, namespace, False)
             logger.info("Patched BatchSandbox %s retry bridge spec.pause=nil->false", sandbox_id)
         else:
             self.patch_workload(sandbox_id, namespace, {"spec": {"pause": False}})
             logger.info("Patched BatchSandbox %s spec.pause=false", sandbox_id)
-
     def get_expiration(self, workload: Dict[str, Any]) -> Optional[datetime]:
         """Parse expiration timestamp from `spec.expireTime`."""
         spec = workload.get("spec", {})
         expire_time_str = spec.get("expireTime")
-        
+
         if not expire_time_str:
             return None
-        
+
         try:
             return datetime.fromisoformat(expire_time_str.replace('Z', '+00:00'))
         except (ValueError, TypeError) as e:
@@ -800,7 +844,6 @@ class BatchSandboxProvider(WorkloadProvider):
             )
         except Exception:
             return None
-
         for pod in pods:
             message = _extract_platform_unschedulable_message_from_pod(
                 pod,
@@ -876,7 +919,7 @@ class BatchSandboxProvider(WorkloadProvider):
             "message": message,
             "last_transition_at": creation_timestamp,
         }
-    
+
     def get_internal_endpoint(
         self, workload: Dict[str, Any], port: int, sandbox_id: str
     ) -> Optional[Endpoint]:

--- a/server/opensandbox_server/services/k8s/kubernetes_service.py
+++ b/server/opensandbox_server/services/k8s/kubernetes_service.py
@@ -389,6 +389,23 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
             },
         )
 
+    def _ensure_sub_path_initializer_support(self, request: CreateSandboxRequest) -> None:
+        """Reject directory initialization unless the active provider implements it."""
+        if not any(volume.ensure_sub_path_directory for volume in request.volumes or []):
+            return
+        if self.workload_provider.supports_ensure_sub_path_directory():
+            return
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.INVALID_PARAMETER,
+                "message": (
+                    "ensureSubPathDirectory is supported only by the Kubernetes "
+                    "BatchSandbox provider in template mode."
+                ),
+            },
+        )
+
     def _ensure_secure_access_support(self, request: CreateSandboxRequest) -> None:
         """Validate that secure access can be enforced for the configured exposure mode."""
         if not request.secure_access:
@@ -832,6 +849,8 @@ class KubernetesSandboxService(K8sDiagnosticsMixin, SandboxService, ExtensionSer
                         ),
                     },
                 )
+
+            self._ensure_sub_path_initializer_support(request)
 
             if has_pool_ref and pool_ref != POOL_AUTO_ASSIGN_REF:
                 await asyncio.to_thread(self._ensure_pool_ref_exists, pool_ref)

--- a/server/opensandbox_server/services/k8s/volume_helper.py
+++ b/server/opensandbox_server/services/k8s/volume_helper.py
@@ -16,12 +16,17 @@
 Volume helper utilities for Kubernetes pod specs.
 """
 
+import json
 import logging
 from typing import Any, Dict, List
 
 from opensandbox_server.api.schema import Volume
 
 logger = logging.getLogger(__name__)
+
+SUBPATH_INITIALIZER_NAME = "volume-subpath-initializer"
+_SUBPATH_INITIALIZER_ROOT = "/opensandbox-subpath-pvcs"
+_MAX_FS_GROUP = 2_147_483_647
 
 
 def _get_pvc_source_read_only_policies(volumes: List[Volume]) -> Dict[str, bool]:
@@ -125,3 +130,154 @@ def apply_volumes_to_pod_spec(
 
     pod_spec["volumes"] = pod_volumes
     main_container["volumeMounts"] = mounts
+
+
+def add_subpath_initializer_to_pod_spec(
+    pod_spec: Dict[str, Any],
+    volumes: List[Volume],
+    initializer_image: str,
+    fs_group: int,
+) -> None:
+    """Append the fixed PVC subPath initializer when a request requires it."""
+    requested_volumes = [volume for volume in volumes if volume.ensure_sub_path_directory]
+    if not requested_volumes:
+        return
+
+    if not initializer_image or not initializer_image.strip():
+        raise ValueError(
+            "runtime.execd_image must be set when ensureSubPathDirectory=true."
+        )
+
+    init_containers = pod_spec.get("initContainers", [])
+    if not isinstance(init_containers, list):
+        raise ValueError("Pod spec initContainers must be a list.")
+    if any(
+        isinstance(container, dict) and container.get("name") == SUBPATH_INITIALIZER_NAME
+        for container in init_containers
+    ):
+        raise ValueError(
+            f"Pod template cannot define reserved init container '{SUBPATH_INITIALIZER_NAME}'."
+        )
+
+    pvc_volume_names: Dict[str, str] = {}
+    for pod_volume in pod_spec.get("volumes", []):
+        if not isinstance(pod_volume, dict):
+            continue
+        pvc = pod_volume.get("persistentVolumeClaim")
+        if isinstance(pvc, dict) and isinstance(pvc.get("claimName"), str):
+            pvc_volume_names[pvc["claimName"]] = pod_volume["name"]
+
+    plans_by_claim: Dict[str, Dict[str, Any]] = {}
+    for volume in requested_volumes:
+        # Volume schema validation guarantees pvc and sub_path are present here.
+        assert volume.pvc is not None
+        assert volume.sub_path is not None
+        claim_name = volume.pvc.claim_name
+        if claim_name not in pvc_volume_names:
+            raise ValueError(f"PVC '{claim_name}' is missing from the generated pod volumes.")
+        plan = plans_by_claim.setdefault(claim_name, {"subPaths": []})
+        if volume.sub_path not in plan["subPaths"]:
+            plan["subPaths"].append(volume.sub_path)
+
+    plan_entries = []
+    root_mounts = []
+    for index, (claim_name, plan) in enumerate(plans_by_claim.items()):
+        root_mount_path = f"{_SUBPATH_INITIALIZER_ROOT}/{index}"
+        plan_entries.append({"mountPath": root_mount_path, "subPaths": plan["subPaths"]})
+        root_mounts.append(
+            {
+                "name": pvc_volume_names[claim_name],
+                "mountPath": root_mount_path,
+            }
+        )
+
+    init_containers.append(
+        {
+            "name": SUBPATH_INITIALIZER_NAME,
+            "image": initializer_image.strip(),
+            "command": ["/opensandbox-subpath-initializer"],
+            "args": [
+                "--plan-json",
+                json.dumps(plan_entries, separators=(",", ":")),
+                "--fs-group",
+                str(fs_group),
+            ],
+            "volumeMounts": root_mounts,
+            "securityContext": {
+                "runAsUser": 0,
+                "runAsGroup": 0,
+                "runAsNonRoot": False,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {
+                    "drop": ["ALL"],
+                    "add": ["CHOWN", "DAC_OVERRIDE"],
+                },
+            },
+        }
+    )
+    pod_spec["initContainers"] = init_containers
+
+
+def get_subpath_initializer_main_container_identity(
+    template_pod_spec: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return selected, validated identity fields from the template sandbox."""
+    containers = template_pod_spec.get("containers")
+    main_container = next(
+        (
+            container
+            for container in containers
+            if isinstance(container, dict) and container.get("name") == "sandbox"
+        ),
+        None,
+    ) if isinstance(containers, list) else None
+    security_context = (
+        main_container.get("securityContext")
+        if isinstance(main_container, dict)
+        else None
+    )
+    if not isinstance(security_context, dict):
+        raise ValueError(
+            "BatchSandbox template spec.template.spec.containers[name=sandbox]"
+            ".securityContext.runAsGroup must be an integer from 1 to 2147483647 "
+            "when ensureSubPathDirectory=true."
+        )
+
+    run_as_group = security_context.get("runAsGroup")
+    if type(run_as_group) is not int or not 1 <= run_as_group <= _MAX_FS_GROUP:
+        raise ValueError(
+            "BatchSandbox template spec.template.spec.containers[name=sandbox]"
+            ".securityContext.runAsGroup must be an integer from 1 to 2147483647 "
+            "when ensureSubPathDirectory=true."
+        )
+    return {
+        field: security_context[field]
+        for field in ("runAsUser", "runAsGroup", "runAsNonRoot")
+        if field in security_context
+    }
+
+
+def merge_subpath_initializer_main_container_identity(
+    pod_spec: Dict[str, Any],
+    identity: Dict[str, Any],
+) -> None:
+    """Merge selected template identity fields into the generated sandbox."""
+    containers = pod_spec.get("containers")
+    main_container = next(
+        (
+            container
+            for container in containers
+            if isinstance(container, dict) and container.get("name") == "sandbox"
+        ),
+        None,
+    ) if isinstance(containers, list) else None
+    if main_container is None:
+        raise ValueError("Generated pod spec is missing the sandbox container.")
+
+    security_context = main_container.get("securityContext")
+    if security_context is None:
+        security_context = {}
+        main_container["securityContext"] = security_context
+    if not isinstance(security_context, dict):
+        raise ValueError("Generated sandbox securityContext must be an object.")
+    security_context.update(identity)

--- a/server/opensandbox_server/services/k8s/workload_provider.py
+++ b/server/opensandbox_server/services/k8s/workload_provider.py
@@ -243,6 +243,10 @@ class WorkloadProvider(ABC):
         """
         return False
 
+    def supports_ensure_sub_path_directory(self) -> bool:
+        """Whether the provider safely initializes requested PVC subpaths."""
+        return False
+
     def legacy_resource_name(self, sandbox_id: str) -> str:
         """
         Convert a sandbox_id to the legacy resource name with prefix.

--- a/server/tests/k8s/test_batchsandbox_provider.py
+++ b/server/tests/k8s/test_batchsandbox_provider.py
@@ -140,9 +140,9 @@ class TestBatchSandboxProvider:
             expires_at=expires_at,
             execd_image="execd:latest",
         )
-        
+
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify API call
         call_args = mock_k8s_client.create_custom_object.call_args
         body = call_args.kwargs["body"]
@@ -880,7 +880,7 @@ spec:
         )
 
         assert result == {"name": "test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-    
+
     # ===== Workload List Tests =====
 
     def test_list_workloads_returns_items(self, mock_k8s_client, mock_batchsandbox_list_response):
@@ -1335,7 +1335,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1367,7 +1367,7 @@ spec:
 
         # Should succeed and return workload info
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify poolRef is used
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -1435,9 +1435,9 @@ spec:
             execd_image="execd:latest",
             extensions={"poolRef": "my-pool"},
         )
-        
+
         assert result == {"name": "sandbox-test-id", "uid": "test-uid", "apiVersion": "sandbox.opensandbox.io/v1alpha1", "kind": "BatchSandbox"}
-        
+
         # Verify the call
         body = mock_k8s_client.create_custom_object.call_args.kwargs["body"]
         assert body["spec"]["poolRef"] == "my-pool"
@@ -2866,6 +2866,325 @@ spec:
         data_mount = next((m for m in mounts if m["name"] == "data-volume"), None)
         assert data_mount is not None
         assert data_mount.get("subPath") == "task-001"
+        assert [container["name"] for container in pod_spec["initContainers"]] == [
+            "execd-installer"
+        ]
+
+    def test_create_workload_initializes_multiple_subpaths_for_one_pvc(
+        self, mock_k8s_client, tmp_path
+    ):
+        """The initializer receives one root PVC mount and a safe JSON plan."""
+        from opensandbox_server.api.schema import PVC, Volume
+        import json
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            "spec:\n  template:\n    spec:\n      containers:\n        - name: sandbox\n"
+            "          securityContext:\n            runAsUser: 1233\n"
+            "            runAsGroup: 1234\n            runAsNonRoot: true\n"
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+        volumes = [
+            Volume(
+                name="workspace-a",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace/a",
+                sub_path="jobs/a",
+                ensure_sub_path_directory=True,
+            ),
+            Volume(
+                name="workspace-b",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace/b",
+                sub_path="jobs/b",
+                ensure_sub_path_directory=True,
+            ),
+        ]
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            volumes=volumes,
+        )
+
+        pod_spec = mock_k8s_client.create_custom_object.call_args.kwargs["body"]["spec"][
+            "template"
+        ]["spec"]
+        assert [container["name"] for container in pod_spec["initContainers"]] == [
+            "execd-installer",
+            "volume-subpath-initializer",
+        ]
+        initializer = pod_spec["initContainers"][1]
+        assert initializer["image"] == "execd:latest"
+        assert initializer["command"] == ["/opensandbox-subpath-initializer"]
+        assert initializer["args"][-2:] == ["--fs-group", "1234"]
+        # Root handles PVC ownership, but cannot escalate; only traversal and chown caps remain.
+        assert initializer["securityContext"] == {
+            "runAsUser": 0,
+            "runAsGroup": 0,
+            "runAsNonRoot": False,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {
+                "drop": ["ALL"],
+                "add": ["CHOWN", "DAC_OVERRIDE"],
+            },
+        }
+        assert initializer["volumeMounts"] == [
+            {"name": "workspace-a", "mountPath": "/opensandbox-subpath-pvcs/0"}
+        ]
+        assert json.loads(initializer["args"][1]) == [
+            {"mountPath": "/opensandbox-subpath-pvcs/0", "subPaths": ["jobs/a", "jobs/b"]}
+        ]
+        main_mounts = pod_spec["containers"][0]["volumeMounts"]
+        assert {mount["subPath"] for mount in main_mounts if mount["name"] == "workspace-a"} == {
+            "jobs/a",
+            "jobs/b",
+        }
+
+    def test_create_workload_rejects_template_initializer_name_collision(
+        self, mock_k8s_client, tmp_path
+    ):
+        from opensandbox_server.api.schema import PVC, Volume
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            "spec:\n  template:\n    spec:\n      initContainers:\n"
+            "        - name: volume-subpath-initializer\n"
+            "      containers:\n        - name: sandbox\n"
+            "          securityContext:\n            runAsGroup: 1000\n"
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+
+        with pytest.raises(ValueError, match="reserved init container"):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={},
+                labels={},
+                expires_at=None,
+                execd_image="execd:latest",
+                volumes=[
+                    Volume(
+                        name="workspace",
+                        pvc=PVC(claim_name="workspace-pvc"),
+                        mount_path="/workspace",
+                        sub_path="jobs/123",
+                        ensure_sub_path_directory=True,
+                    )
+                ],
+            )
+
+        mock_k8s_client.create_custom_object.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "main_container_security_context_yaml",
+        [
+            "      restartPolicy: Never\n",
+            "      securityContext: {}\n",
+            "      securityContext:\n        runAsGroup: 0\n",
+            "      securityContext:\n        runAsGroup: -1\n",
+            "      securityContext:\n        runAsGroup: 2147483648\n",
+            "      securityContext:\n        runAsGroup: true\n",
+            "      securityContext:\n        runAsGroup: \"1234\"\n",
+        ],
+        ids=[
+            "missing-sandbox-container",
+            "missing-run-as-group",
+            "zero",
+            "negative",
+            "too-large",
+            "bool",
+            "string",
+        ],
+    )
+    def test_create_workload_rejects_invalid_template_main_container_run_as_group(
+        self, mock_k8s_client, tmp_path, main_container_security_context_yaml
+    ):
+        """Directory initialization requires a valid main container runAsGroup."""
+        from opensandbox_server.api.schema import PVC, Volume
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "        - name: sandbox\n"
+            f"{main_container_security_context_yaml}"
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+
+        with pytest.raises(ValueError, match="securityContext.runAsGroup must be an integer"):
+            provider.create_workload(
+                sandbox_id="test-id",
+                namespace="test-ns",
+                image_spec=ImageSpec(uri="python:3.11"),
+                entrypoint=["/bin/bash"],
+                env={},
+                resource_limits={},
+                labels={},
+                expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                execd_image="execd:latest",
+                volumes=volumes,
+            )
+
+        mock_k8s_client.create_custom_object.assert_not_called()
+
+    def test_create_workload_merges_selected_template_identity_for_subpath_initializer(
+        self, mock_k8s_client, tmp_path
+    ):
+        """Only selected template identity fields are merged into the sandbox."""
+        from opensandbox_server.api.schema import PVC, Volume
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            """
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 2000
+      containers:
+        - name: sandbox
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+"""
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            execd_image="execd:latest",
+            volumes=[
+                Volume(
+                    name="workspace",
+                    pvc=PVC(claim_name="workspace-pvc"),
+                    mount_path="/workspace",
+                    sub_path="jobs/123",
+                    ensure_sub_path_directory=True,
+                )
+            ],
+        )
+
+        pod_spec = mock_k8s_client.create_custom_object.call_args.kwargs["body"]["spec"][
+            "template"
+        ]["spec"]
+        assert pod_spec["securityContext"] == {
+            "runAsUser": 2000,
+        }
+        assert pod_spec["containers"][0]["securityContext"] == {
+            "runAsUser": 1000,
+            "runAsGroup": 1000,
+            "runAsNonRoot": True,
+        }
+        initializer = pod_spec["initContainers"][-1]
+        assert initializer["args"][-2:] == ["--fs-group", "1000"]
+
+    def test_create_workload_preserves_generated_network_and_isolation_security_context(
+        self, mock_k8s_client, tmp_path
+    ):
+        """Identity merging preserves generated network and isolation fields."""
+        from opensandbox_server.api.schema import PVC, Volume
+
+        template_file = tmp_path / "template.yaml"
+        template_file.write_text(
+            "spec:\n  template:\n    spec:\n      containers:\n        - name: sandbox\n"
+            "          securityContext:\n            runAsUser: 1001\n"
+            "            runAsGroup: 1000\n            runAsNonRoot: true\n"
+            "            seccompProfile:\n              type: RuntimeDefault\n"
+        )
+        provider = BatchSandboxProvider(
+            mock_k8s_client, _app_config_with_template(str(template_file))
+        )
+        mock_k8s_client.create_custom_object.return_value = {
+            "metadata": {"name": "test-id", "uid": "test-uid"}
+        }
+
+        provider.create_workload(
+            sandbox_id="test-id",
+            namespace="test-ns",
+            image_spec=ImageSpec(uri="python:3.11"),
+            entrypoint=["/bin/bash"],
+            env={},
+            resource_limits={},
+            labels={},
+            expires_at=None,
+            execd_image="execd:latest",
+            network_policy=NetworkPolicy(default_action="deny", egress=[]),
+            egress_image="opensandbox/egress:v1.1.5",
+            extensions={"bootstrap.execd.isolation": "enable"},
+            volumes=[
+                Volume(
+                    name="workspace",
+                    pvc=PVC(claim_name="workspace-pvc"),
+                    mount_path="/workspace",
+                    sub_path="jobs/123",
+                    ensure_sub_path_directory=True,
+                )
+            ],
+        )
+
+        pod_spec = mock_k8s_client.create_custom_object.call_args.kwargs["body"]["spec"][
+            "template"
+        ]["spec"]
+        main_container = next(
+            container
+            for container in pod_spec["containers"]
+            if container["name"] == "sandbox"
+        )
+        assert main_container["securityContext"] == {
+            "capabilities": {"add": ["SYS_ADMIN"], "drop": ["NET_ADMIN"]},
+            "seccompProfile": {"type": "Unconfined"},
+            "appArmorProfile": {"type": "Unconfined"},
+            "runAsUser": 1001,
+            "runAsGroup": 1000,
+            "runAsNonRoot": True,
+        }
+        assert pod_spec["initContainers"][-1]["args"][-2:] == ["--fs-group", "1000"]
 
     def test_create_workload_with_host_volume(self, mock_k8s_client):
         """

--- a/server/tests/k8s/test_kubernetes_service.py
+++ b/server/tests/k8s/test_kubernetes_service.py
@@ -35,6 +35,8 @@ from opensandbox_server.api.schema import (
     ListSandboxesRequest,
     NetworkPolicy,
     PlatformSpec,
+    PVC,
+    Volume,
 )
 from opensandbox_server.config import (
     EGRESS_MODE_DNS,
@@ -89,6 +91,41 @@ class TestKubernetesSandboxServiceInit:
             assert exc_info.value.detail["code"] == SandboxErrorCodes.K8S_INITIALIZATION_ERROR
 
 class TestKubernetesSandboxServiceCreate:
+
+    def test_ensure_subpath_directory_rejects_non_batchsandbox_provider(
+        self, k8s_service, create_sandbox_request
+    ):
+        create_sandbox_request.volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+        k8s_service.workload_provider.supports_ensure_sub_path_directory.return_value = False
+
+        with pytest.raises(HTTPException, match="BatchSandbox provider") as exc_info:
+            k8s_service._ensure_sub_path_initializer_support(create_sandbox_request)
+
+        assert exc_info.value.status_code == 400
+
+    def test_ensure_subpath_directory_allows_batchsandbox_provider(
+        self, k8s_service, create_sandbox_request
+    ):
+        create_sandbox_request.volumes = [
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+        ]
+        k8s_service.workload_provider.supports_ensure_sub_path_directory.return_value = True
+
+        k8s_service._ensure_sub_path_initializer_support(create_sandbox_request)
 
     def test_credential_proxy_requires_dns_nft_mode(
         self, k8s_service, create_sandbox_request

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -3531,6 +3531,33 @@ class TestDockerVolumeValidation:
         assert response.status.state == "Running"
 
     @pytest.mark.asyncio
+    async def test_ensure_subpath_directory_is_rejected_before_docker_side_effects(self, mock_docker):
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        service = DockerSandboxService(config=_app_config())
+        request = CreateSandboxRequest(
+            image=ImageSpec(uri="python:3.11"),
+            timeout=120,
+            resourceLimits=ResourceLimits(root={}),
+            entrypoint=["python"],
+            volumes=[
+                Volume(
+                    name="workspace",
+                    pvc=PVC(claim_name="workspace-pvc"),
+                    mount_path="/workspace",
+                    sub_path="jobs/123",
+                    ensure_sub_path_directory=True,
+                )
+            ],
+        )
+
+        with pytest.raises(HTTPException, match="BatchSandbox provider") as exc_info:
+            await service.create_sandbox(request)
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        mock_client.api.inspect_volume.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_host_volume_binds_passed_to_docker(self, mock_docker):
         """Host volume binds should be passed to Docker host config."""
         mock_client = MagicMock()

--- a/server/tests/test_schema.py
+++ b/server/tests/test_schema.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from opensandbox_server.api.schema import (
@@ -37,7 +38,6 @@ from opensandbox_server.api.schema import (
 
 
 class TestHost:
-
     def test_valid_path(self):
         backend = Host(path="/data/opensandbox")
         assert backend.path == "/data/opensandbox"
@@ -171,6 +171,67 @@ class TestVolume:
         assert volume.read_only is True
         assert volume.host is None
 
+    def test_ensure_subpath_directory_defaults_to_false_and_serializes(self):
+        volume = Volume(
+            name="workspace",
+            pvc=PVC(claim_name="workspace-pvc"),
+            mount_path="/workspace",
+            sub_path="jobs/123",
+        )
+
+        assert volume.ensure_sub_path_directory is False
+        assert volume.model_dump(by_alias=True)["ensureSubPathDirectory"] is False
+        assert (
+            Volume.model_json_schema(by_alias=True)["properties"]["ensureSubPathDirectory"][
+                "default"
+            ]
+            is False
+        )
+
+    def test_ensure_subpath_directory_rejects_unsupported_combinations(self):
+        with pytest.raises(ValidationError, match="readOnly=true"):
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                read_only=True,
+                ensure_sub_path_directory=True,
+            )
+
+        with pytest.raises(ValidationError, match="only for PVC"):
+            Volume(
+                name="workspace",
+                host=Host(path="/data/workspace"),
+                mount_path="/workspace",
+                sub_path="jobs/123",
+                ensure_sub_path_directory=True,
+            )
+
+    @pytest.mark.parametrize(
+        "sub_path",
+        ["", "   ", "/absolute", ".", "..", "a//b", "a/./b", "a/../b", "a\x00b"],
+    )
+    def test_ensure_subpath_directory_rejects_invalid_subpaths(self, sub_path):
+        with pytest.raises(ValidationError, match="non-empty subPath|normalized relative subPath"):
+            Volume(
+                name="workspace",
+                pvc=PVC(claim_name="workspace-pvc"),
+                mount_path="/workspace",
+                sub_path=sub_path,
+                ensure_sub_path_directory=True,
+            )
+
+    def test_lifecycle_spec_exposes_ensure_subpath_directory(self):
+        from pathlib import Path
+
+        spec_path = Path(__file__).resolve().parents[2] / "specs" / "sandbox-lifecycle.yml"
+        spec = yaml.safe_load(spec_path.read_text())
+        field = spec["components"]["schemas"]["Volume"]["properties"]["ensureSubPathDirectory"]
+
+        assert field["type"] == "boolean"
+        assert field["default"] is False
+
     def test_valid_volume_with_subpath(self):
         volume = Volume(
             name="workdir",
@@ -234,6 +295,7 @@ class TestVolume:
             "mountPath": "/mnt/work",
             "readOnly": False,
             "subPath": "task-001",
+            "ensureSubPathDirectory": False,
         }
 
     def test_serialization_pvc_volume(self):
@@ -253,6 +315,7 @@ class TestVolume:
             },
             "mountPath": "/mnt/models",
             "readOnly": True,
+            "ensureSubPathDirectory": False,
         }
 
     def test_deserialization_host_volume(self):

--- a/specs/sandbox-lifecycle.yml
+++ b/specs/sandbox-lifecycle.yml
@@ -1551,7 +1551,7 @@ components:
         Storage mount definition for a sandbox. Each volume entry contains:
         - A unique name identifier
         - Exactly one backend struct (host, pvc, ossfs, etc.) with backend-specific fields
-        - Common mount settings (mountPath, readOnly, subPath)
+        - Common mount settings (mountPath, readOnly, subPath, ensureSubPathDirectory)
       required: [name, mountPath]
       properties:
         name:
@@ -1584,6 +1584,28 @@ components:
             Optional subdirectory under the backend path to mount.
             For `ossfs` backend, this field is used as the bucket prefix.
             Must be a relative path without '..' components.
+        ensureSubPathDirectory:
+          type: boolean
+          default: false
+          description: |
+            When true, Kubernetes BatchSandbox template-mode creation ensures that
+            `subPath` exists before the main container starts using the fixed trusted
+            initializer bundled with a compatible published execd image that contains
+            `/opensandbox-subpath-initializer`. It supports only writable PVC mounts
+            with a non-empty normalized relative `subPath`. The existing BatchSandbox
+            template main `sandbox` container must explicitly set
+            `securityContext.runAsGroup` to an integer from `1` through `2147483647`.
+            No Pod `fsGroup` is set or required. The initializer assigns that GID and
+            mode `02770` only to newly created segments; it does not alter existing
+            directories. When enabled, the server applies/merges the template
+            `sandbox` container's selected identity fields (`runAsUser`, `runAsGroup`,
+            and `runAsNonRoot`) into the generated sandbox so its effective group
+            matches the initializer-created directory. It preserves runtime-required
+            capabilities, seccomp, and AppArmor settings and does not otherwise
+            replace the security context. Storage and mount behavior remains
+            Kubernetes/CSI dependent; the initializer does not recursively alter
+            existing paths. It is not supported for host or ossfs backends, read-only
+            mounts, Docker, other Kubernetes providers, or pool mode.
       additionalProperties: false
 
     Host:

--- a/tests/python/tests/test_sandbox_e2e_sync.py
+++ b/tests/python/tests/test_sandbox_e2e_sync.py
@@ -20,7 +20,9 @@ This mirrors `test_sandbox_e2e.py` but uses the synchronous SDK.
 """
 
 import logging
+import os
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from io import BytesIO
@@ -68,6 +70,17 @@ from tests.base_e2e_test import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_NONROOT_SUBPATH_TEMPLATE_FILE = "/etc/opensandbox/e2e-subpath-nonroot.batchsandbox-template.yaml"
+
+
+def _uses_nonroot_subpath_template() -> bool:
+    return (
+        is_kubernetes_runtime()
+        and os.environ.get("E2E_BATCHSANDBOX_TEMPLATE_FILE")
+        == _NONROOT_SUBPATH_TEMPLATE_FILE
+    )
 
 
 def _now_ms() -> int:
@@ -778,6 +791,82 @@ class TestSandboxE2ESync:
                 pass
 
         logger.info("TEST 1f PASSED: PVC subPath named volume mount test completed successfully")
+
+    @pytest.mark.timeout(120)
+    @pytest.mark.order(1)
+    def test_01g_pvc_unseeded_subpath_initializer_nonroot(self) -> None:
+        """Create and use a non-root, runAsGroup-owned PVC subPath through the lifecycle API."""
+        if not _uses_nonroot_subpath_template():
+            pytest.skip(
+                "requires E2E_BATCHSANDBOX_TEMPLATE_FILE="
+                f"{_NONROOT_SUBPATH_TEMPLATE_FILE} in the Kubernetes E2E runner"
+            )
+
+        logger.info("=" * 80)
+        logger.info("TEST 1g: Creating a non-root sandbox with an unseeded PVC subPath initializer")
+        logger.info("=" * 80)
+
+        pvc_volume_name = get_test_pvc_name()
+        container_mount_path = "/mnt/ensure-subpath"
+        unseeded_sub_path = f"ensure-subpath-initializer-{uuid.uuid4().hex}"
+        cfg = create_connection_config_sync()
+        sandbox = SandboxSync.create(
+            image=SandboxImageSpec(get_sandbox_image()),
+            resource=get_e2e_sandbox_resource(),
+            connection_config=cfg,
+            timeout=timedelta(minutes=5),
+            ready_timeout=timedelta(seconds=30),
+            volumes=[
+                Volume(
+                    name="test-pvc-unseeded-subpath",
+                    pvc=PVC(claimName=pvc_volume_name),
+                    mountPath=container_mount_path,
+                    readOnly=False,
+                    subPath=unseeded_sub_path,
+                    ensureSubPathDirectory=True,
+                ),
+            ],
+        )
+        try:
+            info = sandbox.get_info()
+            assert info.status.state == "Running"
+
+            result = sandbox.commands.run(
+                f"test -d {container_mount_path} && "
+                f"test ! -e {container_mount_path}/marker.txt && "
+                f"test ! -e {container_mount_path}/datasets && "
+                "test \"$(id -u)\" = 1000 && "
+                "test \"$(id -g)\" = 2000 && "
+                f"test \"$(stat -c '%g' {container_mount_path})\" = 2000 && "
+                f"mode=$(stat -c '%a' {container_mount_path}) && "
+                "test $(((mode / 10) % 10)) -ge 2 && "
+                "test $((mode % 10)) -lt 2"
+            )
+            assert result.error is None, (
+                "business container does not have the expected runAs uid/gid and a group-writable, "
+                "non-world-writable initialized subPath"
+            )
+
+            result = sandbox.commands.run(
+                f"printf '%s\\n' 'ensure-subpath-write-test' > "
+                f"{container_mount_path}/output.txt && "
+                f"cat {container_mount_path}/output.txt"
+            )
+            assert result.error is None, f"Failed to write initialized subPath: {result.error}"
+            assert len(result.logs.stdout) == 1
+            assert result.logs.stdout[0].text == "ensure-subpath-write-test"
+        finally:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass
+            sandbox.close()
+            try:
+                cfg.transport.close()
+            except Exception:
+                pass
+
+        logger.info("TEST 1g PASSED: Non-root PVC subPath initializer test completed successfully")
 
     @pytest.mark.timeout(120)
     @pytest.mark.order(2)


### PR DESCRIPTION
# Summary

This PR adds opt-in initialization of missing Kubernetes PVC `subPath` directories before a sandbox workload starts. Kubernetes requires the directory to exist before mounting a `subPath`; previously, requests targeting a new directory could fail before the sandbox container started.

The implementation adds a trusted execd binary that creates requested directories safely, then reuses the existing `execd-installer` init container to run it. It does not add a second init container or a second image pull.

## What changed

- Add optional `ensureSubPathDirectory` to the lifecycle volume model and public lifecycle schema.
- Add `/opensandbox-subpath-initializer` to the execd image, with Linux secure-tree creation and unsupported-platform handling.
- Reuse `execd-installer` to mount each referenced PVC root and execute the initializer after staging execd/bootstrap assets.
- Validate and merge the template sandbox container identity (`runAsUser`, `runAsGroup`, `runAsNonRoot`) so newly created directories are usable by non-root workloads.
- Add default-off `[kubernetes].enable_sub_path_initializer`; a request is rejected with HTTP 400 before PVC or workload creation until an administrator both deploys an initializer-capable `runtime.execd_image` and explicitly enables the gate.
- Reject the option for unsupported providers, including AgentSandbox, Docker, and pool mode.
- Update the schema, Go/Python/JavaScript/Kotlin/C# SDKs, configuration/docs/examples, and unit/E2E coverage.

## Compatibility and deployment

- This is additive and disabled by default. Existing volume requests, templates, and deployments keep their current behavior.
- The stock Helm configuration continues to use its current execd image and leaves the gate disabled. It therefore fails closed instead of producing a Pod with an executable-not-found init container.
- After an initializer-capable execd image is formally released, administrators can upgrade `runtime.execd_image` and set `enable_sub_path_initializer = true`; a later Helm release can make that compatible pair the default.
- The feature is limited to Kubernetes `BatchSandbox` template mode. It does not provision PVCs or change existing PVC lifecycle management.

## Security and performance

- The initializer rejects unsafe path components and does not follow symlinks while descending from the mounted PVC root.
- Newly created path segments use the validated sandbox `runAsGroup`; existing directories are not recursively altered.
- The normal initialization path uses a capability-only installer context (`CHOWN`, `DAC_OVERRIDE`, no privilege escalation). The existing IPv6-disable egress path retains its established privileged installer contract.
- Reusing `execd-installer` avoids a second init-container lifecycle, a second image reference, and an additional registry pull on the sandbox startup path.

# Testing

## Verification completed

- Rebased onto upstream `main` at `7b584d0d95e6f71a68721def6e18a70e5f8bb130`.
- `uv run pytest tests/k8s/test_batchsandbox_provider.py tests/k8s/test_kubernetes_service.py tests/test_config.py` — **331 passed**.
- `uv run ruff check` for the touched Kubernetes/config modules — passed.
- `pnpm docs:build` — passed.
- `bash -n scripts/common/kubernetes-e2e.sh` and `git diff --check` — passed.
- Coverage includes secure tree creation, provider/config fail-closed behavior before PVC/workload side effects, single-installer manifest construction, non-root identity propagation, egress security-context composition, SDK mapping, and the non-root Kubernetes E2E matrix.

## Not fully verified

- Local C# validation remains blocked because this environment provides .NET 8 while the relevant SDK target is `net10.0`.
- Local Kind-based Kubernetes E2E remains blocked because dependency access through `proxy.golang.org` prevented the required Go dependency setup.

# Breaking Changes

- [x] None

`ensureSubPathDirectory` is an additive opt-in API. Requests using it on an unsupported provider, or before the administrator enables the compatible-image gate, receive a stable validation error.

# Checklist

- [x] Motivation and scope documented.
- [x] Documentation and examples updated.
- [x] Unit, provider, schema, SDK, and E2E coverage added or updated.
- [x] Security, startup performance, and backward compatibility considered.
- [ ] Linked issue — no issue number was available.