### PR TITLE
fix(server): reject non-finite CPU limits

### DIFF
--- a/server/opensandbox_server/services/helpers.py
+++ b/server/opensandbox_server/services/helpers.py
@@ -22,6 +22,7 @@ so multiple container runtimes (docker, kubernetes, etc.) can reuse them.
 from __future__ import annotations
 
 import logging
+import math
 import re
 from datetime import datetime, timezone
 from typing import Dict, Optional
@@ -92,10 +93,17 @@ def parse_nano_cpus(value: Optional[str]) -> Optional[int]:
     except ValueError:
         logger.warning("Invalid CPU limit format '%s'; ignoring.", value)
         return None
+    if not math.isfinite(cpus):
+        logger.warning("CPU limit must be finite. Got '%s'. Ignoring.", value)
+        return None
     if cpus <= 0:
         logger.warning("CPU limit must be positive. Got '%s'. Ignoring.", value)
         return None
-    return int(cpus * 1_000_000_000)
+    nano_cpus = cpus * 1_000_000_000
+    if not math.isfinite(nano_cpus):
+        logger.warning("CPU limit is too large. Got '%s'. Ignoring.", value)
+        return None
+    return int(nano_cpus)
 
 
 def parse_gpu_request(value: Optional[str]) -> Optional[int]:

--- a/server/opensandbox_server/services/helpers.py
+++ b/server/opensandbox_server/services/helpers.py
@@ -103,7 +103,11 @@ def parse_nano_cpus(value: Optional[str]) -> Optional[int]:
     if not math.isfinite(nano_cpus):
         logger.warning("CPU limit is too large. Got '%s'. Ignoring.", value)
         return None
-    return int(nano_cpus)
+    nano_cpus = int(nano_cpus)
+    if nano_cpus > (1 << 63) - 1:
+        logger.warning("CPU limit is too large. Got '%s'. Ignoring.", value)
+        return None
+    return nano_cpus
 
 
 def parse_gpu_request(value: Optional[str]) -> Optional[int]:

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -101,8 +101,10 @@ def test_parse_nano_cpus():
     assert parse_nano_cpus("bad") is None
 
 
-@pytest.mark.parametrize("value", ["nan", "inf", "-inf", "1e308", "1e309", "-1e309"])
-def test_parse_nano_cpus_rejects_non_finite_values(value: str):
+@pytest.mark.parametrize(
+    "value", ["nan", "inf", "-inf", "1e10", "1e308", "1e309", "-1e309"]
+)
+def test_parse_nano_cpus_rejects_non_finite_and_overflow_values(value: str):
     assert parse_nano_cpus(value) is None
 
 

--- a/server/tests/test_docker_service.py
+++ b/server/tests/test_docker_service.py
@@ -96,7 +96,15 @@ def test_parse_memory_limit_handles_units():
 def test_parse_nano_cpus():
     assert parse_nano_cpus("500m") == 500_000_000
     assert parse_nano_cpus("2") == 2_000_000_000
+    assert parse_nano_cpus("1.5") == 1_500_000_000
+    assert parse_nano_cpus("250.5m") == 250_500_000
     assert parse_nano_cpus("bad") is None
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf", "1e308", "1e309", "-1e309"])
+def test_parse_nano_cpus_rejects_non_finite_values(value: str):
+    assert parse_nano_cpus(value) is None
+
 
 def test_parse_gpu_request():
     assert parse_gpu_request("1") == 1


### PR DESCRIPTION
# Summary
- reject `nan`, infinite, and overflowed CPU limits before converting them to Docker NanoCpus
- retain valid decimal and millicpu conversions
- add regression coverage for non-finite and extreme exponent inputs

# Testing
- [ ] Not run (please explain)
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual verification
- [x] Other: Ruff and Pyright

Commands:
- `uv run pytest tests/test_docker_service.py -q` (142 passed)
- `uv run ruff check opensandbox_server/services/helpers.py tests/test_docker_service.py`
- `uv run pyright opensandbox_server/services/helpers.py`

# Breaking Changes
- [x] None
- [ ] Yes (describe below)

# Related Issues / Links
- N/A; found while reviewing resource-limit validation.