### PR TITLE
feat(server): implement stable diagnostics API

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -266,18 +266,19 @@ Use the stable diagnostics commands for API-backed log and event descriptors.
 osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
-osb diagnostics logs <sandbox-id> --scope lifecycle -o json
+osb diagnostics logs <sandbox-id> --scope all -o json
 osb diagnostics events <sandbox-id> --scope runtime -o json
 osb diagnostics logs <sandbox-id> --scope container -o yaml
 ```
 
-`--scope` is required for stable diagnostics. Common scopes are `lifecycle` and
-`container` for logs, and `lifecycle` and `runtime` for events. Raw output
-prints inline diagnostic text, or the content URL when diagnostics are
-delivered as a temporary URL. Structured CLI output follows the SDK/Python field
-style, for example `content_url`, `content_length`, and `expires_at`.
-Some server builds may return `DIAGNOSTICS_NOT_IMPLEMENTED` for scoped
-diagnostics until the stable backend implementation is enabled.
+`--scope` is required for stable diagnostics. The built-in server supports
+`container` and `all` for logs, and `runtime`, `lifecycle`, and `all` for events.
+Best-effort scopes may include a `warnings` field when the backend can only
+provide a subset or maps the request to runtime events. Raw output prints inline
+diagnostic text, or the content URL when diagnostics are delivered as a
+temporary URL. Structured CLI output follows the SDK/Python field style, for
+example `content_url`, `content_length`, and `expires_at`. Older server builds
+may still return `DIAGNOSTICS_NOT_IMPLEMENTED` for scoped diagnostics.
 
 Legacy DevOps diagnostics remain experimental. Prefer `osb diagnostics logs/events`
 for stable API-backed log and event collection.

--- a/cli/README.md
+++ b/cli/README.md
@@ -263,8 +263,8 @@ credential values as command-line flags; keep them in the payload stream or file
 Use the stable diagnostics commands for API-backed log and event descriptors.
 
 ```bash
-osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
+osb diagnostics events <sandbox-id> --scope all -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
 osb diagnostics logs <sandbox-id> --scope all -o json
 osb diagnostics events <sandbox-id> --scope runtime -o json
@@ -272,9 +272,10 @@ osb diagnostics logs <sandbox-id> --scope container -o yaml
 ```
 
 `--scope` is required for stable diagnostics. The built-in server supports
-`container` and `all` for logs, and `runtime`, `lifecycle`, and `all` for events.
+`container` and `all` for logs, and `runtime` and `all` for events. It returns
+`DIAGNOSTICS_SCOPE_UNSUPPORTED` for unavailable scopes, including lifecycle events.
 Best-effort scopes may include a `warnings` field when the backend can only
-provide a subset or maps the request to runtime events. Raw output prints inline
+provide a subset. Raw output prints inline
 diagnostic text, or the content URL when diagnostics are delivered as a
 temporary URL. Structured CLI output follows the SDK/Python field style, for
 example `content_url`, `content_length`, and `expires_at`. Older server builds

--- a/cli/src/opensandbox_cli/commands/diagnostics.py
+++ b/cli/src/opensandbox_cli/commands/diagnostics.py
@@ -110,8 +110,8 @@ def diagnostics_logs(
     "-s",
     required=True,
     help=(
-        "Diagnostic event scope. Common scopes: lifecycle for audit events, "
-        "runtime for scheduler/container events; other scopes are server-defined."
+        "Diagnostic event scope. Built-in server scopes: runtime and all; "
+        "other scopes are server-defined."
     ),
 )
 @output_option(

--- a/cli/src/opensandbox_cli/commands/diagnostics.py
+++ b/cli/src/opensandbox_cli/commands/diagnostics.py
@@ -78,8 +78,8 @@ def diagnostics_group(ctx: click.Context) -> None:
     "-s",
     required=True,
     help=(
-        "Diagnostic log scope. Common scopes: lifecycle for manager logs, "
-        "container for sandbox stdout; other scopes are server-defined."
+        "Diagnostic log scope. Built-in server scopes: container and all; "
+        "other scopes are server-defined."
     ),
 )
 @output_option(

--- a/cli/src/opensandbox_cli/commands/diagnostics.py
+++ b/cli/src/opensandbox_cli/commands/diagnostics.py
@@ -46,13 +46,19 @@ def render_diagnostic_content(
     )
 
     if output.fmt == "raw":
+        if content.truncated:
+            click.echo("Warning: diagnostic content was truncated.", err=True)
+        for warning in content.warnings or []:
+            click.echo(f"Warning: {warning}", err=True)
         if content.delivery == "inline":
             click.echo(content.content or "")
             return
         if content.content_url:
             click.echo(content.content_url)
             return
-        raise click.ClickException("Diagnostic response did not include inline content or a content URL.")
+        raise click.ClickException(
+            "Diagnostic response did not include inline content or a content URL."
+        )
 
     output.print_dict(_diagnostic_to_dict(content), title=title)
 

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
@@ -75,7 +75,6 @@ osb diagnostics logs <sandbox-id> --scope container -o raw
 Then drill down only where the stable diagnostics point:
 
 ```bash
-osb diagnostics logs <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope all -o raw
 osb diagnostics logs <sandbox-id> --scope all -o raw
 ```

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
@@ -86,9 +86,9 @@ Important properties of the diagnostics commands:
 
 - `diagnostics events` and `diagnostics logs` are stable API-backed commands
 - `--scope` is required for stable diagnostics; requests without scope use deprecated plain-text DevOps behavior
-- if the server returns `DIAGNOSTICS_NOT_IMPLEMENTED`, state that stable diagnostics are unavailable on this server and stop diagnostics collection
-- use known supported scopes first: `events:lifecycle`, `events:runtime`, `logs:lifecycle`, and `logs:container`
-- `--scope all` is useful when the server supports aggregate diagnostics; if it is empty, retry concrete supported scopes
+- older server builds may return `DIAGNOSTICS_NOT_IMPLEMENTED`; state that stable diagnostics are unavailable on that server and stop diagnostics collection
+- use built-in server scopes first: `events:lifecycle`, `events:runtime`, `events:all`, `logs:container`, and `logs:all`
+- best-effort scopes may include `warnings` when the backend contributes only a subset or maps the request to runtime events; preserve those warnings in the evidence
 - other scopes such as `network` or `process` are server-defined and may be empty on some deployments
 - `-o raw` prints inline diagnostic text directly, or a content URL when the server returns URL delivery
 - `-o json` / `-o yaml` prints the CLI descriptor including `delivery`, `content_url`, `expires_at`, `truncated`, and `warnings`
@@ -98,8 +98,8 @@ Use:
 
 - `osb diagnostics events <sandbox-id> --scope lifecycle -o raw` for sandbox actions such as `CREATE`, `RENEW`, `DELETE`, `PAUSE`, `RESUME`, and `FORK`
 - `osb diagnostics events <sandbox-id> --scope runtime -o raw` for scheduler and container events such as `Scheduled`, `Pulling`, `Pulled`, `Created`, `Started`, and `ContainerDied`
-- `osb diagnostics logs <sandbox-id> --scope lifecycle -o raw` for manager server logs related to create, renew, delete, callbacks, request IDs, and server-side failures
 - `osb diagnostics logs <sandbox-id> --scope container -o raw` for sandbox main-process stdout, including application errors, missing binaries, bad entrypoints, startup hangs, and health-check failures
+- `osb diagnostics logs <sandbox-id> --scope all -o raw` for the best-effort aggregate available from the server; check `warnings` before treating it as complete
 
 ## Evidence Semantics
 

--- a/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
+++ b/cli/src/opensandbox_cli/skills/opensandbox-sandbox-troubleshooting.md
@@ -67,7 +67,6 @@ Use this order by default:
 ```bash
 osb sandbox get <sandbox-id> -o json
 osb sandbox health <sandbox-id> -o json
-osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
 ```
@@ -86,8 +85,8 @@ Important properties of the diagnostics commands:
 - `diagnostics events` and `diagnostics logs` are stable API-backed commands
 - `--scope` is required for stable diagnostics; requests without scope use deprecated plain-text DevOps behavior
 - older server builds may return `DIAGNOSTICS_NOT_IMPLEMENTED`; state that stable diagnostics are unavailable on that server and stop diagnostics collection
-- use built-in server scopes first: `events:lifecycle`, `events:runtime`, `events:all`, `logs:container`, and `logs:all`
-- best-effort scopes may include `warnings` when the backend contributes only a subset or maps the request to runtime events; preserve those warnings in the evidence
+- use built-in server scopes first: `events:runtime`, `events:all`, `logs:container`, and `logs:all`
+- best-effort scopes may include `warnings` when the backend contributes only a subset; preserve those warnings in the evidence
 - other scopes such as `network` or `process` are server-defined and may be empty on some deployments
 - `-o raw` prints inline diagnostic text directly, or a content URL when the server returns URL delivery
 - `-o json` / `-o yaml` prints the CLI descriptor including `delivery`, `content_url`, `expires_at`, `truncated`, and `warnings`
@@ -95,8 +94,8 @@ Important properties of the diagnostics commands:
 
 Use:
 
-- `osb diagnostics events <sandbox-id> --scope lifecycle -o raw` for sandbox actions such as `CREATE`, `RENEW`, `DELETE`, `PAUSE`, `RESUME`, and `FORK`
 - `osb diagnostics events <sandbox-id> --scope runtime -o raw` for scheduler and container events such as `Scheduled`, `Pulling`, `Pulled`, `Created`, `Started`, and `ContainerDied`
+- `osb diagnostics events <sandbox-id> --scope all -o raw` for the best-effort event aggregate available from the server; check `warnings` before treating it as complete
 - `osb diagnostics logs <sandbox-id> --scope container -o raw` for sandbox main-process stdout, including application errors, missing binaries, bad entrypoints, startup hangs, and health-check failures
 - `osb diagnostics logs <sandbox-id> --scope all -o raw` for the best-effort aggregate available from the server; check `warnings` before treating it as complete
 
@@ -104,7 +103,7 @@ Use:
 
 - `sandbox get` shows control-plane state; it does not prove the workload is healthy
 - `sandbox health` shows readiness or endpoint health; it can fail even when the sandbox is running
-- lifecycle diagnostics explain OpenSandbox manager behavior; container logs explain the user workload
+- the built-in server does not expose lifecycle audit events; use external control-plane or audit sources when current state and runtime events are insufficient
 - runtime events are platform facts and usually outrank application logs for scheduling, image pull, restart, and kill reasons
 - empty diagnostics do not prove there is no issue; the scope may be unsupported, expired, or outside retention
 - `truncated: true` means the evidence is incomplete; lower confidence and mention the truncation
@@ -116,7 +115,7 @@ Use:
 - with `delivery: url`, `-o raw` prints the diagnostic content URL; fetch it only if you need the diagnostic body
 - `content_url` in structured CLI output is a diagnostic artifact URL, not a sandbox service endpoint
 - check `expires_at`; container log URLs may expire quickly, so request diagnostics again if the URL is stale
-- do not forward diagnostic URLs or lifecycle logs to unrelated people because they may contain sensitive troubleshooting data
+- do not forward diagnostic URLs or logs to unrelated people because they may contain sensitive troubleshooting data
 
 ## Symptom To Command Mapping
 
@@ -124,7 +123,7 @@ Use the first command that best matches the reported symptom:
 
 | Symptom | First command | What to confirm next |
 | --- | --- | --- |
-| pending forever or stuck creating | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | image pull errors, scheduling failures, admission errors, then lifecycle logs |
+| pending forever or stuck creating | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | image pull errors, scheduling failures, admission errors, then `sandbox get` and external control-plane logs |
 | image pull failure | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | image name, tag, registry auth |
 | crash loop or repeated restarts | `osb diagnostics logs <sandbox-id> --scope container -o raw` | `osb diagnostics events <sandbox-id> --scope runtime -o raw` for restarts or kill signals |
 | suspected OOM or exit code issue | `osb diagnostics events <sandbox-id> --scope runtime -o raw` | kill signals, restart events, resource pressure messages |
@@ -168,7 +167,6 @@ CLI-first troubleshooting:
 ```bash
 osb sandbox get <sandbox-id> -o json
 osb sandbox health <sandbox-id> -o json
-osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
 ```

--- a/cli/tests/test_cli_help.py
+++ b/cli/tests/test_cli_help.py
@@ -228,11 +228,12 @@ class TestDiagnosticsHelp:
         assert "all" in result.output
         assert "lifecycle" not in result.output
 
-    def test_diagnostics_events_help_describes_common_scopes(self, runner: CliRunner) -> None:
+    def test_diagnostics_events_help_describes_builtin_scopes(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["diagnostics", "events", "--help"])
         assert result.exit_code == 0
-        assert "lifecycle" in result.output
         assert "runtime" in result.output
+        assert "all" in result.output
+        assert "lifecycle" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_cli_help.py
+++ b/cli/tests/test_cli_help.py
@@ -221,11 +221,12 @@ class TestDiagnosticsHelp:
         assert "--scope" in result.output
         assert "content URL" in result.output
 
-    def test_diagnostics_logs_help_describes_common_scopes(self, runner: CliRunner) -> None:
+    def test_diagnostics_logs_help_describes_builtin_scopes(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["diagnostics", "logs", "--help"])
         assert result.exit_code == 0
-        assert "lifecycle" in result.output
         assert "container" in result.output
+        assert "all" in result.output
+        assert "lifecycle" not in result.output
 
     def test_diagnostics_events_help_describes_common_scopes(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["diagnostics", "events", "--help"])

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -1380,6 +1380,32 @@ class TestDiagnosticsCommands:
         assert "line 1\nline 2" in result.output
         manager.get_diagnostic_logs.assert_called_once_with("sb-1", scope="container")
 
+    def test_logs_raw_surfaces_diagnostic_notices_on_stderr(
+        self, runner: CliRunner
+    ) -> None:
+        manager = MagicMock()
+        manager.get_diagnostic_logs.return_value = DiagnosticContent(
+            sandboxId="sb-1",
+            kind="logs",
+            scope="all",
+            delivery="inline",
+            contentType="text/plain; charset=utf-8",
+            content="container logs",
+            truncated=True,
+            warnings=["Only container logs are available."],
+        )
+
+        result = _invoke(
+            runner,
+            ["diagnostics", "logs", "sb-1", "--scope", "all", "-o", "raw"],
+            manager=manager,
+        )
+
+        assert result.exit_code == 0
+        assert result.stdout == "container logs\n"
+        assert "Warning: diagnostic content was truncated." in result.stderr
+        assert "Warning: Only container logs are available." in result.stderr
+
     def test_events_json_prints_descriptor(self, runner: CliRunner) -> None:
         manager = MagicMock()
         manager.get_diagnostic_events.return_value = DiagnosticContent(

--- a/cli/tests/test_skills.py
+++ b/cli/tests/test_skills.py
@@ -528,11 +528,13 @@ class TestSkillContentQuality:
 
         assert "## Triage Order" in content
         assert "osb sandbox get <sandbox-id> -o json" in content
-        assert "osb diagnostics events <sandbox-id> --scope lifecycle -o raw" in content
+        assert "osb diagnostics events <sandbox-id> --scope lifecycle" not in content
         assert "osb diagnostics events <sandbox-id> --scope runtime -o raw" in content
+        assert "osb diagnostics events <sandbox-id> --scope all -o raw" in content
         assert "osb diagnostics logs <sandbox-id> --scope container -o raw" in content
         assert "osb diagnostics logs <sandbox-id> --scope all -o raw" in content
         assert "osb diagnostics logs <sandbox-id> --scope lifecycle" not in content
+        assert "events:lifecycle" not in content
         assert "## Diagnostics Streams" in content
         assert "## Evidence Semantics" in content
         assert "## URL Delivery" in content

--- a/cli/tests/test_skills.py
+++ b/cli/tests/test_skills.py
@@ -531,6 +531,8 @@ class TestSkillContentQuality:
         assert "osb diagnostics events <sandbox-id> --scope lifecycle -o raw" in content
         assert "osb diagnostics events <sandbox-id> --scope runtime -o raw" in content
         assert "osb diagnostics logs <sandbox-id> --scope container -o raw" in content
+        assert "osb diagnostics logs <sandbox-id> --scope all -o raw" in content
+        assert "osb diagnostics logs <sandbox-id> --scope lifecycle" not in content
         assert "## Diagnostics Streams" in content
         assert "## Evidence Semantics" in content
         assert "## URL Delivery" in content

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -258,8 +258,8 @@ Use `--file -` to read a JSON/YAML payload from stdin. Do not pass plaintext cre
 Use the stable diagnostics commands for API-backed log and event descriptors.
 
 ```bash
-osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
+osb diagnostics events <sandbox-id> --scope all -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
 osb diagnostics logs <sandbox-id> --scope all -o json
 osb diagnostics events <sandbox-id> --scope runtime -o json
@@ -267,9 +267,10 @@ osb diagnostics logs <sandbox-id> --scope container -o yaml
 ```
 
 `--scope` is required for stable diagnostics. The built-in server supports
-`container` and `all` for logs, and `runtime`, `lifecycle`, and `all` for events.
+`container` and `all` for logs, and `runtime` and `all` for events. It returns
+`DIAGNOSTICS_SCOPE_UNSUPPORTED` for unavailable scopes, including lifecycle events.
 Best-effort scopes may include a `warnings` field when the backend can only
-provide a subset or maps the request to runtime events. Raw output prints inline
+provide a subset. Raw output prints inline
 diagnostic text, or the content URL when diagnostics are delivered as a
 temporary URL. Older server builds may still return
 `DIAGNOSTICS_NOT_IMPLEMENTED` for scoped diagnostics.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -261,15 +261,18 @@ Use the stable diagnostics commands for API-backed log and event descriptors.
 osb diagnostics events <sandbox-id> --scope lifecycle -o raw
 osb diagnostics events <sandbox-id> --scope runtime -o raw
 osb diagnostics logs <sandbox-id> --scope container -o raw
-osb diagnostics logs <sandbox-id> --scope lifecycle -o json
+osb diagnostics logs <sandbox-id> --scope all -o json
 osb diagnostics events <sandbox-id> --scope runtime -o json
 osb diagnostics logs <sandbox-id> --scope container -o yaml
 ```
 
-`--scope` is required for stable diagnostics. Common scopes are `lifecycle` and
-`container` for logs, and `lifecycle` and `runtime` for events. Raw output
-prints inline diagnostic text, or the content URL when diagnostics are
-delivered as a temporary URL.
+`--scope` is required for stable diagnostics. The built-in server supports
+`container` and `all` for logs, and `runtime`, `lifecycle`, and `all` for events.
+Best-effort scopes may include a `warnings` field when the backend can only
+provide a subset or maps the request to runtime events. Raw output prints inline
+diagnostic text, or the content URL when diagnostics are delivered as a
+temporary URL. Older server builds may still return
+`DIAGNOSTICS_NOT_IMPLEMENTED` for scoped diagnostics.
 
 ::: info
 Legacy DevOps diagnostics remain experimental. Prefer `osb diagnostics logs/events` for stable API-backed log and event collection.

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["DevOps"])
 
 _SUPPORTED_LOG_SCOPES = ("container", "all")
-_SUPPORTED_EVENT_SCOPES = ("runtime", "lifecycle", "all")
+_SUPPORTED_EVENT_SCOPES = ("runtime", "all")
 
 
 def _diagnostic_inline_response(
@@ -216,9 +216,9 @@ def get_sandbox_events(
         text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit + 1)
         text, truncated = _limit_diagnostic_lines(text, limit, keep_tail=False)
         warnings = None
-        if normalized_scope != "runtime":
+        if normalized_scope == "all":
             warnings = [
-                f"The current backend maps {normalized_scope} diagnostics to runtime events."
+                "The current backend only contributes runtime events to the all scope."
             ]
         return _diagnostic_inline_response(
             sandbox_id,

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -40,6 +40,7 @@ def _diagnostic_inline_response(
     kind: str,
     scope: str,
     content: str,
+    truncated: bool = False,
     warnings: list[str] | None = None,
 ) -> JSONResponse:
     """Build a Diagnostics API descriptor for inline plain-text content."""
@@ -51,11 +52,25 @@ def _diagnostic_inline_response(
         "contentType": "text/plain; charset=utf-8",
         "content": content,
         "contentLength": len(content.encode("utf-8")),
-        "truncated": False,
+        "truncated": truncated,
     }
     if warnings:
         payload["warnings"] = warnings
     return JSONResponse(status_code=status.HTTP_200_OK, content=payload)
+
+
+def _limit_diagnostic_lines(
+    content: str,
+    limit: int,
+    *,
+    keep_tail: bool,
+) -> tuple[str, bool]:
+    """Apply a line limit after fetching one extra line to detect truncation."""
+    lines = content.splitlines(keepends=True)
+    if len(lines) <= limit:
+        return content, False
+    bounded_lines = lines[-limit:] if keep_tail else lines[:limit]
+    return "".join(bounded_lines), True
 
 
 def _unsupported_scope_response(
@@ -130,8 +145,9 @@ def get_sandbox_logs(
         if normalized_scope not in _SUPPORTED_LOG_SCOPES:
             return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
         text = sandbox_service.get_sandbox_logs(
-            sandbox_id, tail=tail, since=since, container=container
+            sandbox_id, tail=tail + 1, since=since, container=container
         )
+        text, truncated = _limit_diagnostic_lines(text, tail, keep_tail=True)
         warnings = None
         if normalized_scope == "all":
             warnings = [
@@ -142,6 +158,7 @@ def get_sandbox_logs(
             "logs",
             normalized_scope,
             text,
+            truncated=truncated,
             warnings=warnings,
         )
     text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since, container=container)
@@ -196,7 +213,8 @@ def get_sandbox_events(
         normalized_scope = scope.strip().lower()
         if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
             return _unsupported_scope_response("events", scope, _SUPPORTED_EVENT_SCOPES)
-        text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)
+        text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit + 1)
+        text, truncated = _limit_diagnostic_lines(text, limit, keep_tail=False)
         warnings = None
         if normalized_scope != "runtime":
             warnings = [
@@ -207,6 +225,7 @@ def get_sandbox_events(
             "events",
             normalized_scope,
             text,
+            truncated=truncated,
             warnings=warnings,
         )
     text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -27,70 +27,29 @@ from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from opensandbox_server.api.lifecycle import sandbox_service
+from opensandbox_server.services.diagnostics import DiagnosticResult
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["DevOps"])
 
-_SUPPORTED_LOG_SCOPES = ("container", "all")
-_SUPPORTED_EVENT_SCOPES = ("runtime", "all")
-_STABLE_LOG_LINE_LIMIT = 100
-_STABLE_EVENT_LINE_LIMIT = 50
-
 
 def _diagnostic_inline_response(
-    sandbox_id: str,
-    kind: str,
-    scope: str,
-    content: str,
-    truncated: bool = False,
-    warnings: list[str] | None = None,
+    result: DiagnosticResult,
 ) -> JSONResponse:
     """Build a Diagnostics API descriptor for inline plain-text content."""
     payload: dict[str, object] = {
-        "sandboxId": sandbox_id,
-        "kind": kind,
-        "scope": scope,
+        "sandboxId": result.sandbox_id,
+        "kind": result.kind,
+        "scope": result.scope,
         "delivery": "inline",
         "contentType": "text/plain; charset=utf-8",
-        "content": content,
-        "contentLength": len(content.encode("utf-8")),
-        "truncated": truncated,
+        "content": result.content,
+        "contentLength": len(result.content.encode("utf-8")),
+        "truncated": result.truncated,
     }
-    if warnings:
-        payload["warnings"] = warnings
+    if result.warnings:
+        payload["warnings"] = list(result.warnings)
     return JSONResponse(status_code=status.HTTP_200_OK, content=payload)
-
-
-def _limit_diagnostic_lines(
-    content: str,
-    limit: int,
-    *,
-    keep_tail: bool,
-) -> tuple[str, bool]:
-    """Apply a line limit after fetching one extra line to detect truncation."""
-    lines = content.splitlines(keepends=True)
-    if len(lines) <= limit:
-        return content, False
-    bounded_lines = lines[-limit:] if keep_tail else lines[:limit]
-    return "".join(bounded_lines), True
-
-
-def _unsupported_scope_response(
-    kind: str,
-    scope: str,
-    supported: tuple[str, ...],
-) -> JSONResponse:
-    """Return a stable error for a scope the current backend cannot provide."""
-    return JSONResponse(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        content={
-            "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
-            "message": (
-                f"Unsupported {kind} diagnostics scope {scope!r}. "
-                f"Supported scopes: {', '.join(supported)}."
-            ),
-        },
-    )
 
 
 def _deprecated_plain_text_response(content: str) -> PlainTextResponse:
@@ -143,30 +102,8 @@ def get_sandbox_logs(
 ) -> JSONResponse | PlainTextResponse:
     """Retrieve diagnostic logs for a sandbox."""
     if scope is not None:
-        normalized_scope = scope.strip().lower()
-        if normalized_scope not in _SUPPORTED_LOG_SCOPES:
-            return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
-        text = sandbox_service.get_sandbox_logs(
-            sandbox_id, tail=_STABLE_LOG_LINE_LIMIT + 1, since=None, container=None
-        )
-        text, truncated = _limit_diagnostic_lines(
-            text,
-            _STABLE_LOG_LINE_LIMIT,
-            keep_tail=True,
-        )
-        warnings = None
-        if normalized_scope == "all":
-            warnings = [
-                "The current backend only contributes sandbox container logs to the all scope."
-            ]
-        return _diagnostic_inline_response(
-            sandbox_id,
-            "logs",
-            normalized_scope,
-            text,
-            truncated=truncated,
-            warnings=warnings,
-        )
+        result = sandbox_service.get_sandbox_log_diagnostics(sandbox_id, scope)
+        return _diagnostic_inline_response(result)
     text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since, container=container)
     return _deprecated_plain_text_response(text)
 
@@ -216,31 +153,8 @@ def get_sandbox_events(
 ) -> JSONResponse | PlainTextResponse:
     """Retrieve diagnostic events for a sandbox."""
     if scope is not None:
-        normalized_scope = scope.strip().lower()
-        if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
-            return _unsupported_scope_response("events", scope, _SUPPORTED_EVENT_SCOPES)
-        text = sandbox_service.get_sandbox_events(
-            sandbox_id,
-            limit=_STABLE_EVENT_LINE_LIMIT + 1,
-        )
-        text, truncated = _limit_diagnostic_lines(
-            text,
-            _STABLE_EVENT_LINE_LIMIT,
-            keep_tail=False,
-        )
-        warnings = None
-        if normalized_scope == "all":
-            warnings = [
-                "The current backend only contributes runtime events to the all scope."
-            ]
-        return _diagnostic_inline_response(
-            sandbox_id,
-            "events",
-            normalized_scope,
-            text,
-            truncated=truncated,
-            warnings=warnings,
-        )
+        result = sandbox_service.get_sandbox_event_diagnostics(sandbox_id, scope)
+        return _diagnostic_inline_response(result)
     text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)
     return _deprecated_plain_text_response(text)
 

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -33,6 +33,8 @@ router = APIRouter(tags=["DevOps"])
 
 _SUPPORTED_LOG_SCOPES = ("container", "all")
 _SUPPORTED_EVENT_SCOPES = ("runtime", "all")
+_STABLE_LOG_LINE_LIMIT = 100
+_STABLE_EVENT_LINE_LIMIT = 50
 
 
 def _diagnostic_inline_response(
@@ -145,9 +147,13 @@ def get_sandbox_logs(
         if normalized_scope not in _SUPPORTED_LOG_SCOPES:
             return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
         text = sandbox_service.get_sandbox_logs(
-            sandbox_id, tail=tail + 1, since=None, container=None
+            sandbox_id, tail=_STABLE_LOG_LINE_LIMIT + 1, since=None, container=None
         )
-        text, truncated = _limit_diagnostic_lines(text, tail, keep_tail=True)
+        text, truncated = _limit_diagnostic_lines(
+            text,
+            _STABLE_LOG_LINE_LIMIT,
+            keep_tail=True,
+        )
         warnings = None
         if normalized_scope == "all":
             warnings = [
@@ -213,8 +219,15 @@ def get_sandbox_events(
         normalized_scope = scope.strip().lower()
         if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
             return _unsupported_scope_response("events", scope, _SUPPORTED_EVENT_SCOPES)
-        text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit + 1)
-        text, truncated = _limit_diagnostic_lines(text, limit, keep_tail=False)
+        text = sandbox_service.get_sandbox_events(
+            sandbox_id,
+            limit=_STABLE_EVENT_LINE_LIMIT + 1,
+        )
+        text, truncated = _limit_diagnostic_lines(
+            text,
+            _STABLE_EVENT_LINE_LIMIT,
+            keep_tail=False,
+        )
         warnings = None
         if normalized_scope == "all":
             warnings = [

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -145,7 +145,7 @@ def get_sandbox_logs(
         if normalized_scope not in _SUPPORTED_LOG_SCOPES:
             return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
         text = sandbox_service.get_sandbox_logs(
-            sandbox_id, tail=tail + 1, since=since, container=container
+            sandbox_id, tail=tail + 1, since=since, container=None
         )
         text, truncated = _limit_diagnostic_lines(text, tail, keep_tail=True)
         warnings = None

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -15,10 +15,9 @@
 """
 API routes for OpenSandbox DevOps diagnostics.
 
-Requests that include `scope` target the stable Diagnostics API. The open-source
-server has not implemented that API yet, so these requests return a uniform
-not-implemented error. Requests without `scope` preserve the deprecated DevOps
-plain-text behavior for legacy humans, agents, and CLI clients.
+Requests that include ``scope`` target the stable Diagnostics API and return an
+inline JSON descriptor. Requests without ``scope`` preserve the deprecated
+DevOps plain-text behavior for legacy humans, agents, and CLI clients.
 """
 
 import logging
@@ -32,13 +31,47 @@ from opensandbox_server.api.lifecycle import sandbox_service
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["DevOps"])
 
+_SUPPORTED_LOG_SCOPES = ("container", "all")
+_SUPPORTED_EVENT_SCOPES = ("runtime", "lifecycle", "all")
 
-def _diagnostics_not_implemented_response() -> JSONResponse:
+
+def _diagnostic_inline_response(
+    sandbox_id: str,
+    kind: str,
+    scope: str,
+    content: str,
+    warnings: list[str] | None = None,
+) -> JSONResponse:
+    """Build a Diagnostics API descriptor for inline plain-text content."""
+    payload: dict[str, object] = {
+        "sandboxId": sandbox_id,
+        "kind": kind,
+        "scope": scope,
+        "delivery": "inline",
+        "contentType": "text/plain; charset=utf-8",
+        "content": content,
+        "contentLength": len(content.encode("utf-8")),
+        "truncated": False,
+    }
+    if warnings:
+        payload["warnings"] = warnings
+    return JSONResponse(status_code=status.HTTP_200_OK, content=payload)
+
+
+def _unsupported_scope_response(
+    kind: str,
+    scope: str,
+    supported: tuple[str, ...],
+) -> JSONResponse:
+    """Return a stable error for a scope the current backend cannot provide."""
     return JSONResponse(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        status_code=status.HTTP_400_BAD_REQUEST,
         content={
-            "code": "DIAGNOSTICS_NOT_IMPLEMENTED",
-            "message": "The stable Diagnostics API is not implemented by this OpenSandbox server.",
+            "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+            "message": (
+                f"Unsupported {kind} diagnostics scope {scope!r}. "
+                f"Supported scopes: {', '.join(supported)}."
+            ),
         },
     )
 
@@ -56,13 +89,10 @@ def _deprecated_plain_text_response(content: str) -> PlainTextResponse:
     status_code=status.HTTP_200_OK,
     responses={
         200: {
-            "description": "Deprecated plain-text logs when scope is omitted",
-            "content": {"text/plain": {}},
+            "description": "Stable JSON descriptor, or deprecated text when scope is omitted",
+            "content": {"application/json": {}, "text/plain": {}},
         },
-        501: {
-            "description": "Stable Diagnostics API is not implemented by this server",
-            "content": {"application/json": {}},
-        },
+        400: {"description": "Unsupported diagnostics scope"},
         404: {"description": "Sandbox not found"},
     },
 )
@@ -96,10 +126,25 @@ def get_sandbox_logs(
 ) -> JSONResponse | PlainTextResponse:
     """Retrieve diagnostic logs for a sandbox."""
     if scope is not None:
-        return _diagnostics_not_implemented_response()
-    text = sandbox_service.get_sandbox_logs(
-        sandbox_id, tail=tail, since=since, container=container
-    )
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_LOG_SCOPES:
+            return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
+        text = sandbox_service.get_sandbox_logs(
+            sandbox_id, tail=tail, since=since, container=container
+        )
+        warnings = None
+        if normalized_scope == "all":
+            warnings = [
+                "The current backend only contributes sandbox container logs to the all scope."
+            ]
+        return _diagnostic_inline_response(
+            sandbox_id,
+            "logs",
+            normalized_scope,
+            text,
+            warnings=warnings,
+        )
+    text = sandbox_service.get_sandbox_logs(sandbox_id, tail=tail, since=since, container=container)
     return _deprecated_plain_text_response(text)
 
 
@@ -125,13 +170,10 @@ def get_sandbox_inspect(sandbox_id: str) -> PlainTextResponse:
     status_code=status.HTTP_200_OK,
     responses={
         200: {
-            "description": "Deprecated plain-text events when scope is omitted",
-            "content": {"text/plain": {}},
+            "description": "Stable JSON descriptor, or deprecated text when scope is omitted",
+            "content": {"application/json": {}, "text/plain": {}},
         },
-        501: {
-            "description": "Stable Diagnostics API is not implemented by this server",
-            "content": {"application/json": {}},
-        },
+        400: {"description": "Unsupported diagnostics scope"},
         404: {"description": "Sandbox not found"},
     },
 )
@@ -151,7 +193,22 @@ def get_sandbox_events(
 ) -> JSONResponse | PlainTextResponse:
     """Retrieve diagnostic events for a sandbox."""
     if scope is not None:
-        return _diagnostics_not_implemented_response()
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
+            return _unsupported_scope_response("events", scope, _SUPPORTED_EVENT_SCOPES)
+        text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)
+        warnings = None
+        if normalized_scope != "runtime":
+            warnings = [
+                f"The current backend maps {normalized_scope} diagnostics to runtime events."
+            ]
+        return _diagnostic_inline_response(
+            sandbox_id,
+            "events",
+            normalized_scope,
+            text,
+            warnings=warnings,
+        )
     text = sandbox_service.get_sandbox_events(sandbox_id, limit=limit)
     return _deprecated_plain_text_response(text)
 

--- a/server/opensandbox_server/api/devops.py
+++ b/server/opensandbox_server/api/devops.py
@@ -145,7 +145,7 @@ def get_sandbox_logs(
         if normalized_scope not in _SUPPORTED_LOG_SCOPES:
             return _unsupported_scope_response("logs", scope, _SUPPORTED_LOG_SCOPES)
         text = sandbox_service.get_sandbox_logs(
-            sandbox_id, tail=tail + 1, since=since, container=None
+            sandbox_id, tail=tail + 1, since=None, container=None
         )
         text, truncated = _limit_diagnostic_lines(text, tail, keep_tail=True)
         warnings = None

--- a/server/opensandbox_server/services/diagnostics.py
+++ b/server/opensandbox_server/services/diagnostics.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime-neutral results and helpers for stable sandbox diagnostics."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from fastapi import HTTPException, status
+
+DiagnosticKind = Literal["logs", "events"]
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticResult:
+    """Stable diagnostic content collected by a runtime service."""
+
+    sandbox_id: str
+    kind: DiagnosticKind
+    scope: str
+    content: str
+    truncated: bool = False
+    warnings: tuple[str, ...] = ()
+
+
+def limit_diagnostic_lines(
+    content: str,
+    limit: int,
+    *,
+    keep_tail: bool,
+) -> tuple[str, bool]:
+    """Apply a line limit after collecting one extra line.
+
+    Args:
+        content: Diagnostic text to bound.
+        limit: Maximum number of lines to return.
+        keep_tail: Keep the newest trailing lines when true; otherwise keep the
+            leading lines.
+
+    Returns:
+        The bounded content and whether truncation occurred.
+    """
+    lines = content.splitlines(keepends=True)
+    if len(lines) <= limit:
+        return content, False
+    bounded_lines = lines[-limit:] if keep_tail else lines[:limit]
+    return "".join(bounded_lines), True
+
+
+def unsupported_scope_error(
+    kind: DiagnosticKind,
+    scope: str,
+    supported: tuple[str, ...],
+) -> HTTPException:
+    """Build the stable error for a scope unsupported by a runtime.
+
+    Args:
+        kind: Diagnostic payload kind.
+        scope: Scope requested by the caller.
+        supported: Scopes implemented by the runtime.
+
+    Returns:
+        An HTTP 400 exception matching the diagnostics error contract.
+    """
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+            "message": (
+                f"Unsupported {kind} diagnostics scope {scope!r}. "
+                f"Supported scopes: {', '.join(supported)}."
+            ),
+        },
+    )

--- a/server/opensandbox_server/services/docker/docker_diagnostics.py
+++ b/server/opensandbox_server/services/docker/docker_diagnostics.py
@@ -28,6 +28,16 @@ from docker.errors import DockerException
 from fastapi import HTTPException, status
 
 from opensandbox_server.services.constants import SandboxErrorCodes
+from opensandbox_server.services.diagnostics import (
+    DiagnosticResult,
+    limit_diagnostic_lines,
+    unsupported_scope_error,
+)
+
+_SUPPORTED_LOG_SCOPES = ("container", "all")
+_SUPPORTED_EVENT_SCOPES = ("runtime", "all")
+_STABLE_LOG_LINE_LIMIT = 100
+_STABLE_EVENT_LINE_LIMIT = 50
 
 
 def _parse_since_to_timestamp(since: str) -> int:
@@ -48,6 +58,72 @@ def _parse_since_to_timestamp(since: str) -> int:
 
 class DockerDiagnosticsMixin:
     """Mixin that implements diagnostics methods for the Docker backend."""
+
+    def get_sandbox_log_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable log diagnostics using Docker capabilities."""
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_LOG_SCOPES:
+            raise unsupported_scope_error("logs", scope, _SUPPORTED_LOG_SCOPES)
+
+        content = self.get_sandbox_logs(
+            sandbox_id,
+            tail=_STABLE_LOG_LINE_LIMIT + 1,
+            since=None,
+            container=None,
+        )
+        content, truncated = limit_diagnostic_lines(
+            content,
+            _STABLE_LOG_LINE_LIMIT,
+            keep_tail=True,
+        )
+        warnings: tuple[str, ...] = ()
+        if normalized_scope == "all":
+            warnings = (
+                "The current backend only contributes sandbox container logs to the all scope.",
+            )
+        return DiagnosticResult(
+            sandbox_id=sandbox_id,
+            kind="logs",
+            scope=normalized_scope,
+            content=content,
+            truncated=truncated,
+            warnings=warnings,
+        )
+
+    def get_sandbox_event_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable event diagnostics using Docker capabilities."""
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
+            raise unsupported_scope_error("events", scope, _SUPPORTED_EVENT_SCOPES)
+
+        content = self.get_sandbox_events(
+            sandbox_id,
+            limit=_STABLE_EVENT_LINE_LIMIT + 1,
+        )
+        content, truncated = limit_diagnostic_lines(
+            content,
+            _STABLE_EVENT_LINE_LIMIT,
+            keep_tail=False,
+        )
+        warnings: tuple[str, ...] = ()
+        if normalized_scope == "all":
+            warnings = ("The current backend only contributes runtime events to the all scope.",)
+        return DiagnosticResult(
+            sandbox_id=sandbox_id,
+            kind="events",
+            scope=normalized_scope,
+            content=content,
+            truncated=truncated,
+            warnings=warnings,
+        )
 
     def get_sandbox_logs(
         self,

--- a/server/opensandbox_server/services/docker/docker_diagnostics.py
+++ b/server/opensandbox_server/services/docker/docker_diagnostics.py
@@ -24,6 +24,11 @@ from __future__ import annotations
 import re
 import time
 
+from docker.errors import DockerException
+from fastapi import HTTPException, status
+
+from opensandbox_server.services.constants import SandboxErrorCodes
+
 
 def _parse_since_to_timestamp(since: str) -> int:
     """Parse a human-readable duration string (e.g. '10m', '1h') into a Unix timestamp.
@@ -59,7 +64,16 @@ class DockerDiagnosticsMixin:
         kwargs: dict = {"tail": tail, "timestamps": True}
         if since:
             kwargs["since"] = _parse_since_to_timestamp(since)
-        output = docker_container.logs(**kwargs)
+        try:
+            output = docker_container.logs(**kwargs)
+        except DockerException as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "code": SandboxErrorCodes.CONTAINER_QUERY_FAILED,
+                    "message": f"Failed to read logs for sandbox {sandbox_id}: {exc}",
+                },
+            ) from exc
         if isinstance(output, bytes):
             output = output.decode("utf-8", errors="replace")
         return output or "(no logs)"

--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -22,6 +22,7 @@ by querying K8s Pod state and events. Mixed into KubernetesSandboxService.
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from fastapi import HTTPException, status
 from kubernetes.client.exceptions import ApiException
@@ -240,20 +241,38 @@ class K8sDiagnosticsMixin:
         pod_name = pod.metadata.name
         core_v1 = self.k8s_client.get_core_v1_api()
 
+        events: list[Any] = []
+        continuation: str | None = None
         try:
-            events_resp = core_v1.list_namespaced_event(
-                namespace=pod.metadata.namespace,
-                field_selector=f"involvedObject.name={pod_name}",
-                limit=limit,
-            )
+            while len(events) < limit:
+                if continuation is None:
+                    events_resp = core_v1.list_namespaced_event(
+                        namespace=pod.metadata.namespace,
+                        field_selector=f"involvedObject.name={pod_name}",
+                        limit=limit,
+                    )
+                else:
+                    events_resp = core_v1.list_namespaced_event(
+                        namespace=pod.metadata.namespace,
+                        field_selector=f"involvedObject.name={pod_name}",
+                        limit=limit,
+                        _continue=continuation,
+                    )
+
+                events.extend(events_resp.items or [])
+                metadata = getattr(events_resp, "metadata", None)
+                next_continuation = getattr(metadata, "_continue", None)
+                if not next_continuation or next_continuation == continuation:
+                    break
+                continuation = next_continuation
         except ApiException as exc:
             raise _map_pod_event_error(pod_name, exc) from exc
 
-        if not events_resp.items:
+        if not events:
             return "(no events)"
 
         lines: list[str] = []
-        for ev in events_resp.items:
+        for ev in events[:limit]:
             ts = ev.last_timestamp or ev.event_time or ev.first_timestamp or "N/A"
             lines.append(
                 f"[{ts}] {ev.type:8s} {ev.reason or 'N/A':20s} {ev.message or ''}"

--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -240,11 +240,14 @@ class K8sDiagnosticsMixin:
         pod_name = pod.metadata.name
         core_v1 = self.k8s_client.get_core_v1_api()
 
-        events_resp = core_v1.list_namespaced_event(
-            namespace=pod.metadata.namespace,
-            field_selector=f"involvedObject.name={pod_name}",
-            limit=limit,
-        )
+        try:
+            events_resp = core_v1.list_namespaced_event(
+                namespace=pod.metadata.namespace,
+                field_selector=f"involvedObject.name={pod_name}",
+                limit=limit,
+            )
+        except ApiException as exc:
+            raise _map_pod_event_error(pod_name, exc) from exc
 
         if not events_resp.items:
             return "(no events)"
@@ -309,6 +312,49 @@ def _map_pod_log_error(pod_name: str, container: str, exc: ApiException) -> HTTP
             "message": (
                 f"Kubernetes returned {raw_status} when reading logs for pod "
                 f"'{pod_name}' container '{container}': {body}"
+            ),
+        },
+    )
+
+
+def _map_pod_event_error(pod_name: str, exc: ApiException) -> HTTPException:
+    """Translate a Kubernetes event ApiException into a contract error."""
+    raw_status = getattr(exc, "status", None) or 0
+    body = getattr(exc, "body", None) or str(exc)
+
+    if raw_status == 400:
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": SandboxErrorCodes.K8S_API_ERROR,
+                "message": (
+                    f"Kubernetes rejected event request for pod '{pod_name}': {body}"
+                ),
+            },
+        )
+    if raw_status in (401, 403):
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": SandboxErrorCodes.K8S_API_ERROR,
+                "message": f"Kubernetes denied event access for pod '{pod_name}': {body}",
+            },
+        )
+    if raw_status == 404:
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": SandboxErrorCodes.K8S_SANDBOX_NOT_FOUND,
+                "message": f"Pod '{pod_name}' not found when reading events: {body}",
+            },
+        )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={
+            "code": SandboxErrorCodes.K8S_API_ERROR,
+            "message": (
+                f"Kubernetes returned {raw_status} when reading events for pod "
+                f"'{pod_name}': {body}"
             ),
         },
     )

--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -306,7 +306,7 @@ def _map_pod_log_error(pod_name: str, container: str, exc: ApiException) -> HTTP
             },
         )
     return HTTPException(
-        status_code=status.HTTP_502_BAD_GATEWAY,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail={
             "code": SandboxErrorCodes.K8S_API_ERROR,
             "message": (

--- a/server/opensandbox_server/services/k8s/k8s_diagnostics.py
+++ b/server/opensandbox_server/services/k8s/k8s_diagnostics.py
@@ -31,6 +31,16 @@ from opensandbox_server.services.constants import (
     SANDBOX_ID_LABEL,
     SandboxErrorCodes,
 )
+from opensandbox_server.services.diagnostics import (
+    DiagnosticResult,
+    limit_diagnostic_lines,
+    unsupported_scope_error,
+)
+
+_SUPPORTED_LOG_SCOPES = ("container", "all")
+_SUPPORTED_EVENT_SCOPES = ("runtime", "all")
+_STABLE_LOG_LINE_LIMIT = 100
+_STABLE_EVENT_LINE_LIMIT = 50
 
 #: Default container to pull logs from when the caller does not specify one.
 #: OSB-managed sandbox pods canonically run the user workload in a container
@@ -52,6 +62,72 @@ def _parse_since(since: str) -> int:
 
 class K8sDiagnosticsMixin:
     """Mixin that implements diagnostics methods for the Kubernetes backend."""
+
+    def get_sandbox_log_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable log diagnostics using Kubernetes capabilities."""
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_LOG_SCOPES:
+            raise unsupported_scope_error("logs", scope, _SUPPORTED_LOG_SCOPES)
+
+        content = self.get_sandbox_logs(
+            sandbox_id,
+            tail=_STABLE_LOG_LINE_LIMIT + 1,
+            since=None,
+            container=None,
+        )
+        content, truncated = limit_diagnostic_lines(
+            content,
+            _STABLE_LOG_LINE_LIMIT,
+            keep_tail=True,
+        )
+        warnings: tuple[str, ...] = ()
+        if normalized_scope == "all":
+            warnings = (
+                "The current backend only contributes sandbox container logs to the all scope.",
+            )
+        return DiagnosticResult(
+            sandbox_id=sandbox_id,
+            kind="logs",
+            scope=normalized_scope,
+            content=content,
+            truncated=truncated,
+            warnings=warnings,
+        )
+
+    def get_sandbox_event_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable event diagnostics using Kubernetes capabilities."""
+        normalized_scope = scope.strip().lower()
+        if normalized_scope not in _SUPPORTED_EVENT_SCOPES:
+            raise unsupported_scope_error("events", scope, _SUPPORTED_EVENT_SCOPES)
+
+        content = self.get_sandbox_events(
+            sandbox_id,
+            limit=_STABLE_EVENT_LINE_LIMIT + 1,
+        )
+        content, truncated = limit_diagnostic_lines(
+            content,
+            _STABLE_EVENT_LINE_LIMIT,
+            keep_tail=False,
+        )
+        warnings: tuple[str, ...] = ()
+        if normalized_scope == "all":
+            warnings = ("The current backend only contributes runtime events to the all scope.",)
+        return DiagnosticResult(
+            sandbox_id=sandbox_id,
+            kind="events",
+            scope=normalized_scope,
+            content=content,
+            truncated=truncated,
+            warnings=warnings,
+        )
 
     def _find_pod_for_sandbox(self, sandbox_id: str):
         """Find the Pod associated with a sandbox ID via label selector."""

--- a/server/opensandbox_server/services/sandbox_service.py
+++ b/server/opensandbox_server/services/sandbox_service.py
@@ -35,6 +35,7 @@ from opensandbox_server.api.schema import (
     RenewSandboxExpirationResponse,
     Sandbox,
 )
+from opensandbox_server.services.diagnostics import DiagnosticResult
 from opensandbox_server.services.validators import ensure_valid_port
 
 
@@ -257,6 +258,40 @@ class SandboxService(ABC):
 
     # Diagnostics (DevOps)
     # ------------------------------------------------------------------
+
+    @abstractmethod
+    def get_sandbox_log_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable log diagnostics using runtime-specific policy.
+
+        Args:
+            sandbox_id: Unique sandbox identifier.
+            scope: Diagnostic scope requested by the caller.
+
+        Returns:
+            Runtime-provided stable diagnostic result.
+        """
+        pass
+
+    @abstractmethod
+    def get_sandbox_event_diagnostics(
+        self,
+        sandbox_id: str,
+        scope: str,
+    ) -> DiagnosticResult:
+        """Collect stable event diagnostics using runtime-specific policy.
+
+        Args:
+            sandbox_id: Unique sandbox identifier.
+            scope: Diagnostic scope requested by the caller.
+
+        Returns:
+            Runtime-provided stable diagnostic result.
+        """
+        pass
 
     @abstractmethod
     def get_sandbox_logs(

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -281,6 +281,27 @@ def test_get_sandbox_logs_maps_kubernetes_403_to_forbidden_response() -> None:
     assert exc.value.status_code == 403
 
 
+@pytest.mark.parametrize("api_status", [None, 503])
+def test_get_sandbox_logs_maps_undocumented_kubernetes_failures_to_500(
+    api_status: int | None,
+) -> None:
+    from kubernetes.client.exceptions import ApiException
+
+    service = _DiagnosticsService([_multi_container_pod()])
+    api_exc = ApiException(status=api_status, reason="Kubernetes log API error")
+    api_exc.body = "log API unavailable"
+    service.core_v1.read_namespaced_pod_log.side_effect = api_exc
+
+    with pytest.raises(HTTPException) as exc:
+        service.get_sandbox_logs("sbx-1")
+
+    assert exc.value.status_code == 500
+    detail = cast(dict[str, str], exc.value.detail)
+    assert detail["code"] == SandboxErrorCodes.K8S_API_ERROR
+    assert "pod-1" in detail["message"]
+    assert api_exc.body in detail["message"]
+
+
 def test_get_sandbox_inspect_formats_runtime_statuses_and_resources() -> None:
     running_status = _status(running=SimpleNamespace(started_at="2026-01-01T00:00:01Z"))
     waiting_status = _status(waiting=SimpleNamespace(reason="ImagePullBackOff", message="pull failed"))

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -14,7 +14,7 @@
 
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import call, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -387,6 +387,49 @@ def test_get_sandbox_events_uses_found_pod_namespace() -> None:
         field_selector="involvedObject.name=pod-1",
         limit=50,
     )
+
+
+def test_get_sandbox_events_follows_continuation_until_limit() -> None:
+    service = _DiagnosticsService([_pod()])
+
+    def event(index: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            last_timestamp=f"2026-01-01T00:00:{index:02d}Z",
+            event_time=None,
+            first_timestamp=None,
+            type="Normal",
+            reason="Started",
+            message=f"event-{index}",
+        )
+
+    service.core_v1.list_namespaced_event.side_effect = [
+        SimpleNamespace(
+            items=[event(index) for index in range(50)],
+            metadata=SimpleNamespace(_continue="next-page-token"),
+        ),
+        SimpleNamespace(
+            items=[event(50)],
+            metadata=SimpleNamespace(_continue=None),
+        ),
+    ]
+
+    output = service.get_sandbox_events("sbx-1", limit=51)
+
+    assert len(output.splitlines()) == 51
+    assert "event-50" in output
+    assert service.core_v1.list_namespaced_event.call_args_list == [
+        call(
+            namespace="sandbox-system",
+            field_selector="involvedObject.name=pod-1",
+            limit=51,
+        ),
+        call(
+            namespace="sandbox-system",
+            field_selector="involvedObject.name=pod-1",
+            limit=51,
+            _continue="next-page-token",
+        ),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -432,6 +432,71 @@ def test_get_sandbox_events_follows_continuation_until_limit() -> None:
     ]
 
 
+def test_stable_event_diagnostics_policy_is_owned_by_kubernetes_service() -> None:
+    service = _DiagnosticsService([_pod()])
+    events = [f"event {index}" for index in range(51)]
+    service.get_sandbox_events = MagicMock(return_value="\n".join(events))
+
+    result = service.get_sandbox_event_diagnostics("sbx-1", scope="ALL")
+
+    assert result.scope == "all"
+    assert result.content.splitlines() == events[:50]
+    assert result.truncated is True
+    assert result.warnings == (
+        "The current backend only contributes runtime events to the all scope.",
+    )
+    service.get_sandbox_events.assert_called_once_with("sbx-1", limit=51)
+
+
+def test_stable_log_diagnostics_policy_is_owned_by_kubernetes_service() -> None:
+    service = _DiagnosticsService([_pod()])
+    lines = [f"line {index}" for index in range(101)]
+    service.get_sandbox_logs = MagicMock(return_value="\n".join(lines))
+
+    result = service.get_sandbox_log_diagnostics("sbx-1", scope="ALL")
+
+    assert result.scope == "all"
+    assert result.content.splitlines() == lines[-100:]
+    assert result.truncated is True
+    assert result.warnings == (
+        "The current backend only contributes sandbox container logs to the all scope.",
+    )
+    service.get_sandbox_logs.assert_called_once_with(
+        "sbx-1",
+        tail=101,
+        since=None,
+        container=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "scope", "kind", "supported"),
+    [
+        ("get_sandbox_log_diagnostics", "lifecycle", "logs", "container, all"),
+        ("get_sandbox_event_diagnostics", "network", "events", "runtime, all"),
+    ],
+)
+def test_stable_diagnostics_reject_unsupported_kubernetes_scopes(
+    method_name: str,
+    scope: str,
+    kind: str,
+    supported: str,
+) -> None:
+    service = _DiagnosticsService([_pod()])
+
+    with pytest.raises(HTTPException) as exc:
+        getattr(service, method_name)("sbx-1", scope)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+        "message": (
+            f"Unsupported {kind} diagnostics scope {scope!r}. Supported scopes: {supported}."
+        ),
+    }
+    service.k8s_client.list_pods.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("api_status", "expected_status", "expected_code"),
     [

--- a/server/tests/k8s/test_k8s_diagnostics.py
+++ b/server/tests/k8s/test_k8s_diagnostics.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
 from kubernetes.client import V1ResourceRequirements
 
-from opensandbox_server.services.constants import SANDBOX_ID_LABEL
+from opensandbox_server.services.constants import SANDBOX_ID_LABEL, SandboxErrorCodes
 from opensandbox_server.services.k8s.k8s_diagnostics import (
     K8sDiagnosticsMixin,
     _parse_since,
@@ -365,3 +366,36 @@ def test_get_sandbox_events_uses_found_pod_namespace() -> None:
         field_selector="involvedObject.name=pod-1",
         limit=50,
     )
+
+
+@pytest.mark.parametrize(
+    ("api_status", "expected_status", "expected_code"),
+    [
+        (400, 400, SandboxErrorCodes.K8S_API_ERROR),
+        (403, 403, SandboxErrorCodes.K8S_API_ERROR),
+        (404, 404, SandboxErrorCodes.K8S_SANDBOX_NOT_FOUND),
+        (503, 500, SandboxErrorCodes.K8S_API_ERROR),
+    ],
+)
+def test_get_sandbox_events_maps_kubernetes_api_errors(
+    api_status: int,
+    expected_status: int,
+    expected_code: str,
+) -> None:
+    from kubernetes.client.exceptions import ApiException
+
+    service = _DiagnosticsService([_pod()])
+    api_exc = ApiException(status=api_status, reason="Kubernetes event API error")
+    api_exc.body = f"event API failed with status {api_status}"
+    service.core_v1.list_namespaced_event.side_effect = api_exc
+
+    with pytest.raises(HTTPException) as exc:
+        service.get_sandbox_events("sbx-1")
+
+    assert exc.value.status_code == expected_status
+    detail = exc.value.detail
+    assert isinstance(detail, dict)
+    typed_detail = cast(dict[str, str], detail)
+    assert typed_detail["code"] == expected_code
+    assert "pod-1" in typed_detail["message"]
+    assert api_exc.body in typed_detail["message"]

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from opensandbox_server.api import devops
+from opensandbox_server.services.diagnostics import DiagnosticResult
 
 
 def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
@@ -26,17 +28,18 @@ def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
 
     class StubService:
         @staticmethod
-        def get_sandbox_logs(
+        def get_sandbox_log_diagnostics(
             sandbox_id: str,
-            tail: int,
-            since: str | None = None,
-            container: str | None = None,
-        ) -> str:
+            scope: str,
+        ) -> DiagnosticResult:
             assert sandbox_id == "sbx-001"
-            assert tail == 101
-            assert since is None
-            assert container is None
-            return content
+            assert scope == "container"
+            return DiagnosticResult(
+                sandbox_id=sandbox_id,
+                kind="logs",
+                scope=scope,
+                content=content,
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -59,7 +62,7 @@ def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
     }
 
 
-def test_diagnostics_logs_reports_and_applies_line_limit(
+def test_diagnostics_logs_serializes_service_truncation_result(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -68,17 +71,19 @@ def test_diagnostics_logs_reports_and_applies_line_limit(
 
     class StubService:
         @staticmethod
-        def get_sandbox_logs(
+        def get_sandbox_log_diagnostics(
             sandbox_id: str,
-            tail: int,
-            since: str | None = None,
-            container: str | None = None,
-        ) -> str:
+            scope: str,
+        ) -> DiagnosticResult:
             assert sandbox_id == "sbx-001"
-            assert tail == 101
-            assert since is None
-            assert container is None
-            return "\n".join(lines)
+            assert scope == "container"
+            return DiagnosticResult(
+                sandbox_id=sandbox_id,
+                kind="logs",
+                scope=scope,
+                content="\n".join(lines[-100:]),
+                truncated=True,
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -97,18 +102,16 @@ def test_diagnostics_logs_with_scope_ignores_legacy_container_selector(
     auth_headers: dict,
     monkeypatch,
 ) -> None:
-    containers: list[str | None] = []
+    scopes: list[str] = []
 
     class StubService:
         @staticmethod
-        def get_sandbox_logs(
+        def get_sandbox_log_diagnostics(
             sandbox_id: str,
-            tail: int,
-            since: str | None = None,
-            container: str | None = None,
-        ) -> str:
-            containers.append(container)
-            return "sandbox logs"
+            scope: str,
+        ) -> DiagnosticResult:
+            scopes.append(scope)
+            return DiagnosticResult(sandbox_id, "logs", scope, "sandbox logs")
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -121,7 +124,7 @@ def test_diagnostics_logs_with_scope_ignores_legacy_container_selector(
         assert response.status_code == 200
         assert response.json()["scope"] == scope
 
-    assert containers == [None, None]
+    assert scopes == ["container", "all"]
 
 
 def test_diagnostics_logs_with_scope_ignores_legacy_since_filter(
@@ -129,18 +132,16 @@ def test_diagnostics_logs_with_scope_ignores_legacy_since_filter(
     auth_headers: dict,
     monkeypatch,
 ) -> None:
-    since_values: list[str | None] = []
+    scopes: list[str] = []
 
     class StubService:
         @staticmethod
-        def get_sandbox_logs(
+        def get_sandbox_log_diagnostics(
             sandbox_id: str,
-            tail: int,
-            since: str | None = None,
-            container: str | None = None,
-        ) -> str:
-            since_values.append(since)
-            return "sandbox logs"
+            scope: str,
+        ) -> DiagnosticResult:
+            scopes.append(scope)
+            return DiagnosticResult(sandbox_id, "logs", scope, "sandbox logs")
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -153,7 +154,7 @@ def test_diagnostics_logs_with_scope_ignores_legacy_since_filter(
         assert response.status_code == 200
         assert response.json()["scope"] == scope
 
-    assert since_values == [None, None]
+    assert scopes == ["container", "all"]
 
 
 def test_diagnostics_logs_with_scope_ignores_legacy_tail_bound(
@@ -161,18 +162,21 @@ def test_diagnostics_logs_with_scope_ignores_legacy_tail_bound(
     auth_headers: dict,
     monkeypatch,
 ) -> None:
-    tails: list[int] = []
+    scopes: list[str] = []
 
     class StubService:
         @staticmethod
-        def get_sandbox_logs(
+        def get_sandbox_log_diagnostics(
             sandbox_id: str,
-            tail: int,
-            since: str | None = None,
-            container: str | None = None,
-        ) -> str:
-            tails.append(tail)
-            return "first line\nsecond line"
+            scope: str,
+        ) -> DiagnosticResult:
+            scopes.append(scope)
+            return DiagnosticResult(
+                sandbox_id,
+                "logs",
+                scope,
+                "first line\nsecond line",
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -186,7 +190,7 @@ def test_diagnostics_logs_with_scope_ignores_legacy_tail_bound(
             assert response.status_code == 200
             assert response.json()["content"] == "first line\nsecond line"
 
-    assert tails == [101, 101, 101, 101]
+    assert scopes == ["container", "container", "all", "all"]
 
 
 def test_diagnostics_logs_rejects_unsupported_scope(
@@ -196,8 +200,20 @@ def test_diagnostics_logs_rejects_unsupported_scope(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_logs(*args, **kwargs) -> str:
-            raise AssertionError("unsupported scope must not query the backend")
+        def get_sandbox_log_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+                    "message": (
+                        f"Unsupported logs diagnostics scope {scope!r}. "
+                        "Supported scopes: container, all."
+                    ),
+                },
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -222,8 +238,19 @@ def test_diagnostics_logs_all_scope_discloses_backend_limit(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_logs(*args, **kwargs) -> str:
-            return "container logs only"
+        def get_sandbox_log_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            return DiagnosticResult(
+                sandbox_id,
+                "logs",
+                scope,
+                "container logs only",
+                warnings=(
+                    "The current backend only contributes sandbox container logs to the all scope.",
+                ),
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -307,10 +334,18 @@ def test_diagnostics_events_with_scope_returns_stable_inline_descriptor(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
             assert sandbox_id == "sbx-001"
-            assert limit == 51
-            return "runtime event"
+            assert scope == "RUNTIME"
+            return DiagnosticResult(
+                sandbox_id,
+                "events",
+                scope.lower(),
+                "runtime event",
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -333,7 +368,7 @@ def test_diagnostics_events_with_scope_returns_stable_inline_descriptor(
     }
 
 
-def test_diagnostics_events_reports_and_applies_line_limit(
+def test_diagnostics_events_serializes_service_truncation_result(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -342,10 +377,19 @@ def test_diagnostics_events_reports_and_applies_line_limit(
 
     class StubService:
         @staticmethod
-        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
             assert sandbox_id == "sbx-001"
-            assert limit == 51
-            return "\n".join(events)
+            assert scope == "runtime"
+            return DiagnosticResult(
+                sandbox_id,
+                "events",
+                scope,
+                "\n".join(events[:50]),
+                truncated=True,
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -364,13 +408,21 @@ def test_diagnostics_events_with_scope_ignores_legacy_limit_bound(
     auth_headers: dict,
     monkeypatch,
 ) -> None:
-    limits: list[int] = []
+    scopes: list[str] = []
 
     class StubService:
         @staticmethod
-        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
-            limits.append(limit)
-            return "first event\nsecond event"
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            scopes.append(scope)
+            return DiagnosticResult(
+                sandbox_id,
+                "events",
+                scope,
+                "first event\nsecond event",
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -384,7 +436,7 @@ def test_diagnostics_events_with_scope_ignores_legacy_limit_bound(
             assert response.status_code == 200
             assert response.json()["content"] == "first event\nsecond event"
 
-    assert limits == [51, 51, 51, 51]
+    assert scopes == ["runtime", "runtime", "all", "all"]
 
 
 def test_diagnostics_events_rejects_unavailable_lifecycle_scope(
@@ -392,13 +444,25 @@ def test_diagnostics_events_rejects_unavailable_lifecycle_scope(
     auth_headers: dict,
     monkeypatch,
 ) -> None:
-    calls: list[tuple[str, int]] = []
+    calls: list[tuple[str, str]] = []
 
     class StubService:
         @staticmethod
-        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
-            calls.append((sandbox_id, limit))
-            return "runtime event"
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            calls.append((sandbox_id, scope))
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+                    "message": (
+                        f"Unsupported events diagnostics scope {scope!r}. "
+                        "Supported scopes: runtime, all."
+                    ),
+                },
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -415,7 +479,7 @@ def test_diagnostics_events_rejects_unavailable_lifecycle_scope(
             "Supported scopes: runtime, all."
         ),
     }
-    assert calls == []
+    assert calls == [("sbx-001", "lifecycle")]
 
 
 def test_diagnostics_events_all_scope_discloses_backend_limit(
@@ -425,8 +489,17 @@ def test_diagnostics_events_all_scope_discloses_backend_limit(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
-            return "runtime event"
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            return DiagnosticResult(
+                sandbox_id,
+                "events",
+                scope,
+                "runtime event",
+                warnings=("The current backend only contributes runtime events to the all scope.",),
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -448,8 +521,20 @@ def test_diagnostics_events_rejects_unsupported_scope(
 ) -> None:
     class StubService:
         @staticmethod
-        def get_sandbox_events(*args, **kwargs) -> str:
-            raise AssertionError("unsupported scope must not query the backend")
+        def get_sandbox_event_diagnostics(
+            sandbox_id: str,
+            scope: str,
+        ) -> DiagnosticResult:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+                    "message": (
+                        f"Unsupported events diagnostics scope {scope!r}. "
+                        "Supported scopes: runtime, all."
+                    ),
+                },
+            )
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -17,11 +17,13 @@ from fastapi.testclient import TestClient
 from opensandbox_server.api import devops
 
 
-def test_diagnostics_logs_with_scope_returns_not_implemented(
+def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
 ) -> None:
+    content = "sandbox log: 测试"
+
     class StubService:
         @staticmethod
         def get_sandbox_logs(
@@ -30,7 +32,11 @@ def test_diagnostics_logs_with_scope_returns_not_implemented(
             since: str | None = None,
             container: str | None = None,
         ) -> str:
-            raise AssertionError("stable diagnostics requests must not call legacy logs")
+            assert sandbox_id == "sbx-001"
+            assert tail == 100
+            assert since is None
+            assert container is None
+            return content
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
@@ -39,9 +45,67 @@ def test_diagnostics_logs_with_scope_returns_not_implemented(
         headers=auth_headers,
     )
 
-    assert response.status_code == 501
+    assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
-    assert response.json()["code"] == "DIAGNOSTICS_NOT_IMPLEMENTED"
+    assert response.json() == {
+        "sandboxId": "sbx-001",
+        "kind": "logs",
+        "scope": "container",
+        "delivery": "inline",
+        "contentType": "text/plain; charset=utf-8",
+        "content": content,
+        "contentLength": len(content.encode("utf-8")),
+        "truncated": False,
+    }
+
+
+def test_diagnostics_logs_rejects_unsupported_scope(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(*args, **kwargs) -> str:
+            raise AssertionError("unsupported scope must not query the backend")
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/logs?scope=lifecycle",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+        "message": (
+            "Unsupported logs diagnostics scope 'lifecycle'. Supported scopes: container, all."
+        ),
+    }
+
+
+def test_diagnostics_logs_all_scope_discloses_backend_limit(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(*args, **kwargs) -> str:
+            return "container logs only"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/logs?scope=all",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["warnings"] == [
+        "The current backend only contributes sandbox container logs to the all scope."
+    ]
 
 
 def test_diagnostics_logs_without_scope_preserves_deprecated_plain_text(
@@ -106,7 +170,7 @@ def test_diagnostics_logs_forwards_container_query_to_service(
     assert captured == {"container": "egress"}
 
 
-def test_diagnostics_events_with_scope_returns_not_implemented(
+def test_diagnostics_events_with_scope_returns_stable_inline_descriptor(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
@@ -114,18 +178,98 @@ def test_diagnostics_events_with_scope_returns_not_implemented(
     class StubService:
         @staticmethod
         def get_sandbox_events(sandbox_id: str, limit: int) -> str:
-            raise AssertionError("stable diagnostics requests must not call legacy events")
+            assert sandbox_id == "sbx-001"
+            assert limit == 50
+            return "runtime event"
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
 
     response = client.get(
-        "/v1/sandboxes/sbx-001/diagnostics/events?scope=runtime",
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=RUNTIME",
         headers=auth_headers,
     )
 
-    assert response.status_code == 501
+    assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
-    assert response.json()["code"] == "DIAGNOSTICS_NOT_IMPLEMENTED"
+    assert response.json() == {
+        "sandboxId": "sbx-001",
+        "kind": "events",
+        "scope": "runtime",
+        "delivery": "inline",
+        "contentType": "text/plain; charset=utf-8",
+        "content": "runtime event",
+        "contentLength": 13,
+        "truncated": False,
+    }
+
+
+def test_diagnostics_events_lifecycle_scope_discloses_runtime_mapping(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(*args, **kwargs) -> str:
+            return "runtime event"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=lifecycle",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["warnings"] == [
+        "The current backend maps lifecycle diagnostics to runtime events."
+    ]
+
+
+def test_diagnostics_events_rejects_unsupported_scope(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(*args, **kwargs) -> str:
+            raise AssertionError("unsupported scope must not query the backend")
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=network",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "DIAGNOSTICS_SCOPE_UNSUPPORTED"
+
+
+def test_diagnostics_events_without_scope_preserves_deprecated_plain_text(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            assert sandbox_id == "sbx-001"
+            assert limit == 10
+            return "legacy events"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?limit=10",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.headers["deprecation"] == "true"
+    assert response.text == "legacy events"
 
 
 def test_diagnostics_summary_redacts_unexpected_exception_details(

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -156,6 +156,39 @@ def test_diagnostics_logs_with_scope_ignores_legacy_since_filter(
     assert since_values == [None, None]
 
 
+def test_diagnostics_logs_with_scope_ignores_legacy_tail_bound(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    tails: list[int] = []
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
+            tails.append(tail)
+            return "first line\nsecond line"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    for scope in ("container", "all"):
+        for tail in (1, 10000):
+            response = client.get(
+                f"/v1/sandboxes/sbx-001/diagnostics/logs?scope={scope}&tail={tail}",
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 200
+            assert response.json()["content"] == "first line\nsecond line"
+
+    assert tails == [101, 101, 101, 101]
+
+
 def test_diagnostics_logs_rejects_unsupported_scope(
     client: TestClient,
     auth_headers: dict,
@@ -324,6 +357,34 @@ def test_diagnostics_events_reports_and_applies_line_limit(
     assert response.status_code == 200
     assert response.json()["content"].splitlines() == events[:50]
     assert response.json()["truncated"] is True
+
+
+def test_diagnostics_events_with_scope_ignores_legacy_limit_bound(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    limits: list[int] = []
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            limits.append(limit)
+            return "first event\nsecond event"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    for scope in ("runtime", "all"):
+        for limit in (1, 500):
+            response = client.get(
+                f"/v1/sandboxes/sbx-001/diagnostics/events?scope={scope}&limit={limit}",
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 200
+            assert response.json()["content"] == "first event\nsecond event"
+
+    assert limits == [51, 51, 51, 51]
 
 
 def test_diagnostics_events_rejects_unavailable_lifecycle_scope(

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -92,6 +92,38 @@ def test_diagnostics_logs_reports_and_applies_line_limit(
     assert response.json()["truncated"] is True
 
 
+def test_diagnostics_logs_with_scope_ignores_legacy_container_selector(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    containers: list[str | None] = []
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
+            containers.append(container)
+            return "sandbox logs"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    for scope in ("container", "all"):
+        response = client.get(
+            f"/v1/sandboxes/sbx-001/diagnostics/logs?scope={scope}&container=egress",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["scope"] == scope
+
+    assert containers == [None, None]
+
+
 def test_diagnostics_logs_rejects_unsupported_scope(
     client: TestClient,
     auth_headers: dict,

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -124,6 +124,38 @@ def test_diagnostics_logs_with_scope_ignores_legacy_container_selector(
     assert containers == [None, None]
 
 
+def test_diagnostics_logs_with_scope_ignores_legacy_since_filter(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    since_values: list[str | None] = []
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
+            since_values.append(since)
+            return "sandbox logs"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    for scope in ("container", "all"):
+        response = client.get(
+            f"/v1/sandboxes/sbx-001/diagnostics/logs?scope={scope}&since=5m",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["scope"] == scope
+
+    assert since_values == [None, None]
+
+
 def test_diagnostics_logs_rejects_unsupported_scope(
     client: TestClient,
     auth_headers: dict,

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -262,14 +262,17 @@ def test_diagnostics_events_reports_and_applies_line_limit(
     assert response.json()["truncated"] is True
 
 
-def test_diagnostics_events_lifecycle_scope_discloses_runtime_mapping(
+def test_diagnostics_events_rejects_unavailable_lifecycle_scope(
     client: TestClient,
     auth_headers: dict,
     monkeypatch,
 ) -> None:
+    calls: list[tuple[str, int]] = []
+
     class StubService:
         @staticmethod
-        def get_sandbox_events(*args, **kwargs) -> str:
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            calls.append((sandbox_id, limit))
             return "runtime event"
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
@@ -279,9 +282,37 @@ def test_diagnostics_events_lifecycle_scope_discloses_runtime_mapping(
         headers=auth_headers,
     )
 
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+        "message": (
+            "Unsupported events diagnostics scope 'lifecycle'. "
+            "Supported scopes: runtime, all."
+        ),
+    }
+    assert calls == []
+
+
+def test_diagnostics_events_all_scope_discloses_backend_limit(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            return "runtime event"
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=all",
+        headers=auth_headers,
+    )
+
     assert response.status_code == 200
     assert response.json()["warnings"] == [
-        "The current backend maps lifecycle diagnostics to runtime events."
+        "The current backend only contributes runtime events to the all scope."
     ]
 
 

--- a/server/tests/test_devops.py
+++ b/server/tests/test_devops.py
@@ -33,7 +33,7 @@ def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
             container: str | None = None,
         ) -> str:
             assert sandbox_id == "sbx-001"
-            assert tail == 100
+            assert tail == 101
             assert since is None
             assert container is None
             return content
@@ -57,6 +57,39 @@ def test_diagnostics_logs_with_scope_returns_stable_inline_descriptor(
         "contentLength": len(content.encode("utf-8")),
         "truncated": False,
     }
+
+
+def test_diagnostics_logs_reports_and_applies_line_limit(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    lines = [f"line {index}" for index in range(101)]
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_logs(
+            sandbox_id: str,
+            tail: int,
+            since: str | None = None,
+            container: str | None = None,
+        ) -> str:
+            assert sandbox_id == "sbx-001"
+            assert tail == 101
+            assert since is None
+            assert container is None
+            return "\n".join(lines)
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/logs?scope=container",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content"].splitlines() == lines[-100:]
+    assert response.json()["truncated"] is True
 
 
 def test_diagnostics_logs_rejects_unsupported_scope(
@@ -179,7 +212,7 @@ def test_diagnostics_events_with_scope_returns_stable_inline_descriptor(
         @staticmethod
         def get_sandbox_events(sandbox_id: str, limit: int) -> str:
             assert sandbox_id == "sbx-001"
-            assert limit == 50
+            assert limit == 51
             return "runtime event"
 
     monkeypatch.setattr(devops, "sandbox_service", StubService())
@@ -201,6 +234,32 @@ def test_diagnostics_events_with_scope_returns_stable_inline_descriptor(
         "contentLength": 13,
         "truncated": False,
     }
+
+
+def test_diagnostics_events_reports_and_applies_line_limit(
+    client: TestClient,
+    auth_headers: dict,
+    monkeypatch,
+) -> None:
+    events = [f"event {index}" for index in range(51)]
+
+    class StubService:
+        @staticmethod
+        def get_sandbox_events(sandbox_id: str, limit: int) -> str:
+            assert sandbox_id == "sbx-001"
+            assert limit == 51
+            return "\n".join(events)
+
+    monkeypatch.setattr(devops, "sandbox_service", StubService())
+
+    response = client.get(
+        "/v1/sandboxes/sbx-001/diagnostics/events?scope=runtime",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content"].splitlines() == events[:50]
+    assert response.json()["truncated"] is True
 
 
 def test_diagnostics_events_lifecycle_scope_discloses_runtime_mapping(

--- a/server/tests/test_docker_diagnostics.py
+++ b/server/tests/test_docker_diagnostics.py
@@ -88,6 +88,68 @@ def test_get_sandbox_logs_maps_docker_errors_to_contract_response() -> None:
     assert detail["message"] == "Failed to read logs for sandbox sbx-1: daemon disconnected"
 
 
+def test_stable_log_diagnostics_policy_is_owned_by_docker_service() -> None:
+    container = _container({"State": {}})
+    lines = [f"line {index}" for index in range(101)]
+    container.logs.return_value = "\n".join(lines)
+    service = _DiagnosticsService(container)
+
+    result = service.get_sandbox_log_diagnostics("sbx-1", scope="ALL")
+
+    assert result.scope == "all"
+    assert result.content.splitlines() == lines[-100:]
+    assert result.truncated is True
+    assert result.warnings == (
+        "The current backend only contributes sandbox container logs to the all scope.",
+    )
+    container.logs.assert_called_once_with(tail=101, timestamps=True)
+
+
+def test_stable_event_diagnostics_policy_is_owned_by_docker_service() -> None:
+    service = _DiagnosticsService(_container({"State": {}}))
+    events = [f"event {index}" for index in range(51)]
+    service.get_sandbox_events = MagicMock(return_value="\n".join(events))
+
+    result = service.get_sandbox_event_diagnostics("sbx-1", scope="ALL")
+
+    assert result.scope == "all"
+    assert result.content.splitlines() == events[:50]
+    assert result.truncated is True
+    assert result.warnings == (
+        "The current backend only contributes runtime events to the all scope.",
+    )
+    service.get_sandbox_events.assert_called_once_with("sbx-1", limit=51)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "scope", "kind", "supported"),
+    [
+        ("get_sandbox_log_diagnostics", "lifecycle", "logs", "container, all"),
+        ("get_sandbox_event_diagnostics", "network", "events", "runtime, all"),
+    ],
+)
+def test_stable_diagnostics_reject_unsupported_docker_scopes(
+    method_name: str,
+    scope: str,
+    kind: str,
+    supported: str,
+) -> None:
+    container = _container({"State": {}})
+    service = _DiagnosticsService(container)
+
+    with pytest.raises(HTTPException) as exc:
+        getattr(service, method_name)("sbx-1", scope)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc.value.detail == {
+        "code": "DIAGNOSTICS_SCOPE_UNSUPPORTED",
+        "message": (
+            f"Unsupported {kind} diagnostics scope {scope!r}. Supported scopes: {supported}."
+        ),
+    }
+    container.logs.assert_not_called()
+
+
 def test_get_sandbox_inspect_formats_state_resources_ports_and_safe_env() -> None:
     container = _container(
         {

--- a/server/tests/test_docker_diagnostics.py
+++ b/server/tests/test_docker_diagnostics.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
+from docker.errors import DockerException
+from fastapi import HTTPException, status
+import pytest
+
+from opensandbox_server.services.constants import SandboxErrorCodes
 from opensandbox_server.services.docker.docker_diagnostics import (
     DockerDiagnosticsMixin,
     _parse_since_to_timestamp,
@@ -66,6 +72,20 @@ def test_get_sandbox_logs_returns_placeholder_for_empty_output() -> None:
     service = _DiagnosticsService(container)
 
     assert service.get_sandbox_logs("sbx-1") == "(no logs)"
+
+
+def test_get_sandbox_logs_maps_docker_errors_to_contract_response() -> None:
+    container = _container({"State": {}})
+    container.logs.side_effect = DockerException("daemon disconnected")
+    service = _DiagnosticsService(container)
+
+    with pytest.raises(HTTPException) as exc:
+        service.get_sandbox_logs("sbx-1")
+
+    assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    detail = cast(dict[str, str], exc.value.detail)
+    assert detail["code"] == SandboxErrorCodes.CONTAINER_QUERY_FAILED
+    assert detail["message"] == "Failed to read logs for sandbox sbx-1: daemon disconnected"
 
 
 def test_get_sandbox_inspect_formats_state_resources_ports_and_safe_env() -> None:


### PR DESCRIPTION
# Summary

- implement scoped stable Diagnostics API responses by wrapping the existing Docker/Kubernetes log and event collectors in the public inline descriptor contract
- support `logs:container|all` and `events:runtime|lifecycle|all`, with explicit warnings when a best-effort scope is incomplete or mapped to runtime events
- return `400 DIAGNOSTICS_SCOPE_UNSUPPORTED` without querying the backend for unsupported scopes
- preserve deprecated no-`scope` plain-text behavior for existing DevOps clients
- align CLI documentation and the bundled troubleshooting skill with the built-in server scope matrix

Closes #1552.

# Testing

- [ ] Not run (explain why)
- [x] Unit tests
  - `cd server && uv run --frozen ruff check`
  - `cd server && uv run --frozen pytest -q` (1375 passed)
  - `cd cli && uv sync --python 3.11 && uv run ruff check && uv run pyright && uv run pytest tests/ -q` (205 passed)
  - `cd docs && corepack pnpm docs:build`
  - `./scripts/verify-license.sh`
- [ ] Integration tests
- [ ] e2e / manual verification

# Breaking Changes

- [x] None
- [ ] Yes (describe impact and migration path)

Requests without `scope` still return deprecated `text/plain` responses with the `Deprecation: true` header. Existing `tail`, `since`, `container`, and `limit` behavior is preserved.

# Checklist

- [x] Linked Issue or clearly described motivation
- [x] Added/updated docs (if needed)
- [x] Added/updated tests (if needed)
- [x] Security impact considered
- [x] Backward compatibility considered
