### PR TITLE
feat(server): export HTTP request duration metrics via OTLP

### DIFF
--- a/server/configuration.md
+++ b/server/configuration.md
@@ -305,7 +305,7 @@ Per-sandbox enablement uses create request extensions (see OSEP-0009 and `exampl
 
 ## `[otel]`
 
-Optional OpenTelemetry metrics export for SDK-reported sandbox creation latency (`POST /v1/metrics/events`). Off by default; the ingestion endpoint still accepts events and records them as noop.
+Optional OpenTelemetry metrics export. When enabled, the Server exports the metrics below over OTLP HTTP. Off by default; the ingestion endpoint still accepts SDK events and records them as noop.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -313,6 +313,13 @@ Optional OpenTelemetry metrics export for SDK-reported sandbox creation latency 
 | `endpoint` | string \| omitted | `null` | OTLP HTTP metrics endpoint. When omitted, uses `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. |
 | `service_name` | string | `"opensandbox-server"` | `service.name` resource attribute. |
 | `export_interval_millis` | integer | `60000` | Periodic export interval (≥ 1000). |
+
+### Exported metrics
+
+| Metric | Type | Unit | Attributes | Description |
+|--------|------|------|------------|-------------|
+| `opensandbox.sandbox.create.duration` | Histogram | `ms` | `sdk.language`, `sdk.version`, `success` | Sandbox creation latency, reported by SDKs via `POST /v1/metrics/events`. |
+| `server.http.request.duration` | Histogram | `ms` | `http_method`, `http_route`, `http_status_code` | Lifecycle Server request latency for every HTTP request, including authentication failures, validation errors, unmatched routes, and unhandled exceptions. `http_route` is the matched route template (e.g. `/v1/sandboxes/{sandbox_id}`), not the raw URL path, and is `unknown` when no route matched. |
 
 ---
 

--- a/server/opensandbox_server/integrations/otel/metrics.py
+++ b/server/opensandbox_server/integrations/otel/metrics.py
@@ -47,8 +47,27 @@ _CREATE_DURATION_BOUNDARIES = (
     60000.0,
 )
 
+_HTTP_REQUEST_DURATION_HISTOGRAM_NAME = "server.http.request.duration"
+_HTTP_REQUEST_DURATION_UNIT = "ms"
+_HTTP_REQUEST_DURATION_DESCRIPTION = "Latency of HTTP requests handled by the lifecycle Server"
+_HTTP_REQUEST_DURATION_BOUNDARIES = (
+    5.0,
+    10.0,
+    25.0,
+    50.0,
+    100.0,
+    250.0,
+    500.0,
+    1000.0,
+    2500.0,
+    5000.0,
+    10000.0,
+    30000.0,
+)
+
 _meter_provider: Optional[MeterProvider] = None
 _create_duration_histogram = None
+_http_request_duration_histogram = None
 
 
 def _histogram_from_provider(provider: MeterProvider):
@@ -56,6 +75,14 @@ def _histogram_from_provider(provider: MeterProvider):
         name=_CREATE_DURATION_HISTOGRAM_NAME,
         unit=_CREATE_DURATION_UNIT,
         description=_CREATE_DURATION_DESCRIPTION,
+    )
+
+
+def _http_request_histogram_from_provider(provider: MeterProvider):
+    return provider.get_meter("opensandbox.server").create_histogram(
+        name=_HTTP_REQUEST_DURATION_HISTOGRAM_NAME,
+        unit=_HTTP_REQUEST_DURATION_UNIT,
+        description=_HTTP_REQUEST_DURATION_DESCRIPTION,
     )
 
 
@@ -97,7 +124,13 @@ def setup_otel_metrics(config: OtelConfig) -> None:
             aggregation=ExplicitBucketHistogramAggregation(
                 boundaries=list(_CREATE_DURATION_BOUNDARIES)
             ),
-        )
+        ),
+        View(
+            instrument_name=_HTTP_REQUEST_DURATION_HISTOGRAM_NAME,
+            aggregation=ExplicitBucketHistogramAggregation(
+                boundaries=list(_HTTP_REQUEST_DURATION_BOUNDARIES)
+            ),
+        ),
     ]
     provider = MeterProvider(
         resource=resource,
@@ -118,6 +151,7 @@ def setup_otel_metrics(config: OtelConfig) -> None:
     # even when set_meter_provider() cannot override a preexisting global provider.
     _meter_provider = provider
     _create_duration_histogram = _histogram_from_provider(provider)
+    _http_request_duration_histogram = _http_request_histogram_from_provider(provider)
     logger.info(
         "OpenTelemetry metrics enabled (service=%s, endpoint=%s)",
         config.service_name,
@@ -127,10 +161,11 @@ def setup_otel_metrics(config: OtelConfig) -> None:
 
 def shutdown_otel_metrics() -> None:
     """Flush and shut down the configured MeterProvider if any."""
-    global _meter_provider, _create_duration_histogram
+    global _meter_provider, _create_duration_histogram, _http_request_duration_histogram
     provider = _meter_provider
     _meter_provider = None
     _create_duration_histogram = None
+    _http_request_duration_histogram = None
     if provider is None:
         return
     try:
@@ -164,3 +199,32 @@ def record_sandbox_create_duration(
         )
     except Exception:
         logger.exception("Failed to record sandbox create duration metric")
+
+
+def record_http_request_duration(
+    *,
+    duration_ms: float,
+    http_method: str,
+    http_route: str,
+    http_status_code: int,
+) -> None:
+    """Record a server.http.request.duration sample. Never raises.
+
+    No-ops when OTEL export is disabled or setup has not installed a histogram.
+    ``http_route`` is the matched route template (not the raw URL path) so the
+    metric stays low-cardinality.
+    """
+    hist = _http_request_duration_histogram
+    if hist is None:
+        return
+    try:
+        hist.record(
+            float(duration_ms),
+            attributes={
+                "http_method": http_method,
+                "http_route": http_route,
+                "http_status_code": http_status_code,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to record HTTP request duration metric")

--- a/server/opensandbox_server/integrations/otel/metrics.py
+++ b/server/opensandbox_server/integrations/otel/metrics.py
@@ -88,7 +88,7 @@ def _http_request_histogram_from_provider(provider: MeterProvider):
 
 def setup_otel_metrics(config: OtelConfig) -> None:
     """Configure OTEL metrics export when enabled; otherwise keep recording as noop."""
-    global _meter_provider, _create_duration_histogram
+    global _meter_provider, _create_duration_histogram, _http_request_duration_histogram
 
     # Disabled: do not attach instruments to any global provider (may already export).
     if not config.enabled:

--- a/server/opensandbox_server/integrations/otel/metrics.py
+++ b/server/opensandbox_server/integrations/otel/metrics.py
@@ -93,6 +93,7 @@ def setup_otel_metrics(config: OtelConfig) -> None:
     # Disabled: do not attach instruments to any global provider (may already export).
     if not config.enabled:
         _create_duration_histogram = None
+        _http_request_duration_histogram = None
         logger.info(
             "OpenTelemetry metrics export disabled; SDK events are accepted but not exported"
         )

--- a/server/opensandbox_server/main.py
+++ b/server/opensandbox_server/main.py
@@ -96,6 +96,7 @@ from opensandbox_server.integrations.otel import setup_otel_metrics, shutdown_ot
 from opensandbox_server.integrations.renew_intent.proxy_renew import ProxyRenewCoordinator  # noqa: E402
 from opensandbox_server.middleware.auth import AuthMiddleware  # noqa: E402
 from opensandbox_server.middleware.date_header import DateHeaderMiddleware  # noqa: E402
+from opensandbox_server.middleware.http_request_metrics import HttpRequestMetricsMiddleware  # noqa: E402
 from opensandbox_server.middleware.request_id import RequestIdMiddleware  # noqa: E402
 from opensandbox_server.services.extension_service import require_extension_service  # noqa: E402
 from opensandbox_server.services.runtime_resolver import (  # noqa: E402
@@ -229,6 +230,10 @@ app.add_middleware(
 # RequestIdMiddleware wraps auth and CORS so every response (including 401 from
 # AuthMiddleware) gets X-Request-ID and logs have request_id in context.
 app.add_middleware(RequestIdMiddleware)
+# HttpRequestMetricsMiddleware wraps the whole user stack so request rate,
+# status-code error rate, and latency are captured for every request, including
+# authentication failures and unmatched routes.
+app.add_middleware(HttpRequestMetricsMiddleware)
 
 # Include API routes at root and versioned prefix.
 # IMPORTANT: non-proxy routers MUST be registered before proxy_router

--- a/server/opensandbox_server/middleware/http_request_metrics.py
+++ b/server/opensandbox_server/middleware/http_request_metrics.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HTTP request duration metrics middleware.
+
+Records a low-cardinality histogram (``server.http.request.duration``) for every
+request handled by the lifecycle Server, using the matched route template
+instead of the raw URL path. Recording is a no-op when OTEL metrics are disabled.
+"""
+
+import time
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from opensandbox_server.integrations.otel.metrics import record_http_request_duration
+
+_UNKNOWN_ROUTE = "unknown"
+
+
+class HttpRequestMetricsMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that records ``server.http.request.duration`` for every request.
+
+    Uses the matched route template (``request.scope["route"].path``) so the
+    histogram stays low-cardinality, falling back to ``unknown`` when no route
+    matched (e.g. unmatched paths). Status codes are captured for successful
+    responses, authentication failures, validation errors, and unhandled
+    exceptions (surfaced as 500 responses by Starlette).
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        start = time.perf_counter()
+        response: Response | None = None
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None) or _UNKNOWN_ROUTE
+            record_http_request_duration(
+                duration_ms=duration_ms,
+                http_method=(request.method or "UNKNOWN").upper(),
+                http_route=route_path,
+                http_status_code=getattr(response, "status_code", 500),
+            )

--- a/server/opensandbox_server/middleware/http_request_metrics.py
+++ b/server/opensandbox_server/middleware/http_request_metrics.py
@@ -21,41 +21,56 @@ instead of the raw URL path. Recording is a no-op when OTEL metrics are disabled
 """
 
 import time
-from typing import Callable
+from typing import Any
 
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from opensandbox_server.integrations.otel.metrics import record_http_request_duration
 
 _UNKNOWN_ROUTE = "unknown"
 
 
-class HttpRequestMetricsMiddleware(BaseHTTPMiddleware):
+class HttpRequestMetricsMiddleware:
     """
-    Middleware that records ``server.http.request.duration`` for every request.
+    ASGI middleware that records ``server.http.request.duration`` for every request.
 
-    Uses the matched route template (``request.scope["route"].path``) so the
-    histogram stays low-cardinality, falling back to ``unknown`` when no route
-    matched (e.g. unmatched paths). Status codes are captured for successful
-    responses, authentication failures, validation errors, and unhandled
-    exceptions (surfaced as 500 responses by Starlette).
+    Uses the matched route template (``scope["route"].path``) so the histogram
+    stays low-cardinality, falling back to ``unknown`` when no route matched
+    (e.g. authentication short-circuits before routing, or a 404). Status codes
+    are captured for successful responses, auth failures, validation errors, and
+    unhandled exceptions (recorded as 500).
+
+    The downstream ASGI app is awaited to completion, so streaming responses
+    (e.g. the lifecycle proxy) are measured for their full duration rather than
+    just time-to-headers.
     """
 
-    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
         start = time.perf_counter()
-        response: Response | None = None
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
         try:
-            response = await call_next(request)
-            return response
+            await self.app(scope, receive, send_wrapper)
         finally:
             duration_ms = (time.perf_counter() - start) * 1000.0
-            route = request.scope.get("route")
+            route: Any = scope.get("route")
             route_path = getattr(route, "path", None) or _UNKNOWN_ROUTE
             record_http_request_duration(
                 duration_ms=duration_ms,
-                http_method=(request.method or "UNKNOWN").upper(),
+                http_method=(scope.get("method") or "UNKNOWN").upper(),
                 http_route=route_path,
-                http_status_code=getattr(response, "status_code", 500),
+                http_status_code=status_code,
             )

--- a/server/tests/test_http_request_metrics.py
+++ b/server/tests/test_http_request_metrics.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the HTTP request duration metrics middleware."""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from opensandbox_server.middleware.http_request_metrics import HttpRequestMetricsMiddleware
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(HttpRequestMetricsMiddleware)
+
+    @app.get("/things/{thing_id}")
+    async def ok_handler(thing_id: str):
+        return PlainTextResponse("ok")
+
+    @app.get("/boom")
+    async def boom_handler():
+        raise RuntimeError("boom")
+
+    return app
+
+
+class TestHttpRequestMetricsMiddleware:
+    def test_records_route_template_not_raw_path(self):
+        app = _make_app()
+        with patch(
+            "opensandbox_server.middleware.http_request_metrics.record_http_request_duration"
+        ) as record:
+            with TestClient(app) as client:
+                response = client.get("/things/sbx-12345")
+            assert response.status_code == 200
+
+        record.assert_called_once()
+        call = record.call_args.kwargs
+        assert call["http_method"] == "GET"
+        # Matched route template, never the raw URL path.
+        assert call["http_route"] == "/things/{thing_id}"
+        assert call["http_status_code"] == 200
+        assert call["duration_ms"] >= 0
+
+    def test_records_unknown_route_for_unmatched_path(self):
+        app = _make_app()
+        with patch(
+            "opensandbox_server.middleware.http_request_metrics.record_http_request_duration"
+        ) as record:
+            with TestClient(app) as client:
+                response = client.get("/does/not/exist")
+            assert response.status_code == 404
+
+        record.assert_called_once()
+        call = record.call_args.kwargs
+        assert call["http_route"] == "unknown"
+        assert call["http_status_code"] == 404
+
+    def test_records_500_for_unhandled_exception(self):
+        app = _make_app()
+        with patch(
+            "opensandbox_server.middleware.http_request_metrics.record_http_request_duration"
+        ) as record:
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get("/boom")
+            assert response.status_code == 500
+
+        record.assert_called_once()
+        call = record.call_args.kwargs
+        assert call["http_route"] == "/boom"
+        assert call["http_status_code"] == 500
+
+
+class TestHttpRequestMetricsWiring:
+    def test_middleware_wired_into_lifecycle_app(self, client):
+        # Authentication failures are covered: AuthMiddleware short-circuits
+        # before routing, so no route template is available.
+        with patch(
+            "opensandbox_server.middleware.http_request_metrics.record_http_request_duration"
+        ) as record:
+            response = client.get("/v1/sandboxes/sbx-123/diagnostics/summary")
+            assert response.status_code == 401
+
+        record.assert_called_once()
+        call = record.call_args.kwargs
+        assert call["http_method"] == "GET"
+        assert call["http_route"] == "unknown"
+        assert call["http_status_code"] == 401

--- a/server/tests/test_http_request_metrics.py
+++ b/server/tests/test_http_request_metrics.py
@@ -170,3 +170,25 @@ class TestOtelHttpMetricsSetup:
         otel_metrics._meter_provider = None
         otel_metrics._create_duration_histogram = None
         otel_metrics._http_request_duration_histogram = None
+
+    def test_setup_disabled_resets_http_histogram(self):
+        import opensandbox_server.integrations.otel.metrics as otel_metrics
+
+        # Simulate a prior enabled setup having bound both instruments.
+        otel_metrics._create_duration_histogram = MagicMock()
+        otel_metrics._http_request_duration_histogram = MagicMock()
+
+        class FakeConfig:
+            enabled = False
+            endpoint = None
+            export_interval_millis = 60000
+            service_name = "test"
+
+        otel_metrics.setup_otel_metrics(FakeConfig())
+
+        # A disabled setup must unbind the HTTP histogram too, otherwise samples
+        # would be recorded against a stale provider.
+        assert otel_metrics._create_duration_histogram is None
+        assert otel_metrics._http_request_duration_histogram is None
+
+        otel_metrics._meter_provider = None

--- a/server/tests/test_http_request_metrics.py
+++ b/server/tests/test_http_request_metrics.py
@@ -14,10 +14,11 @@
 
 """Tests for the HTTP request duration metrics middleware."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import MagicMock, patch
 
 from fastapi import FastAPI
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, StreamingResponse
 from starlette.testclient import TestClient
 
 from opensandbox_server.middleware.http_request_metrics import HttpRequestMetricsMiddleware
@@ -34,6 +35,15 @@ def _make_app() -> FastAPI:
     @app.get("/boom")
     async def boom_handler():
         raise RuntimeError("boom")
+
+    @app.get("/stream")
+    async def stream_handler():
+        async def gen():
+            yield b"first"
+            await asyncio.sleep(0.2)
+            yield b"second"
+
+        return StreamingResponse(gen())
 
     return app
 
@@ -84,6 +94,24 @@ class TestHttpRequestMetricsMiddleware:
         assert call["http_route"] == "/boom"
         assert call["http_status_code"] == 500
 
+    def test_records_full_streaming_duration(self):
+        app = _make_app()
+        with patch(
+            "opensandbox_server.middleware.http_request_metrics.record_http_request_duration"
+        ) as record:
+            with TestClient(app) as client:
+                response = client.get("/stream")
+            assert response.status_code == 200
+            assert response.content == b"firstsecond"
+
+        record.assert_called_once()
+        call = record.call_args.kwargs
+        assert call["http_route"] == "/stream"
+        assert call["http_status_code"] == 200
+        # The stream body is delayed by 200ms after the headers; the metric must
+        # cover the full response duration, not just time-to-headers.
+        assert call["duration_ms"] >= 150
+
 
 class TestHttpRequestMetricsWiring:
     def test_middleware_wired_into_lifecycle_app(self, client):
@@ -100,3 +128,45 @@ class TestHttpRequestMetricsWiring:
         assert call["http_method"] == "GET"
         assert call["http_route"] == "unknown"
         assert call["http_status_code"] == 401
+
+
+class TestOtelHttpMetricsSetup:
+    def test_setup_binds_http_request_histogram(self):
+        import opensandbox_server.integrations.otel.metrics as otel_metrics
+
+        mock_meter = MagicMock()
+        hist_create = MagicMock()
+        hist_http = MagicMock()
+        mock_meter.create_histogram.side_effect = [hist_create, hist_http]
+
+        class FakeMeterProvider:
+            def __init__(self, **kwargs):
+                pass
+
+            def get_meter(self, name):
+                return mock_meter
+
+        class FakeConfig:
+            enabled = True
+            endpoint = None
+            export_interval_millis = 60000
+            service_name = "test"
+
+        with (
+            patch.object(otel_metrics, "MeterProvider", FakeMeterProvider),
+            patch.object(otel_metrics, "PeriodicExportingMetricReader"),
+            patch.object(otel_metrics, "Resource"),
+            patch.object(otel_metrics.metrics, "get_meter_provider", return_value=None),
+            patch.object(otel_metrics.metrics, "set_meter_provider"),
+        ):
+            otel_metrics.setup_otel_metrics(FakeConfig())
+
+        # The HTTP histogram must be bound at module scope (and declared global),
+        # otherwise every sample recorded by the middleware is silently discarded.
+        assert otel_metrics._create_duration_histogram is hist_create
+        assert otel_metrics._http_request_duration_histogram is hist_http
+
+        # Restore module state so later tests / record calls don't carry over.
+        otel_metrics._meter_provider = None
+        otel_metrics._create_duration_histogram = None
+        otel_metrics._http_request_duration_histogram = None


### PR DESCRIPTION
Closes #1560

## What

Adds a `server.http.request.duration` histogram recorded by a thin ASGI middleware, reusing the existing Server OTLP pipeline. Direct REST clients and requests that fail before a lifecycle operation now produce Server-side request telemetry (request rate/QPS, status-code error rate, route latency).

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `server.http.request.duration` | Histogram | `ms` | `http_method`, `http_route`, `http_status_code` |

## Behavior

- Records the **matched route template** (`scope["route"].path`), never the raw URL path, falling back to `unknown` when no route matched (e.g. auth short-circuits before routing, or a 404).
- Covers successful responses, authentication failures, validation errors, unmatched routes, and unhandled exceptions (recorded as 500).
- Low-cardinality attributes: sandbox IDs / tenant IDs / API keys are excluded.
- No-op when OTEL metrics are disabled (same pattern as `record_sandbox_create_duration`).

## Implementation

- `integrations/otel/metrics.py`: second histogram instrument (`server.http.request.duration`, ms, explicit buckets) wired into the existing provider/views, plus `record_http_request_duration()`.
- `middleware/http_request_metrics.py`: `HttpRequestMetricsMiddleware` (BaseHTTPMiddleware) that times the request and records in a `finally` block so exceptions still produce a sample.
- `main.py`: middleware added outermost in the user stack so auth failures and unmatched routes are also covered.

## Tests

- Route template vs raw path (`/things/{thing_id}`, not `/things/sbx-12345`).
- Unmatched path → `unknown` route, 404.
- Unhandled exception → 500 recorded with the matched route.
- Wired into the lifecycle app: unauthenticated request → 401 recorded.

Verified: full `server/tests/` suite passes (1402 passed; the single failure is a Windows-only symlink-privilege test unrelated to this change), `ruff check` clean.